### PR TITLE
Implement border-radius support and fix table overflow bugs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - name: Checkout
@@ -26,7 +26,7 @@ jobs:
       run: dotnet build src/PeachPDF.Tests/PeachPDF.Tests.csproj --no-restore --configuration Release
 
     - name: Install Playwright browsers
-      run: pwsh src/PeachPDF.Tests/bin/Release/net8.0/playwright.ps1 install --with-deps chromium
+      run: pwsh src/PeachPDF.Tests/bin/Release/net8.0/playwright.ps1 install chromium
 
     - name: Test
       run: dotnet test src/PeachPDF.Tests/PeachPDF.Tests.csproj --no-build --configuration Release --logger "trx;LogFileName=test-results.trx"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Restore
+      run: dotnet restore src/PeachPDF.Tests/PeachPDF.Tests.csproj
+
+    - name: Build
+      run: dotnet build src/PeachPDF.Tests/PeachPDF.Tests.csproj --no-restore --configuration Release
+
+    - name: Install Playwright browsers
+      run: pwsh src/PeachPDF.Tests/bin/Release/net8.0/playwright.ps1 install --with-deps chromium
+
+    - name: Test
+      run: dotnet test src/PeachPDF.Tests/PeachPDF.Tests.csproj --no-build --configuration Release --logger "trx;LogFileName=test-results.trx"
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: test-results
+        path: src/PeachPDF.Tests/**/*.trx

--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -178,17 +178,17 @@ Form elements are rendered as static boxes. There is no interactive behavior —
 | `border-collapse` | [border-collapse](https://developer.mozilla.org/en-US/docs/Web/CSS/border-collapse) | Full support for tables |
 | `border-spacing` | [border-spacing](https://developer.mozilla.org/en-US/docs/Web/CSS/border-spacing) | Full support for tables |
 
-### Border Radius (PeachPDF Extension)
+### Border Radius
 
-PeachPDF uses custom property names for border radius rather than the standard `border-radius`. Standard `border-radius` is not recognized.
+| Property | MDN Reference | Notes |
+|----------|--------------|-------|
+| `border-radius` | [border-radius](https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius) | Shorthand; supports 1–4 values with optional `/` for elliptical radii (e.g. `10px / 20px`) |
+| `border-top-left-radius` | [border-top-left-radius](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-left-radius) | Accepts `<length>` or `<percentage>`; optional second value sets the vertical radius independently |
+| `border-top-right-radius` | [border-top-right-radius](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-right-radius) | Same as above |
+| `border-bottom-right-radius` | [border-bottom-right-radius](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-right-radius) | Same as above |
+| `border-bottom-left-radius` | [border-bottom-left-radius](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-left-radius) | Same as above |
 
-| Property | Equivalent standard CSS | Notes |
-|----------|------------------------|-------|
-| `corner-radius` | [`border-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius) | Sets all four corners |
-| `corner-nw-radius` | [`border-top-left-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-left-radius) | Top-left corner |
-| `corner-ne-radius` | [`border-top-right-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-right-radius) | Top-right corner |
-| `corner-se-radius` | [`border-bottom-right-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-right-radius) | Bottom-right corner |
-| `corner-sw-radius` | [`border-bottom-left-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-left-radius) | Bottom-left corner |
+Percentages are relative to the border-box width (horizontal radius) and height (vertical radius). Overlapping adjacent radii are automatically reduced proportionally per the CSS spec.
 
 ### Backgrounds
 
@@ -379,7 +379,6 @@ The following CSS features are not supported:
 - **Filters and effects** — `filter`, `backdrop-filter`, `mix-blend-mode`, `opacity`
 - **CSS variables** — `var()` and `--custom-properties`
 - **`calc()` expressions**
-- **`border-radius`** — use the [PeachPDF extension properties](#border-radius-peachpdf-extension) instead
 - **`background` shorthand** — use individual `background-*` properties
 - **`letter-spacing`**
 - **`text-transform`** — `uppercase`, `lowercase`, `capitalize`

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -1,9 +1,5 @@
-// See https://aka.ms/new-console-template for more information
-
 using PeachPDF;
 using PeachPDF.PdfSharpCore;
-
-var httpClient = new HttpClient();
 
 PdfGenerateConfig pdfConfig = new()
 {
@@ -13,15 +9,257 @@ PdfGenerateConfig pdfConfig = new()
 };
 
 PdfGenerator generator = new();
-
 var stream = new MemoryStream();
 
-var html = """
-           <img width="auto" alt="signature" height="75" style="margin: 5px" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgAAAACFCAYAAAAtmkC4AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAT6UlEQVR4nO2dCXLcOBJFpYi+l6tPZvfJbJ/MM9me9EAQlgSIHe9FKCSVaqFIAj83JP769V/eAAAA4Cr+egMAAIDrwAAAAAC4EAwAAAD4w7dv395er9e/X3A2GAAAAPAvIvo/f/58+/Hjxx9DAM4FAwAA4HJU8EX8Bfn+999/v339+vXfx+FMMAAAAC7GF3+Xf/75h3TAwWAAAABcjHj6Mb58+YL4HwwGAADApeTEHfE/GwwAAIAL0YK/GOT/zwcDAADgMnLiL6F/xP98MAAAAC4iVvDnPwfOBwMAAOASRNilsl88/JgRIKF/cv93gAEAAHABKv5CSvzx/u8BAwAA4HBc8c89D+4BAwAA4GCk0Y9F/MX7h7t4ZABonki+y00mXwAAsA6pRj8Kof87qTIAXLHXXJIaA/I4BSRno61D2SwEYG0s45Mlf/dSbADI5K8Wpdw4ghgB8qXVpUQCzkUnCrne8jPXGmBNLMv99HlwJ1UGgC4hCd1c8pimBOAs/OYhlskFAMZjLfpjyd/dFBkA1puKG+o8Yp3D3t/fyR8CLESJ+DNu78ZsAMRuKr+hBCmA88i1DQWAdbCIv4D4g9kAiN1UIvbiBSoIxVloUSfXFWB9rEV/RGlBMBkAain63j7rRs/GEkokjAiwBtaiPxF/xiwIWQMg1j6Sif9srM1DuAcA5kPeH2qobgQUu4l0aSDsjWWSIAIEsAYW8We9P/gkDYCYVelO/H7Bn0QJMAL2xhJKZDIBWANrPp/ibPBJGgByY4UMACb+c2GpJ8A+WPP+379/fwPwSRoAoR7Sftg3ZFUiDvtCHhFgD2j2A0+JGgCxCZ6J/1ys15Z7AGA+GOvwlKIiQIq+zqXEmwCAuViLdBF/SBE1AKzdpPwUAE0m9gRvAmAPLMY6RbpzcXVRm6mtqIvFewH4+AUodIzbD0L/AHvgbsUeA/Efi14T+Qrpn66K05o6rclYwSAIGgBy84R6/Ft5LWjpQBhC/wD7ECrM9pExzRzcFxF76woMwZ1j5Wd9vTDzWkUjAP4/FjrIkCVKD4C9sKwNJvQP8H80pDsaa94f8e9DTvR9p1mJPd+NCMyaX4MGgHVpH0sA98ZqwSL+AL/RjbFkXb38PMoYYF+OOeTC+y4l6W/3uXJdlzIAQv8Iwn4elkIirjvcjhuu1bnRD7P3Hicrir8rjprTds/VzvjevpzfEoF3I+F6XmKvn5le/WQAlLSLpLXkvlgGKbuGwe3EPG+ZzLXtuaUw7+kxpBgp/vq/6jlxhXFWaqQlsTB/ygBTsbfUXshzfGNAfn9/f/8TVRqJyQCIWShECvbEWviH+MPNaLg/ltsVeotfbqyOrPgPiaN7bPq4noedHMTSor4S0XdxC//0s2aunKveDTAGBsD6WAv/AG5ExodbbW+tk+kheDnxHyGyFnF0xWynQsQS4a8V/RCuASDM8P4FUwSAFQBtca3A0RfdcrNTTAS3kstha12MCLMbGejhxeXG4Cjxtyw9dJFzI1+zRM1CSXGfRlla/i++YSfneIkUQAhWADzDtTJFXPXia459pCFABzGAMBpujzkyrmEcEg75W6uxkwv9j9jdr6TjoO9YrBxBdL3vlNPaQ/iF2D2yRASATn5t8Ys+XMNJb4RRgmv5HMQfbsQVu9Ac6HtnfghXkNe3MuZz4t9bLEL/n4sfJfSf7zo5qxAyaGKd+3o2U3KPQQ2QWefpgwFQEtbfqcBjBm7ozD2H7g2nBUajimYsS4leRHHgMlKebizPHntNi1qAlBHee4xamt2ExHHliLA1z99b+AX/2oYcw5FUFwGyAiCOPznkimdGCO9KS4kAViEl/rkx4abzFBnPuu579PE8JZfvTxUdrqgHKwm/ELu2y/QBeGrFvTAAqjwADR32JOXhyABB/OE2UmPVIrbu6/3IXo0RMFP8c/n+3RwES/2CMOr/Sh3PzPNaFQEg/P8Zi7WpuTtp+hB6fS8jIHWDaQQC4DZaiK02cfGRcSWPW99rtuefmtNzNQcrrQizev2jDZrUtZ1JNgIQYqULvgIloTP/phvhgZ9k2QO0IHbP14wHEcjY+Nexl3rPVT1/a2h8lfx/yaqFkcfX8l5rTTYCYD1Rt4b/c+LvX+RQzrDnkp5cDvMb4g+XkcrF1owHmftC9QBKygjIidZM8d8l0mv1+lfqS7DK3PvBAPhJYV8ROfH3b7jYBe8Z/p81uQCsSK9crHqV+h6hHgElxyL0DA+3jDrMjABYvP6ZYhs7vlXm3mY1ALcZCmp1xvqEW63Nnjdn6n1HNBIBWIkfziY2Pi3EVgv/fG809N4zi+5apxxmOY65XgUzwv0Wvi5Uc1VlABApeIt6/qXrhnuSGuQvIjtwGTIuQwZ7a7HV95LxF3pvy1zQS/xzRlDp585IE1jaE68QYtfiytA91zPqq9fE/y64USqhug/AzcRurFTerGXO0cLKhScAo2md97d8XqgrYM5r1WPqQUo4a89DaL6blboQVvL6XbF1o0K6V4Kg58raQdI/3+4KDksXX12iqp/1xwCwVvbfvgIgdgOmxD80sHqes9QxIv5wIzPWYNeIvzDaKdhhXrAU+q3o3KgREDtuvS9D7YFdWrbod6MPxRGAm/P/KeszFQoLvcYPxbQiFeL7tvggB+hBKho2Cqv49zqm2Oc/rfYfoQeWlMn3xXceFGL1Yj4j9+MhBVBATQFRbPLpJcapEN/rEkMNQBkd+vexLlHreUyxz2+x1K93PZil0G/15Yoapv/h7SBpNQha4t9jTSIAN1CTU09NPj1ITR54/3AjM6NhlmI1lx4Gem3Ucja7FPpZ8XP8loZFtcaBm0JwPzd0fxUbADeuAKj1IkZOPrmlPQC3MTP0Xyr+PSJ0qTmhxTLgXvVgOxX6leIWBbqRAcEq+DGB199LSBYB0gWwvnHIyMnHkiMDuImZof9S8RdaH1POIWgxZ7fO/+9a6FdLrPJfi/T85Xs9oAYgQ60FPXLysVjLALcQK4QdMRZqjPHWTkHrtf4j2L3QryWpkH1rigyA25YAprz41MUZWfiXe88XhX9wGbEx0XsspEQsltPtIcit1/rHCDW5KT3HFq//y0b7EuzGBwNgRlXiqtSGEEcW/lms5m94/3ARMTGZvauedRlgi+MI0eP/f/r/WOavr19pXNaTDwZA7oLe0gOgNu8vjCr8sw4egFuItV7tHfpPibuK/4iUYGxOGJkGtHazixlqeu12LvTbCWoAAtRW048s/LPkGbGc4Sb8ddZKr3GQC1+rwI9ICaYcgpXC57lIiG6PjvCPAQPA40kIbVThn2Vw4P3DTaRSbyPX16sH64p/75RgSvx77fpZUg9mbYaE1z+ex0WAJ12sJ0uH5O+hGooeoX/qNAA+skrPDVf8Y8fVMiSfq/ifOT+v0AUR0vwxAEJ5qh8XVV4+6aE/qvDPkvd3nwtwA6NSbxZBc8PXI1YjjKr4D6Eev3s+VDNyOX73d7z+eRRFAE7uApgaSDlKdgGsJWWg+BD+h5uQcSH3vDs+RhXYKSEh650SjM29I8RfP9vVBPk51wBJIyRybsj1z6fIADh1meCTvH9q2VFL3IEVsqLd3/H+4RZiofaWwpIT/9A80bvwL+Vhjxr/Wq2vP5fw69evN5jP4wjA7jxdOjOi8M+fzPzr4P6O9w+307LVbS7kHxvrPVOCq1T8i4jrsYScQ/cxQv1rYjYATu0C+GQgjbC0U5a+8JOCQLiYXntgWLahjQlaT+9/RsV/CpknxbDR+dJNxbCef32uXgaYyqHliOXkW3r/OUv//f09+BqAG+ghtJZC25pdQFt5/6tV/PtFf7qJjZ4fhH9trjUAUrl7ywTSu/AvZ+mHPueEiAxACX7ouVZoc93pBH+JX4ie3v/Mor8c35yGRz/o278NVxoAKXG1DKTey/5Sx6eW/o9L2jIDxAiNkR6b0bjCn9sErNe88NRhAQjxoQ+Az6n55ac5tJ5NR6xbebaY/ABOo2QMWML9wlORfTovPHVYAGJcFwFILfmzTB6p1z9FxN/S2CN2DBgAcAtPipKtwl+yDW0v73+1oj84i6sMgNQgtVrSPQv/UsZF7v1Z/gc3IcauVp9bIpUlbWlbVq4/nRdWK/qDs7jGAHjS6jf3vBYDMbbsKNSPoNfSJ4BdsHTGzLWlDVHTna6X979y0R+cwQcDINbbWW/EnTsBPmn1q/TabSw1QfkhyJ5VxgC7EKtZCi2NTeHv3ldDj6ggRX8wgk8RgFw17I48Ca3n3qNngY81x0f4H27Ezfk/mZue9KTvseSNoj8YxfEpgNhgKumZPavAJzQpEf4H+I2Kb87rD0UuNXL3NHoXiiw+8dIp+oORmA2AHZcJpvKELSz3pyG+0gKfEbsOnoybzoIzcMdErChQ62tat6XtURNE0R+M5IMBECpE23nSbLFkr4f3nxP/2HHLtWjV+ewW5Fy6oiAbmIjHSC71DGRu0k1pQuIu40U9/RHz2BOhpugPRpONALgWdiiUtqqB0KqI5mn6IHRcNeKv/Ny0DmMkbi9ywT1neq/KNRglCtAft0fGiGtqWYVQAkV/MINPEYATcswt8v76PiFqJ5in4k/73zShtd5yXlMTq/ztSREYrMWo69gyHUfRH8ziuCLAmGVe47W3XN7zVPyFkJAhXL+JdVH0z7meQ/dxTRMAWGmVFqToD2ZSZADsUCMQW+9fGu5taXm3EH8EKowb7n/SpyK2wRKAT8slwRT9wUw+pQB8/AnVn2RXmjRbFtG08v5biL8QOs+3FwD6Xn+oF7wb+dH7wzdk9WctJANI0cr7p+gPZlMcAVi1RiBWRFMT+m9l4bcSf/hM6NyG1nqHzrFGrfzn6/txXSBGy7mBoj+YTbEB4LNCVXpKaFtFKEot/Nbiz/a/v7Fs6mI5v/L3WM0AqwMgRgvvn6I/WIVPBkBuqd9qSwFTy3Fqimhig7N09cAIz/82kUptlyyUNHpxd5MT3HtaPoOVAeDTYlUQRX+wEtkIgGWP7VlV1ClBqC2ieWrhpwZ4bf+AJ3ufn0LuHivZu91/z9A9JI8RjoUcJfNMylmh6A9mkDUAfG8/FjodjS+07k6GT5bqlTzuE9vSV4+v1ki6ff1/yqgSngi1nMfY6oFZNQHu9X4hCsvwtP4p5axgaMIMmvQBGF0HECsAk4m8x7aeOXJ5aQZ4PZaIylOR9FNY7nWUz5avli1lVeDluyv2FIWtS6gNt2C9NrHncX1hJsUGQMxjGrWEKucN1h5Drfefy0u3GOC3FgDmxL9l2kmNuNjnyf0uX/r3UAom1kvgiYFMUeIaxHb9sxC7r560FAdoQVUEQMXe95R6T1QjBUHIDfCeoWmXkMF1uiCk0im9vCZ9T0uoN3RsK6yIgXFY7kEq/mFlPhkA1nazoef1LAbsKf6x4pzUAM2Jf6sq8tD2pqcXAM4Qf8U1AuSzZve9oDhsPqH7zTIGKfqD1amKAOgSqlAevseSwN6ef0mXvVy+v/We4zexSi2FRrhS+0r09PZVXLiP1sVyXSj6g9WpXgYYE+WWUYBRgmD18lK5PC1CXKk18k6MqKUo5fW/vea1WK/VtdUx5bYmdr/DWtTU4NDmF3bg0SqAWBSgRUFgTBBUbEeFgvVYUoaI0KtxzA1LAHPiP7spj1/bEjMEYtGvF8K+LbFrnbqmsRQWRX+wGp8MgJJuVL6372+1+qQiP1WN3Vr8tSOcHr96aBbhF6jSrmd18Q8RO54X98BxlG7CFRJ/dz4BWIlPBkDpJBZbPlVjBLTq815C6Njl89/f37OvJd//jJT4c25hBUpEO+b5y2O0+YUVadIIKIYIq4ZFU6JtEf5egvCq3OGQXN4zcuKPtwQrEFvt5JNaufKdfSVgUZoYAKn1024DFT90FlriFqK3ILhthFPP0UI/PNNnIP6wAzLO/TqnUFF0ynlB/GFlmkUAXCNA26bG0gIl9Pa03e5tGvaPdTrUSAXUg/jDTvhzli/mqXolxB9Wp2kKQMVRvlty6Cm0UcaoAaTCox6+ipTr8c8YzCetAkD84SRyDateiD8sTvMaAPWUfS865FXHHpsRYpfP00Id/ZkB3I7ezZwAWhMzvldpWAXwlC5FgO4gEWTid71qFzenNju37n424t8OxB92JCbwqzWsAqil6yoANyUgk7xfBMj6+Tx6fnbdaAbxh10JRSgRfziJrgaAC2Jfh3WlxIog/rAzuS2iXUgZwo4MMwCgjlChUY8Nl1qD+MPu5Pb+0J9npy4BasEAWJzQcsrVxTNVHY34wy6oAaAV/W74X9uHcy/DzmAAQDOojobTkN0gBV/ouY/hBDAAFicUWlyxJmDF7XwBWsHSYDgRDIANCFUjr1QHkCuUQvzhBF6IPxwGBgA8Iif+eE0AAGuCAbApK0QAcsV+VEcDAKwLBsAGhLoozqw+zuX7qfQHAFgfDIANEC9alx2pxy3fR0cBclX+Avl+AIA9wADYhFBHQG2xPAJLRzTEHwBgHzAANiGUBhgRBbB4/QLFfgAAe4EBsAkirqHlgD2jABavn3w/AMCeYABsxKgogMXrp8ofAGBvMAA2IhYFEKOgRf7dGu4n1w8AsD8YAJsRigIIGqovFWar6At4/QAA54ABsBkaBVBc4RYjQAU9J9Ilwi/g9QMAnAUGwIaoeIcK9ETQJUKgRoJvCGjBntXjF/D6AQDOAwNgU9Qbj1Xpuw2DaqC6HwDgbDAANiZnBNRAnh8A4A4wADZHxdrN50u+vsQoQPQBAO4DA+AARLi1LsCCGggIPwDAvWAAHIRrAKioh/L4KvoIPwDAvWAAHIqKe0zkEX8AgLv5DwbmtSr4JsI3AAAAAEkAAAAAAAAAAAAAAAAAAAAA">
-           """;
+static string Swatch(string desc, string css) =>
+    "<td>" +
+    $"<div class=\"box\" style=\"background-image: {css}\"></div>" +
+    $"<div class=\"desc\">{desc}</div>" +
+    $"<div class=\"css\">{css}</div>" +
+    "</td>";
+
+static string RadiusSwatch(string desc, string borderRadiusCss, string boxCss = "") =>
+    "<td>" +
+    $"<div class=\"rbox\" style=\"{boxCss}border-radius: {borderRadiusCss}\"></div>" +
+    $"<div class=\"desc\">{desc}</div>" +
+    $"<div class=\"css\">border-radius: {borderRadiusCss}</div>" +
+    "</td>";
+
+static string Row(params string[] cells) =>
+    $"<table class=\"sw\"><tr>{string.Join("", cells)}</tr></table>";
+
+const string Css = """
+    <style>
+    @page { size: a4; margin: 15mm }
+    body { font: 8.5pt Arial, sans-serif; margin: 0 }
+    h1 { font-size: 15pt; margin: 0 0 0.3em }
+    h2 { font-size: 10pt; margin: 0.9em 0 0.3em; padding-bottom: 2px; border-bottom: 1px solid #999 }
+    p.intro { margin: 0 0 0.7em; color: #555 }
+    table.sw { border-collapse: collapse; width: 100%; margin-bottom: 0.3em }
+    table.sw td { padding: 3px; vertical-align: top; width: 25% }
+    .box { height: 48px; border: 1px solid #000; margin-bottom: 3px }
+    .desc { font-size: 7pt; font-weight: bold; color: #444; margin-bottom: 1px }
+    .css { font-size: 6pt; color: #666; line-height: 1.3; word-break: break-all }
+    </style>
+    """;
+
+var html = "<!DOCTYPE html><html><head>" + Css + "</head><body>" +
+
+    "<h1>CSS Gradient Test Page</h1>" +
+
+    "<h2>1 — linear-gradient: Direction &amp; Angle</h2>" +
+    Row(
+        Swatch("default (to bottom)", "linear-gradient(red, blue)"),
+        Swatch("to top", "linear-gradient(to top, red, blue)"),
+        Swatch("to right", "linear-gradient(to right, red, blue)"),
+        Swatch("45deg", "linear-gradient(45deg, red, blue)")
+    ) +
+
+    "<h2>2 — linear-gradient: Multi-Stop &amp; Positions</h2>" +
+    Row(
+        Swatch("3 stops", "linear-gradient(to right, red, yellow, blue)"),
+        Swatch("abs lengths", "linear-gradient(to right, red 0, yellow 40px, blue 80px)"),
+        Swatch("hard stop", "linear-gradient(to right, red 0 50%, blue 50% 100%)"),
+        Swatch("color hint", "linear-gradient(to right, red, 30%, blue)")
+    ) +
+
+    "<h2>3 — linear-gradient: Alpha Transparency</h2>" +
+    Row(
+        Swatch("transparent → color", "linear-gradient(to right, rgba(255,0,0,0), red)"),
+        Swatch("color → transparent", "linear-gradient(to right, rgba(0,128,255,1), rgba(0,128,255,0))"),
+        Swatch("rgba() 80% opacity", "linear-gradient(to right, rgba(255,0,0,0.8), rgba(0,0,255,0.8))"),
+        Swatch("multi-stop alpha", "linear-gradient(to right, red, rgba(255,255,0,0.5), rgba(0,0,255,0))")
+    ) +
+
+    "<h2>4 — repeating-linear-gradient</h2>" +
+    Row(
+        Swatch("stripes 20px", "repeating-linear-gradient(to right, red 0 10px, blue 10px 20px)"),
+        Swatch("45deg stripes", "repeating-linear-gradient(45deg, red 0 8px, white 8px 16px)"),
+        Swatch("fade repeat", "repeating-linear-gradient(to right, red 0, blue 30px)"),
+        Swatch("full span = no repeat", "repeating-linear-gradient(to right, red, blue)")
+    ) +
+
+    "<h2>5 — radial-gradient: Basic</h2>" +
+    Row(
+        Swatch("default (ellipse center)", "radial-gradient(red, blue)"),
+        Swatch("circle", "radial-gradient(circle, red, blue)"),
+        Swatch("at 25% 25%", "radial-gradient(at 25% 25%, red, blue)"),
+        Swatch("circle at 50% 25%", "radial-gradient(circle at 50% 25%, yellow, orange, red)")
+    ) +
+
+    "<h2>6 — radial-gradient: Size Keywords &amp; Explicit</h2>" +
+    Row(
+        Swatch("farthest-corner", "radial-gradient(farthest-corner at 30% 30%, red, blue)"),
+        Swatch("closest-side", "radial-gradient(closest-side at 30% 30%, red, blue)"),
+        Swatch("farthest-side", "radial-gradient(farthest-side at 30% 30%, red, blue)"),
+        Swatch("explicit 30px", "radial-gradient(30px at center, red, blue)")
+    ) +
+
+    "<h2>7 — radial-gradient: Alpha</h2>" +
+    Row(
+        Swatch("transparent center", "radial-gradient(rgba(255,0,0,0), rgba(255,0,0,1))"),
+        Swatch("spotlight", "radial-gradient(circle, rgba(255,255,255,0.9), rgba(255,255,255,0))"),
+        Swatch("sunset", "radial-gradient(circle, #fff7e6, #ff6b35, #1a1a2e)"),
+        Swatch("multi-stop alpha", "radial-gradient(circle, rgba(255,0,0,1), rgba(255,255,0,0.5), rgba(0,0,255,0))")
+    ) +
+
+    "<h2>8 — repeating-radial-gradient</h2>" +
+    Row(
+        Swatch("rings", "repeating-radial-gradient(circle, red 0 10px, blue 10px 20px)"),
+        Swatch("fade rings", "repeating-radial-gradient(circle, red 0, blue 25px)"),
+        Swatch("ellipse rings", "repeating-radial-gradient(red 0 8px, white 8px 16px)"),
+        Swatch("with alpha", "repeating-radial-gradient(circle, rgba(255,0,0,0.8) 0 10px, rgba(0,0,255,0.8) 10px 20px)")
+    ) +
+
+    "<h2>9 — conic-gradient: Basic</h2>" +
+    Row(
+        Swatch("default", "conic-gradient(red, blue)"),
+        Swatch("3 stops", "conic-gradient(red, yellow, blue)"),
+        Swatch("from 90deg", "conic-gradient(from 90deg, red, blue)"),
+        Swatch("at 25% 75%", "conic-gradient(at 25% 75%, red, green, blue)")
+    ) +
+
+    "<h2>10 — conic-gradient: Stop Positions</h2>" +
+    Row(
+        Swatch("angle stops", "conic-gradient(red 0deg, blue 180deg, green 360deg)"),
+        Swatch("percent stops", "conic-gradient(red 0%, blue 50%, green 100%)"),
+        Swatch("hard stop", "conic-gradient(red 0 90deg, blue 90deg 180deg, green 180deg 360deg)"),
+        Swatch("pie chart", "conic-gradient(#e74c3c 0 25%, #3498db 25% 65%, #2ecc71 65% 100%)")
+    ) +
+
+    "<h2>11 — conic-gradient: Alpha &amp; From+At</h2>" +
+    Row(
+        Swatch("with alpha", "conic-gradient(rgba(255,0,0,0), red)"),
+        Swatch("from 45deg at 30% 70%", "conic-gradient(from 45deg at 30% 70%, red, blue)"),
+        Swatch("color wheel", "conic-gradient(red, yellow, lime, cyan, blue, magenta, red)"),
+        Swatch("starburst", "conic-gradient(gold 0 10%, white 10% 20%, gold 20% 30%, white 30% 40%, gold 40% 50%, white 50% 60%, gold 60% 70%, white 70% 80%, gold 80% 90%, white 90% 100%)")
+    ) +
+
+    "<h2>12 — repeating-conic-gradient</h2>" +
+    Row(
+        Swatch("60deg tile", "repeating-conic-gradient(red 0deg 30deg, blue 30deg 60deg)"),
+        Swatch("from 45deg", "repeating-conic-gradient(from 45deg, red 0deg, blue 60deg)"),
+        Swatch("checkerboard-like", "repeating-conic-gradient(#000 0 25%, #fff 25% 50%)"),
+        Swatch("narrow slice", "repeating-conic-gradient(red 0 5deg, blue 5deg 10deg)")
+    ) +
+
+    "<h2>13 — Color Space Interpolation: in oklab</h2>" +
+    Row(
+        Swatch("sRGB red→blue", "linear-gradient(to right, red, blue)"),
+        Swatch("oklab red→blue", "linear-gradient(in oklab to right, red, blue)"),
+        Swatch("oklab red→green", "linear-gradient(in oklab to right, red, green)"),
+        Swatch("oklab red→yellow→blue", "linear-gradient(in oklab to right, red, yellow, blue)")
+    ) +
+
+    "<h2>14 — Color Space Interpolation: Polar (HSL, OKLch)</h2>" +
+    Row(
+        Swatch("hsl shorter red→blue", "linear-gradient(in hsl, red, blue)"),
+        Swatch("hsl longer red→blue", "linear-gradient(in hsl longer hue, red, blue)"),
+        Swatch("oklch shorter red→blue", "linear-gradient(in oklch, red, blue)"),
+        Swatch("oklch longer red→blue", "linear-gradient(in oklch longer hue, red, blue)")
+    ) +
+
+    "<h2>15 — Color Space Interpolation: Lab, LCH, sRGB-linear</h2>" +
+    Row(
+        Swatch("lab red→blue", "linear-gradient(in lab to right, red, blue)"),
+        Swatch("lch red→blue", "linear-gradient(in lch to right, red, blue)"),
+        Swatch("srgb-linear red→blue", "linear-gradient(in srgb-linear to right, red, blue)"),
+        Swatch("display-p3 red→blue", "linear-gradient(in display-p3 to right, red, blue)")
+    ) +
+
+    "<h2>16 — Color Space: Radial &amp; Conic</h2>" +
+    Row(
+        Swatch("radial oklab", "radial-gradient(in oklab circle, red, blue)"),
+        Swatch("radial oklch", "radial-gradient(in oklch circle, red, blue)"),
+        Swatch("conic oklab", "conic-gradient(in oklab, red, blue)"),
+        Swatch("conic oklch longer", "conic-gradient(in oklch longer hue, red, blue)")
+    ) +
+
+    "</body></html>";
 
 var document = await generator.GeneratePdf(html, pdfConfig);
 document.Save(stream);
 
-File.Delete("test_flyer.pdf");
-File.WriteAllBytes("test_flyer.pdf", stream.ToArray());
+File.Delete("test_gradients.pdf");
+File.WriteAllBytes("test_gradients.pdf", stream.ToArray());
+Console.WriteLine("Saved test_gradients.pdf");
+
+// --- Border-radius showcase ---
+
+const string RadiusCss = """
+    <style>
+    @page { size: a4; margin: 15mm }
+    body { font: 8.5pt Arial, sans-serif; margin: 0 }
+    h1 { font-size: 15pt; margin: 0 0 0.3em }
+    h2 { font-size: 10pt; margin: 0.9em 0 0.3em; padding-bottom: 2px; border-bottom: 1px solid #999 }
+    p.intro { margin: 0 0 0.7em; color: #555 }
+    table.sw { border-collapse: collapse; width: 100%; margin-bottom: 0.3em }
+    table.sw td { padding: 3px; vertical-align: top; width: 25% }
+    .rbox { height: 60px; background: steelblue; border: 2px solid #1a6b8a; margin-bottom: 3px }
+    .desc { font-size: 7pt; font-weight: bold; color: #444; margin-bottom: 1px }
+    .css { font-size: 6pt; color: #666; line-height: 1.3; word-break: break-all }
+    </style>
+    """;
+
+var radiusHtml = "<!DOCTYPE html><html><head>" + RadiusCss + "</head><body>" +
+
+    "<h1>CSS border-radius Test Page</h1>" +
+
+    "<h2>1 — Shorthand: 1–4 values</h2>" +
+    Row(
+        RadiusSwatch("1 value — all equal", "20px"),
+        RadiusSwatch("2 values — opposite pairs", "10px 30px"),
+        RadiusSwatch("3 values — TL / TR+BL / BR", "8px 20px 35px"),
+        RadiusSwatch("4 values — each corner", "5px 15px 30px 45px")
+    ) +
+
+    "<h2>2 — Individual Longhands</h2>" +
+    Row(
+        RadiusSwatch("top-left only", "0", "border-top-left-radius: 30px; "),
+        RadiusSwatch("bottom-right only", "0", "border-bottom-right-radius: 30px; "),
+        RadiusSwatch("TL + BR set", "0", "border-top-left-radius: 25px; border-bottom-right-radius: 25px; "),
+        RadiusSwatch("all 4 longhands", "0", "border-top-left-radius: 10px; border-top-right-radius: 20px; border-bottom-right-radius: 30px; border-bottom-left-radius: 15px; ")
+    ) +
+
+    "<h2>3 — Elliptical Corners (/ syntax)</h2>" +
+    Row(
+        RadiusSwatch("flat wide (40px / 10px)", "40px / 10px"),
+        RadiusSwatch("tall narrow (10px / 40px)", "10px / 40px"),
+        RadiusSwatch("uniform ellipse (30px / 20px)", "30px / 20px"),
+        RadiusSwatch("asymmetric", "20px 0 / 0 20px")
+    ) +
+
+    "<h2>4 — Percentage Values</h2>" +
+    Row(
+        RadiusSwatch("50% — pill/ellipse", "50%"),
+        RadiusSwatch("25% — quarter round", "25%"),
+        RadiusSwatch("50% / 25%", "50% / 25%"),
+        RadiusSwatch("25% / 50%", "25% / 50%")
+    ) +
+
+    "<h2>5 — Overlapping Radii Reduction</h2>" +
+    "<p class=\"intro\">Each box is 80px wide. A radius larger than half the box is automatically scaled down.</p>" +
+    Row(
+        RadiusSwatch("60px on 80px box", "60px", "width: 80px; "),
+        RadiusSwatch("100px (auto-capped)", "100px", "width: 80px; "),
+        RadiusSwatch("50% on tall box", "50%", "width: 80px; height: 80px; "),
+        RadiusSwatch("no overlap — 20px", "20px", "width: 80px; ")
+    ) +
+
+    "<h2>6 — Combined Styles</h2>" +
+    Row(
+        RadiusSwatch("solid border + bg", "15px"),
+        RadiusSwatch("dashed border", "15px", "border-style: dashed; "),
+        RadiusSwatch("dotted border", "15px", "border-style: dotted; "),
+        RadiusSwatch("no border, bg only", "15px", "border: none; ")
+    ) +
+
+    "</body></html>";
+
+var radiusStream = new MemoryStream();
+var radiusDocument = await generator.GeneratePdf(radiusHtml, pdfConfig);
+radiusDocument.Save(radiusStream);
+
+File.Delete("test_border_radius.pdf");
+File.WriteAllBytes("test_border_radius.pdf", radiusStream.ToArray());
+Console.WriteLine("Saved test_border_radius.pdf");

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -184,6 +184,10 @@ File.Delete("test_gradients.pdf");
 File.WriteAllBytes("test_gradients.pdf", stream.ToArray());
 Console.WriteLine("Saved test_gradients.pdf");
 
+File.Delete("test_gradients.html");
+File.WriteAllText("test_gradients.html", html);
+Console.WriteLine("Saved test_gradients.html");
+
 // --- Border-radius showcase ---
 
 const string RadiusCss = """
@@ -263,3 +267,7 @@ radiusDocument.Save(radiusStream);
 File.Delete("test_border_radius.pdf");
 File.WriteAllBytes("test_border_radius.pdf", radiusStream.ToArray());
 Console.WriteLine("Saved test_border_radius.pdf");
+
+File.Delete("test_border_radius.html");
+File.WriteAllText("test_border_radius.html", radiusHtml);
+Console.WriteLine("Saved test_border_radius.html");

--- a/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTablePageBreakTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTablePageBreakTests.cs
@@ -742,7 +742,7 @@ namespace PeachPDF.Tests.Html.Core.Dom
         {
             public override void Start(double x, double y) { }
             public override void LineTo(double x, double y) { }
-            public override void ArcTo(double x, double y, double size, Corner corner) { }
+            public override void ArcTo(double x, double y, double radiusX, double radiusY, Corner corner) { }
             public override void Dispose() { }
         }
 

--- a/src/PeachPDF.Tests/Integration/BackgroundShorthandIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/BackgroundShorthandIntegrationTests.cs
@@ -15,7 +15,9 @@ namespace PeachPDF.Tests.Integration
         private static async Task<string> GetPdfText(string html)
         {
             var generator = new PdfGenerator();
-            var doc = await generator.GeneratePdf(html, PageSize.A4);
+            var config = new PdfGenerateConfig { PageSize = PageSize.A4, CompressContentStreams = false };
+            config.SetMargins(20);
+            var doc = await generator.GeneratePdf(html, config);
             var ms = new MemoryStream();
             doc.Save(ms);
             return Encoding.Latin1.GetString(ms.ToArray());

--- a/src/PeachPDF.Tests/Integration/BorderRadiusIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/BorderRadiusIntegrationTests.cs
@@ -1,0 +1,191 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore.Drawing;
+
+namespace PeachPDF.Tests.Integration
+{
+    public class BorderRadiusIntegrationTests
+    {
+        // --- Circular radii (symmetric X = Y) ---
+
+        [Fact]
+        public async Task BorderRadius_Shorthand_SetsAllCorners()
+        {
+            var divBox = await FindDivBox("border-radius: 10px; border: 1px solid black;");
+
+            Assert.Equal(10.0, divBox.ActualBorderTopLeftRadiusX);
+            Assert.Equal(10.0, divBox.ActualBorderTopLeftRadiusY);
+            Assert.Equal(10.0, divBox.ActualBorderTopRightRadiusX);
+            Assert.Equal(10.0, divBox.ActualBorderTopRightRadiusY);
+            Assert.Equal(10.0, divBox.ActualBorderBottomRightRadiusX);
+            Assert.Equal(10.0, divBox.ActualBorderBottomRightRadiusY);
+            Assert.Equal(10.0, divBox.ActualBorderBottomLeftRadiusX);
+            Assert.Equal(10.0, divBox.ActualBorderBottomLeftRadiusY);
+            Assert.True(divBox.IsRounded);
+        }
+
+        [Fact]
+        public async Task BorderRadius_TwoValues_SetsOpposingCorners()
+        {
+            var divBox = await FindDivBox("border-radius: 10px 20px;");
+
+            Assert.Equal(10.0, divBox.ActualBorderTopLeftRadiusX);
+            Assert.Equal(20.0, divBox.ActualBorderTopRightRadiusX);
+            Assert.Equal(10.0, divBox.ActualBorderBottomRightRadiusX);
+            Assert.Equal(20.0, divBox.ActualBorderBottomLeftRadiusX);
+        }
+
+        [Fact]
+        public async Task BorderRadius_FourValues_SetsAllCornersIndividually()
+        {
+            var divBox = await FindDivBox("border-radius: 5px 10px 15px 20px;");
+
+            Assert.Equal(5.0, divBox.ActualBorderTopLeftRadiusX);
+            Assert.Equal(10.0, divBox.ActualBorderTopRightRadiusX);
+            Assert.Equal(15.0, divBox.ActualBorderBottomRightRadiusX);
+            Assert.Equal(20.0, divBox.ActualBorderBottomLeftRadiusX);
+        }
+
+        [Fact]
+        public async Task BorderTopLeftRadius_Longhand_SetsOnlyTopLeft()
+        {
+            var divBox = await FindDivBox("border-top-left-radius: 12px;");
+
+            Assert.Equal(12.0, divBox.ActualBorderTopLeftRadiusX);
+            Assert.Equal(12.0, divBox.ActualBorderTopLeftRadiusY);
+            Assert.Equal(0.0, divBox.ActualBorderTopRightRadiusX);
+            Assert.Equal(0.0, divBox.ActualBorderBottomRightRadiusX);
+            Assert.Equal(0.0, divBox.ActualBorderBottomLeftRadiusX);
+            Assert.True(divBox.IsRounded);
+        }
+
+        [Fact]
+        public async Task BorderRadius_Zero_IsNotRounded()
+        {
+            var divBox = await FindDivBox("");
+            Assert.False(divBox.IsRounded);
+        }
+
+        // --- Elliptical radii (X ≠ Y) ---
+
+        [Fact]
+        public async Task BorderRadius_EllipticalShorthand_SetsAllCornersXAndY()
+        {
+            // border-radius: 40px / 15px → each corner: X=40, Y=15
+            var divBox = await FindDivBox("border-radius: 40px / 15px;");
+
+            Assert.Equal(40.0, divBox.ActualBorderTopLeftRadiusX);
+            Assert.Equal(15.0, divBox.ActualBorderTopLeftRadiusY);
+            Assert.Equal(40.0, divBox.ActualBorderTopRightRadiusX);
+            Assert.Equal(15.0, divBox.ActualBorderTopRightRadiusY);
+            Assert.Equal(40.0, divBox.ActualBorderBottomRightRadiusX);
+            Assert.Equal(15.0, divBox.ActualBorderBottomRightRadiusY);
+            Assert.Equal(40.0, divBox.ActualBorderBottomLeftRadiusX);
+            Assert.Equal(15.0, divBox.ActualBorderBottomLeftRadiusY);
+        }
+
+        [Fact]
+        public async Task BorderTopLeftRadius_Longhand_EllipticalValues()
+        {
+            // border-top-left-radius: 15px 25px → X=15, Y=25
+            var divBox = await FindDivBox("border-top-left-radius: 15px 25px;");
+
+            Assert.Equal(15.0, divBox.ActualBorderTopLeftRadiusX);
+            Assert.Equal(25.0, divBox.ActualBorderTopLeftRadiusY);
+            Assert.Equal(0.0, divBox.ActualBorderTopRightRadiusX);
+        }
+
+        // --- Percentage values ---
+
+        [Fact]
+        public async Task BorderRadius_Percentage_ResolvesRelativeToDimensions()
+        {
+            // 200px × 100px box; border-radius: 50% → X = 50% of 200 = 100, Y = 50% of 100 = 50
+            var html = @"<!DOCTYPE html><html><head><style>
+div { width: 200px; height: 100px; border-radius: 50%; }
+</style></head><body><div></div></body></html>";
+
+            var divBox = await FindDivBoxFromHtml(html);
+
+            Assert.Equal(100.0, divBox.ActualBorderTopLeftRadiusX, 1);
+            Assert.Equal(50.0, divBox.ActualBorderTopLeftRadiusY, 1);
+        }
+
+        // --- Overlapping radii reduction ---
+
+        [Fact]
+        public async Task BorderRadius_OverlappingRadii_AreReducedProportionally()
+        {
+            // 100px × 100px box; border-radius: 60px — adjacent radii sum to 120 > 100,
+            // so all must scale by 100/120 ≈ 0.833, giving ~50px at the boundary.
+            var html = @"<!DOCTYPE html><html><head><style>
+div { width: 100px; height: 100px; border-radius: 60px; }
+</style></head><body><div></div></body></html>";
+
+            var divBox = await FindDivBoxFromHtml(html);
+            var radii = divBox.ComputeRadii(new PeachPDF.Html.Adapters.Entities.RRect(0, 0, 100, 100));
+
+            // After reduction TLX + TRX must equal 100 (the width), so each ≈ 50.
+            Assert.Equal(100.0, radii.TLX + radii.TRX, 2);
+            Assert.Equal(100.0, radii.BLX + radii.BRX, 2);
+            Assert.Equal(100.0, radii.TLY + radii.BLY, 2);
+            Assert.Equal(100.0, radii.TRY + radii.BRY, 2);
+        }
+
+        [Fact]
+        public async Task BorderRadius_NonOverlappingRadii_AreNotChanged()
+        {
+            // 200px × 200px box; border-radius: 30px — 30+30=60 < 200, no reduction.
+            var html = @"<!DOCTYPE html><html><head><style>
+div { width: 200px; height: 200px; border-radius: 30px; }
+</style></head><body><div></div></body></html>";
+
+            var divBox = await FindDivBoxFromHtml(html);
+            var radii = divBox.ComputeRadii(new PeachPDF.Html.Adapters.Entities.RRect(0, 0, 200, 200));
+
+            Assert.Equal(30.0, radii.TLX, 2);
+            Assert.Equal(30.0, radii.TLY, 2);
+        }
+
+        // --- Helpers ---
+
+        private Task<CssBox> FindDivBox(string css)
+        {
+            var html = $@"<!DOCTYPE html><html><head><style>
+div {{ width: 200px; height: 100px; {css} }}
+</style></head><body><div></div></body></html>";
+            return FindDivBoxFromHtml(html);
+        }
+
+        private async Task<CssBox> FindDivBoxFromHtml(string html)
+        {
+            var adapter = new PdfSharpAdapter();
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            var size = new XSize(595, 842);
+            container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+            container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+            var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            return FindByTag(container.Root!, "div")!;
+        }
+
+        private static CssBox? FindByTag(CssBox box, string tag)
+        {
+            if (box.HtmlTag?.Name.Equals(tag, StringComparison.OrdinalIgnoreCase) == true)
+                return box;
+            foreach (var child in box.Boxes)
+            {
+                var found = FindByTag(child, tag);
+                if (found != null) return found;
+            }
+            return null;
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/OverflowClipIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/OverflowClipIntegrationTests.cs
@@ -1,0 +1,189 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore;
+using PeachPDF.PdfSharpCore.Drawing;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Verifies that overflow:hidden clips at the CSS padding edge, not the content edge.
+    ///
+    /// The bug: table cells inherit overflow:hidden from the PeachPDF default stylesheet.
+    /// The old clip used ClientRectangle (content-box) which was occasionally too narrow for
+    /// child elements that fill the content area, causing border-radius arcs to be cut off.
+    /// The fix expands the clip to the padding-box (ClientRectangle + ActualPadding*).
+    /// </summary>
+    public class OverflowClipIntegrationTests
+    {
+        // --- Geometry tests (verify clip bounds after layout) ---
+
+        [Fact]
+        public async Task OverflowHidden_WithPadding_ChildBoundsWithinPaddingBoxClip()
+        {
+            // Container: overflow:hidden, padding:10px, 100px content width.
+            // Child fills the content area.
+            // New clip right = ClientRight + ActualPaddingRight (= padding-box right).
+            var html = @"<!DOCTYPE html><html><head><style>
+body { margin: 0; }
+.outer { overflow: hidden; padding: 10px; width: 100px; height: 100px; }
+.inner { height: 80px; border-radius: 20px; }
+</style></head><body><div class='outer'><div class='inner'></div></div></body></html>";
+
+            var root = await GetRootBox(html);
+            var outer = FindFirst(root, b => b.HtmlTag?.Name == "div" && b.Overflow == "hidden");
+            var inner = FindFirst(outer!, b => b.HtmlTag?.Name == "div" && b != outer);
+
+            Assert.NotNull(outer);
+            Assert.NotNull(inner);
+
+            var paddingBoxRight = outer!.ClientRight + outer.ActualPaddingRight;
+
+            Assert.True(inner!.ActualRight <= paddingBoxRight,
+                $"Child right ({inner.ActualRight:F3}) exceeds padding-box clip right ({paddingBoxRight:F3})");
+        }
+
+        [Fact]
+        public async Task RoundedBoxInTableCell_NonUniformRadius_BoundsWithinPaddingBoxClip()
+        {
+            // Reproduces the original bug: td gets overflow:hidden from the default stylesheet.
+            // The div with a non-uniform border-radius (10px 30px) fills the td content area.
+            // Its right edge must fit within the td's padding-box clip.
+            var html = @"<!DOCTYPE html><html><head><style>
+body { margin: 0; }
+table { border-collapse: collapse; width: 300px; }
+td { padding: 3px; }
+</style></head><body>
+<table><tr>
+  <td><div style='border-radius: 10px 30px; height: 60px; border: 2px solid black;'></div></td>
+</tr></table>
+</body></html>";
+
+            var root = await GetRootBox(html);
+            var td = FindFirst(root, b => b.HtmlTag?.Name == "td");
+            var div = FindFirst(td!, b => b.HtmlTag?.Name == "div");
+
+            Assert.NotNull(td);
+            Assert.NotNull(div);
+
+            // td has overflow:hidden from the PeachPDF default stylesheet
+            Assert.Equal("hidden", td!.Overflow);
+
+            var paddingBoxRight = td.ClientRight + td.ActualPaddingRight;
+
+            Assert.True(div!.ActualRight <= paddingBoxRight,
+                $"Div right ({div.ActualRight:F3}) exceeds padding-box clip right ({paddingBoxRight:F3})");
+        }
+
+        [Fact]
+        public async Task RoundedBoxInTableCell_FourValueRadius_BoundsWithinPaddingBoxClip()
+        {
+            var html = @"<!DOCTYPE html><html><head><style>
+body { margin: 0; }
+table { border-collapse: collapse; width: 300px; }
+td { padding: 3px; }
+</style></head><body>
+<table><tr>
+  <td><div style='border-radius: 5px 15px 30px 45px; height: 60px; border: 2px solid black;'></div></td>
+</tr></table>
+</body></html>";
+
+            var root = await GetRootBox(html);
+            var td = FindFirst(root, b => b.HtmlTag?.Name == "td");
+            var div = FindFirst(td!, b => b.HtmlTag?.Name == "div");
+
+            Assert.NotNull(td);
+            Assert.NotNull(div);
+
+            var paddingBoxRight = td!.ClientRight + td.ActualPaddingRight;
+
+            Assert.True(div!.ActualRight <= paddingBoxRight,
+                $"Div right ({div.ActualRight:F3}) exceeds padding-box clip right ({paddingBoxRight:F3})");
+        }
+
+        [Fact]
+        public async Task OverflowHidden_ZeroPadding_ClipEqualsContentBox()
+        {
+            // When padding is 0, padding-box == content-box.
+            // The clip right should equal ClientRight (no expansion).
+            var html = @"<!DOCTYPE html><html><head><style>
+body { margin: 0; }
+.outer { overflow: hidden; padding: 0; width: 100px; height: 100px; }
+.inner { height: 80px; }
+</style></head><body><div class='outer'><div class='inner'></div></div></body></html>";
+
+            var root = await GetRootBox(html);
+            var outer = FindFirst(root, b => b.HtmlTag?.Name == "div" && b.Overflow == "hidden");
+            var inner = FindFirst(outer!, b => b.HtmlTag?.Name == "div" && b != outer);
+
+            Assert.NotNull(outer);
+            Assert.NotNull(inner);
+
+            // Zero padding: padding-box right = ClientRight + 0 = ClientRight
+            Assert.Equal(0.0, outer!.ActualPaddingRight, 3);
+            var paddingBoxRight = outer.ClientRight + outer.ActualPaddingRight;
+            Assert.Equal(outer.ClientRight, paddingBoxRight, 3);
+
+            // Child still fits
+            Assert.True(inner!.ActualRight <= paddingBoxRight + 0.01,
+                $"Child right ({inner.ActualRight:F3}) exceeds content-box clip right ({paddingBoxRight:F3})");
+        }
+
+        // --- Smoke tests (PDF generation must not throw) ---
+
+        [Fact]
+        public async Task RoundedBoxInTableCell_MultipleRadii_GeneratesPdf()
+        {
+            var html = @"<!DOCTYPE html><html><head><style>
+table { border-collapse: collapse; width: 100%; }
+td { padding: 3px; }
+.rbox { height: 60px; background: steelblue; border: 2px solid #1a6b8a; }
+</style></head><body>
+<table><tr>
+  <td><div class='rbox' style='border-radius: 20px;'></div></td>
+  <td><div class='rbox' style='border-radius: 10px 30px;'></div></td>
+  <td><div class='rbox' style='border-radius: 8px 20px 35px;'></div></td>
+  <td><div class='rbox' style='border-radius: 5px 15px 30px 45px;'></div></td>
+</tr></table>
+</body></html>";
+
+            var generator = new PdfGenerator();
+            var ex = await Record.ExceptionAsync(() => generator.GeneratePdf(html, PageSize.A4));
+            Assert.Null(ex);
+        }
+
+        // --- Helpers ---
+
+        private static CssBox? FindFirst(CssBox box, Func<CssBox, bool> predicate)
+        {
+            if (predicate(box)) return box;
+            foreach (var child in box.Boxes)
+            {
+                var found = FindFirst(child, predicate);
+                if (found != null) return found;
+            }
+            return null;
+        }
+
+        private static async Task<CssBox> GetRootBox(string html)
+        {
+            var adapter = new PdfSharpAdapter();
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            var size = new XSize(595, 842);
+            container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+            container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+            var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            return container.Root!;
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/PageBreakTableIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/PageBreakTableIntegrationTests.cs
@@ -1,0 +1,196 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore;
+using PeachPDF.PdfSharpCore.Drawing;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Verifies table page-break behaviour for single-row tables.
+    ///
+    /// The bug: the per-row page-break check in CssLayoutEngineTable.LayoutCells
+    /// guards with `i &gt; 0`, so single-row tables (always i == 0) never get
+    /// repositioned and their content straddles page boundaries.
+    ///
+    /// The fix adds a pre-check before the row loop: if the first row would cross
+    /// a page boundary AND the entire table body fits on one page, the whole table
+    /// is moved to the next page.
+    /// </summary>
+    public class PageBreakTableIntegrationTests
+    {
+        // A4 at 1:1 point scale: 595 × 842 pt, no margins (test default).
+        private const double PageHeight = 842.0;
+
+        // A spacer this tall pushes the table close enough to the page end to
+        // trigger WillCrossPageBoundary for a typical single-row table height
+        // (~14 pt estimated). Leaves ~8 pt of space, which is less than the estimate.
+        private const double SpacerThatCrossesPage = 833;
+
+        // A spacer this tall leaves plenty of room — no page-break needed.
+        private const double SpacerThatFits = 200;
+
+        [Fact]
+        public async Task SingleRowTable_CrossingPageBoundary_IsMovedToNextPage()
+        {
+            // Single-row table near the end of page 1.
+            // Before the fix: the row content (tall .rbox div) straddled the boundary.
+            // After the fix: the whole table is relocated to page 2.
+            var html = BuildHtml(SpacerThatCrossesPage, rowCount: 1);
+            var (table, _) = await GetTableAndPageHeight(html);
+
+            Assert.NotNull(table);
+            Assert.True(table!.Location.Y >= PageHeight,
+                $"Single-row table should be on page 2 (Y ≥ {PageHeight}) but Y={table.Location.Y:F1}");
+        }
+
+        [Fact]
+        public async Task SingleRowTable_FitsOnCurrentPage_IsNotMoved()
+        {
+            // Table starts well within page 1 — the pre-check guard
+            // (WillCrossPageBoundary returns false) must not move it.
+            var html = BuildHtml(SpacerThatFits, rowCount: 1);
+            var (table, _) = await GetTableAndPageHeight(html);
+
+            Assert.NotNull(table);
+            Assert.True(table!.Location.Y < PageHeight,
+                $"Table that fits should stay on page 1 (Y < {PageHeight}) but Y={table.Location.Y:F1}");
+        }
+
+        [Fact]
+        public async Task MultiRowTable_CrossingPageBoundary_PerRowBreakStillWorks()
+        {
+            // Multi-row table near the end of page 1. The existing per-row page-break
+            // logic (i > 0) should still split the table between pages normally.
+            // We just verify the table generates a PDF without throwing.
+            var html = BuildHtml(SpacerThatCrossesPage, rowCount: 3);
+            var ex = await Record.ExceptionAsync(() =>
+            {
+                var generator = new PdfGenerator();
+                return generator.GeneratePdf(html, PageSize.A4);
+            });
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public async Task SingleRowTable_WithRoundedBoxes_GeneratesPdf()
+        {
+            // Reproduces the "6 — Combined Styles" section from the border-radius
+            // test harness: a single-row table with tall .rbox content near the bottom
+            // of a page full of preceding sections.
+            const string html = """
+                <!DOCTYPE html><html><head><style>
+                @page { size: a4; margin: 15mm }
+                body { font: 8.5pt Arial, sans-serif; margin: 0 }
+                h2 { font-size: 10pt; margin: 0.9em 0 0.3em; padding-bottom: 2px; border-bottom: 1px solid #999 }
+                table.sw { border-collapse: collapse; width: 100%; margin-bottom: 0.3em }
+                table.sw td { padding: 3px; vertical-align: top; width: 25% }
+                .rbox { height: 60px; background: steelblue; border: 2px solid #1a6b8a; margin-bottom: 3px }
+                .desc { font-size: 7pt; font-weight: bold; color: #444; margin-bottom: 1px }
+                .css  { font-size: 6pt; color: #666; line-height: 1.3; word-break: break-all }
+                </style></head><body>
+                <h2>1</h2><table class="sw"><tr>
+                  <td><div class="rbox" style="border-radius:20px"></div><div class="desc">a</div><div class="css">a</div></td>
+                  <td><div class="rbox" style="border-radius:10px 30px"></div><div class="desc">b</div><div class="css">b</div></td>
+                  <td><div class="rbox" style="border-radius:8px 20px 35px"></div><div class="desc">c</div><div class="css">c</div></td>
+                  <td><div class="rbox" style="border-radius:5px 15px 30px 45px"></div><div class="desc">d</div><div class="css">d</div></td>
+                </tr></table>
+                <h2>2</h2><table class="sw"><tr>
+                  <td><div class="rbox" style="border-top-left-radius:30px"></div><div class="desc">a</div><div class="css">a</div></td>
+                  <td><div class="rbox" style="border-bottom-right-radius:30px"></div><div class="desc">b</div><div class="css">b</div></td>
+                  <td><div class="rbox" style="border-top-left-radius:25px;border-bottom-right-radius:25px"></div><div class="desc">c</div><div class="css">c</div></td>
+                  <td><div class="rbox" style="border-top-left-radius:10px;border-top-right-radius:20px;border-bottom-right-radius:30px;border-bottom-left-radius:15px"></div><div class="desc">d</div><div class="css">d</div></td>
+                </tr></table>
+                <h2>3</h2><table class="sw"><tr>
+                  <td><div class="rbox" style="border-radius:40px/10px"></div><div class="desc">a</div><div class="css">a</div></td>
+                  <td><div class="rbox" style="border-radius:10px/40px"></div><div class="desc">b</div><div class="css">b</div></td>
+                  <td><div class="rbox" style="border-radius:30px/20px"></div><div class="desc">c</div><div class="css">c</div></td>
+                  <td><div class="rbox" style="border-radius:20px 0/0 20px"></div><div class="desc">d</div><div class="css">d</div></td>
+                </tr></table>
+                <h2>4</h2><table class="sw"><tr>
+                  <td><div class="rbox" style="border-radius:50%"></div><div class="desc">a</div><div class="css">a</div></td>
+                  <td><div class="rbox" style="border-radius:25%"></div><div class="desc">b</div><div class="css">b</div></td>
+                  <td><div class="rbox" style="border-radius:50%/25%"></div><div class="desc">c</div><div class="css">c</div></td>
+                  <td><div class="rbox" style="border-radius:25%/50%"></div><div class="desc">d</div><div class="css">d</div></td>
+                </tr></table>
+                <h2>5</h2><table class="sw"><tr>
+                  <td><div class="rbox" style="width:80px;border-radius:60px"></div><div class="desc">a</div><div class="css">a</div></td>
+                  <td><div class="rbox" style="width:80px;border-radius:100px"></div><div class="desc">b</div><div class="css">b</div></td>
+                  <td><div class="rbox" style="width:80px;height:80px;border-radius:50%"></div><div class="desc">c</div><div class="css">c</div></td>
+                  <td><div class="rbox" style="width:80px;border-radius:20px"></div><div class="desc">d</div><div class="css">d</div></td>
+                </tr></table>
+                <h2>6 — Combined Styles</h2><table class="sw"><tr>
+                  <td><div class="rbox" style="border-radius:15px"></div><div class="desc">solid border + bg</div><div class="css">border-radius: 15px</div></td>
+                  <td><div class="rbox" style="border-style:dashed;border-radius:15px"></div><div class="desc">dashed border</div><div class="css">border-radius: 15px</div></td>
+                  <td><div class="rbox" style="border-style:dotted;border-radius:15px"></div><div class="desc">dotted border</div><div class="css">border-radius: 15px</div></td>
+                  <td><div class="rbox" style="border:none;border-radius:15px"></div><div class="desc">no border, bg only</div><div class="css">border-radius: 15px</div></td>
+                </tr></table>
+                </body></html>
+                """;
+
+            var generator = new PdfGenerator();
+            var ex = await Record.ExceptionAsync(() => generator.GeneratePdf(html, PageSize.A4));
+            Assert.Null(ex);
+        }
+
+        // --- Helpers ---
+
+        private static string BuildHtml(double spacerHeight, int rowCount)
+        {
+            var rows = new System.Text.StringBuilder();
+            for (var r = 0; r < rowCount; r++)
+            {
+                rows.Append("<tr>");
+                rows.Append("<td><div class='rbox'></div></td>");
+                rows.Append("<td><div class='rbox'></div></td>");
+                rows.Append("</tr>");
+            }
+
+            return $$"""
+                <!DOCTYPE html><html><head><style>
+                body { margin: 0; }
+                .spacer { height: {{spacerHeight}}px; }
+                table { border-collapse: collapse; width: 100%; }
+                td { padding: 3px; }
+                .rbox { height: 60px; }
+                </style></head><body>
+                <div class='spacer'></div>
+                <table>{{rows}}</table>
+                </body></html>
+                """;
+        }
+
+        private static async Task<(CssBox? table, double pageHeight)> GetTableAndPageHeight(string html)
+        {
+            var adapter = new PdfSharpAdapter();
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            var size = new XSize(595, PageHeight);
+            container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+            container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+            var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            var table = FindFirst(container.Root!, b => b.Display == "table");
+            return (table, container.PageSize.Height);
+        }
+
+        private static CssBox? FindFirst(CssBox box, Func<CssBox, bool> predicate)
+        {
+            if (predicate(box)) return box;
+            foreach (var child in box.Boxes)
+            {
+                var found = FindFirst(child, predicate);
+                if (found != null) return found;
+            }
+            return null;
+        }
+    }
+}

--- a/src/PeachPDF/Adapters/GraphicsPathAdapter.cs
+++ b/src/PeachPDF/Adapters/GraphicsPathAdapter.cs
@@ -51,11 +51,11 @@ namespace PeachPDF.Adapters
             _lastPoint = new RPoint(x, y);
         }
 
-        public override void ArcTo(double x, double y, double size, Corner corner)
+        public override void ArcTo(double x, double y, double radiusX, double radiusY, Corner corner)
         {
-            float left = (float)(Math.Min(x, _lastPoint.X) - (corner == Corner.TopRight || corner == Corner.BottomRight ? size : 0));
-            float top = (float)(Math.Min(y, _lastPoint.Y) - (corner == Corner.BottomLeft || corner == Corner.BottomRight ? size : 0));
-            _graphicsPath.AddArc(left, top, (float)size * 2, (float)size * 2, GetStartAngle(corner), 90);
+            float left = (float)(Math.Min(x, _lastPoint.X) - (corner == Corner.TopRight || corner == Corner.BottomRight ? radiusX : 0));
+            float top = (float)(Math.Min(y, _lastPoint.Y) - (corner == Corner.BottomLeft || corner == Corner.BottomRight ? radiusY : 0));
+            _graphicsPath.AddArc(left, top, (float)radiusX * 2, (float)radiusY * 2, GetStartAngle(corner), 90);
             _lastPoint = new RPoint(x, y);
         }
 

--- a/src/PeachPDF/Html/Adapters/RGraphicsPath.cs
+++ b/src/PeachPDF/Html/Adapters/RGraphicsPath.cs
@@ -30,9 +30,14 @@ namespace PeachPDF.Html.Adapters
         public abstract void LineTo(double x, double y);
 
         /// <summary>
+        /// Add elliptical arc with separate horizontal and vertical radii to the given point.
+        /// </summary>
+        public abstract void ArcTo(double x, double y, double radiusX, double radiusY, Corner corner);
+
+        /// <summary>
         /// Add circular arc of the given size to the given point from the last point.
         /// </summary>
-        public abstract void ArcTo(double x, double y, double size, Corner corner);
+        public void ArcTo(double x, double y, double size, Corner corner) => ArcTo(x, y, size, size, corner);
 
         /// <summary>
         /// Release path resources.

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -1631,7 +1631,10 @@ namespace PeachPDF.Html.Core.Dom
                     RGraphicsPath? roundrect = null;
                     if (IsRounded)
                     {
-                        roundrect = RenderUtils.GetRoundRect(g, rect, ActualCornerNw, ActualCornerNe, ActualCornerSe, ActualCornerSw);
+                        var radii = ComputeRadii(rect);
+                        roundrect = RenderUtils.GetRoundRect(g, rect,
+                            radii.TLX, radii.TLY, radii.TRX, radii.TRY,
+                            radii.BRX, radii.BRY, radii.BLX, radii.BLY);
                     }
 
                     Object? prevMode = null;

--- a/src/PeachPDF/Html/Core/Dom/CssBoxProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBoxProperties.cs
@@ -16,6 +16,7 @@ using PeachPDF.Html.Adapters.Entities;
 using PeachPDF.Html.Core.Entities;
 using PeachPDF.Html.Core.Parse;
 using PeachPDF.Html.Core.Utils;
+using System;
 using System.Globalization;
 
 namespace PeachPDF.Html.Core.Dom
@@ -41,7 +42,6 @@ namespace PeachPDF.Html.Core.Dom
         private string _borderLeftColor = "black";
         private string? _bottom;
         private string _color = "black";
-        private string _cornerRadius = "0";
         private string _fontSize = "medium";
         private string _paddingLeft = "0";
         private string _paddingBottom = "0";
@@ -56,10 +56,14 @@ namespace PeachPDF.Html.Core.Dom
 
         #region Fields
 
-        private double _actualCornerNw = double.NaN;
-        private double _actualCornerNe = double.NaN;
-        private double _actualCornerSw = double.NaN;
-        private double _actualCornerSe = double.NaN;
+        private double _actualBorderTopLeftRadiusX = double.NaN;
+        private double _actualBorderTopLeftRadiusY = double.NaN;
+        private double _actualBorderTopRightRadiusX = double.NaN;
+        private double _actualBorderTopRightRadiusY = double.NaN;
+        private double _actualBorderBottomRightRadiusX = double.NaN;
+        private double _actualBorderBottomRightRadiusY = double.NaN;
+        private double _actualBorderBottomLeftRadiusX = double.NaN;
+        private double _actualBorderBottomLeftRadiusY = double.NaN;
         private RColor _actualColor = RColor.Empty;
         private double _actualPaddingTop = double.NaN;
         private double _actualPaddingBottom = double.NaN;
@@ -184,51 +188,88 @@ namespace PeachPDF.Html.Core.Dom
         public string BorderCollapse { get; set; } = "separate";
         public string BoxSizing { get; set; } = CssConstants.ContentBox;
 
-        public string CornerRadius
+        public string BorderRadius
         {
-            get => _cornerRadius;
             set
             {
-                var r = RegexParserUtils.CssLengthRegex().Matches(value);
+                var slash = value.IndexOf('/');
+                var hGroup = (slash >= 0 ? value[..slash] : value).Trim();
+                var vGroup = slash >= 0 ? value[(slash + 1)..].Trim() : hGroup;
 
-                switch (r.Count)
-                {
-                    case 1:
-                        CornerNeRadius = r[0].Value;
-                        CornerNwRadius = r[0].Value;
-                        CornerSeRadius = r[0].Value;
-                        CornerSwRadius = r[0].Value;
-                        break;
-                    case 2:
-                        CornerNeRadius = r[0].Value;
-                        CornerNwRadius = r[0].Value;
-                        CornerSeRadius = r[1].Value;
-                        CornerSwRadius = r[1].Value;
-                        break;
-                    case 3:
-                        CornerNeRadius = r[0].Value;
-                        CornerNwRadius = r[1].Value;
-                        CornerSeRadius = r[2].Value;
-                        break;
-                    case 4:
-                        CornerNeRadius = r[0].Value;
-                        CornerNwRadius = r[1].Value;
-                        CornerSeRadius = r[2].Value;
-                        CornerSwRadius = r[3].Value;
-                        break;
-                }
+                var h = ExpandRadiusShorthand(hGroup);
+                var v = ExpandRadiusShorthand(vGroup);
 
-                _cornerRadius = value;
+                // Store each corner as "hValue vValue" so the computed properties
+                // can extract both axes independently.
+                BorderTopLeftRadius = $"{h[0]} {v[0]}";
+                BorderTopRightRadius = $"{h[1]} {v[1]}";
+                BorderBottomRightRadius = $"{h[2]} {v[2]}";
+                BorderBottomLeftRadius = $"{h[3]} {v[3]}";
             }
         }
 
-        public string CornerNwRadius { get; set; } = "0";
+        // Expands a 1–4 value group into [TL, TR, BR, BL] per CSS shorthand rules.
+        private static string[] ExpandRadiusShorthand(string group)
+        {
+            var tokens = group.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+            return tokens.Length switch
+            {
+                1 => [tokens[0], tokens[0], tokens[0], tokens[0]],
+                2 => [tokens[0], tokens[1], tokens[0], tokens[1]],
+                3 => [tokens[0], tokens[1], tokens[2], tokens[1]],
+                4 => [tokens[0], tokens[1], tokens[2], tokens[3]],
+                _ => ["0", "0", "0", "0"]
+            };
+        }
 
-        public string CornerNeRadius { get; set; } = "0";
+        private string _borderTopLeftRadius = "0";
+        private string _borderTopRightRadius = "0";
+        private string _borderBottomRightRadius = "0";
+        private string _borderBottomLeftRadius = "0";
 
-        public string CornerSeRadius { get; set; } = "0";
+        public string BorderTopLeftRadius
+        {
+            get => _borderTopLeftRadius;
+            set
+            {
+                _borderTopLeftRadius = value;
+                _actualBorderTopLeftRadiusX = double.NaN;
+                _actualBorderTopLeftRadiusY = double.NaN;
+            }
+        }
 
-        public string CornerSwRadius { get; set; } = "0";
+        public string BorderTopRightRadius
+        {
+            get => _borderTopRightRadius;
+            set
+            {
+                _borderTopRightRadius = value;
+                _actualBorderTopRightRadiusX = double.NaN;
+                _actualBorderTopRightRadiusY = double.NaN;
+            }
+        }
+
+        public string BorderBottomRightRadius
+        {
+            get => _borderBottomRightRadius;
+            set
+            {
+                _borderBottomRightRadius = value;
+                _actualBorderBottomRightRadiusX = double.NaN;
+                _actualBorderBottomRightRadiusY = double.NaN;
+            }
+        }
+
+        public string BorderBottomLeftRadius
+        {
+            get => _borderBottomLeftRadius;
+            set
+            {
+                _borderBottomLeftRadius = value;
+                _actualBorderBottomLeftRadiusX = double.NaN;
+                _actualBorderBottomLeftRadiusY = double.NaN;
+            }
+        }
         public string CounterIncrement { get; set; } = CssConstants.None;
         public string CounterReset { get; set; } = CssConstants.None;
         public string CounterSet { get; set; } = CssConstants.None;
@@ -768,70 +809,133 @@ namespace PeachPDF.Html.Core.Dom
             }
         }
 
-        /// <summary>
-        /// Gets the actual length of the north west corner
-        /// </summary>
-        public double ActualCornerNw
+        public double ActualBorderTopLeftRadiusX
         {
             get
             {
-                if (double.IsNaN(_actualCornerNw))
-                {
-                    _actualCornerNw = CssValueParser.ParseLength(CornerNwRadius, 0, this);
-                }
-                return _actualCornerNw;
+                if (double.IsNaN(_actualBorderTopLeftRadiusX))
+                    _actualBorderTopLeftRadiusX = CssValueParser.ParseLength(FirstCssValue(BorderTopLeftRadius), ActualBoxSizingWidth, this);
+                return _actualBorderTopLeftRadiusX;
             }
         }
 
-        /// <summary>
-        /// Gets the actual length of the north east corner
-        /// </summary>
-        public double ActualCornerNe
+        public double ActualBorderTopLeftRadiusY
         {
             get
             {
-                if (double.IsNaN(_actualCornerNe))
-                {
-                    _actualCornerNe = CssValueParser.ParseLength(CornerNeRadius, 0, this);
-                }
-                return _actualCornerNe;
+                if (double.IsNaN(_actualBorderTopLeftRadiusY))
+                    _actualBorderTopLeftRadiusY = CssValueParser.ParseLength(SecondCssValue(BorderTopLeftRadius), ActualBoxSizingHeight, this);
+                return _actualBorderTopLeftRadiusY;
             }
         }
 
-        /// <summary>
-        /// Gets the actual length of the south east corner
-        /// </summary>
-        public double ActualCornerSe
+        public double ActualBorderTopRightRadiusX
         {
             get
             {
-                if (double.IsNaN(_actualCornerSe))
-                {
-                    _actualCornerSe = CssValueParser.ParseLength(CornerSeRadius, 0, this);
-                }
-                return _actualCornerSe;
+                if (double.IsNaN(_actualBorderTopRightRadiusX))
+                    _actualBorderTopRightRadiusX = CssValueParser.ParseLength(FirstCssValue(BorderTopRightRadius), ActualBoxSizingWidth, this);
+                return _actualBorderTopRightRadiusX;
             }
         }
 
-        /// <summary>
-        /// Gets the actual length of the south west corner
-        /// </summary>
-        public double ActualCornerSw
+        public double ActualBorderTopRightRadiusY
         {
             get
             {
-                if (double.IsNaN(_actualCornerSw))
-                {
-                    _actualCornerSw = CssValueParser.ParseLength(CornerSwRadius, 0, this);
-                }
-                return _actualCornerSw;
+                if (double.IsNaN(_actualBorderTopRightRadiusY))
+                    _actualBorderTopRightRadiusY = CssValueParser.ParseLength(SecondCssValue(BorderTopRightRadius), ActualBoxSizingHeight, this);
+                return _actualBorderTopRightRadiusY;
             }
         }
 
+        public double ActualBorderBottomRightRadiusX
+        {
+            get
+            {
+                if (double.IsNaN(_actualBorderBottomRightRadiusX))
+                    _actualBorderBottomRightRadiusX = CssValueParser.ParseLength(FirstCssValue(BorderBottomRightRadius), ActualBoxSizingWidth, this);
+                return _actualBorderBottomRightRadiusX;
+            }
+        }
+
+        public double ActualBorderBottomRightRadiusY
+        {
+            get
+            {
+                if (double.IsNaN(_actualBorderBottomRightRadiusY))
+                    _actualBorderBottomRightRadiusY = CssValueParser.ParseLength(SecondCssValue(BorderBottomRightRadius), ActualBoxSizingHeight, this);
+                return _actualBorderBottomRightRadiusY;
+            }
+        }
+
+        public double ActualBorderBottomLeftRadiusX
+        {
+            get
+            {
+                if (double.IsNaN(_actualBorderBottomLeftRadiusX))
+                    _actualBorderBottomLeftRadiusX = CssValueParser.ParseLength(FirstCssValue(BorderBottomLeftRadius), ActualBoxSizingWidth, this);
+                return _actualBorderBottomLeftRadiusX;
+            }
+        }
+
+        public double ActualBorderBottomLeftRadiusY
+        {
+            get
+            {
+                if (double.IsNaN(_actualBorderBottomLeftRadiusY))
+                    _actualBorderBottomLeftRadiusY = CssValueParser.ParseLength(SecondCssValue(BorderBottomLeftRadius), ActualBoxSizingHeight, this);
+                return _actualBorderBottomLeftRadiusY;
+            }
+        }
+
+        // Returns the first whitespace-delimited token in a CSS value string.
+        private static string FirstCssValue(string value)
+        {
+            var space = value.IndexOf(' ');
+            return space < 0 ? value : value[..space];
+        }
+
+        // Returns the second whitespace-delimited token, or the first if there is no second (spec: omitted v-radius = h-radius).
+        private static string SecondCssValue(string value)
+        {
+            var space = value.IndexOf(' ');
+            return space < 0 ? value : value[(space + 1)..].TrimStart();
+        }
+
         /// <summary>
-        /// Gets a value indicating if at least one of the corners of the box is rounded
+        /// Computes overlap-reduced radii for the given rendering rectangle, per CSS spec §4.
+        /// Horizontal and vertical axes are reduced independently.
         /// </summary>
-        public bool IsRounded => ActualCornerNe > 0f || ActualCornerNw > 0f || ActualCornerSe > 0f || ActualCornerSw > 0f;
+        internal BorderRadii ComputeRadii(RRect rect)
+        {
+            double tlX = ActualBorderTopLeftRadiusX,     tlY = ActualBorderTopLeftRadiusY;
+            double trX = ActualBorderTopRightRadiusX,    trY = ActualBorderTopRightRadiusY;
+            double brX = ActualBorderBottomRightRadiusX, brY = ActualBorderBottomRightRadiusY;
+            double blX = ActualBorderBottomLeftRadiusX,  blY = ActualBorderBottomLeftRadiusY;
+
+            // Horizontal reduction: check top side and bottom side independently.
+            double fTop = tlX + trX > 0 && rect.Width > 0 ? rect.Width / (tlX + trX) : 1.0;
+            double fBot = blX + brX > 0 && rect.Width > 0 ? rect.Width / (blX + brX) : 1.0;
+            double fX = Math.Min(1.0, Math.Min(fTop, fBot));
+
+            // Vertical reduction: check left side and right side independently.
+            double fLeft  = tlY + blY > 0 && rect.Height > 0 ? rect.Height / (tlY + blY) : 1.0;
+            double fRight = trY + brY > 0 && rect.Height > 0 ? rect.Height / (trY + brY) : 1.0;
+            double fY = Math.Min(1.0, Math.Min(fLeft, fRight));
+
+            return new BorderRadii(tlX * fX, tlY * fY, trX * fX, trY * fY,
+                                   brX * fX, brY * fY, blX * fX, blY * fY);
+        }
+
+        /// <summary>
+        /// Gets a value indicating if at least one of the corners of the box is rounded.
+        /// </summary>
+        public bool IsRounded =>
+            ActualBorderTopLeftRadiusX > 0 || ActualBorderTopLeftRadiusY > 0 ||
+            ActualBorderTopRightRadiusX > 0 || ActualBorderTopRightRadiusY > 0 ||
+            ActualBorderBottomRightRadiusX > 0 || ActualBorderBottomRightRadiusY > 0 ||
+            ActualBorderBottomLeftRadiusX > 0 || ActualBorderBottomLeftRadiusY > 0;
 
         /// <summary>
         /// Gets the actual width of whitespace between words.
@@ -1160,11 +1264,10 @@ namespace PeachPDF.Html.Core.Dom
             BorderBottomStyle = p.BorderBottomStyle;
             BorderLeftStyle = p.BorderLeftStyle;
             _bottom = p._bottom;
-            CornerNwRadius = p.CornerNwRadius;
-            CornerNeRadius = p.CornerNeRadius;
-            CornerSeRadius = p.CornerSeRadius;
-            CornerSwRadius = p.CornerSwRadius;
-            _cornerRadius = p._cornerRadius;
+            BorderTopLeftRadius = p.BorderTopLeftRadius;
+            BorderTopRightRadius = p.BorderTopRightRadius;
+            BorderBottomRightRadius = p.BorderBottomRightRadius;
+            BorderBottomLeftRadius = p.BorderBottomLeftRadius;
             Display = p.Display;
             Float = p.Float;
             Height = p.Height;
@@ -1190,5 +1293,25 @@ namespace PeachPDF.Html.Core.Dom
             MaxWidth = p.MaxWidth;
             _wordSpacing = p._wordSpacing;
         }
+    }
+
+    /// <summary>
+    /// Holds the eight computed (overlap-reduced) corner radii for a box rectangle.
+    /// </summary>
+    internal readonly struct BorderRadii
+    {
+        public readonly double TLX, TLY, TRX, TRY, BRX, BRY, BLX, BLY;
+
+        public BorderRadii(double tlX, double tlY, double trX, double trY,
+                           double brX, double brY, double blX, double blY)
+        {
+            TLX = tlX; TLY = tlY;
+            TRX = trX; TRY = trY;
+            BRX = brX; BRY = brY;
+            BLX = blX; BLY = blY;
+        }
+
+        public bool IsRounded => TLX > 0 || TLY > 0 || TRX > 0 || TRY > 0 ||
+                                 BRX > 0 || BRY > 0 || BLX > 0 || BLY > 0;
     }
 }

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
@@ -745,6 +745,33 @@ namespace PeachPDF.Html.Core.Dom
                 ? (int)((startY - marginTop) / pageHeight)
                 : 0;
 
+            // Pre-check: move the entire table to the next page when the first body row
+            // would cross a page boundary AND the full table body fits on one page.
+            // The per-row page-break check uses `i > 0` so it never fires for single-row
+            // tables; this pre-check handles that case by adjusting the table's location.
+            // Restricted to tables without repeating headers/footers to avoid repositioning
+            // proxy boxes that were already placed above.
+            if (_bodyRows.Count > 0
+                && pageHeight < double.MaxValue - 1
+                && _tableBox.HtmlContainer != null
+                && !_shouldRepeatHeaders
+                && !_shouldRepeatFooters)
+            {
+                var firstRowHeight = EstimateRowHeight(_bodyRows[0]);
+                var availableHeight = pageHeight - _footerHeight - marginTop - marginBottom;
+                var estimatedBodyHeight = _bodyRows.Sum(EstimateRowHeight);
+
+                if (WillCrossPageBoundary(currentY, currentY + firstRowHeight, pageHeight, marginTop, availableHeight, currentPageNumber)
+                    && estimatedBodyHeight <= availableHeight)
+                {
+                    var pageBreakOffset = CalculatePageBreakOffset(currentY, pageHeight, marginTop, marginBottom, currentPageNumber);
+                    _tableBox.Location = _tableBox.Location with { Y = _tableBox.Location.Y + pageBreakOffset };
+                    startY = Math.Max(_tableBox.ClientTop + GetVerticalSpacing(), 0);
+                    currentY = startY;
+                    currentPageNumber = (int)((startY - marginTop) / pageHeight);
+                }
+            }
+
             Dictionary<int, List<CssBox>> rowSpannedBoxes = new();
 
             for (var i = 0; i < _bodyRows.Count; i++)

--- a/src/PeachPDF/Html/Core/Handlers/BordersDrawHandler.cs
+++ b/src/PeachPDF/Html/Core/Handlers/BordersDrawHandler.cs
@@ -202,73 +202,62 @@ namespace PeachPDF.Html.Core.Handlers
         /// <returns>Beveled border path, null if there is no rounded corners</returns>
         private static RGraphicsPath? GetRoundedBorderPath(RGraphics g, Border border, CssBox b, RRect r)
         {
+            var rad = b.ComputeRadii(r);
+            if (!rad.IsRounded) return null;
+
             RGraphicsPath? path = null;
             switch (border)
             {
                 case Border.Top:
-                    if (b.ActualCornerNw > 0 || b.ActualCornerNe > 0)
+                    if (rad.TLX > 0 || rad.TLY > 0 || rad.TRX > 0 || rad.TRY > 0)
                     {
                         path = g.GetGraphicsPath();
-                        path.Start(r.Left + b.ActualBorderLeftWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + b.ActualCornerNw);
-
-                        if (b.ActualCornerNw > 0)
-                            path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2 + b.ActualCornerNw, r.Top + b.ActualBorderTopWidth / 2, b.ActualCornerNw, RGraphicsPath.Corner.TopLeft);
-
-                        path.LineTo(r.Right - b.ActualBorderRightWidth / 2 - b.ActualCornerNe, r.Top + b.ActualBorderTopWidth / 2);
-
-                        if (b.ActualCornerNe > 0)
-                            path.ArcTo(r.Right - b.ActualBorderRightWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + b.ActualCornerNe, b.ActualCornerNe, RGraphicsPath.Corner.TopRight);
+                        path.Start(r.Left + b.ActualBorderLeftWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + rad.TLY);
+                        if (rad.TLX > 0 || rad.TLY > 0)
+                            path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2 + rad.TLX, r.Top + b.ActualBorderTopWidth / 2, rad.TLX, rad.TLY, RGraphicsPath.Corner.TopLeft);
+                        path.LineTo(r.Right - b.ActualBorderRightWidth / 2 - rad.TRX, r.Top + b.ActualBorderTopWidth / 2);
+                        if (rad.TRX > 0 || rad.TRY > 0)
+                            path.ArcTo(r.Right - b.ActualBorderRightWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + rad.TRY, rad.TRX, rad.TRY, RGraphicsPath.Corner.TopRight);
                     }
                     break;
                 case Border.Bottom:
-                    if (b.ActualCornerSw > 0 || b.ActualCornerSe > 0)
+                    if (rad.BLX > 0 || rad.BLY > 0 || rad.BRX > 0 || rad.BRY > 0)
                     {
                         path = g.GetGraphicsPath();
-                        path.Start(r.Right - b.ActualBorderRightWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - b.ActualCornerSe);
-
-                        if (b.ActualCornerSe > 0)
-                            path.ArcTo(r.Right - b.ActualBorderRightWidth / 2 - b.ActualCornerSe, r.Bottom - b.ActualBorderBottomWidth / 2, b.ActualCornerSe, RGraphicsPath.Corner.BottomRight);
-
-                        path.LineTo(r.Left + b.ActualBorderLeftWidth / 2 + b.ActualCornerSw, r.Bottom - b.ActualBorderBottomWidth / 2);
-
-                        if (b.ActualCornerSw > 0)
-                            path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - b.ActualCornerSw, b.ActualCornerSw, RGraphicsPath.Corner.BottomLeft);
+                        path.Start(r.Right - b.ActualBorderRightWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - rad.BRY);
+                        if (rad.BRX > 0 || rad.BRY > 0)
+                            path.ArcTo(r.Right - b.ActualBorderRightWidth / 2 - rad.BRX, r.Bottom - b.ActualBorderBottomWidth / 2, rad.BRX, rad.BRY, RGraphicsPath.Corner.BottomRight);
+                        path.LineTo(r.Left + b.ActualBorderLeftWidth / 2 + rad.BLX, r.Bottom - b.ActualBorderBottomWidth / 2);
+                        if (rad.BLX > 0 || rad.BLY > 0)
+                            path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - rad.BLY, rad.BLX, rad.BLY, RGraphicsPath.Corner.BottomLeft);
                     }
                     break;
                 case Border.Right:
-                    if (b.ActualCornerNe > 0 || b.ActualCornerSe > 0)
+                    if (rad.TRX > 0 || rad.TRY > 0 || rad.BRX > 0 || rad.BRY > 0)
                     {
                         path = g.GetGraphicsPath();
-
                         bool noTop = b.BorderTopStyle == CssConstants.None || b.BorderTopStyle == CssConstants.Hidden;
                         bool noBottom = b.BorderBottomStyle == CssConstants.None || b.BorderBottomStyle == CssConstants.Hidden;
-                        path.Start(r.Right - b.ActualBorderRightWidth / 2 - (noTop ? b.ActualCornerNe : 0), r.Top + b.ActualBorderTopWidth / 2 + (noTop ? 0 : b.ActualCornerNe));
-
-                        if (b.ActualCornerNe > 0 && noTop)
-                            path.ArcTo(r.Right - b.ActualBorderLeftWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + b.ActualCornerNe, b.ActualCornerNe, RGraphicsPath.Corner.TopRight);
-
-                        path.LineTo(r.Right - b.ActualBorderRightWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - b.ActualCornerSe);
-
-                        if (b.ActualCornerSe > 0 && noBottom)
-                            path.ArcTo(r.Right - b.ActualBorderRightWidth / 2 - b.ActualCornerSe, r.Bottom - b.ActualBorderBottomWidth / 2, b.ActualCornerSe, RGraphicsPath.Corner.BottomRight);
+                        path.Start(r.Right - b.ActualBorderRightWidth / 2 - (noTop ? rad.TRX : 0), r.Top + b.ActualBorderTopWidth / 2 + (noTop ? 0 : rad.TRY));
+                        if ((rad.TRX > 0 || rad.TRY > 0) && noTop)
+                            path.ArcTo(r.Right - b.ActualBorderLeftWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + rad.TRY, rad.TRX, rad.TRY, RGraphicsPath.Corner.TopRight);
+                        path.LineTo(r.Right - b.ActualBorderRightWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - rad.BRY);
+                        if ((rad.BRX > 0 || rad.BRY > 0) && noBottom)
+                            path.ArcTo(r.Right - b.ActualBorderRightWidth / 2 - rad.BRX, r.Bottom - b.ActualBorderBottomWidth / 2, rad.BRX, rad.BRY, RGraphicsPath.Corner.BottomRight);
                     }
                     break;
                 case Border.Left:
-                    if (b.ActualCornerNw > 0 || b.ActualCornerSw > 0)
+                    if (rad.TLX > 0 || rad.TLY > 0 || rad.BLX > 0 || rad.BLY > 0)
                     {
                         path = g.GetGraphicsPath();
-
                         bool noTop = b.BorderTopStyle == CssConstants.None || b.BorderTopStyle == CssConstants.Hidden;
                         bool noBottom = b.BorderBottomStyle == CssConstants.None || b.BorderBottomStyle == CssConstants.Hidden;
-                        path.Start(r.Left + b.ActualBorderLeftWidth / 2 + (noBottom ? b.ActualCornerSw : 0), r.Bottom - b.ActualBorderBottomWidth / 2 - (noBottom ? 0 : b.ActualCornerSw));
-
-                        if (b.ActualCornerSw > 0 && noBottom)
-                            path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - b.ActualCornerSw, b.ActualCornerSw, RGraphicsPath.Corner.BottomLeft);
-
-                        path.LineTo(r.Left + b.ActualBorderLeftWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + b.ActualCornerNw);
-
-                        if (b.ActualCornerNw > 0 && noTop)
-                            path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2 + b.ActualCornerNw, r.Top + b.ActualBorderTopWidth / 2, b.ActualCornerNw, RGraphicsPath.Corner.TopLeft);
+                        path.Start(r.Left + b.ActualBorderLeftWidth / 2 + (noBottom ? rad.BLX : 0), r.Bottom - b.ActualBorderBottomWidth / 2 - (noBottom ? 0 : rad.BLY));
+                        if ((rad.BLX > 0 || rad.BLY > 0) && noBottom)
+                            path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - rad.BLY, rad.BLX, rad.BLY, RGraphicsPath.Corner.BottomLeft);
+                        path.LineTo(r.Left + b.ActualBorderLeftWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + rad.TLY);
+                        if ((rad.TLX > 0 || rad.TLY > 0) && noTop)
+                            path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2 + rad.TLX, r.Top + b.ActualBorderTopWidth / 2, rad.TLX, rad.TLY, RGraphicsPath.Corner.TopLeft);
                     }
                     break;
             }

--- a/src/PeachPDF/Html/Core/Utils/CssUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/CssUtils.cs
@@ -70,11 +70,10 @@ namespace PeachPDF.Html.Core.Utils
                 "break-after" => cssBox.BreakAfter,
                 "break-before" => cssBox.BreakBefore,
                 "break-inside" => cssBox.BreakInside,
-                "corner-radius" => cssBox.CornerRadius,
-                "corner-nw-radius" => cssBox.CornerNwRadius,
-                "corner-ne-radius" => cssBox.CornerNeRadius,
-                "corner-se-radius" => cssBox.CornerSeRadius,
-                "corner-sw-radius" => cssBox.CornerSwRadius,
+                "border-top-left-radius" => cssBox.BorderTopLeftRadius,
+                "border-top-right-radius" => cssBox.BorderTopRightRadius,
+                "border-bottom-right-radius" => cssBox.BorderBottomRightRadius,
+                "border-bottom-left-radius" => cssBox.BorderBottomLeftRadius,
                 "counter-increment" => cssBox.CounterIncrement,
                 "counter-reset" => cssBox.CounterReset,
                 "counter-set" => cssBox.CounterSet,
@@ -269,20 +268,20 @@ namespace PeachPDF.Html.Core.Utils
                     }
 
                     break;
-                case "corner-radius":
-                    cssBox.CornerRadius = value;
+                case "border-radius":
+                    cssBox.BorderRadius = value;
                     break;
-                case "corner-nw-radius":
-                    cssBox.CornerNwRadius = value;
+                case "border-top-left-radius":
+                    cssBox.BorderTopLeftRadius = value;
                     break;
-                case "corner-ne-radius":
-                    cssBox.CornerNeRadius = value;
+                case "border-top-right-radius":
+                    cssBox.BorderTopRightRadius = value;
                     break;
-                case "corner-se-radius":
-                    cssBox.CornerSeRadius = value;
+                case "border-bottom-right-radius":
+                    cssBox.BorderBottomRightRadius = value;
                     break;
-                case "corner-sw-radius":
-                    cssBox.CornerSwRadius = value;
+                case "border-bottom-left-radius":
+                    cssBox.BorderBottomLeftRadius = value;
                     break;
                 case "counter-increment":
                     cssBox.CounterIncrement = value;

--- a/src/PeachPDF/Html/Core/Utils/RenderUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/RenderUtils.cs
@@ -47,9 +47,13 @@ namespace PeachPDF.Html.Core.Utils
                 if (containingBlock.Overflow == CssConstants.Hidden)
                 {
                     var prevClip = g.GetClip();
-                    var rect = box.ContainingBlock.ClientRectangle;
-                    rect.X -= 2; // TODO:a find better way to fix it
-                    rect.Width += 2;
+                    // CSS spec: overflow clips at the padding edge, not the content edge.
+                    // Expand ClientRectangle (content-box) outward by the containing block's padding.
+                    var rect = containingBlock.ClientRectangle;
+                    rect.X -= containingBlock.ActualPaddingLeft;
+                    rect.Width += containingBlock.ActualPaddingLeft + containingBlock.ActualPaddingRight;
+                    rect.Y -= containingBlock.ActualPaddingTop;
+                    rect.Height += containingBlock.ActualPaddingTop + containingBlock.ActualPaddingBottom;
 
                     if (!box.IsFixed)
                         rect.Offset(box.HtmlContainer!.ScrollOffset);

--- a/src/PeachPDF/Html/Core/Utils/RenderUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/RenderUtils.cs
@@ -70,44 +70,40 @@ namespace PeachPDF.Html.Core.Utils
 
 
         /// <summary>
-        /// Creates a rounded rectangle using the specified corner radius<br/>
+        /// Creates a rounded rectangle path. Each corner has separate horizontal (X) and vertical (Y) radii,
+        /// supporting elliptical corners per the CSS border-radius spec.
+        /// <code>
         /// NW-----NE
         ///  |       |
-        ///  |       |
         /// SW-----SE
+        /// </code>
         /// </summary>
-        /// <param name="g">the device to draw into</param>
-        /// <param name="rect">Rectangle to round</param>
-        /// <param name="nwRadius">Radius of the north east corner</param>
-        /// <param name="neRadius">Radius of the north west corner</param>
-        /// <param name="seRadius">Radius of the south east corner</param>
-        /// <param name="swRadius">Radius of the south west corner</param>
-        /// <returns>GraphicsPath with the lines of the rounded rectangle ready to be painted</returns>
-        public static RGraphicsPath GetRoundRect(RGraphics g, RRect rect, double nwRadius, double neRadius, double seRadius, double swRadius)
+        public static RGraphicsPath GetRoundRect(RGraphics g, RRect rect,
+            double nwX, double nwY, double neX, double neY,
+            double seX, double seY, double swX, double swY)
         {
             var path = g.GetGraphicsPath();
 
-            path.Start(rect.Left + nwRadius, rect.Top);
+            // Top edge: start after NW corner, end before NE corner.
+            path.Start(rect.Left + nwX, rect.Top);
+            path.LineTo(rect.Right - neX, rect.Top);
+            if (neX > 0 || neY > 0)
+                path.ArcTo(rect.Right, rect.Top + neY, neX, neY, RGraphicsPath.Corner.TopRight);
 
-            path.LineTo(rect.Right - neRadius, rect.Y);
+            // Right edge.
+            path.LineTo(rect.Right, rect.Bottom - seY);
+            if (seX > 0 || seY > 0)
+                path.ArcTo(rect.Right - seX, rect.Bottom, seX, seY, RGraphicsPath.Corner.BottomRight);
 
-            if (neRadius > 0f)
-                path.ArcTo(rect.Right, rect.Top + neRadius, neRadius, RGraphicsPath.Corner.TopRight);
+            // Bottom edge.
+            path.LineTo(rect.Left + swX, rect.Bottom);
+            if (swX > 0 || swY > 0)
+                path.ArcTo(rect.Left, rect.Bottom - swY, swX, swY, RGraphicsPath.Corner.BottomLeft);
 
-            path.LineTo(rect.Right, rect.Bottom - seRadius);
-
-            if (seRadius > 0f)
-                path.ArcTo(rect.Right - seRadius, rect.Bottom, seRadius, RGraphicsPath.Corner.BottomRight);
-
-            path.LineTo(rect.Left + swRadius, rect.Bottom);
-
-            if (swRadius > 0f)
-                path.ArcTo(rect.Left, rect.Bottom - swRadius, swRadius, RGraphicsPath.Corner.BottomLeft);
-
-            path.LineTo(rect.Left, rect.Top + nwRadius);
-
-            if (nwRadius > 0f)
-                path.ArcTo(rect.Left + nwRadius, rect.Top, nwRadius, RGraphicsPath.Corner.TopLeft);
+            // Left edge.
+            path.LineTo(rect.Left, rect.Top + nwY);
+            if (nwX > 0 || nwY > 0)
+                path.ArcTo(rect.Left + nwX, rect.Top, nwX, nwY, RGraphicsPath.Corner.TopLeft);
 
             return path;
         }

--- a/src/PeachPDF/PdfGenerateConfig.cs
+++ b/src/PeachPDF/PdfGenerateConfig.cs
@@ -145,6 +145,13 @@ namespace PeachPDF
         }
 
         /// <summary>
+        /// Gets or sets whether PDF content streams are compressed with FlateDecode.
+        /// Defaults to <c>true</c>. Set to <c>false</c> to produce human-readable PDF streams,
+        /// which is useful for testing or debugging.
+        /// </summary>
+        public bool CompressContentStreams { get; set; } = true;
+
+        /// <summary>
         /// Set all 4 margins to the given value.
         /// </summary>
         /// <param name="value"></param>

--- a/src/PeachPDF/PdfGenerator.cs
+++ b/src/PeachPDF/PdfGenerator.cs
@@ -152,6 +152,8 @@ namespace PeachPDF
 
             if (string.IsNullOrEmpty(html) && config.NetworkLoader is null) return;
 
+            document.PdfDocument.Options.CompressContentStreams = config.CompressContentStreams;
+
             _pdfSharpAdapter.NetworkLoader = config.NetworkLoader ?? new DataUriNetworkLoader();
             _pdfSharpAdapter.PixelsPerPoint = config.PixelsPerInch / 72d;
 

--- a/src/PeachPDF/PdfSharpCore/Pdf/PdfDocumentOptions.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf/PdfDocumentOptions.cs
@@ -60,11 +60,7 @@ namespace PeachPDF.PdfSharpCore.Pdf
             get { return _compressContentStreams; }
             set { _compressContentStreams = value; }
         }
-#if DEBUG
-        bool _compressContentStreams = false;
-#else
         bool _compressContentStreams = true;
-#endif
 
         /// <summary>
         /// Gets or sets a value indicating that all objects are not compressed.


### PR DESCRIPTION
This pull request adds comprehensive test harnesses and documentation updates for CSS gradients and border-radius support, and makes minor codebase improvements. The most important changes are summarized below.

---

**Test Harness Improvements:**

* The `Program.cs` test harness now generates two new test documents: a CSS gradients showcase and a border-radius showcase, each as both PDF and HTML files. These documents visually demonstrate the rendering of gradients and border-radius variations, providing a robust way to verify rendering and feature support. [[1]](diffhunk://#diff-0eb42a38ac56a0be7b03f4c7ca38a7308cf89933d16ae9208e6188c450e35a2fL16-R273) [[2]](diffhunk://#diff-0eb42a38ac56a0be7b03f4c7ca38a7308cf89933d16ae9208e6188c450e35a2fL1-L7)

**Documentation Updates:**

* The `html-css-support.md` documentation is updated to reflect that standard CSS `border-radius` properties are now supported, replacing the previous PeachPDF-specific extensions. The documentation now includes a table describing each supported border-radius property and removes references to the old extension properties.
* The unsupported features section is updated to remove `border-radius` from the unsupported list, reflecting the new support.

**Internal API Consistency:**

* Updates a test adapter in `CssLayoutEngineTablePageBreakTests.cs` to match the new `ArcTo` method signature, which now takes separate `radiusX` and `radiusY` parameters, ensuring consistency with the rendering API.