### PR TITLE
Add Pages deploy workflow and prerelease flag

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,41 @@
+name: Deploy GitHub Pages
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: "!github.event.release.prerelease"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,11 @@ jobs:
         VERSION=$(grep -oP '(?<=<PackageVersion>)[^<]+' src/PeachPDF/PeachPDF.csproj)
         echo "value=$VERSION" >> $GITHUB_OUTPUT
         echo "Version: $VERSION"
+        if [[ "$VERSION" == *"preview"* ]]; then
+          echo "prerelease=true" >> $GITHUB_OUTPUT
+        else
+          echo "prerelease=false" >> $GITHUB_OUTPUT
+        fi
 
     - name: Create and push tag
       run: |
@@ -38,9 +43,14 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
+        PRERELEASE_FLAG=""
+        if [[ "${{ steps.version.outputs.prerelease }}" == "true" ]]; then
+          PRERELEASE_FLAG="--prerelease"
+        fi
         gh release create "v${{ steps.version.outputs.value }}" \
           --title "v${{ steps.version.outputs.value }}" \
-          --generate-notes
+          --generate-notes \
+          $PRERELEASE_FLAG
 
     - name: Build
       run: dotnet build src/PeachPDF/PeachPDF.csproj --configuration Release


### PR DESCRIPTION
Adds a new GitHub Actions workflow to build and deploy the docs site from `docs/` to GitHub Pages when a release is published, skipping prerelease releases. Updates the publish workflow to detect preview package versions and create GitHub releases with `--prerelease` when appropriate.