### PR TITLE
Docs: use NetworkLoader and update deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Peach PDF is a pure .NET HTML -> PDF rendering library. This library does not de
 
 - .NET 8
 
-_Note: This package depends on PeachPDF.PdfSharpCore and various SixLabors libraries. Both have their own licenses, but the end result is still open source_
+_Note: This package depends on PeachPDF.PdfSharpCore which has its own license, but the end result is still open source_
 
 ## Installing PeachPDF
 
@@ -36,25 +36,25 @@ document.Save(stream);
 
 ### Rendering an MHTML file
 
-You can generate PDF documents using self contained MHTML files (what Chrome calls "single page documents") by using the included MimeKitNetworkAdapter
+You can generate PDF documents using self contained MHTML files (what Chrome calls "single page documents") by using the included MimeKitNetworkLoader
 
 ```csharp
 PdfGenerateConfig pdfConfig = new(){
   PageSize = PageSize.Letter,
-  PageOrientation = PageOrientation.Portrait
-  NetworkAdapter = new MimeKitNetworkAdapter(File.OpenRead("example.mhtml"))
+  PageOrientation = PageOrientation.Portrait,
+  NetworkLoader = new MimeKitNetworkLoader(File.OpenRead("example.mhtml"))
 };
 
 PdfGenerator generator = new();
 
 var stream = new MemoryStream();
 
-// Passing null to GeneratePdf will load the HTML from the provided network adapter instance instead
+// Passing null to GeneratePdf will load the HTML from the provided network loader instance instead
 var document = await generator.GeneratePdf(null, pdfConfig);
 document.Save(stream);
 ```
 
-### Rending HTML from a URI
+### Rendering HTML from a URI
 
 You can also render HTML from the Internet to a PDF
 
@@ -63,20 +63,20 @@ HttpClient httpClient = new();
 
 PdfGenerateConfig pdfConfig = new(){
   PageSize = PageSize.Letter,
-  PageOrientation = PageOrientation.Portrait
-  NetworkAdapter = new HttpClientNetworkADapter(httpClient, new Uri("https://www.example.com"))
+  PageOrientation = PageOrientation.Portrait,
+  NetworkLoader = new HttpClientNetworkLoader(httpClient, new Uri("https://www.example.com"))
 };
 
 PdfGenerator generator = new();
 
 var stream = new MemoryStream();
 
-// Passing null to GeneratePdf will load the HTML from the provided network adapter instance instead
+// Passing null to GeneratePdf will load the HTML from the provided network loader instance instead
 var document = await generator.GeneratePdf(null, pdfConfig);
 document.Save(stream);
 ```
 
-Note that loading images using relative paths will default to local file system unless a RNetworkLoader instance is provided (such as HttpClientNetworkAdapter) that sets the BaseUri property or if the HTML has a <base> element with an href property set. Images will need to be in the current working directory.
+Note that loading images using relative paths will default to the local file system unless an `HttpClientNetworkLoader` (or custom `RNetworkLoader`) with an appropriate `BaseUri` is provided, or if the HTML has a `<base>` element with an `href` set. Images will need to be in the current working directory when using the default loader.
 
 ## Fonts
 
@@ -94,15 +94,15 @@ generator.AddFontFamilyMapping("Segoe UI","sans-serif"); // or any other system 
 The recommended way to install custom fonts is to install them into your operating system.
 PeachPDF by default picks up TrueType fonts from the operating system (%SystemRoot%\Fonts and %LOCALAPPDATA%\Microsoft\Windows\Fonts on Windows, /Library/Fonts on Mac, and /usr/share/fonts, /usr/local/share/fonts/, and $HOME/.fonts on Linux)
 
-You can also add a font at runtime by loading the ttf font into a Stream, and then using the AddFontFromStream API:
+You can also add a font at runtime by loading the font into a Stream, and then using the AddFontFromStream API:
 
 ```csharp
 PdfGenerator generator = new();
-await generator.AddFontFromStream(fontStream); // where fontStream is a System.IO.Stream of the loaded TTF file
+await generator.AddFontFromStream(fontStream); // Supports TrueType (TTF), CFF, WOFF, and WOFF2 formats
 ```
 
 Web fonts loaded via @font-face are also supported.
 
 ### Supported font formats
 
-We support any font supported by SixLabors.Fonts, currently TrueType, CFF, WOFF, and WOFF2 as of the time of this writing.
+We support TrueType, CFF, WOFF, and WOFF2 font formats.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ Peach PDF is a pure .NET HTML -> PDF rendering library. This library does not de
 
 - .NET 8
 
-_Note: This package depends on PeachPDF.PdfSharpCore and various SixLabors libraries. Both have their own licenses, but the end result is still open source_
+_Note: This package depends on PeachPDF.PdfSharpCore which has its own license, but the end result is still open source_
 
 ## Installing PeachPDF
 
@@ -36,25 +36,25 @@ document.Save(stream);
 
 ### Rendering an MHTML file
 
-You can generate PDF documents using self contained MHTML files (what Chrome calls "single page documents") by using the included MimeKitNetworkAdapter
+You can generate PDF documents using self contained MHTML files (what Chrome calls "single page documents") by using the included MimeKitNetworkLoader
 
 ```csharp
 PdfGenerateConfig pdfConfig = new(){
   PageSize = PageSize.Letter,
-  PageOrientation = PageOrientation.Portrait
-  NetworkAdapter = new MimeKitNetworkAdapter(File.OpenRead("example.mhtml"))
+  PageOrientation = PageOrientation.Portrait,
+  NetworkLoader = new MimeKitNetworkLoader(File.OpenRead("example.mhtml"))
 };
 
 PdfGenerator generator = new();
 
 var stream = new MemoryStream();
 
-// Passing null to GeneratePdf will load the HTML from the provided network adapter instance instead
+// Passing null to GeneratePdf will load the HTML from the provided network loader instance instead
 var document = await generator.GeneratePdf(null, pdfConfig);
 document.Save(stream);
 ```
 
-### Rending HTML from a URI
+### Rendering HTML from a URI
 
 You can also render HTML from the Internet to a PDF
 
@@ -63,15 +63,15 @@ HttpClient httpClient = new();
 
 PdfGenerateConfig pdfConfig = new(){
   PageSize = PageSize.Letter,
-  PageOrientation = PageOrientation.Portrait
-  NetworkAdapter = new HttpClientNetworkADapter(httpClient, new Uri("https://www.example.com"))
+  PageOrientation = PageOrientation.Portrait,
+  NetworkLoader = new HttpClientNetworkLoader(httpClient, new Uri("https://www.example.com"))
 };
 
 PdfGenerator generator = new();
 
 var stream = new MemoryStream();
 
-// Passing null to GeneratePdf will load the HTML from the provided network adapter instance instead
+// Passing null to GeneratePdf will load the HTML from the provided network loader instance instead
 var document = await generator.GeneratePdf(null, pdfConfig);
 document.Save(stream);
 ```
@@ -92,15 +92,15 @@ generator.AddFontFamilyMapping("Segoe UI","sans-serif"); // or any other system 
 The recommended way to install custom fonts is to install them into your operating system.
 PeachPDF by default picks up TrueType fonts from the operating system (%SystemRoot%\Fonts and %LOCALAPPDATA%\Microsoft\Windows\Fonts on Windows, /Library/Fonts on Mac, and /usr/share/fonts, /usr/local/share/fonts/, and $HOME/.fonts on Linux)
 
-You can also add a font at runtime by loading the ttf font into a Stream, and then using the AddFontFromStream API:
+You can also add a font at runtime by loading the font into a Stream, and then using the AddFontFromStream API:
 
 ```csharp
 PdfGenerator generator = new();
-await generator.AddFontFromStream(fontStream); // where fontStream is a System.IO.Stream of the loaded TTF file
+await generator.AddFontFromStream(fontStream); // Supports TrueType (TTF), CFF, WOFF, and WOFF2 formats
 ```
 
 Web fonts loaded via @font-face are also supported.
 
 ### Supported font formats
 
-We support any font supported by SixLabors.Fonts, currently TrueType, CFF, WOFF, and WOFF2 as of the time of this writing.
+We support TrueType, CFF, WOFF, and WOFF2 font formats.

--- a/src/PdfSharpCore/PeachPDF.PdfSharpCore.csproj
+++ b/src/PdfSharpCore/PeachPDF.PdfSharpCore.csproj
@@ -7,7 +7,7 @@
     <Authors>Stefan Steiger and Contributors</Authors>
     <Description>PdfSharp for .NET Core
 
-PeachPDF.PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally MigraDoc has been ported as well (from version 1.32). Images have been implemented with ImageSharp from https://www.nuget.org/packages/SixLabors.ImageSharp</Description>
+PeachPDF.PdfSharpCore is a partial port of PdfSharp.Xamarin for .NET Core Additionally MigraDoc has been ported as well (from version 1.32). Images have been implemented with StbImageSharp.</Description>
     <Copyright>Copyright (c) 2005-2007 empira Software GmbH, Cologne (Germany)</Copyright>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>

--- a/src/PdfSharpCore/README.md
+++ b/src/PdfSharpCore/README.md
@@ -6,7 +6,7 @@
 
 **PeachPDF.PdfSharpCore** is a partial port of [PdfSharp.Xamarin](https://github.com/roceh/PdfSharp.Xamarin/) for .NET Standard.
 Additionally MigraDoc has been ported as well (from version 1.32).
-Image support has been implemented with [SixLabors.ImageSharp](https://github.com/JimBobSquarePants/ImageSharp/) and Fonts support with [SixLabors.Fonts](https://github.com/SixLabors/Fonts).
+Image support has been implemented with [StbImageSharp](https://github.com/StbSharp/StbImageSharp/).
 
 
 ## Table of Contents
@@ -20,7 +20,7 @@ Image support has been implemented with [SixLabors.ImageSharp](https://github.co
 ## Example
 
 The following code snippet creates a simple PDF-file with the text 'Hello World!'.
-The code is written for a .NET 6 console app with top level statements.
+The code is written for a .NET 8 console app with top level statements.
 
 ```csharp
 using PeachPDF.PdfSharpCore.Drawing;
@@ -54,7 +54,8 @@ We appreciate feedback and contribution to this repo!
 
 This software is released under the MIT License. See the [LICENSE](LICENCE.md) file for more info.
 
-PeachPDF.PdfSharpCore relies on the following projects, that are not under the MIT license:
+PeachPDF.PdfSharpCore relies on the following MIT-licensed packages:
 
-* *SixLabors.ImageSharp* and *SixLabors.Fonts*
-  * SixLabors.ImageSharp and SixLabors.Fonts, libraries which PeachPDF.PdfSharpCore relies upon, are licensed under Apache 2.0 when distributed as part of PeachPDF.PdfSharpCore. The SixLabors.ImageSharp license covers all other usage, see https://github.com/SixLabors/ImageSharp/blob/master/LICENSE
+* *SharpZipLib*
+* *StbImageSharp*
+* *StbImageWriteSharp*


### PR DESCRIPTION
Replace references to NetworkAdapter with NetworkLoader across README and docs (examples updated to use MimeKitNetworkLoader and HttpClientNetworkLoader; comments updated). Clarify dependency note to reference PeachPDF.PdfSharpCore only, improve font/runtimes docs (AddFontFromStream note and supported formats), fix typos ("Rending" → "Rendering"). Update PdfSharpCore package metadata and README to reflect image support via StbImageSharp, bump example target to .NET 8, and adjust listed runtime dependencies (SharpZipLib, StbImageSharp, StbImageWriteSharp).