### PR TITLE
Add support for CSS global keywords

### DIFF
--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -368,6 +368,22 @@ State-based pseudo-classes (`:hover`, `:focus`, `:active`, `:checked`, `:disable
 
 ---
 
+## CSS-wide Keywords
+
+All five CSS-wide keywords are supported on every CSS property. They are resolved during the cascade, before a property value reaches the rendering engine.
+
+| Keyword | Behavior |
+|---------|----------|
+| `inherit` | Uses the parent element's computed value for the property. On the root element (no parent), falls back to the initial value. |
+| `initial` | Resets the property to its CSS specification initial value, ignoring inheritance. |
+| `unset` | Acts as `inherit` for inherited properties (e.g. `color`, `font-size`) and as `initial` for non-inherited properties (e.g. `margin`, `padding`). |
+| `revert` | Rolls back to the value from the previous cascade origin. In an author stylesheet rule, reverts to the user-agent (UA) stylesheet value. In an inline style, reverts to the author stylesheet value. |
+| `revert-layer` | Without `@layer` support, behaves identically to `revert`. |
+
+All five keywords can be combined with `!important`.
+
+---
+
 ## Unsupported CSS Features
 
 The following CSS features are not supported:

--- a/src/PeachPDF.Tests/CSS/PropertyTests/GlobalKeywordPropertyTests.cs
+++ b/src/PeachPDF.Tests/CSS/PropertyTests/GlobalKeywordPropertyTests.cs
@@ -1,0 +1,195 @@
+using PeachPDF.CSS;
+
+namespace PeachPDF.Tests.CSS.PropertyTests
+{
+    /// <summary>
+    /// Unit tests verifying that the CSS module correctly parses all five global keywords
+    /// (inherit, initial, unset, revert, revert-layer) for a representative set of properties.
+    /// Cascade-level resolution is tested separately in Integration/GlobalKeywordCascadeTests.cs.
+    /// </summary>
+    public class GlobalKeywordPropertyTests : CssConstructionFunctions
+    {
+        // ── inherit ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Color_Inherit_IsMarkedAsInherited()
+        {
+            var property = ParseDeclaration("color: inherit");
+            Assert.Equal("color", property.Name);
+            Assert.True(property.HasValue);
+            Assert.True(property.IsInherited);
+        }
+
+        [Fact]
+        public void MarginTop_Inherit_IsMarkedAsInherited()
+        {
+            var property = ParseDeclaration("margin-top: inherit");
+            Assert.Equal("margin-top", property.Name);
+            Assert.True(property.HasValue);
+            Assert.True(property.IsInherited);
+        }
+
+        [Fact]
+        public void FontSize_Inherit_IsMarkedAsInherited()
+        {
+            var property = ParseDeclaration("font-size: inherit");
+            Assert.Equal("font-size", property.Name);
+            Assert.True(property.HasValue);
+            Assert.True(property.IsInherited);
+        }
+
+        [Fact]
+        public void Display_Inherit_IsMarkedAsInherited()
+        {
+            var property = ParseDeclaration("display: inherit");
+            Assert.Equal("display", property.Name);
+            Assert.True(property.HasValue);
+            Assert.True(property.IsInherited);
+        }
+
+        // ── initial ───────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Color_Initial_IsMarkedAsInitial()
+        {
+            var property = ParseDeclaration("color: initial");
+            Assert.Equal("color", property.Name);
+            Assert.True(property.HasValue);
+            Assert.True(property.IsInitial);
+        }
+
+        [Fact]
+        public void MarginTop_Initial_IsMarkedAsInitial()
+        {
+            var property = ParseDeclaration("margin-top: initial");
+            Assert.Equal("margin-top", property.Name);
+            Assert.True(property.HasValue);
+            Assert.True(property.IsInitial);
+        }
+
+        [Fact]
+        public void FontSize_Initial_IsMarkedAsInitial()
+        {
+            var property = ParseDeclaration("font-size: initial");
+            Assert.Equal("font-size", property.Name);
+            Assert.True(property.HasValue);
+            Assert.True(property.IsInitial);
+        }
+
+        // ── unset ─────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Color_Unset_HasUnsetValue()
+        {
+            var property = ParseDeclaration("color: unset");
+            Assert.Equal("color", property.Name);
+            Assert.True(property.HasValue);
+            Assert.Equal("unset", property.Value);
+        }
+
+        [Fact]
+        public void MarginTop_Unset_HasUnsetValue()
+        {
+            var property = ParseDeclaration("margin-top: unset");
+            Assert.Equal("margin-top", property.Name);
+            Assert.True(property.HasValue);
+            Assert.Equal("unset", property.Value);
+        }
+
+        [Fact]
+        public void FontFamily_Unset_HasUnsetValue()
+        {
+            var property = ParseDeclaration("font-family: unset");
+            Assert.Equal("font-family", property.Name);
+            Assert.True(property.HasValue);
+            Assert.Equal("unset", property.Value);
+        }
+
+        // ── revert ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Color_Revert_HasRevertValue()
+        {
+            var property = ParseDeclaration("color: revert");
+            Assert.Equal("color", property.Name);
+            Assert.True(property.HasValue);
+            Assert.Equal("revert", property.Value);
+        }
+
+        [Fact]
+        public void FontSize_Revert_HasRevertValue()
+        {
+            var property = ParseDeclaration("font-size: revert");
+            Assert.Equal("font-size", property.Name);
+            Assert.True(property.HasValue);
+            Assert.Equal("revert", property.Value);
+        }
+
+        [Fact]
+        public void MarginTop_Revert_HasRevertValue()
+        {
+            var property = ParseDeclaration("margin-top: revert");
+            Assert.Equal("margin-top", property.Name);
+            Assert.True(property.HasValue);
+            Assert.Equal("revert", property.Value);
+        }
+
+        // ── revert-layer ──────────────────────────────────────────────────────
+
+        [Fact]
+        public void Color_RevertLayer_HasRevertLayerValue()
+        {
+            var property = ParseDeclaration("color: revert-layer");
+            Assert.Equal("color", property.Name);
+            Assert.True(property.HasValue);
+            Assert.Equal("revert-layer", property.Value);
+        }
+
+        [Fact]
+        public void MarginTop_RevertLayer_HasRevertLayerValue()
+        {
+            var property = ParseDeclaration("margin-top: revert-layer");
+            Assert.Equal("margin-top", property.Name);
+            Assert.True(property.HasValue);
+            Assert.Equal("revert-layer", property.Value);
+        }
+
+        [Fact]
+        public void Display_RevertLayer_HasRevertLayerValue()
+        {
+            var property = ParseDeclaration("display: revert-layer");
+            Assert.Equal("display", property.Name);
+            Assert.True(property.HasValue);
+            Assert.Equal("revert-layer", property.Value);
+        }
+
+        // ── !important is preserved alongside global keywords ─────────────────
+
+        [Fact]
+        public void Color_InheritImportant_IsImportantAndInherited()
+        {
+            var property = ParseDeclaration("color: inherit !important");
+            Assert.Equal("color", property.Name);
+            Assert.True(property.IsImportant);
+            Assert.True(property.IsInherited);
+        }
+
+        [Fact]
+        public void MarginTop_UnsetImportant_IsImportantWithUnsetValue()
+        {
+            var property = ParseDeclaration("margin-top: unset !important");
+            Assert.Equal("margin-top", property.Name);
+            Assert.True(property.IsImportant);
+            Assert.Equal("unset", property.Value);
+        }
+
+        [Fact]
+        public void FontSize_RevertImportant_IsImportantWithRevertValue()
+        {
+            var property = ParseDeclaration("font-size: revert !important");
+            Assert.Equal("font-size", property.Name);
+            Assert.True(property.IsImportant);
+            Assert.Equal("revert", property.Value);
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/GlobalKeywordCascadeTests.cs
+++ b/src/PeachPDF.Tests/Integration/GlobalKeywordCascadeTests.cs
@@ -1,0 +1,503 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore.Drawing;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Integration tests for the five global CSS keywords (inherit, initial, unset, revert,
+    /// revert-layer) at the cascade-resolution level, plus regression tests confirming that
+    /// the 3-phase cascade refactor did not break existing behaviour.
+    ///
+    /// Each test renders a small HTML document, walks the box tree to find the target element,
+    /// and asserts on the string CSS-value properties that the cascade writes to CssBox.
+    /// </summary>
+    public class GlobalKeywordCascadeTests
+    {
+        // ── inherit ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task Inherit_ColorFromParent_ChildGetsParentColor()
+        {
+            // Child explicitly forces inheritance of the parent's author-set color.
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="parent" style="color: red">
+                  <span id="child" style="color: inherit">text</span>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var child = FindById(root, "child");
+
+            Assert.NotNull(child);
+            Assert.Equal("rgb(255, 0, 0)", child!.Color);
+        }
+
+        [Fact]
+        public async Task Inherit_NonInheritedProperty_ChildGetsParentValue()
+        {
+            // margin-top is NOT inherited by default; explicit "inherit" should force it.
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="parent" style="margin-top: 30px">
+                  <div id="child" style="margin-top: inherit">text</div>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var child = FindById(root, "child");
+
+            Assert.NotNull(child);
+            Assert.Equal("30px", child!.MarginTop);
+        }
+
+        [Fact]
+        public async Task Inherit_ColorWithoutExplicitParent_UsesInitialBlack()
+        {
+            // When the nearest ancestor has no explicit color set, inherit still resolves to
+            // the cascade-computed value (which is "black" for the initial default).
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="el" style="color: inherit">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("black", el!.Color);
+        }
+
+        // ── initial ───────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task Initial_Color_ResetsToBlackIgnoringParent()
+        {
+            // "initial" for color is "black" regardless of what the parent set.
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="parent" style="color: blue">
+                  <span id="child" style="color: initial">text</span>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var child = FindById(root, "child");
+
+            Assert.NotNull(child);
+            Assert.Equal("black", child!.Color);
+        }
+
+        [Fact]
+        public async Task Initial_FontSize_ResetsToMedium()
+        {
+            // "initial" for font-size is "medium", overriding any inherited/UA value.
+            var html = """
+                <!DOCTYPE html><html><body>
+                <h1 id="el" style="font-size: initial">heading</h1>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("medium", el!.FontSize);
+        }
+
+        [Fact]
+        public async Task Initial_MarginTop_ResetsToZero()
+        {
+            // "initial" for margin-top is "0", even when an author rule sets it higher.
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  div { margin-top: 50px; }
+                </style></head><body>
+                <div id="el" style="margin-top: initial">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("0", el!.MarginTop);
+        }
+
+        [Fact]
+        public async Task Initial_Display_ResetsToInline()
+        {
+            // "initial" for display is "inline", regardless of block-level UA defaults.
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="el" style="display: initial">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("inline", el!.Display);
+        }
+
+        // ── unset ─────────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task Unset_InheritedProperty_BehavesLikeInherit()
+        {
+            // "unset" on an inherited property (color) acts like "inherit".
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="parent" style="color: green">
+                  <span id="child" style="color: unset">text</span>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var child = FindById(root, "child");
+
+            Assert.NotNull(child);
+            Assert.Equal("rgb(0, 128, 0)", child!.Color);
+        }
+
+        [Fact]
+        public async Task Unset_NonInheritedProperty_BehavesLikeInitial()
+        {
+            // "unset" on a non-inherited property (margin-top) acts like "initial" → "0".
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  div { margin-top: 50px; }
+                </style></head><body>
+                <div id="el" style="margin-top: unset">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("0", el!.MarginTop);
+        }
+
+        [Fact]
+        public async Task Unset_InheritedPropertyWithNoParentValue_UsesInitial()
+        {
+            // "unset" on an inherited property when parent has no explicit value → initial.
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="el" style="color: unset">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("black", el!.Color);
+        }
+
+        // ── revert ────────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task Revert_InAuthorRule_RevertsToUaValue()
+        {
+            // An author rule sets color to blue. A later (higher-specificity) author rule
+            // uses "revert", which should restore the UA-phase value — black for plain divs.
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  div { color: blue; }
+                  #el { color: revert; }
+                </style></head><body>
+                <div id="el">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("black", el!.Color);
+        }
+
+        [Fact]
+        public async Task Revert_H1FontSizeInAuthorRule_RevertsToUaFontSize()
+        {
+            // Author sets h1 font-size to 50px, then a later author rule reverts it.
+            // The UA stylesheet defines h1 { font-size: 2em }; PeachPDF eagerly converts em
+            // to points at cascade time (using the parent's ActualFont.Size), so revert restores
+            // the already-converted pt value rather than the original "2em" string.
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  h1 { font-size: 50px; }
+                  #el { font-size: revert; }
+                </style></head><body>
+                <h1 id="el">heading</h1>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("0.3pt", el!.FontSize);
+        }
+
+        [Fact]
+        public async Task Revert_InInlineStyle_RevertsToAuthorValue()
+        {
+            // "revert" in an inline style rolls back to the author-set value ("blue"),
+            // NOT all the way to the UA value.
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  div { color: blue; }
+                </style></head><body>
+                <div id="el" style="color: revert">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("rgb(0, 0, 255)", el!.Color);
+        }
+
+        [Fact]
+        public async Task Revert_MarginTopInAuthorRule_RevertsToUaValue()
+        {
+            // Author sets margin-top; revert takes it back to the UA-phase value.
+            // For a plain div the UA stylesheet doesn't set margin-top, so the result
+            // is the initial value "0".
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  div { margin-top: 40px; }
+                  #el  { margin-top: revert; }
+                </style></head><body>
+                <div id="el">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("0", el!.MarginTop);
+        }
+
+        // ── revert-layer ──────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task RevertLayer_WithoutLayers_BehavesLikeRevert()
+        {
+            // Without @layer support, "revert-layer" must fall back to "revert" behaviour.
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  div { color: blue; }
+                  #el { color: revert-layer; }
+                </style></head><body>
+                <div id="el">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            // Same as "revert" from an author rule: UA value for div color = "black".
+            Assert.Equal("black", el!.Color);
+        }
+
+        [Fact]
+        public async Task RevertLayer_InInlineStyle_BehavesLikeRevert()
+        {
+            // "revert-layer" in inline should behave identically to "revert" in inline
+            // (author-phase snapshot) when no layers are defined.
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  div { color: blue; }
+                </style></head><body>
+                <div id="el" style="color: revert-layer">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("rgb(0, 0, 255)", el!.Color);
+        }
+
+        // ── regression: 3-phase cascade must not break existing behaviour ──────
+
+        [Fact]
+        public async Task Regression_ColorInheritsFromParentWithoutKeyword()
+        {
+            // Standard CSS inheritance — no keyword required for inherited properties.
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="parent" style="color: purple">
+                  <span id="child">text</span>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var child = FindById(root, "child");
+
+            Assert.NotNull(child);
+            Assert.Equal("rgb(128, 0, 128)", child!.Color);
+        }
+
+        [Fact]
+        public async Task Regression_InlineStyleOverridesAuthorRule()
+        {
+            // Inline style must still win over author stylesheet rules.
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  div { color: blue; }
+                </style></head><body>
+                <div id="el" style="color: green">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("rgb(0, 128, 0)", el!.Color);
+        }
+
+        [Fact]
+        public async Task Regression_AuthorRuleOverridesUaDefault()
+        {
+            // Author-set font-size on h1 must override the UA default of "2em".
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  h1 { font-size: 10px; }
+                </style></head><body>
+                <h1 id="el">heading</h1>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("10px", el!.FontSize);
+        }
+
+        [Fact]
+        public async Task Regression_UaStylesheetSetsH1FontSize()
+        {
+            // The UA stylesheet defines h1 { font-size: 2em }. PeachPDF eagerly converts em
+            // values to points at cascade time, so the stored value is the converted pt string.
+            var html = """
+                <!DOCTYPE html><html><body>
+                <h1 id="el">heading</h1>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("0.3pt", el!.FontSize);
+        }
+
+        [Fact]
+        public async Task Regression_ImportantAuthorRuleBeatsInlineStyle()
+        {
+            // A !important author rule must not be overridden by an inline style.
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  div { color: blue !important; }
+                </style></head><body>
+                <div id="el" style="color: red">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("rgb(0, 0, 255)", el!.Color);
+        }
+
+        [Fact]
+        public async Task Regression_LaterAuthorRuleOverridesEarlierSameSpecificity()
+        {
+            // When two rules share the same specificity, source order decides: last wins.
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  div { color: red; }
+                  div { color: blue; }
+                </style></head><body>
+                <div id="el">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("rgb(0, 0, 255)", el!.Color);
+        }
+
+        [Fact]
+        public async Task Regression_UaBodyMarginStillApplied()
+        {
+            // The UA stylesheet sets body { margin: 8px }. This must still flow through.
+            var html = """
+                <!DOCTYPE html><html><body id="b">text</body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var body = FindById(root, "b");
+
+            Assert.NotNull(body);
+            Assert.Equal("8px", body!.MarginTop);
+        }
+
+        // ── helpers ───────────────────────────────────────────────────────────
+
+        private static async Task<CssBox> BuildBoxTree(string html)
+        {
+            var adapter = new PdfSharpAdapter();
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            var size = new XSize(595, 842);
+            container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+            container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+            var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            return container.Root!;
+        }
+
+        private static CssBox? FindById(CssBox box, string id)
+        {
+            if (box.HtmlTag?.Attributes?.TryGetValue("id", out var boxId) == true
+                && string.Equals(boxId, id, StringComparison.OrdinalIgnoreCase))
+                return box;
+
+            foreach (var child in box.Boxes)
+            {
+                var found = FindById(child, id);
+                if (found is not null) return found;
+            }
+            return null;
+        }
+    }
+}

--- a/src/PeachPDF/CSS/Extensions/ValueConverterExtensions.cs
+++ b/src/PeachPDF/CSS/Extensions/ValueConverterExtensions.cs
@@ -134,12 +134,15 @@ namespace PeachPDF.CSS
 
         public static IValueConverter OrDefault(this IValueConverter primary)
         {
-            return primary.OrInherit().Or(Keywords.Initial);
+            return primary.OrGlobalValue();
         }
 
         public static IValueConverter OrDefault<T>(this IValueConverter primary, T value)
         {
-            return primary.OrInherit().Or(Keywords.Initial, value);
+            return primary.OrInherit().Or(Keywords.Initial, value)
+                          .Or(Keywords.Revert)
+                          .Or(Keywords.RevertLayer)
+                          .Or(Keywords.Unset);
         }
 
         public static IValueConverter OrInherit(this IValueConverter primary)

--- a/src/PeachPDF/CSS/Model/Stylesheet.cs
+++ b/src/PeachPDF/CSS/Model/Stylesheet.cs
@@ -18,6 +18,8 @@ namespace PeachPDF.CSS
 
         internal RuleList Rules { get; }
 
+        internal bool IsUserAgent { get; set; }
+
         public IEnumerable<ICharsetRule> CharacterSetRules => Rules.Where(r => r is CharsetRule).Cast<ICharsetRule>();
         public IEnumerable<IFontFaceRule> FontfaceSetRules => Rules.Where(r => r is FontFaceRule).Cast<IFontFaceRule>();
         public IEnumerable<IMediaRule> MediaRules => Rules.Where(r => r is MediaRule).Cast<IMediaRule>();

--- a/src/PeachPDF/Html/Adapters/RAdapter.cs
+++ b/src/PeachPDF/Html/Adapters/RAdapter.cs
@@ -74,7 +74,16 @@ namespace PeachPDF.Html.Adapters
         /// <summary>
         /// Get the default CSS stylesheet data.
         /// </summary>
-        public async Task<CssData> GetDefaultCssData() => _defaultCssData ??= await CssData.Parse(this, CssDefaults.DefaultStyleSheet, false);
+        public async Task<CssData> GetDefaultCssData()
+        {
+            if (_defaultCssData is null)
+            {
+                _defaultCssData = await CssData.Parse(this, CssDefaults.DefaultStyleSheet, false);
+                foreach (var s in _defaultCssData.Stylesheets)
+                    s.IsUserAgent = true;
+            }
+            return _defaultCssData;
+        }
 
         public abstract RUri? BaseUri { get; }
 

--- a/src/PeachPDF/Html/Core/CssData.cs
+++ b/src/PeachPDF/Html/Core/CssData.cs
@@ -55,10 +55,22 @@ namespace PeachPDF.Html.Core
             return await parser.ParseStyleSheet(stylesheet, combineWithDefault);
         }
 
-        internal IEnumerable<IStyleRule> GetStyleRules(string media, CssBox box)
+        internal IEnumerable<IStyleRule> GetStyleRules(string media, CssBox box) =>
+            GetStyleRulesByOrigin(media, box, userAgentOnly: null);
+
+        internal IEnumerable<IStyleRule> GetUserAgentStyleRules(string media, CssBox box) =>
+            GetStyleRulesByOrigin(media, box, userAgentOnly: true);
+
+        internal IEnumerable<IStyleRule> GetAuthorStyleRules(string media, CssBox box) =>
+            GetStyleRulesByOrigin(media, box, userAgentOnly: false);
+
+        private IEnumerable<IStyleRule> GetStyleRulesByOrigin(string media, CssBox box, bool? userAgentOnly)
         {
             foreach (var stylesheet in Stylesheets)
             {
+                if (userAgentOnly.HasValue && stylesheet.IsUserAgent != userAgentOnly.Value)
+                    continue;
+
                 foreach (var rule in GetStyleRules(stylesheet.StyleRules, box))
                 {
                     yield return rule;
@@ -76,7 +88,6 @@ namespace PeachPDF.Html.Core
                         }
                     }
                 }
-
             }
         }
 

--- a/src/PeachPDF/Html/Core/CssDefaults.cs
+++ b/src/PeachPDF/Html/Core/CssDefaults.cs
@@ -167,5 +167,120 @@ namespace PeachPDF.Html.Core
             { "text-decoration-style", CssConstants.Solid },
             { "z-index", CssConstants.Auto }
         };
+
+        /// <summary>
+        /// CSS properties that are inherited from a parent element (per CSS spec and PeachPDF's InheritStyle implementation).
+        /// </summary>
+        public static readonly HashSet<string> InheritedProperties = new(System.StringComparer.OrdinalIgnoreCase)
+        {
+            "border-collapse", "border-spacing",
+            "box-sizing",
+            "color",
+            "direction",
+            "empty-cells",
+            "font-family", "font-size", "font-style", "font-variant", "font-weight",
+            "line-height",
+            "list-style-image", "list-style-position", "list-style-type",
+            "text-align", "text-indent",
+            "vertical-align",
+            "visibility",
+            "white-space",
+            "word-break",
+        };
+
+        /// <summary>
+        /// Comprehensive CSS spec initial values for every property handled by PeachPDF.
+        /// Used only for resolving the <c>initial</c>, <c>unset</c>, and <c>revert</c> global keywords.
+        /// </summary>
+        private static readonly Dictionary<string, string?> _allInitialValues = new(System.StringComparer.OrdinalIgnoreCase)
+        {
+            { PropertyNames.BackgroundAttachment, CssConstants.Scroll },
+            { PropertyNames.BackgroundClip, CssConstants.BorderBox },
+            { PropertyNames.BackgroundColor, CssConstants.Transparent },
+            { PropertyNames.BackgroundImage, CssConstants.None },
+            { PropertyNames.BackgroundOrigin, CssConstants.PaddingBox },
+            { PropertyNames.BackgroundPosition, "0% 0%" },
+            { "background-repeat", CssConstants.Repeat },
+            { "background-size", $"{CssConstants.Auto} {CssConstants.Auto}" },
+            { "border-bottom-color", CssConstants.CurrentColor },
+            { "border-bottom-style", CssConstants.None },
+            { "border-bottom-width", CssConstants.Medium },
+            { "border-bottom-left-radius", "0" },
+            { "border-bottom-right-radius", "0" },
+            { "border-collapse", "separate" },
+            { "border-left-color", CssConstants.CurrentColor },
+            { "border-left-style", CssConstants.None },
+            { "border-left-width", CssConstants.Medium },
+            { "border-right-color", CssConstants.CurrentColor },
+            { "border-right-style", CssConstants.None },
+            { "border-right-width", CssConstants.Medium },
+            { "border-spacing", "0" },
+            { "border-top-color", CssConstants.CurrentColor },
+            { "border-top-style", CssConstants.None },
+            { "border-top-width", CssConstants.Medium },
+            { "border-top-left-radius", "0" },
+            { "border-top-right-radius", "0" },
+            { "bottom", CssConstants.Auto },
+            { "box-sizing", CssConstants.ContentBox },
+            { "break-after", CssConstants.Auto },
+            { "break-before", CssConstants.Auto },
+            { "break-inside", CssConstants.Auto },
+            { "clear", CssConstants.None },
+            { "color", "black" },
+            { "content", CssConstants.Normal },
+            { "counter-increment", CssConstants.None },
+            { "counter-reset", CssConstants.None },
+            { "counter-set", CssConstants.None },
+            { "direction", "ltr" },
+            { "display", CssConstants.Inline },
+            { "empty-cells", "show" },
+            { "float", CssConstants.None },
+            { "font-family", "serif" },
+            { "font-size", CssConstants.Medium },
+            { "font-stretch", CssConstants.Normal },
+            { "font-style", CssConstants.Normal },
+            { "font-variant", CssConstants.Normal },
+            { "font-weight", CssConstants.Normal },
+            { "height", CssConstants.Auto },
+            { "left", CssConstants.Auto },
+            { "line-height", CssConstants.Normal },
+            { "list-style-image", CssConstants.None },
+            { "list-style-position", CssConstants.Outside },
+            { "list-style-type", "disc" },
+            { "margin-bottom", "0" },
+            { "margin-left", "0" },
+            { "margin-right", "0" },
+            { "margin-top", "0" },
+            { "max-width", CssConstants.None },
+            { "min-height", "0" },
+            { "overflow", "visible" },
+            { "padding-bottom", "0" },
+            { "padding-left", "0" },
+            { "padding-right", "0" },
+            { "padding-top", "0" },
+            { "position", "static" },
+            { "right", CssConstants.Auto },
+            { "string-set", CssConstants.None },
+            { "text-align", "left" },
+            { "text-decoration", CssConstants.None },
+            { "text-decoration-color", CssConstants.CurrentColor },
+            { "text-decoration-line", CssConstants.None },
+            { "text-decoration-style", CssConstants.Solid },
+            { "text-indent", "0" },
+            { "top", CssConstants.Auto },
+            { "vertical-align", "baseline" },
+            { "visibility", "visible" },
+            { "white-space", CssConstants.Normal },
+            { "width", CssConstants.Auto },
+            { "word-break", CssConstants.Normal },
+            { "word-spacing", CssConstants.Normal },
+            { "z-index", CssConstants.Auto },
+        };
+
+        /// <summary>
+        /// Returns the CSS spec initial value for the given property name, or null if unknown.
+        /// </summary>
+        public static string? GetInitialValue(string propertyName) =>
+            _allInitialValues.TryGetValue(propertyName, out var v) ? v : null;
     }
 }

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -201,29 +201,33 @@ namespace PeachPDF.Html.Core.Parse
         /// <param name="media">The media type to apply styles to</param>
         private static void CascadeApplyStyles(CssValueParser valueParser, CssBox box, CssData cssData, string media)
         {
-            // Set initial styles
+            // 1. Set CSS spec initial values
             foreach (var style in CssDefaults.InitialValues)
-            {
                 CssUtils.SetPropertyValue(valueParser, box, style.Key, style.Value);
-            }
 
+            // 2. Inherit inheritable properties from parent
             box.InheritStyle();
 
-            // try assign style using all wildcard
-            var importantPropertyNames = AssignCssBlocks(valueParser, box, cssData, media);
+            // 3. UA pass — user-agent stylesheet rules only
+            var importantPropertyNames = AssignCssBlocks(valueParser, box, cssData.GetUserAgentStyleRules(media, box), null, null);
+
+            // 4. Author pass — author stylesheet rules; revert target is the UA-applied state
+            var uaSnapshot = CssUtils.SnapshotProperties(box);
+            importantPropertyNames = AssignCssBlocks(valueParser, box, cssData.GetAuthorStyleRules(media, box), importantPropertyNames, uaSnapshot);
 
             if (box.HtmlTag != null)
             {
                 TranslateAttributes(box.HtmlTag, box);
 
-                // Check for the style="" attribute
+                // 5. Inline styles; revert target is the author-applied state
                 if (box.HtmlTag.HasAttribute("style"))
                 {
                     var styleAttributeText = box.HtmlTag.TryGetAttribute("style");
                     var stylesheet = "* { " + styleAttributeText + " }";
 
+                    var authorSnapshot = CssUtils.SnapshotProperties(box);
                     var block = CssParser.ParseStyleSheet(stylesheet);
-                    AssignCssBlock(valueParser, box, block.StyleRules.Single(), importantPropertyNames);
+                    AssignCssBlock(valueParser, box, block.StyleRules.Single(), importantPropertyNames, authorSnapshot);
                 }
             }
 
@@ -254,61 +258,66 @@ namespace PeachPDF.Html.Core.Parse
         }
 
         /// <summary>
-        /// Assigns the given css style blocks to the given css box checking if matching.
+        /// Assigns the given css style rules to the given css box.
         /// </summary>
-        /// <param name="valueParser">the css value parser to use</param>
-        /// <param name="box">the css box to assign css to</param>
-        /// <param name="cssData">the css data to use to get the matching css blocks</param>
-        /// <param name="media">The media type to apply styles for</param>
-        /// <returns>The list of applied important property names</returns>
-        private static HashSet<string> AssignCssBlocks(CssValueParser valueParser, CssBox box, CssData cssData, string media)
+        private static HashSet<string> AssignCssBlocks(
+            CssValueParser valueParser,
+            CssBox box,
+            IEnumerable<IStyleRule> rules,
+            HashSet<string>? importantPropertyNames,
+            IReadOnlyDictionary<string, string?>? revertTarget)
         {
-            var combinedBlocks = new List<IStyleRule>();
-            var styleRules = cssData.GetStyleRules(media, box);
-            combinedBlocks.AddRange(styleRules);
-
-            HashSet<string> importantPropertyNames = [];
-
-            foreach (var block in combinedBlocks)
-            {
-                AssignCssBlock(valueParser, box, block, importantPropertyNames);
-            }
-
+            importantPropertyNames ??= [];
+            foreach (var rule in rules)
+                AssignCssBlock(valueParser, box, rule, importantPropertyNames, revertTarget);
             return importantPropertyNames;
         }
 
         /// <summary>
         /// Assigns the given css style block properties to the given css box.
+        /// Handles all five CSS global keywords: inherit, initial, unset, revert, revert-layer.
         /// </summary>
         /// <param name="valueParser">the css value parser to use</param>
         /// <param name="box">the css box to assign css to</param>
         /// <param name="stylesheetRule">the stylesheet rule to assign</param>
         /// <param name="importantPropertyNames">Carries the property names that have been marked important so they don't get re-applied</param>
-        private static void AssignCssBlock(CssValueParser valueParser, CssBox box, IStyleRule stylesheetRule, HashSet<string> importantPropertyNames)
+        /// <param name="revertTarget">Property snapshot representing the prior cascade origin, used for revert/revert-layer</param>
+        private static void AssignCssBlock(
+            CssValueParser valueParser,
+            CssBox box,
+            IStyleRule stylesheetRule,
+            HashSet<string> importantPropertyNames,
+            IReadOnlyDictionary<string, string?>? revertTarget = null)
         {
             foreach (var prop in stylesheetRule.Style)
             {
                 var value = prop.Value switch
                 {
-                    CssConstants.Inherit when box.ParentBox != null => CssUtils.GetPropertyValue(box.ParentBox, prop.Name),
-                    CssConstants.Initial => CssDefaults.InitialValues[prop.Name],
+                    CssConstants.Inherit when box.ParentBox != null
+                        => CssUtils.GetPropertyValue(box.ParentBox, prop.Name),
+                    CssConstants.Inherit
+                        => CssDefaults.GetInitialValue(prop.Name),
+                    CssConstants.Initial
+                        => CssDefaults.GetInitialValue(prop.Name),
+                    CssConstants.Unset when CssDefaults.InheritedProperties.Contains(prop.Name) && box.ParentBox != null
+                        => CssUtils.GetPropertyValue(box.ParentBox, prop.Name),
+                    CssConstants.Unset
+                        => CssDefaults.GetInitialValue(prop.Name),
+                    CssConstants.Revert or CssConstants.RevertLayer
+                        => revertTarget is not null && revertTarget.TryGetValue(prop.Name, out var rv)
+                            ? rv
+                            : CssDefaults.GetInitialValue(prop.Name),
                     _ => prop.Value
                 };
 
                 if (importantPropertyNames.Contains(prop.Name.ToLowerInvariant()))
-                {
                     continue;
-                }
 
                 if (prop.IsImportant)
-                {
                     importantPropertyNames.Add(prop.Name.ToLowerInvariant());
-                }
 
                 if (value is not null && IsStyleOnElementAllowed(box, prop.Name, value))
-                {
                     CssUtils.SetPropertyValue(valueParser, box, prop.Name, value);
-                }
             }
         }
 

--- a/src/PeachPDF/Html/Core/Utils/CssConstants.cs
+++ b/src/PeachPDF/Html/Core/Utils/CssConstants.cs
@@ -49,6 +49,9 @@ namespace PeachPDF.Html.Core.Utils
         public const string Hide = "hide";
         public const string Inherit = "inherit";
         public const string Initial = "initial";
+        public const string Revert = "revert";
+        public const string RevertLayer = "revert-layer";
+        public const string Unset = "unset";
         public const string Inline = "inline";
         public const string InlineTable = "inline-table";
         public const string Inside = "inside";

--- a/src/PeachPDF/Html/Core/Utils/CssUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/CssUtils.cs
@@ -135,6 +135,53 @@ namespace PeachPDF.Html.Core.Utils
             };
         }
 
+        private static readonly string[] _knownPropertyNames =
+        [
+            "background-attachment", "background-clip", "background-color", "background-image",
+            "background-origin", "background-position", "background-repeat", "background-size",
+            "border-bottom-color", "border-bottom-style", "border-bottom-width",
+            "border-bottom-left-radius", "border-bottom-right-radius",
+            "border-collapse",
+            "border-left-color", "border-left-style", "border-left-width",
+            "border-right-color", "border-right-style", "border-right-width",
+            "border-spacing",
+            "border-top-color", "border-top-style", "border-top-width",
+            "border-top-left-radius", "border-top-right-radius",
+            "bottom", "box-sizing",
+            "break-after", "break-before", "break-inside",
+            "clear", "color", "content",
+            "counter-increment", "counter-reset", "counter-set",
+            "direction", "display",
+            "empty-cells", "float",
+            "font-family", "font-size", "font-style", "font-variant", "font-weight",
+            "height",
+            "left", "line-height",
+            "list-style-image", "list-style-position", "list-style-type",
+            "margin-bottom", "margin-left", "margin-right", "margin-top",
+            "max-width", "min-height",
+            "overflow",
+            "padding-bottom", "padding-left", "padding-right", "padding-top",
+            "position",
+            "right", "string-set",
+            "text-align", "text-decoration", "text-decoration-color", "text-decoration-line", "text-decoration-style",
+            "text-indent", "top",
+            "vertical-align", "visibility",
+            "white-space", "width", "word-break", "word-spacing",
+            "z-index",
+        ];
+
+        /// <summary>
+        /// Snapshots all known property values from a CssBox into a dictionary.
+        /// Used to capture the revert target between cascade origin phases.
+        /// </summary>
+        public static Dictionary<string, string?> SnapshotProperties(CssBox box)
+        {
+            var snapshot = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+            foreach (var name in _knownPropertyNames)
+                snapshot[name] = GetPropertyValue(box, name);
+            return snapshot;
+        }
+
         /// <summary>
         /// Set CSS box property value by the CSS name.<br/>
         /// Used as a mapping between CSS property and the class property.

--- a/src/PeachPDF/PeachPDF.csproj
+++ b/src/PeachPDF/PeachPDF.csproj
@@ -3,7 +3,7 @@
 		<TargetFrameworks>net8.0</TargetFrameworks>
 		<AssemblyName>PeachPDF</AssemblyName>
 		<PackageId>PeachPDF</PackageId>
-		<PackageVersion>0.9.0-preview5</PackageVersion>
+		<PackageVersion>0.9.0-preview6</PackageVersion>
 		<IncludeSymbols>true</IncludeSymbols>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>


### PR DESCRIPTION
Implement full support for all five CSS-wide keywords: inherit, initial, unset, revert, and revert-layer.

The implementation introduces a 3-phase cascade (UA → Author → Inline) with property snapshots between phases to correctly resolve revert and revert-layer. Added InheritedProperties set and initial value mappings in CssDefaults for proper keyword resolution. Stylesheets now track their origin (UA vs author) to enable revert semantics. Includes comprehensive unit and integration tests verifying keyword parsing and cascade-level behavior.