### PR TITLE
Implement advanced CSS selectors and sibling combinators support

### DIFF
--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -330,9 +330,9 @@ PeachPDF evaluates a subset of CSS selectors. Selectors that are parsed but not 
 | Exact match | `[attr=value]` | Attribute value exactly equals `value` |
 | Whitespace list | `[attr~=value]` | Attribute is a whitespace-separated list containing `value` |
 | Contains | `[attr*=value]` | Attribute value contains `value` as a substring |
-| Starts with | `[attr^=value]` | Parsed but not matched — rules are silently ignored |
-| Ends with | `[attr$=value]` | Parsed but not matched — rules are silently ignored |
-| Hyphen prefix | `[attr\|=value]` | Parsed but not matched — rules are silently ignored |
+| Starts with | `[attr^=value]` | Attribute value starts with `value` |
+| Ends with | `[attr$=value]` | Attribute value ends with `value` |
+| Hyphen prefix | `[attr\|=value]` | Attribute value equals `value` or starts with `value-` |
 
 ### Combinators
 
@@ -340,8 +340,8 @@ PeachPDF evaluates a subset of CSS selectors. Selectors that are parsed but not 
 |------------|--------|-------|
 | Descendant | `div p` | Matches `p` anywhere inside `div` |
 | Child | `div > p` | Matches `p` that is a direct child of `div` |
-| Adjacent sibling | `div + p` | Parsed but not matched — rules are silently ignored |
-| General sibling | `div ~ p` | Parsed but not matched — rules are silently ignored |
+| Adjacent sibling | `div + p` | Matches `p` immediately preceded by `div` at the same level |
+| General sibling | `div ~ p` | Matches `p` preceded by `div` anywhere at the same level |
 
 ### Pseudo-elements
 

--- a/src/PeachPDF.Tests/CSS/SelectorMatchingTests.cs
+++ b/src/PeachPDF.Tests/CSS/SelectorMatchingTests.cs
@@ -1,0 +1,189 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Utils;
+using PeachPDF.PdfSharpCore.Drawing;
+
+namespace PeachPDF.Tests.CSS;
+
+public class SelectorMatchingTests
+{
+    // ── Attribute: starts-with [attr^=value] ─────────────────────────────────
+
+    [Fact]
+    public async Task AttrBegins_Matches_WhenValueStartsWith()
+    {
+        var html = Html("[class^='btn'] { background-color: #ff0000; }", "<span class='btn-primary'>text</span>");
+        var box = await FindBoxByTag(html, "span");
+        Assert.NotEqual("transparent", box.BackgroundColor);
+    }
+
+    [Fact]
+    public async Task AttrBegins_DoesNotMatch_WhenValueDoesNotStartWith()
+    {
+        var html = Html("[class^='btn'] { background-color: #ff0000; }", "<span class='input-btn'>text</span>");
+        var box = await FindBoxByTag(html, "span");
+        Assert.Equal("transparent", box.BackgroundColor);
+    }
+
+    // ── Attribute: ends-with [attr$=value] ───────────────────────────────────
+
+    [Fact]
+    public async Task AttrEnds_Matches_WhenValueEndsWith()
+    {
+        var html = Html("[lang$='-US'] { background-color: #ff0000; }", "<span lang='en-US'>text</span>");
+        var box = await FindBoxByTag(html, "span");
+        Assert.NotEqual("transparent", box.BackgroundColor);
+    }
+
+    [Fact]
+    public async Task AttrEnds_DoesNotMatch_WhenValueDoesNotEndWith()
+    {
+        var html = Html("[lang$='-US'] { background-color: #ff0000; }", "<span lang='US-en'>text</span>");
+        var box = await FindBoxByTag(html, "span");
+        Assert.Equal("transparent", box.BackgroundColor);
+    }
+
+    // ── Attribute: hyphen-prefix [attr|=value] ───────────────────────────────
+
+    [Fact]
+    public async Task AttrHyphen_Matches_ExactValue()
+    {
+        var html = Html("[lang|='en'] { background-color: #ff0000; }", "<span lang='en'>text</span>");
+        var box = await FindBoxByTag(html, "span");
+        Assert.NotEqual("transparent", box.BackgroundColor);
+    }
+
+    [Fact]
+    public async Task AttrHyphen_Matches_HyphenPrefixed()
+    {
+        var html = Html("[lang|='en'] { background-color: #ff0000; }", "<span lang='en-US'>text</span>");
+        var box = await FindBoxByTag(html, "span");
+        Assert.NotEqual("transparent", box.BackgroundColor);
+    }
+
+    [Fact]
+    public async Task AttrHyphen_DoesNotMatch_SubstringOnly()
+    {
+        var html = Html("[lang|='en'] { background-color: #ff0000; }", "<span lang='english'>text</span>");
+        var box = await FindBoxByTag(html, "span");
+        Assert.Equal("transparent", box.BackgroundColor);
+    }
+
+    // ── Combinator: adjacent sibling (div + p) ───────────────────────────────
+
+    [Fact]
+    public async Task AdjacentSibling_Matches_ImmediatelyFollowingSibling()
+    {
+        var html = Html("div + p { background-color: #ff0000; }", "<div>d</div><p id='t'>first</p>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.NotEqual("transparent", boxes[0].BackgroundColor);
+    }
+
+    [Fact]
+    public async Task AdjacentSibling_DoesNotMatch_SecondSibling()
+    {
+        var html = Html("div + p { background-color: #ff0000; }", "<div>d</div><p>first</p><p>second</p>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(2, boxes.Count);
+        Assert.NotEqual("transparent", boxes[0].BackgroundColor);
+        Assert.Equal("transparent", boxes[1].BackgroundColor);
+    }
+
+    [Fact]
+    public async Task AdjacentSibling_DoesNotMatch_PrecedingSibling()
+    {
+        var html = Html("div + p { background-color: #ff0000; }", "<p>before</p><div>d</div>");
+        var box = await FindBoxByTag(html, "p");
+        Assert.Equal("transparent", box.BackgroundColor);
+    }
+
+    // ── Combinator: general sibling (div ~ p) ────────────────────────────────
+
+    [Fact]
+    public async Task GeneralSibling_Matches_AllFollowingSiblings()
+    {
+        var html = Html("div ~ p { background-color: #ff0000; }", "<div>d</div><p>first</p><p>second</p>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(2, boxes.Count);
+        Assert.NotEqual("transparent", boxes[0].BackgroundColor);
+        Assert.NotEqual("transparent", boxes[1].BackgroundColor);
+    }
+
+    [Fact]
+    public async Task GeneralSibling_DoesNotMatch_PrecedingSibling()
+    {
+        var html = Html("div ~ p { background-color: #ff0000; }", "<p>before</p><div>d</div>");
+        var box = await FindBoxByTag(html, "p");
+        Assert.Equal("transparent", box.BackgroundColor);
+    }
+
+    // ── Regression: existing combinators still work ──────────────────────────
+
+    [Fact]
+    public async Task ChildCombinator_StillMatches_DirectChild()
+    {
+        var html = Html("div > p { background-color: #ff0000; }", "<div><p>direct</p><section><p>nested</p></section></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(2, boxes.Count);
+        Assert.NotEqual("transparent", boxes[0].BackgroundColor);
+        Assert.Equal("transparent", boxes[1].BackgroundColor);
+    }
+
+    [Fact]
+    public async Task DescendantCombinator_StillMatches_AnyDescendant()
+    {
+        var html = Html("div p { background-color: #ff0000; }", "<div><section><p>deep</p></section></div><p>outside</p>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(2, boxes.Count);
+        Assert.NotEqual("transparent", boxes[0].BackgroundColor);
+        Assert.Equal("transparent", boxes[1].BackgroundColor);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static string Html(string css, string body) =>
+        $"<!DOCTYPE html><html><head><style>{css}</style></head><body>{body}</body></html>";
+
+    private async Task<CssBox> FindBoxByTag(string html, string tag)
+    {
+        var root = await BuildRoot(html);
+        var box = DomUtils.GetBoxByTagName(root, tag);
+        Assert.NotNull(box);
+        return box!;
+    }
+
+    private async Task<List<CssBox>> FindAllBoxesByTag(string html, string tag)
+    {
+        var root = await BuildRoot(html);
+        var results = new List<CssBox>();
+        CollectByTag(root, tag, results);
+        return results;
+    }
+
+    private static void CollectByTag(CssBox box, string tag, List<CssBox> results)
+    {
+        if (box.HtmlTag?.Name.Equals(tag, StringComparison.OrdinalIgnoreCase) == true)
+            results.Add(box);
+        foreach (var child in box.Boxes)
+            CollectByTag(child, tag, results);
+    }
+
+    private static async Task<CssBox> BuildRoot(string html)
+    {
+        var adapter = new PdfSharpAdapter();
+        var container = new HtmlContainerInt(adapter);
+        await container.SetHtml(html, null);
+
+        var size = new XSize(595, 842);
+        container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+        container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+        var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+        using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+        await container.PerformLayout(graphics);
+
+        Assert.NotNull(container.Root);
+        return container.Root!;
+    }
+}

--- a/src/PeachPDF/Html/Core/CssData.cs
+++ b/src/PeachPDF/Html/Core/CssData.cs
@@ -102,6 +102,9 @@ namespace PeachPDF.Html.Core
                 AttrAvailableSelector attrAvailableSelector => DoesSelectorMatch(attrAvailableSelector, box),
                 AttrContainsSelector attrContainsSelector => DoesSelectorMatch(attrContainsSelector, box),
                 AttrListSelector attrListSelector => DoesSelectorMatch(attrListSelector, box),
+                AttrBeginsSelector attrBeginsSelector => DoesSelectorMatch(attrBeginsSelector, box),
+                AttrEndsSelector attrEndsSelector => DoesSelectorMatch(attrEndsSelector, box),
+                AttrHyphenSelector attrHyphenSelector => DoesSelectorMatch(attrHyphenSelector, box),
                 FirstChildSelector firstChildSelector => DoesSelectorMatch(firstChildSelector, box),
                 _ => false
             };
@@ -281,6 +284,34 @@ namespace PeachPDF.Html.Core
             return false;
         }
 
+        private static bool DoesSelectorMatch(AttrBeginsSelector s, CssBox? box)
+        {
+            if (box?.HtmlTag?.Attributes is null) return false;
+            foreach (var attr in box.HtmlTag.Attributes)
+                if (attr.Key.Equals(s.Attribute, StringComparison.InvariantCultureIgnoreCase))
+                    return attr.Value.StartsWith(s.Value, StringComparison.InvariantCultureIgnoreCase);
+            return false;
+        }
+
+        private static bool DoesSelectorMatch(AttrEndsSelector s, CssBox? box)
+        {
+            if (box?.HtmlTag?.Attributes is null) return false;
+            foreach (var attr in box.HtmlTag.Attributes)
+                if (attr.Key.Equals(s.Attribute, StringComparison.InvariantCultureIgnoreCase))
+                    return attr.Value.EndsWith(s.Value, StringComparison.InvariantCultureIgnoreCase);
+            return false;
+        }
+
+        private static bool DoesSelectorMatch(AttrHyphenSelector s, CssBox? box)
+        {
+            if (box?.HtmlTag?.Attributes is null) return false;
+            foreach (var attr in box.HtmlTag.Attributes)
+                if (attr.Key.Equals(s.Attribute, StringComparison.InvariantCultureIgnoreCase))
+                    return attr.Value.Equals(s.Value, StringComparison.InvariantCultureIgnoreCase)
+                        || attr.Value.StartsWith(s.Value + "-", StringComparison.InvariantCultureIgnoreCase);
+            return false;
+        }
+
         private static bool DoesSelectorMatch(PseudoClassSelector pseudoClassSelector, CssBox? box)
         {
             return pseudoClassSelector.Class == "link" && box is not null && box.IsClickable;
@@ -323,77 +354,71 @@ namespace PeachPDF.Html.Core
 
         private static bool DoesSelectorMatch(ComplexSelector complexSelector, CssBox? box)
         {
-            var selectorsInReverse = complexSelector.Reverse();
+            var selectorsInReverse = complexSelector.Reverse().ToList();
 
             var isLowestItem = true;
-            var isMatch = false;
-
-            var currentLevel = box;
+            var currentRef = box;
 
             foreach (var selector in selectorsInReverse)
             {
-                if (selector.Selector is not null)
+                if (selector.Selector is null) return false;
+
+                if (isLowestItem)
                 {
-                    if (isLowestItem)
-                    {
-                        isMatch = DoesSelectorMatch(selector.Selector, currentLevel);
-
-                        if (!isMatch)
-                        {
-                            return false;
-                        }
-
-                        isLowestItem = false;
-                        currentLevel = box?.ParentBox;
-                        continue;
-                    }
-
-                    if (currentLevel is null)
-                    {
-                        return false;
-                    }
-
-                    switch (selector.Delimiter)
-                    {
-                        case ">":
-
-                            isMatch = DoesSelectorMatch(selector.Selector, currentLevel);
-
-                            if (!isMatch)
-                            {
-                                return false;
-                            }
-
-                            break;
-                        case " " or null:
-                            {
-                                do
-                                {
-                                    isMatch = DoesSelectorMatch(selector.Selector, currentLevel);
-
-                                    if (!isMatch)
-                                    {
-                                        currentLevel = currentLevel.ParentBox;
-                                    }
-
-                                } while (!isMatch && currentLevel is not null);
-
-                                if (!isMatch)
-                                {
-                                    return false;
-                                }
-
-                                break;
-                            }
-                    }
+                    if (!DoesSelectorMatch(selector.Selector, currentRef)) return false;
+                    isLowestItem = false;
+                    continue;
                 }
-                else
+
+                if (currentRef is null) return false;
+
+                switch (selector.Delimiter)
                 {
-                    return false;
+                    case ">":
+                        currentRef = currentRef.ParentBox;
+                        if (!DoesSelectorMatch(selector.Selector, currentRef)) return false;
+                        break;
+
+                    case " " or null:
+                        currentRef = currentRef.ParentBox;
+                        while (currentRef is not null && !DoesSelectorMatch(selector.Selector, currentRef))
+                            currentRef = currentRef.ParentBox;
+                        if (currentRef is null) return false;
+                        break;
+
+                    case "+":
+                    {
+                        var parent = currentRef.ParentBox;
+                        if (parent is null) return false;
+                        var siblings = parent.Boxes.Where(b => b.HtmlTag is not null).ToList();
+                        var idx = siblings.IndexOf(currentRef);
+                        if (idx <= 0) return false;
+                        currentRef = siblings[idx - 1];
+                        if (!DoesSelectorMatch(selector.Selector, currentRef)) return false;
+                        break;
+                    }
+
+                    case "~":
+                    {
+                        var parent = currentRef.ParentBox;
+                        if (parent is null) return false;
+                        var siblings = parent.Boxes.Where(b => b.HtmlTag is not null).ToList();
+                        var idx = siblings.IndexOf(currentRef);
+                        if (idx <= 0) return false;
+                        CssBox? match = null;
+                        for (var i = idx - 1; i >= 0; i--)
+                            if (DoesSelectorMatch(selector.Selector, siblings[i])) { match = siblings[i]; break; }
+                        if (match is null) return false;
+                        currentRef = match;
+                        break;
+                    }
+
+                    default:
+                        return false;
                 }
             }
 
-            return isMatch;
+            return true;
         }
 
         public CssData Clone()

--- a/src/PeachPDF/PeachPDF.csproj
+++ b/src/PeachPDF/PeachPDF.csproj
@@ -3,7 +3,7 @@
 		<TargetFrameworks>net8.0</TargetFrameworks>
 		<AssemblyName>PeachPDF</AssemblyName>
 		<PackageId>PeachPDF</PackageId>
-		<PackageVersion>0.8.0</PackageVersion>
+		<PackageVersion>0.9.0-preview1</PackageVersion>
 		<IncludeSymbols>true</IncludeSymbols>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -15,7 +15,7 @@
 		<GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
 		<GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
 		<RunCodeAnalysis>false</RunCodeAnalysis>
-    <Nullable>enable</Nullable>
+    	<Nullable>enable</Nullable>
 		<IsTrimmable>true</IsTrimmable>
 		<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>


### PR DESCRIPTION
This pull request adds support for additional CSS attribute selectors and combinators to PeachPDF, updates the documentation to reflect these changes, and introduces comprehensive tests to verify correct selector matching. The main improvements are support for `[attr^=value]`, `[attr$=value]`, `[attr|=value]` selectors, and the adjacent (`+`) and general sibling (`~`) combinators.

**CSS Selector Support:**

* Implemented support for the following attribute selectors:
  * `[attr^=value]` (starts with), `[attr$=value]` (ends with), and `[attr|=value]` (hyphen prefix, e.g., for language codes). [[1]](diffhunk://#diff-64141a33b4afa951a8330fba9f8467b5ada163f58b68b263921f7a9a8aa4cde8R105-R107) [[2]](diffhunk://#diff-64141a33b4afa951a8330fba9f8467b5ada163f58b68b263921f7a9a8aa4cde8R287-R314)
* Added support for adjacent sibling (`div + p`) and general sibling (`div ~ p`) combinators in the CSS selector matching logic.

**Documentation:**

* Updated `docs/html-css-support.md` to indicate that these selectors and combinators are now matched (not just parsed and ignored), and clarified their behavior.

**Testing:**

* Added a new test suite `SelectorMatchingTests.cs` with thorough tests for the new selectors and combinators, as well as regression tests for existing selector types.

**Versioning:**

* Bumped the package version to `0.9.0-preview1` to reflect the new features.