### PR TITLE
Fix: Initialize page number from table's absolute Y position for header/footer repetition

### DIFF
--- a/src/PeachPDF.Tests/Integration/TableHeaderRepetitionIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableHeaderRepetitionIntegrationTests.cs
@@ -385,6 +385,63 @@ Assert.True(tableBox.ActualBottom > pageHeight);
        Assert.True(pageSpan >= 2, $"Complex table should span at least 2 pages");
    }
 
+        [Fact]
+        public async Task MultipleTablesWithHeaders_EachTableHasCorrectHeaderProxies()
+        {
+            var html = @"
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        @page { size: A4; margin: 20mm; }
+        table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+        th, td { padding: 8px; border: 1px solid black; }
+        thead { background: #4CAF50; color: white; }
+    </style>
+</head>
+<body>";
+
+            // Table 1: spans multiple pages
+            html += @"<table><thead><tr><th>Table1 Col1</th><th>Table1 Col2</th></tr></thead><tbody>";
+            for (int i = 1; i <= 60; i++)
+                html += $"<tr><td>T1 Row {i} A</td><td>T1 Row {i} B</td></tr>";
+            html += "</tbody></table>";
+
+            // Table 2: also spans multiple pages
+            html += @"<table><thead><tr><th>Table2 ColA</th><th>Table2 ColB</th></tr></thead><tbody>";
+            for (int i = 1; i <= 60; i++)
+                html += $"<tr><td>T2 Row {i} A</td><td>T2 Row {i} B</td></tr>";
+            html += "</tbody></table>";
+
+            html += "</body></html>";
+
+            var (rootBox, container) = await BuildCssBoxTree(html);
+
+            var tablBoxes = FindAllTableBoxes(rootBox);
+            Assert.Equal(2, tablBoxes.Count);
+
+            var table1 = tablBoxes[0];
+            var table2 = tablBoxes[1];
+
+            // Each table should have header proxies
+            var table1Proxies = FindProxyBoxesByDisplay(table1, CssConstants.TableHeaderGroup);
+            var table2Proxies = FindProxyBoxesByDisplay(table2, CssConstants.TableHeaderGroup);
+
+            Assert.NotEmpty(table1Proxies);
+            Assert.NotEmpty(table2Proxies);
+
+            // Table 2 should start below Table 1
+            Assert.True(table2.Location.Y > table1.ActualBottom,
+                $"Table 2 (Y={table2.Location.Y}) should start below Table 1 (bottom={table1.ActualBottom})");
+
+            // Table 2's header proxies should all be within Table 2's Y range
+            foreach (var proxy in table2Proxies)
+            {
+                Assert.True(proxy.Location.Y >= table1.ActualBottom,
+                    $"Table 2 header proxy at Y={proxy.Location.Y} should be below Table 1 bottom={table1.ActualBottom}");
+            }
+        }
+
         #region Helper Methods
 
         private async Task<(CssBox root, HtmlContainerInt container)> BuildCssBoxTree(string html)
@@ -421,6 +478,20 @@ using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
             }
 
             return null;
+        }
+
+        private List<CssBox> FindAllTableBoxes(CssBox root)
+        {
+            var tables = new List<CssBox>();
+            void Collect(CssBox box)
+            {
+                if (box.Display == CssConstants.Table)
+                    tables.Add(box);
+                foreach (var child in box.Boxes)
+                    Collect(child);
+            }
+            Collect(root);
+            return tables;
         }
 
         private CssBox? FindBoxByDisplay(CssBox root, string display)

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
@@ -629,27 +629,27 @@ namespace PeachPDF.Html.Core.Dom
         /// </summary>
         private CssProxyBox? CreateHeaderProxy(double yPosition)
         {
-          if (_headerBox == null)
-         return null;
+            if (_headerBox == null)
+                return null;
 
-          var proxy = new CssProxyBox(_tableBox, _headerBox);
+            var proxy = new CssProxyBox(_tableBox, _headerBox);
             var startX = Math.Max(_tableBox.ClientLeft + GetHorizontalSpacing(), 0);
-        proxy.Location = new RPoint(startX, yPosition);
-   return proxy;
-   }
+            proxy.Location = new RPoint(startX, yPosition);
+            return proxy;
+        }
 
         /// <summary>
-      /// Create a proxy box for the footer at the specified Y position
-/// </summary>
+        /// Create a proxy box for the footer at the specified Y position
+        /// </summary>
         private CssProxyBox? CreateFooterProxy(double yPosition)
-   {
-  if (_footerBox == null)
-         return null;
+        {
+            if (_footerBox == null)
+                return null;
 
-     var proxy = new CssProxyBox(_tableBox, _footerBox);
+            var proxy = new CssProxyBox(_tableBox, _footerBox);
             var startX = Math.Max(_tableBox.ClientLeft + GetHorizontalSpacing(), 0);
-     proxy.Location = new RPoint(startX, yPosition);
-      return proxy;
+            proxy.Location = new RPoint(startX, yPosition);
+            return proxy;
         }
 
         /// <summary>
@@ -658,141 +658,144 @@ namespace PeachPDF.Html.Core.Dom
         /// <param name="g"></param>
         private async ValueTask LayoutCells(RGraphics g)
         {
-       var startX = Math.Max(_tableBox.ClientLeft + GetHorizontalSpacing(), 0);
+            var startX = Math.Max(_tableBox.ClientLeft + GetHorizontalSpacing(), 0);
             var startY = Math.Max(_tableBox.ClientTop + GetVerticalSpacing(), 0);
-       var currentY = startY;
-     var maxRight = startX;
+            var currentY = startY;
+            var maxRight = startX;
             var maxBottom = 0d;
 
-        var pageHeight = _tableBox.HtmlContainer?.PageSize.Height ?? double.MaxValue;
-       var marginTop = _tableBox.HtmlContainer?.MarginTop ?? 0;
+            var pageHeight = _tableBox.HtmlContainer?.PageSize.Height ?? double.MaxValue;
+            var marginTop = _tableBox.HtmlContainer?.MarginTop ?? 0;
             var marginBottom = _tableBox.HtmlContainer?.MarginBottom ?? 0;
 
 #if DEBUG
-      System.Console.WriteLine($"CssLayoutEngineTable.LayoutCells: pageHeight={pageHeight}, marginTop={marginTop}");
+            System.Console.WriteLine($"CssLayoutEngineTable.LayoutCells: pageHeight={pageHeight}, marginTop={marginTop}");
             System.Console.WriteLine($"  _headerBox={(_headerBox == null ? "NULL" : $"Display={_headerBox.Display}")}");
- System.Console.WriteLine($"  _footerBox={(_footerBox == null ? "NULL" : $"Display={_footerBox.Display}")}");
-     System.Console.WriteLine($"  _shouldRepeatHeaders={_shouldRepeatHeaders}");
+            System.Console.WriteLine($"  _footerBox={(_footerBox == null ? "NULL" : $"Display={_footerBox.Display}")}");
+            System.Console.WriteLine($"  _shouldRepeatHeaders={_shouldRepeatHeaders}");
             System.Console.WriteLine($"  _shouldRepeatFooters={_shouldRepeatFooters}");
             System.Console.WriteLine($"  _bodyRows.Count={_bodyRows.Count}");
 #endif
 
             // Step 1: Remove header/footer from document tree
-     RemoveHeaderFooterFromTree();
+            RemoveHeaderFooterFromTree();
 
             // Step 2: Layout header rows ONCE to calculate height
-     if (_shouldRepeatHeaders && _headerBox != null)
- {
-  // Layout header rows directly using table layout logic
-            var headerRowsLayoutY = currentY;
-        foreach (var row in _headerBox.Boxes)
-  {
-      if (row.Display != CssConstants.TableRow)
-  continue;
+            if (_shouldRepeatHeaders && _headerBox != null)
+            {
+                // Layout header rows directly using table layout logic
+                var headerRowsLayoutY = currentY;
+                foreach (var row in _headerBox.Boxes)
+                {
+                    if (row.Display != CssConstants.TableRow)
+                        continue;
 
-     var (newMaxRight, newMaxBottom) = await LayoutBodyRow(g, row, startX, headerRowsLayoutY, -1, new Dictionary<int, List<CssBox>>(), maxRight, headerRowsLayoutY);
-    maxRight = newMaxRight;
- headerRowsLayoutY = newMaxBottom + GetVerticalSpacing();
-    }
+                    var (newMaxRight, newMaxBottom) = await LayoutBodyRow(g, row, startX, headerRowsLayoutY, -1, new Dictionary<int, List<CssBox>>(), maxRight, headerRowsLayoutY);
+                    maxRight = newMaxRight;
+                    headerRowsLayoutY = newMaxBottom + GetVerticalSpacing();
+                }
 
-    // Set header box dimensions
-          _headerBox.Location = new RPoint(startX, currentY);
-  _headerBox.ActualRight = maxRight;
-    _headerBox.ActualBottom = headerRowsLayoutY - GetVerticalSpacing();
-             _headerHeight = _headerBox.ActualBottom - _headerBox.Location.Y;
+                // Set header box dimensions
+                _headerBox.Location = new RPoint(startX, currentY);
+                _headerBox.ActualRight = maxRight;
+                _headerBox.ActualBottom = headerRowsLayoutY - GetVerticalSpacing();
+                _headerHeight = _headerBox.ActualBottom - _headerBox.Location.Y;
 
 #if DEBUG
-      System.Console.WriteLine($"  Header laid out: Height={_headerHeight}, ActualBottom={_headerBox.ActualBottom}");
+                System.Console.WriteLine($"  Header laid out: Height={_headerHeight}, ActualBottom={_headerBox.ActualBottom}");
 #endif
 
-           // Now create proxy that references the already-laid-out header
-    var headerProxy = CreateHeaderProxy(currentY);
-   if (headerProxy != null)
-      {
-   _tableBox.Boxes.Add(headerProxy);  // Add at end instead of inserting at index
-   await headerProxy.PerformLayout(g);
+                // Now create proxy that references the already-laid-out header
+                var headerProxy = CreateHeaderProxy(currentY);
+                if (headerProxy != null)
+                {
+                    _tableBox.Boxes.Add(headerProxy);  // Add at end instead of inserting at index
+                    await headerProxy.PerformLayout(g);
 
-        currentY += _headerHeight + GetVerticalSpacing();
-   maxBottom = currentY;
-        }
-      }
+                    currentY += _headerHeight + GetVerticalSpacing();
+                    maxBottom = currentY;
+                }
+            }
 
-    // Step 3: Layout footer rows once to get dimensions (if needed)
-   if (_shouldRepeatFooters && _footerBox != null)
-     {
- // Layout footer rows directly
-    var footerRowsLayoutY = 0d;
-     foreach (var row in _footerBox.Boxes)
-         {
-   if (row.Display != CssConstants.TableRow)
-       continue;
+            // Step 3: Layout footer rows once to get dimensions (if needed)
+            if (_shouldRepeatFooters && _footerBox != null)
+            {
+                // Layout footer rows directly
+                var footerRowsLayoutY = 0d;
+                foreach (var row in _footerBox.Boxes)
+                {
+                    if (row.Display != CssConstants.TableRow)
+                        continue;
 
-           var (newMaxRight, newMaxBottom) = await LayoutBodyRow(g, row, startX, footerRowsLayoutY, -1, new Dictionary<int, List<CssBox>>(), maxRight, footerRowsLayoutY);
-     footerRowsLayoutY = newMaxBottom + GetVerticalSpacing();
-       }
+                    var (newMaxRight, newMaxBottom) = await LayoutBodyRow(g, row, startX, footerRowsLayoutY, -1, new Dictionary<int, List<CssBox>>(), maxRight, footerRowsLayoutY);
+                    footerRowsLayoutY = newMaxBottom + GetVerticalSpacing();
+                }
 
-        _footerBox.Location = new RPoint(startX, 0);
-    _footerBox.ActualBottom = footerRowsLayoutY - GetVerticalSpacing();
-    _footerHeight = _footerBox.ActualBottom - _footerBox.Location.Y;
-  }
+                _footerBox.Location = new RPoint(startX, 0);
+                _footerBox.ActualBottom = footerRowsLayoutY - GetVerticalSpacing();
+                _footerHeight = _footerBox.ActualBottom - _footerBox.Location.Y;
+            }
 
-   // Step 4: Layout body rows with page break detection
-       var currentPageNumber = 0;
+            // Step 4: Layout body rows with page break detection
+            var currentPageNumber = pageHeight < double.MaxValue - 1
+                ? (int)((startY - marginTop) / pageHeight)
+                : 0;
+
             Dictionary<int, List<CssBox>> rowSpannedBoxes = new();
 
             for (var i = 0; i < _bodyRows.Count; i++)
             {
-          var row = _bodyRows[i];
-       var estimatedRowHeight = EstimateRowHeight(row);
-     var availableHeight = pageHeight - _footerHeight - marginBottom;
+                var row = _bodyRows[i];
+                var estimatedRowHeight = EstimateRowHeight(row);
+                var availableHeight = pageHeight - _footerHeight - marginBottom;
 
-       // Check for page break
-             if (WillCrossPageBoundary(currentY, currentY + estimatedRowHeight, pageHeight, marginTop, availableHeight, currentPageNumber)
-         && i > 0 && _tableBox.HtmlContainer != null)
-          {
-     // Create footer proxy for current page
-      if (_shouldRepeatFooters && _footerHeight > 0)
-         {
-        var footerY = CalculateFooterPositionAtPageBottom(currentY, pageHeight, marginTop, marginBottom, currentPageNumber);
-         var footerProxy = CreateFooterProxy(footerY);
-            if (footerProxy != null)
-      {
-           _tableBox.Boxes.Add(footerProxy);  // Add at end
-          await footerProxy.PerformLayout(g);
-           }
-    }
+                // Check for page break
+                if (WillCrossPageBoundary(currentY, currentY + estimatedRowHeight, pageHeight, marginTop, availableHeight, currentPageNumber)
+            && i > 0 && _tableBox.HtmlContainer != null)
+                {
+                    // Create footer proxy for current page
+                    if (_shouldRepeatFooters && _footerHeight > 0)
+                    {
+                        var footerY = CalculateFooterPositionAtPageBottom(currentY, pageHeight, marginTop, marginBottom, currentPageNumber);
+                        var footerProxy = CreateFooterProxy(footerY);
+                        if (footerProxy != null)
+                        {
+                            _tableBox.Boxes.Add(footerProxy);  // Add at end
+                            await footerProxy.PerformLayout(g);
+                        }
+                    }
 
-    // Move to next page
-               var pageBreakOffset = CalculatePageBreakOffset(currentY, pageHeight, marginTop, marginBottom, currentPageNumber);
-            currentY += pageBreakOffset;
-     currentPageNumber++;
+                    // Move to next page
+                    var pageBreakOffset = CalculatePageBreakOffset(currentY, pageHeight, marginTop, marginBottom, currentPageNumber);
+                    currentY += pageBreakOffset;
+                    currentPageNumber++;
 
-                // Create new header proxy for new page
-          if (_shouldRepeatHeaders && _headerHeight > 0)
-      {
-            var headerProxy = CreateHeaderProxy(currentY);
-                 if (headerProxy != null)
-         {
-  _tableBox.Boxes.Add(headerProxy);  // Add at end
-     await headerProxy.PerformLayout(g);
-      currentY += _headerHeight + GetVerticalSpacing();
-maxRight = Math.Max(maxRight, headerProxy.ActualRight);
-             }
-    }
+                    // Create new header proxy for new page
+                    if (_shouldRepeatHeaders && _headerHeight > 0)
+                    {
+                        var headerProxy = CreateHeaderProxy(currentY);
+                        if (headerProxy != null)
+                        {
+                            _tableBox.Boxes.Add(headerProxy);  // Add at end
+                            await headerProxy.PerformLayout(g);
+                            currentY += _headerHeight + GetVerticalSpacing();
+                            maxRight = Math.Max(maxRight, headerProxy.ActualRight);
+                        }
+                    }
 
-  maxBottom = currentY;
-        }
+                    maxBottom = currentY;
+                }
 
-   // Layout body row
-  var (newMaxRight, newMaxBottom) = await LayoutBodyRow(g, row, startX, currentY, i, rowSpannedBoxes, maxRight, maxBottom);
-           maxRight = newMaxRight;
-   maxBottom = newMaxBottom;
+                // Layout body row
+                var (newMaxRight, newMaxBottom) = await LayoutBodyRow(g, row, startX, currentY, i, rowSpannedBoxes, maxRight, maxBottom);
+                maxRight = newMaxRight;
+                maxBottom = newMaxBottom;
 
-            currentY = maxBottom + GetVerticalSpacing();
+                currentY = maxBottom + GetVerticalSpacing();
 
-           row.Location = new RPoint(row.Boxes.Min(x => x.Location.X), row.Boxes.Min(x => x.Location.Y));
- row.ActualRight = row.Boxes.Max(x => x.ActualRight);
-     row.ActualBottom = maxBottom;
+                row.Location = new RPoint(row.Boxes.Min(x => x.Location.X), row.Boxes.Min(x => x.Location.Y));
+                row.ActualRight = row.Boxes.Max(x => x.ActualRight);
+                row.ActualBottom = maxBottom;
             }
 
             // Step 5: Create final footer proxy
@@ -815,12 +818,12 @@ maxRight = Math.Max(maxRight, headerProxy.ActualRight);
             _tableBox.ActualBottom = Math.Max(maxBottom, startY) + GetVerticalSpacing() + _tableBox.ActualBorderBottomWidth;
 
 #if DEBUG
-         System.Console.WriteLine($"CssLayoutEngineTable.LayoutCells: END - _tableBox.Boxes.Count={_tableBox.Boxes.Count}");
+            System.Console.WriteLine($"CssLayoutEngineTable.LayoutCells: END - _tableBox.Boxes.Count={_tableBox.Boxes.Count}");
             for (int i = 0; i < _tableBox.Boxes.Count; i++)
-       {
-    var box = _tableBox.Boxes[i];
-  System.Console.WriteLine($"  TableBox child {i}: Type={box.GetType().Name}, Display={box.Display}");
-          }
+            {
+                var box = _tableBox.Boxes[i];
+                System.Console.WriteLine($"  TableBox child {i}: Type={box.GetType().Name}, Display={box.Display}");
+            }
 #endif
         }
 


### PR DESCRIPTION
When a document contains multiple tables, the page-break detection in
CssLayoutEngineTable always started currentPageNumber at 0. For tables
that begin beyond the first page boundary this produced a negative page
offset, placing header/footer proxies at wrong (or even negative) Y
positions inside an earlier table's area.

Fix: derive the initial currentPageNumber from the table's startY so
page boundaries are computed relative to where the table actually begins
in the document. The (int) cast truncates toward zero, naturally clamping
to 0 for tables that start inside the first page's top margin.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
