### PR TITLE
Add background origin and clip support

### DIFF
--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -200,9 +200,9 @@ Percentages are relative to the border-box width (horizontal radius) and height 
 | `background-position` | [background-position](https://developer.mozilla.org/en-US/docs/Web/CSS/background-position) | Full support |
 | `background-size` | [background-size](https://developer.mozilla.org/en-US/docs/Web/CSS/background-size) | Full support; `cover`, `contain`, lengths, and percentages |
 | `background-repeat` | [background-repeat](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat) | Full support |
-| `background-origin` | [background-origin](https://developer.mozilla.org/en-US/docs/Web/CSS/background-origin) | Parsed and accepted but has no effect |
+| `background-origin` | [background-origin](https://developer.mozilla.org/en-US/docs/Web/CSS/background-origin) | Full support; `border-box`, `padding-box`, `content-box` |
 | `background-attachment` | [background-attachment](https://developer.mozilla.org/en-US/docs/Web/CSS/background-attachment) | Parsed and accepted but has no effect |
-| `background-clip` | [background-clip](https://developer.mozilla.org/en-US/docs/Web/CSS/background-clip) | Parsed and accepted but has no effect |
+| `background-clip` | [background-clip](https://developer.mozilla.org/en-US/docs/Web/CSS/background-clip) | Full support; `border-box`, `padding-box`, `content-box` |
 
 ### Color & Typography
 

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -25,6 +25,13 @@ static string RadiusSwatch(string desc, string borderRadiusCss, string boxCss = 
     $"<div class=\"css\">border-radius: {borderRadiusCss}</div>" +
     "</td>";
 
+static string OriginSwatch(string desc, string inlineCss, string cssLabel = "") =>
+    "<td>" +
+    $"<div class=\"obox\" style=\"{inlineCss}\"></div>" +
+    $"<div class=\"desc\">{desc}</div>" +
+    $"<div class=\"css\">{(string.IsNullOrEmpty(cssLabel) ? inlineCss : cssLabel)}</div>" +
+    "</td>";
+
 static string Row(params string[] cells) =>
     $"<table class=\"sw\"><tr>{string.Join("", cells)}</tr></table>";
 
@@ -271,3 +278,117 @@ Console.WriteLine("Saved test_border_radius.pdf");
 File.Delete("test_border_radius.html");
 File.WriteAllText("test_border_radius.html", radiusHtml);
 Console.WriteLine("Saved test_border_radius.html");
+
+// --- background-origin + background-clip showcase ---
+
+const string OriginCss = """
+    <style>
+    @page { size: a4; margin: 15mm }
+    body { font: 8.5pt Arial, sans-serif; margin: 0 }
+    h1 { font-size: 15pt; margin: 0 0 0.3em }
+    h2 { font-size: 10pt; margin: 0.9em 0 0.3em; padding-bottom: 2px; border-bottom: 1px solid #999 }
+    p.intro { margin: 0 0 0.7em; color: #555; font-size: 7.5pt }
+    table.sw { border-collapse: collapse; width: 100%; margin-bottom: 0.3em }
+    table.sw td { padding: 3px; vertical-align: top; width: 25% }
+    .obox { height: 60px; border: 8px solid #333; padding: 12px; margin-bottom: 3px; box-sizing: border-box }
+    .desc { font-size: 7pt; font-weight: bold; color: #444; margin-bottom: 1px }
+    .css { font-size: 6pt; color: #666; line-height: 1.3; word-break: break-all }
+    </style>
+    """;
+
+var originHtml = "<!DOCTYPE html><html><head>" + OriginCss + "</head><body>" +
+
+    "<h1>CSS background-origin &amp; background-clip Test Page</h1>" +
+    "<p class=\"intro\">Each box has border: 8px solid #333 and padding: 12px. Three regions: border-box (full), padding-box (inside border), content-box (inside padding).</p>" +
+
+    "<h2>1 — background-origin: Solid Color</h2>" +
+    "<p class=\"intro\">Solid colors fill the clip area regardless of origin — this verifies no rendering errors.</p>" +
+    Row(
+        OriginSwatch("default (padding-box)", "background-color: steelblue"),
+        OriginSwatch("border-box", "background-color: steelblue; background-origin: border-box", "background-origin: border-box"),
+        OriginSwatch("padding-box", "background-color: steelblue; background-origin: padding-box", "background-origin: padding-box"),
+        OriginSwatch("content-box", "background-color: steelblue; background-origin: content-box", "background-origin: content-box")
+    ) +
+
+    "<h2>2 — background-origin: Linear Gradient</h2>" +
+    "<p class=\"intro\">Gradient coordinate space shifts with origin. border-box spans the full box; content-box spans only the content area.</p>" +
+    Row(
+        OriginSwatch("default (padding-box)", "background: linear-gradient(to right, red, blue)"),
+        OriginSwatch("border-box", "background: linear-gradient(to right, red, blue); background-origin: border-box", "background-origin: border-box"),
+        OriginSwatch("padding-box", "background: linear-gradient(to right, red, blue); background-origin: padding-box", "background-origin: padding-box"),
+        OriginSwatch("content-box", "background: linear-gradient(to right, red, blue); background-origin: content-box", "background-origin: content-box")
+    ) +
+
+    "<h2>3 — background-origin: Radial Gradient</h2>" +
+    "<p class=\"intro\">Radial center and radius are computed from the origin rect. content-box produces a more compressed gradient.</p>" +
+    Row(
+        OriginSwatch("default (padding-box)", "background: radial-gradient(circle, yellow, navy)"),
+        OriginSwatch("border-box", "background: radial-gradient(circle, yellow, navy); background-origin: border-box", "background-origin: border-box"),
+        OriginSwatch("padding-box", "background: radial-gradient(circle, yellow, navy); background-origin: padding-box", "background-origin: padding-box"),
+        OriginSwatch("content-box", "background: radial-gradient(circle, yellow, navy); background-origin: content-box", "background-origin: content-box")
+    ) +
+
+    "<h2>4 — background-clip: Solid Color</h2>" +
+    "<p class=\"intro\">background-clip controls where the background is painted. padding-box: no color behind border. content-box: color only in content area.</p>" +
+    Row(
+        OriginSwatch("default (border-box)", "background-color: coral"),
+        OriginSwatch("border-box", "background-color: coral; background-clip: border-box", "background-clip: border-box"),
+        OriginSwatch("padding-box", "background-color: coral; background-clip: padding-box", "background-clip: padding-box"),
+        OriginSwatch("content-box", "background-color: coral; background-clip: content-box", "background-clip: content-box")
+    ) +
+
+    "<h2>5 — background-clip: Linear Gradient</h2>" +
+    "<p class=\"intro\">Gradient fills the origin area but is clipped to the clip area.</p>" +
+    Row(
+        OriginSwatch("default (border-box)", "background: linear-gradient(to right, orange, purple)"),
+        OriginSwatch("border-box", "background: linear-gradient(to right, orange, purple); background-clip: border-box", "background-clip: border-box"),
+        OriginSwatch("padding-box", "background: linear-gradient(to right, orange, purple); background-clip: padding-box", "background-clip: padding-box"),
+        OriginSwatch("content-box", "background: linear-gradient(to right, orange, purple); background-clip: content-box", "background-clip: content-box")
+    ) +
+
+    "<h2>6 — background-origin + background-clip: Combinations</h2>" +
+    Row(
+        OriginSwatch("origin: border, clip: border", "background: linear-gradient(to right, teal, gold); background-origin: border-box; background-clip: border-box", "origin: border-box; clip: border-box"),
+        OriginSwatch("origin: padding, clip: padding", "background: linear-gradient(to right, teal, gold); background-origin: padding-box; background-clip: padding-box", "origin: padding-box; clip: padding-box"),
+        OriginSwatch("origin: content, clip: content", "background: linear-gradient(to right, teal, gold); background-origin: content-box; background-clip: content-box", "origin: content-box; clip: content-box"),
+        OriginSwatch("origin: border, clip: padding", "background: linear-gradient(to right, teal, gold); background-origin: border-box; background-clip: padding-box", "origin: border-box; clip: padding-box")
+    ) +
+
+    "<h2>7 — background-origin + background-clip: More Combinations</h2>" +
+    Row(
+        OriginSwatch("origin: border, clip: content", "background: linear-gradient(to right, crimson, lime); background-origin: border-box; background-clip: content-box", "origin: border-box; clip: content-box"),
+        OriginSwatch("origin: padding, clip: content", "background: linear-gradient(to right, crimson, lime); background-origin: padding-box; background-clip: content-box", "origin: padding-box; clip: content-box"),
+        OriginSwatch("origin: content, clip: padding", "background: linear-gradient(to right, crimson, lime); background-origin: content-box; background-clip: padding-box", "origin: content-box; clip: padding-box"),
+        OriginSwatch("origin: content, clip: border", "background: linear-gradient(to right, crimson, lime); background-origin: content-box; background-clip: border-box", "origin: content-box; clip: border-box")
+    ) +
+
+    "<h2>8 — Shorthand with Origin/Clip Tokens</h2>" +
+    "<p class=\"intro\">A single box-model keyword in the shorthand sets both origin and clip; two keywords set origin then clip.</p>" +
+    Row(
+        OriginSwatch("single keyword — padding", "background: steelblue padding-box", "background: steelblue padding-box"),
+        OriginSwatch("single keyword — content", "background: coral content-box", "background: coral content-box"),
+        OriginSwatch("gradient padding-box content-box", "background: linear-gradient(to right, teal, gold) padding-box content-box", "linear-gradient padding-box content-box"),
+        OriginSwatch("gradient border-box padding-box", "background: linear-gradient(to right, teal, gold) border-box padding-box", "linear-gradient border-box padding-box")
+    ) +
+
+    "<h2>9 — Radial Gradient + Clip Combinations</h2>" +
+    Row(
+        OriginSwatch("radial, clip: border-box", "background: radial-gradient(circle at center, yellow, navy); background-clip: border-box", "radial; clip: border-box"),
+        OriginSwatch("radial, clip: padding-box", "background: radial-gradient(circle at center, yellow, navy); background-clip: padding-box", "radial; clip: padding-box"),
+        OriginSwatch("radial, clip: content-box", "background: radial-gradient(circle at center, yellow, navy); background-clip: content-box", "radial; clip: content-box"),
+        OriginSwatch("radial, origin+clip: content", "background: radial-gradient(circle at center, yellow, navy); background-origin: content-box; background-clip: content-box", "origin: content-box; clip: content-box")
+    ) +
+
+    "</body></html>";
+
+var originStream = new MemoryStream();
+var originDocument = await generator.GeneratePdf(originHtml, pdfConfig);
+originDocument.Save(originStream);
+
+File.Delete("test_background_origin_clip.pdf");
+File.WriteAllBytes("test_background_origin_clip.pdf", originStream.ToArray());
+Console.WriteLine("Saved test_background_origin_clip.pdf");
+
+File.Delete("test_background_origin_clip.html");
+File.WriteAllText("test_background_origin_clip.html", originHtml);
+Console.WriteLine("Saved test_background_origin_clip.html");

--- a/src/PeachPDF.Tests/Integration/BackgroundOriginClipIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/BackgroundOriginClipIntegrationTests.cs
@@ -1,0 +1,115 @@
+using PeachPDF;
+using PeachPDF.PdfSharpCore;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    public class BackgroundOriginClipIntegrationTests
+    {
+        // Box with visible border and padding so all three box-model regions differ.
+        private static string BoxHtml(string css) =>
+            $"<!DOCTYPE html><html><head><style>body {{ margin: 0; }} div {{ width: 120px; height: 80px; border: 10px solid black; padding: 10px; {css} }}</style></head><body><div></div></body></html>";
+
+        private static async Task<string> GetPdfText(string html)
+        {
+            var generator = new PdfGenerator();
+            var config = new PdfGenerateConfig { PageSize = PageSize.A4, CompressContentStreams = false };
+            config.SetMargins(20);
+            var doc = await generator.GeneratePdf(html, config);
+            var ms = new MemoryStream();
+            doc.Save(ms);
+            return Encoding.Latin1.GetString(ms.ToArray());
+        }
+
+        [Fact]
+        public async Task BackgroundOrigin_Default_PaddingBox_Renders()
+        {
+            var pdfText = await GetPdfText(BoxHtml("background-color: steelblue;"));
+            Assert.NotEmpty(pdfText);
+            Assert.Contains(" rg\n", pdfText);
+        }
+
+        [Fact]
+        public async Task BackgroundOrigin_BorderBox_Renders()
+        {
+            var pdfText = await GetPdfText(BoxHtml("background-color: red; background-origin: border-box;"));
+            Assert.NotEmpty(pdfText);
+            Assert.Contains(" rg\n", pdfText);
+        }
+
+        [Fact]
+        public async Task BackgroundOrigin_ContentBox_Renders()
+        {
+            var pdfText = await GetPdfText(BoxHtml("background-color: blue; background-origin: content-box;"));
+            Assert.NotEmpty(pdfText);
+            Assert.Contains(" rg\n", pdfText);
+        }
+
+        [Fact]
+        public async Task BackgroundClip_Default_BorderBox_Renders()
+        {
+            var pdfText = await GetPdfText(BoxHtml("background-color: coral;"));
+            Assert.NotEmpty(pdfText);
+            Assert.Contains(" rg\n", pdfText);
+        }
+
+        [Fact]
+        public async Task BackgroundClip_PaddingBox_Renders()
+        {
+            var pdfText = await GetPdfText(BoxHtml("background-color: red; background-clip: padding-box;"));
+            Assert.NotEmpty(pdfText);
+            Assert.Contains(" rg\n", pdfText);
+        }
+
+        [Fact]
+        public async Task BackgroundClip_ContentBox_Renders()
+        {
+            var pdfText = await GetPdfText(BoxHtml("background-color: red; background-clip: content-box;"));
+            Assert.NotEmpty(pdfText);
+            Assert.Contains(" rg\n", pdfText);
+        }
+
+        [Fact]
+        public async Task BackgroundOrigin_PaddingBox_GradientRendered()
+        {
+            var pdfText = await GetPdfText(BoxHtml("background: linear-gradient(to right, red, blue); background-origin: padding-box;"));
+            Assert.Contains("/ShadingType", pdfText);
+            Assert.Contains("/DeviceRGB", pdfText);
+        }
+
+        [Fact]
+        public async Task BackgroundOrigin_BorderBox_GradientRendered()
+        {
+            var pdfText = await GetPdfText(BoxHtml("background: linear-gradient(to right, red, blue); background-origin: border-box;"));
+            Assert.Contains("/ShadingType", pdfText);
+            Assert.Contains("/DeviceRGB", pdfText);
+        }
+
+        [Fact]
+        public async Task BackgroundOriginAndClip_Shorthand_ExpandsCorrectly()
+        {
+            // Shorthand: single box-model keyword sets both origin and clip
+            var pdfText = await GetPdfText(BoxHtml("background: red content-box;"));
+            Assert.NotEmpty(pdfText);
+            Assert.Contains(" rg\n", pdfText);
+        }
+
+        [Fact]
+        public async Task BackgroundOriginAndClip_TwoKeywords_ExpandsCorrectly()
+        {
+            // Shorthand: two box-model keywords — first is origin, second is clip
+            var pdfText = await GetPdfText(BoxHtml("background: linear-gradient(to right, teal, gold) padding-box content-box;"));
+            Assert.Contains("/ShadingType", pdfText);
+        }
+
+        [Fact]
+        public async Task BackgroundClip_ContentBox_RadialGradientRendered()
+        {
+            var pdfText = await GetPdfText(BoxHtml("background: radial-gradient(circle, yellow, navy); background-clip: content-box;"));
+            Assert.Contains("/ShadingType", pdfText);
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -1513,11 +1513,29 @@ namespace PeachPDF.Html.Core.Dom
         {
             if (rect is { Width: > 0, Height: > 0 })
             {
+                RRect BoxModelRect(string value) => value switch
+                {
+                    CssConstants.BorderBox => rect,
+                    CssConstants.ContentBox => new RRect(
+                        rect.X + ActualBorderLeftWidth + ActualPaddingLeft,
+                        rect.Y + ActualBorderTopWidth  + ActualPaddingTop,
+                        rect.Width  - ActualBorderLeftWidth - ActualBorderRightWidth  - ActualPaddingLeft - ActualPaddingRight,
+                        rect.Height - ActualBorderTopWidth  - ActualBorderBottomWidth - ActualPaddingTop  - ActualPaddingBottom),
+                    _ => new RRect(
+                        rect.X + ActualBorderLeftWidth,
+                        rect.Y + ActualBorderTopWidth,
+                        rect.Width  - ActualBorderLeftWidth - ActualBorderRightWidth,
+                        rect.Height - ActualBorderTopWidth  - ActualBorderBottomWidth),
+                };
+
+                var originRect = BoxModelRect(BackgroundOrigin);
+                var clipRect   = BoxModelRect(BackgroundClip);
+
                 RBrush? brush = null;
 
                 if (BackgroundLinearGradient is { } gradient)
                 {
-                    var (p1, p2) = ComputeGradientLine(rect, gradient.AngleRad);
+                    var (p1, p2) = ComputeGradientLine(originRect, gradient.AngleRad);
                     double gdx = p2.X - p1.X, gdy = p2.Y - p1.Y;
                     double gradientLength = Math.Sqrt(gdx * gdx + gdy * gdy);
                     var stops = NormalizeGradientStops(gradient.Stops, gradientLength, gradient.ColorSpace, gradient.HueMethod);
@@ -1527,28 +1545,28 @@ namespace PeachPDF.Html.Core.Dom
                 else if (BackgroundRadialGradient is { } radialGradient)
                 {
                     var center = new RPoint(
-                        rect.X + radialGradient.CenterX * rect.Width,
-                        rect.Y + radialGradient.CenterY * rect.Height);
+                        originRect.X + radialGradient.CenterX * originRect.Width,
+                        originRect.Y + radialGradient.CenterY * originRect.Height);
 
-                    double cx = radialGradient.CenterX * rect.Width;
-                    double cy = radialGradient.CenterY * rect.Height;
-                    double dxNear = Math.Min(cx, rect.Width - cx);
-                    double dxFar  = Math.Max(cx, rect.Width - cx);
-                    double dyNear = Math.Min(cy, rect.Height - cy);
-                    double dyFar  = Math.Max(cy, rect.Height - cy);
+                    double cx = radialGradient.CenterX * originRect.Width;
+                    double cy = radialGradient.CenterY * originRect.Height;
+                    double dxNear = Math.Min(cx, originRect.Width - cx);
+                    double dxFar  = Math.Max(cx, originRect.Width - cx);
+                    double dyNear = Math.Min(cy, originRect.Height - cy);
+                    double dyFar  = Math.Max(cy, originRect.Height - cy);
 
                     double radiusX, radiusY;
                     if (radialGradient.ExplicitRadiusX.HasValue)
                     {
                         var rx = radialGradient.ExplicitRadiusX.Value;
                         radiusX = rx.Type == Length.Unit.Percent
-                            ? rx.Value / 100.0 * rect.Width
+                            ? rx.Value / 100.0 * originRect.Width
                             : rx.ToPixel();
                         if (radialGradient.ExplicitRadiusY.HasValue)
                         {
                             var ry = radialGradient.ExplicitRadiusY.Value;
                             radiusY = ry.Type == Length.Unit.Percent
-                                ? ry.Value / 100.0 * rect.Height
+                                ? ry.Value / 100.0 * originRect.Height
                                 : ry.ToPixel();
                         }
                         else
@@ -1604,14 +1622,14 @@ namespace PeachPDF.Html.Core.Dom
                 }
                 else if (BackgroundConicGradient is { } conicGradient)
                 {
-                    double cx = rect.X + conicGradient.CenterX * rect.Width;
-                    double cy = rect.Y + conicGradient.CenterY * rect.Height;
+                    double cx = originRect.X + conicGradient.CenterX * originRect.Width;
+                    double cy = originRect.Y + conicGradient.CenterY * originRect.Height;
                     var conicCenter = new RPoint(cx, cy);
 
-                    double dxFar = Math.Max(conicGradient.CenterX * rect.Width,
-                                            (1.0 - conicGradient.CenterX) * rect.Width);
-                    double dyFar = Math.Max(conicGradient.CenterY * rect.Height,
-                                            (1.0 - conicGradient.CenterY) * rect.Height);
+                    double dxFar = Math.Max(conicGradient.CenterX * originRect.Width,
+                                            (1.0 - conicGradient.CenterX) * originRect.Width);
+                    double dyFar = Math.Max(conicGradient.CenterY * originRect.Height,
+                                            (1.0 - conicGradient.CenterY) * originRect.Height);
                     double outerRadius = Math.Sqrt(dxFar * dxFar + dyFar * dyFar);
 
                     var (conicColors, conicAngles) = NormalizeConicStops(conicGradient);
@@ -1631,8 +1649,8 @@ namespace PeachPDF.Html.Core.Dom
                     RGraphicsPath? roundrect = null;
                     if (IsRounded)
                     {
-                        var radii = ComputeRadii(rect);
-                        roundrect = RenderUtils.GetRoundRect(g, rect,
+                        var radii = ComputeRadii(clipRect);
+                        roundrect = RenderUtils.GetRoundRect(g, clipRect,
                             radii.TLX, radii.TLY, radii.TRX, radii.TRY,
                             radii.BRX, radii.BRY, radii.BLX, radii.BLY);
                     }
@@ -1649,7 +1667,7 @@ namespace PeachPDF.Html.Core.Dom
                     }
                     else
                     {
-                        g.DrawRectangle(brush, rect.X, rect.Y, rect.Width, rect.Height);
+                        g.DrawRectangle(brush, clipRect.X, clipRect.Y, clipRect.Width, clipRect.Height);
                     }
 
                     g.ReturnPreviousSmoothingMode(prevMode);
@@ -1660,7 +1678,7 @@ namespace PeachPDF.Html.Core.Dom
 
                 if (_imageLoadHandler is { Image: not null } && isFirst)
                 {
-                    BackgroundImageDrawHandler.DrawBackgroundImage(g, this, _imageLoadHandler, rect);
+                    BackgroundImageDrawHandler.DrawBackgroundImage(g, this, _imageLoadHandler, originRect, clipRect);
                 }
             }
         }

--- a/src/PeachPDF/Html/Core/Dom/CssBoxProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBoxProperties.cs
@@ -350,6 +350,10 @@ namespace PeachPDF.Html.Core.Dom
 
         public string BackgroundRepeat { get; set; } = "repeat";
 
+        public string BackgroundOrigin { get; set; } = CssConstants.PaddingBox;
+
+        public string BackgroundClip { get; set; } = CssConstants.BorderBox;
+
         public ParsedLinearGradient? BackgroundLinearGradient { get; set; }
 
         public ParsedRadialGradient? BackgroundRadialGradient { get; set; }
@@ -1251,6 +1255,8 @@ namespace PeachPDF.Html.Core.Dom
             BackgroundImage = p.BackgroundImage;
             BackgroundPosition = p.BackgroundPosition;
             BackgroundRepeat = p.BackgroundRepeat;
+            BackgroundOrigin = p.BackgroundOrigin;
+            BackgroundClip = p.BackgroundClip;
             _borderTopWidth = p._borderTopWidth;
             _borderRightWidth = p._borderRightWidth;
             _borderBottomWidth = p._borderBottomWidth;

--- a/src/PeachPDF/Html/Core/Handlers/BackgroundImageDrawHandler.cs
+++ b/src/PeachPDF/Html/Core/Handlers/BackgroundImageDrawHandler.cs
@@ -29,24 +29,25 @@ namespace PeachPDF.Html.Core.Handlers
         /// <param name="g">the device to draw into</param>
         /// <param name="box">the box to draw its background image</param>
         /// <param name="imageLoadHandler">the handler that loads image to draw</param>
-        /// <param name="rectangle">the rectangle to draw image in</param>
-        public static void DrawBackgroundImage(RGraphics g, CssBox box, ImageLoadHandler imageLoadHandler, RRect rectangle)
+        /// <param name="positioningRect">the background positioning area (background-origin)</param>
+        /// <param name="clipRect">the background painting area (background-clip)</param>
+        public static void DrawBackgroundImage(RGraphics g, CssBox box, ImageLoadHandler imageLoadHandler, RRect positioningRect, RRect clipRect)
         {
             // image size depends if specific rectangle given in image loader
             var imgSize = new RSize(imageLoadHandler.Image!.Width, imageLoadHandler.Image!.Height);
 
-            // get the location by BackgroundPosition value
-            var location = GetLocation(box.BackgroundPosition, rectangle, imgSize);
+            // get the location by BackgroundPosition value, relative to the positioning area
+            var location = GetLocation(box.BackgroundPosition, positioningRect, imgSize);
 
             var srcRect = new RRect(0, 0, imgSize.Width, imgSize.Height);
 
             // initial image destination rectangle
             var destRect = new RRect(location, imgSize);
 
-            // need to clip so repeated image will be cut on rectangle
-            var lRectangle = rectangle;
-            lRectangle.Intersect(g.GetClip());
-            g.PushClip(lRectangle);
+            // clip to the painting area (background-clip) intersected with the current graphics clip
+            var lClipRect = clipRect;
+            lClipRect.Intersect(g.GetClip());
+            g.PushClip(lClipRect);
 
             switch (box.BackgroundRepeat)
             {
@@ -54,13 +55,13 @@ namespace PeachPDF.Html.Core.Handlers
                     g.DrawImage(imageLoadHandler.Image, destRect, srcRect);
                     break;
                 case "repeat-x":
-                    DrawRepeatX(g, imageLoadHandler, rectangle, srcRect, destRect, imgSize);
+                    DrawRepeatX(g, imageLoadHandler, positioningRect, srcRect, destRect, imgSize);
                     break;
                 case "repeat-y":
-                    DrawRepeatY(g, imageLoadHandler, rectangle, srcRect, destRect, imgSize);
+                    DrawRepeatY(g, imageLoadHandler, positioningRect, srcRect, destRect, imgSize);
                     break;
                 default:
-                    DrawRepeat(g, imageLoadHandler, rectangle, srcRect, destRect, imgSize);
+                    DrawRepeat(g, imageLoadHandler, positioningRect, srcRect, destRect, imgSize);
                     break;
             }
 

--- a/src/PeachPDF/Html/Core/Utils/CssUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/CssUtils.cs
@@ -101,6 +101,8 @@ namespace PeachPDF.Html.Core.Utils
                 "background-image" => cssBox.BackgroundImage,
                 "background-position" => cssBox.BackgroundPosition,
                 "background-repeat" => cssBox.BackgroundRepeat,
+                "background-origin" => cssBox.BackgroundOrigin,
+                "background-clip" => cssBox.BackgroundClip,
                 "content" => cssBox.Content,
                 "color" => cssBox.Color,
                 "display" => cssBox.Display,
@@ -561,9 +563,14 @@ namespace PeachPDF.Html.Core.Utils
                     }
 
                     break;
+                case "background-origin":
+                    cssBox.BackgroundOrigin = value;
+                    break;
+                case "background-clip":
+                    cssBox.BackgroundClip = value;
+                    break;
                 case "unicode-bidi":
                 case "background-attachment":
-                case "background-clip":
                 case "overflow-wrap":
                     break;
             }


### PR DESCRIPTION
Render backgrounds using the configured `background-origin` and `background-clip` box areas, including gradients, solid fills, and background images. Also parse and expose the new CSS properties, update the test harness showcase, add integration coverage, and refresh the support matrix documentation.