### PR TITLE
Support background shorthand and add tests

### DIFF
--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -192,14 +192,15 @@ PeachPDF uses custom property names for border radius rather than the standard `
 
 ### Backgrounds
 
-The `background` shorthand is not supported. Use individual properties.
-
 | Property | MDN Reference | Notes |
 |----------|--------------|-------|
+| `background` | [background](https://developer.mozilla.org/en-US/docs/Web/CSS/background) | Shorthand supported; all longhand components are parsed and applied |
 | `background-color` | [background-color](https://developer.mozilla.org/en-US/docs/Web/CSS/background-color) | Full support |
 | `background-image` | [background-image](https://developer.mozilla.org/en-US/docs/Web/CSS/background-image) | URL, data URI, and all CSS gradient functions: `linear-gradient()`, `radial-gradient()`, `conic-gradient()`, `repeating-linear-gradient()`, `repeating-radial-gradient()`, and `repeating-conic-gradient()`; all accept multi-stop gradients with absolute-length or percentage stop positions, two-position hard-stop shorthand, color hints, and `rgba()`/alpha transparency; radial gradients support `circle`/`ellipse` shape, `at <position>` centering, explicit length radii, and all four size keywords; conic gradients support `from <angle>` and `at <position>`; all gradient functions support CSS Color Level 4 color-space interpolation (`in oklab`, `in hsl`, `in oklch`, `in lab`, `in lch`, `in srgb-linear`, `in display-p3`, `in xyz`, `in xyz-d50`) with polar hue-interpolation methods (`shorter hue`, `longer hue`, `increasing hue`, `decreasing hue`) |
 | `background-position` | [background-position](https://developer.mozilla.org/en-US/docs/Web/CSS/background-position) | Full support |
+| `background-size` | [background-size](https://developer.mozilla.org/en-US/docs/Web/CSS/background-size) | Full support; `cover`, `contain`, lengths, and percentages |
 | `background-repeat` | [background-repeat](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat) | Full support |
+| `background-origin` | [background-origin](https://developer.mozilla.org/en-US/docs/Web/CSS/background-origin) | Parsed and accepted but has no effect |
 | `background-attachment` | [background-attachment](https://developer.mozilla.org/en-US/docs/Web/CSS/background-attachment) | Parsed and accepted but has no effect |
 | `background-clip` | [background-clip](https://developer.mozilla.org/en-US/docs/Web/CSS/background-clip) | Parsed and accepted but has no effect |
 

--- a/src/PeachPDF.Tests/CSS/PropertyTests/BackgroundProperty.cs
+++ b/src/PeachPDF.Tests/CSS/PropertyTests/BackgroundProperty.cs
@@ -736,6 +736,199 @@ namespace PeachPDF.Tests.CSS.PropertyTests
             Assert.True(concrete.HasValue);
             Assert.Equal("url(\"" + url + "\")", concrete.Value);
         }
+
+        [Fact]
+        public void BackgroundTransparentLegal()
+        {
+            var snippet = "background: transparent";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("background", property.Name);
+            Assert.IsType<BackgroundProperty>(property);
+            var concrete = (BackgroundProperty)property;
+            Assert.True(concrete.HasValue);
+            Assert.Equal("rgba(0, 0, 0, 0)", concrete.Value);
+        }
+
+        [Fact]
+        public void BackgroundNoneLegal()
+        {
+            var snippet = "background: none";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("background", property.Name);
+            Assert.IsType<BackgroundProperty>(property);
+            var concrete = (BackgroundProperty)property;
+            Assert.True(concrete.HasValue);
+            Assert.Equal("none", concrete.Value);
+        }
+
+        [Fact]
+        public void BackgroundWithPositionLegal()
+        {
+            var snippet = "background: url(\"img.png\") center center no-repeat";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("background", property.Name);
+            Assert.IsType<BackgroundProperty>(property);
+            var concrete = (BackgroundProperty)property;
+            Assert.True(concrete.HasValue);
+        }
+
+        [Fact]
+        public void BackgroundWithPositionAndSizeLegal()
+        {
+            var snippet = "background: url(\"img.png\") center / cover no-repeat";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("background", property.Name);
+            Assert.IsType<BackgroundProperty>(property);
+            var concrete = (BackgroundProperty)property;
+            Assert.True(concrete.HasValue);
+        }
+
+        [Fact]
+        public void BackgroundLinearGradientLegal()
+        {
+            var snippet = "background: linear-gradient(to right, red, blue)";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("background", property.Name);
+            Assert.IsType<BackgroundProperty>(property);
+            var concrete = (BackgroundProperty)property;
+            Assert.True(concrete.HasValue);
+            Assert.Contains("linear-gradient", concrete.Value);
+        }
+
+        [Fact]
+        public void BackgroundHexColorLegal()
+        {
+            var snippet = "background: #ff0000";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("background", property.Name);
+            Assert.IsType<BackgroundProperty>(property);
+            var concrete = (BackgroundProperty)property;
+            Assert.True(concrete.HasValue);
+            Assert.Equal("rgb(255, 0, 0)", concrete.Value);
+        }
+
+        [Fact]
+        public void BackgroundRgbaColorLegal()
+        {
+            var snippet = "background: rgba(0, 128, 255, 0.5)";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("background", property.Name);
+            Assert.IsType<BackgroundProperty>(property);
+            var concrete = (BackgroundProperty)property;
+            Assert.True(concrete.HasValue);
+            Assert.Equal("rgba(0, 128, 255, 0.5)", concrete.Value);
+        }
+
+        [Fact]
+        public void BackgroundWithRepeatXLegal()
+        {
+            var snippet = "background: url(\"tile.png\") repeat-x top";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("background", property.Name);
+            Assert.IsType<BackgroundProperty>(property);
+            var concrete = (BackgroundProperty)property;
+            Assert.True(concrete.HasValue);
+        }
+
+        [Theory]
+        [InlineData("background: red", "rgb(255, 0, 0)")]
+        [InlineData("background: white url(\"pendant.png\")", "url(\"pendant.png\") rgb(255, 255, 255)")]
+        [InlineData("background: url(\"topbanner.png\") #00d repeat-y fixed", "url(\"topbanner.png\") repeat-y fixed rgb(0, 0, 221)")]
+        [InlineData("background: url(\"img_tree.png\") no-repeat right top", "url(\"img_tree.png\") right top no-repeat")]
+        public void BackgroundShorthandValues(string snippet, string expectedValue)
+        {
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("background", property.Name);
+            Assert.IsType<BackgroundProperty>(property);
+            var concrete = (BackgroundProperty)property;
+            Assert.True(concrete.HasValue);
+            Assert.Equal(expectedValue, concrete.Value);
+        }
+
+        [Fact]
+        public void BackgroundShorthand_Color_SetsBackgroundColor()
+        {
+            var style = ParseDeclarations("background: red");
+            Assert.Equal("rgb(255, 0, 0)", style.BackgroundColor);
+            Assert.Equal("initial", style.BackgroundImage);
+            Assert.Equal("initial", style.BackgroundRepeat);
+            Assert.Equal("initial", style.BackgroundPosition);
+            Assert.Equal("initial", style.BackgroundSize);
+            Assert.Equal("initial", style.BackgroundAttachment);
+        }
+
+        [Fact]
+        public void BackgroundShorthand_Transparent_SetsBackgroundColorToTransparent()
+        {
+            var style = ParseDeclarations("background: transparent");
+            Assert.Equal("rgba(0, 0, 0, 0)", style.BackgroundColor);
+            Assert.Equal("initial", style.BackgroundImage);
+        }
+
+        [Fact]
+        public void BackgroundShorthand_ImageAndColor_SetsBothLonghands()
+        {
+            var style = ParseDeclarations("background: white url(\"pendant.png\")");
+            Assert.Equal("rgb(255, 255, 255)", style.BackgroundColor);
+            Assert.Equal("url(\"pendant.png\")", style.BackgroundImage);
+            Assert.Equal("initial", style.BackgroundRepeat);
+            Assert.Equal("initial", style.BackgroundPosition);
+        }
+
+        [Fact]
+        public void BackgroundShorthand_ImageRepeatAttachmentColor_SetsAllFourLonghands()
+        {
+            var style = ParseDeclarations("background: url(\"topbanner.png\") #00d repeat-y fixed");
+            Assert.Equal("rgb(0, 0, 221)", style.BackgroundColor);
+            Assert.Equal("url(\"topbanner.png\")", style.BackgroundImage);
+            Assert.Equal("repeat-y", style.BackgroundRepeat);
+            Assert.Equal("fixed", style.BackgroundAttachment);
+            Assert.Equal("initial", style.BackgroundPosition);
+        }
+
+        [Fact]
+        public void BackgroundShorthand_ImageNoRepeatPosition_SetsImageRepeatPosition()
+        {
+            var style = ParseDeclarations("background: url(\"img_tree.png\") no-repeat right top");
+            Assert.Equal("url(\"img_tree.png\")", style.BackgroundImage);
+            Assert.Equal("no-repeat", style.BackgroundRepeat);
+            Assert.Equal("right top", style.BackgroundPosition);
+            Assert.Equal("initial", style.BackgroundColor);
+        }
+
+        [Fact]
+        public void BackgroundShorthand_LinearGradient_SetsBackgroundImage()
+        {
+            var style = ParseDeclarations("background: linear-gradient(to right, red, blue)");
+            Assert.Contains("linear-gradient", style.BackgroundImage);
+            Assert.Equal("initial", style.BackgroundColor);
+        }
+
+        [Fact]
+        public void BackgroundShorthand_ImagePositionSize_SetsPositionAndSize()
+        {
+            var style = ParseDeclarations("background: url(\"img.png\") center / cover no-repeat");
+            Assert.Equal("url(\"img.png\")", style.BackgroundImage);
+            Assert.Equal("center", style.BackgroundPosition);
+            Assert.Equal("cover", style.BackgroundSize);
+            Assert.Equal("no-repeat", style.BackgroundRepeat);
+        }
+
+        [Fact]
+        public void BackgroundShorthand_HexColor_SetsBackgroundColor()
+        {
+            var style = ParseDeclarations("background: #336699");
+            Assert.Equal("rgb(51, 102, 153)", style.BackgroundColor);
+            Assert.Equal("initial", style.BackgroundImage);
+        }
+
+        [Fact]
+        public void BackgroundShorthand_None_SetsBackgroundImageToNone()
+        {
+            var style = ParseDeclarations("background: none");
+            Assert.Equal("none", style.BackgroundImage);
+            Assert.Equal("initial", style.BackgroundColor);
+        }
     }
 }
 

--- a/src/PeachPDF.Tests/Integration/BackgroundShorthandIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/BackgroundShorthandIntegrationTests.cs
@@ -1,0 +1,100 @@
+using PeachPDF;
+using PeachPDF.PdfSharpCore;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    public class BackgroundShorthandIntegrationTests
+    {
+        private static string BoxHtml(string css) =>
+            $"<!DOCTYPE html><html><head><style>body {{ margin: 0; }} div {{ width: 200px; height: 100px; {css} }}</style></head><body><div></div></body></html>";
+
+        private static async Task<string> GetPdfText(string html)
+        {
+            var generator = new PdfGenerator();
+            var doc = await generator.GeneratePdf(html, PageSize.A4);
+            var ms = new MemoryStream();
+            doc.Save(ms);
+            return Encoding.Latin1.GetString(ms.ToArray());
+        }
+
+        [Fact]
+        public async Task BackgroundShorthand_SolidColor_RendersSameAslonghand()
+        {
+            var shorthandPdf = await GetPdfText(BoxHtml("background: red;"));
+            var longhandPdf = await GetPdfText(BoxHtml("background-color: red;"));
+
+            // Both should produce a solid background — no gradient shading
+            Assert.DoesNotContain("/ShadingType", shorthandPdf);
+            Assert.DoesNotContain("/ShadingType", longhandPdf);
+
+            // Both should draw a filled rectangle
+            Assert.Contains(" rg\n", shorthandPdf);
+            Assert.Contains(" rg\n", longhandPdf);
+        }
+
+        [Fact]
+        public async Task BackgroundShorthand_WithLinearGradient_RendersGradient()
+        {
+            var pdfText = await GetPdfText(BoxHtml("background: linear-gradient(to right, red, blue);"));
+
+            Assert.Contains("/ShadingType", pdfText);
+            Assert.Contains("/DeviceRGB", pdfText);
+        }
+
+        [Fact]
+        public async Task BackgroundShorthand_WithRadialGradient_RendersGradient()
+        {
+            var pdfText = await GetPdfText(BoxHtml("background: radial-gradient(circle, red, blue);"));
+
+            Assert.Contains("/ShadingType", pdfText);
+        }
+
+        [Fact]
+        public async Task BackgroundShorthand_ColorAndNoRepeat_RendersBackground()
+        {
+            var pdfText = await GetPdfText(BoxHtml("background: red no-repeat;"));
+
+            Assert.DoesNotContain("/ShadingType", pdfText);
+            Assert.Contains(" rg\n", pdfText);
+        }
+
+        [Fact]
+        public async Task BackgroundShorthand_HexColor_RendersBackground()
+        {
+            var pdfText = await GetPdfText(BoxHtml("background: #336699;"));
+
+            Assert.DoesNotContain("/ShadingType", pdfText);
+            Assert.Contains(" rg\n", pdfText);
+        }
+
+        [Fact]
+        public async Task BackgroundShorthand_WithImageAndPosition_RendersSuccessfully()
+        {
+            // Non-existent image gracefully falls back — PDF is still generated
+            var pdfText = await GetPdfText(BoxHtml("background: url('nonexistent.png') no-repeat center;"));
+            Assert.NotEmpty(pdfText);
+        }
+
+        [Fact]
+        public async Task BackgroundShorthand_WithPositionAndSize_RendersSuccessfully()
+        {
+            var pdfText = await GetPdfText(BoxHtml("background: url('img.png') center / cover no-repeat;"));
+            Assert.NotEmpty(pdfText);
+        }
+
+        [Fact]
+        public async Task BackgroundShorthand_Transparent_ProducesNoBrush()
+        {
+            // transparent should not produce a filled background rectangle
+            var transparentPdf = await GetPdfText(BoxHtml("background: transparent;"));
+            var noBgPdf = await GetPdfText(BoxHtml(""));
+
+            // A transparent background should behave like no background
+            Assert.DoesNotContain("/ShadingType", transparentPdf);
+        }
+    }
+}


### PR DESCRIPTION
Document that the CSS `background` shorthand is supported, add extensive unit tests to verify parsing and longhand mapping for background shorthand (colors, transparent/none, images, positions/sizes, repeats, gradients), and add integration tests to validate rendering behavior (solid fills, linear/radial gradients, images, and transparency). Files changed: docs/html-css-support.md (update), src/PeachPDF.Tests/CSS/PropertyTests/BackgroundProperty.cs (many new unit tests), and added src/PeachPDF.Tests/Integration/BackgroundShorthandIntegrationTests.cs (rendering integration tests). These tests ensure shorthand parity with longhand properties and correct PDF output.