### PR TITLE
Add print-focused @media rule support

### DIFF
--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -300,7 +300,7 @@ These properties control how content breaks across PDF pages. Both the legacy `p
 |---------|-------|
 | `@font-face` | Full support; see [Fonts](index.md#fonts) |
 | `@page` | Full support; see [CSS Paged Media](#css-paged-media) below |
-| `@media` | Not supported |
+| `@media` | Partial support; `print` and `all` media types apply, `screen` is ignored; see [CSS Media Queries](#css-media-queries) below |
 | `@keyframes` | Not supported |
 | `@supports` | Not supported |
 | `@layer` | Not supported |
@@ -367,6 +367,40 @@ Because PeachPDF renders a static PDF with no interactive or dynamic state, almo
 | All others | Parsed but not matched — rules are silently ignored |
 
 State-based pseudo-classes (`:hover`, `:focus`, `:active`, `:checked`, `:disabled`) and structural pseudo-classes (`:first-child`, `:last-child`, `:nth-of-type()`, `:not()`, etc.) are not applied.
+
+---
+
+## CSS Media Queries
+
+PeachPDF renders to PDF, so only media queries that target the `print` medium (or the universal `all` medium) are evaluated. Rules inside `@media screen` are ignored entirely, which lets web stylesheets that separate screen and print styles work correctly out of the box.
+
+```css
+/* applied — print medium matches */
+@media print {
+  body { font-size: 12pt; }
+}
+
+/* applied — "all" matches every medium */
+@media all {
+  p { line-height: 1.5; }
+}
+
+/* ignored — screen-only rules are skipped */
+@media screen {
+  body { font-size: 16px; }
+}
+```
+
+| Media query | Applied in PDF? | Notes |
+|-------------|-----------------|-------|
+| `@media print { }` | Yes | Directly targets the print medium |
+| `@media all { }` | Yes | Applies to every medium, including print |
+| `@media only print { }` | Yes | Equivalent to `@media print` |
+| `@media screen { }` | No | Screen-only rules are skipped |
+| `@media not print { }` | No | Explicitly excluded from the print medium |
+| `@media not screen { }` | Yes | Applies to any non-screen medium |
+| Comma-separated list | Partial | Applied if **any** entry in the list matches print (e.g. `@media print, screen` applies) |
+| Media features (`min-width`, `color`, etc.) | No | Features are parsed but not evaluated; the block is treated as if the feature condition were met |
 
 ---
 

--- a/src/PeachPDF.Tests/CSS/PropertyTests/MediaQueryTests.cs
+++ b/src/PeachPDF.Tests/CSS/PropertyTests/MediaQueryTests.cs
@@ -1,0 +1,108 @@
+using PeachPDF.CSS;
+using System.Linq;
+using Xunit;
+
+namespace PeachPDF.Tests.CSS.PropertyTests
+{
+    public class MediaQueryTests : CssConstructionFunctions
+    {
+        // ── media type parsing ─────────────────────────────────────────────────
+
+        [Fact]
+        public void AtMedia_Print_HasTypePrint()
+        {
+            var sheet = ParseStyleSheet("@media print { }");
+            var rule = sheet.Rules.OfType<MediaRule>().FirstOrDefault();
+            Assert.NotNull(rule);
+            var medium = rule.Media.Media.FirstOrDefault();
+            Assert.NotNull(medium);
+            Assert.Equal("print", medium.Type);
+            Assert.False(medium.IsInverse);
+            Assert.False(medium.IsExclusive);
+        }
+
+        [Fact]
+        public void AtMedia_Screen_HasTypeScreen()
+        {
+            var sheet = ParseStyleSheet("@media screen { }");
+            var rule = sheet.Rules.OfType<MediaRule>().FirstOrDefault();
+            Assert.NotNull(rule);
+            var medium = rule.Media.Media.FirstOrDefault();
+            Assert.NotNull(medium);
+            Assert.Equal("screen", medium.Type);
+        }
+
+        [Fact]
+        public void AtMedia_All_HasTypeAll()
+        {
+            var sheet = ParseStyleSheet("@media all { }");
+            var rule = sheet.Rules.OfType<MediaRule>().FirstOrDefault();
+            Assert.NotNull(rule);
+            var medium = rule.Media.Media.FirstOrDefault();
+            Assert.NotNull(medium);
+            Assert.Equal("all", medium.Type);
+        }
+
+        // ── not / only modifiers ───────────────────────────────────────────────
+
+        [Fact]
+        public void AtMedia_NotPrint_HasIsInverseTrue()
+        {
+            var sheet = ParseStyleSheet("@media not print { }");
+            var rule = sheet.Rules.OfType<MediaRule>().FirstOrDefault();
+            Assert.NotNull(rule);
+            var medium = rule.Media.Media.FirstOrDefault();
+            Assert.NotNull(medium);
+            Assert.Equal("print", medium.Type);
+            Assert.True(medium.IsInverse);
+        }
+
+        [Fact]
+        public void AtMedia_OnlyPrint_HasIsExclusiveTrue()
+        {
+            var sheet = ParseStyleSheet("@media only print { }");
+            var rule = sheet.Rules.OfType<MediaRule>().FirstOrDefault();
+            Assert.NotNull(rule);
+            var medium = rule.Media.Media.FirstOrDefault();
+            Assert.NotNull(medium);
+            Assert.Equal("print", medium.Type);
+            Assert.True(medium.IsExclusive);
+        }
+
+        // ── comma-separated media list ─────────────────────────────────────────
+
+        [Fact]
+        public void AtMedia_PrintCommaScreen_HasTwoMediaEntries()
+        {
+            var sheet = ParseStyleSheet("@media print, screen { }");
+            var rule = sheet.Rules.OfType<MediaRule>().FirstOrDefault();
+            Assert.NotNull(rule);
+            var media = rule.Media.Media.ToList();
+            Assert.Equal(2, media.Count);
+            Assert.Equal("print", media[0].Type);
+            Assert.Equal("screen", media[1].Type);
+        }
+
+        // ── nested style rules ─────────────────────────────────────────────────
+
+        [Fact]
+        public void AtMedia_Print_NestedStyleRuleIsAccessible()
+        {
+            var sheet = ParseStyleSheet("@media print { p { color: red; } }");
+            var rule = sheet.Rules.OfType<MediaRule>().FirstOrDefault();
+            Assert.NotNull(rule);
+            var nested = rule.Rules.OfType<StyleRule>().FirstOrDefault();
+            Assert.NotNull(nested);
+            Assert.Equal("p", nested.SelectorText);
+        }
+
+        [Fact]
+        public void AtMedia_Print_MultipleNestedRulesAreParsed()
+        {
+            var sheet = ParseStyleSheet("@media print { p { color: red; } div { font-size: 12pt; } }");
+            var rule = sheet.Rules.OfType<MediaRule>().FirstOrDefault();
+            Assert.NotNull(rule);
+            Assert.Equal(2, rule.Rules.OfType<StyleRule>().Count());
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/MediaQueryIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/MediaQueryIntegrationTests.cs
@@ -1,0 +1,194 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore.Drawing;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Integration tests verifying that @media rules are applied correctly when rendering
+    /// to PDF (print medium). Rules targeting "print" or "all" must apply; rules targeting
+    /// "screen" must not. The "not" modifier inverts that logic.
+    /// </summary>
+    public class MediaQueryIntegrationTests
+    {
+        // ── @media print ───────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task AtMediaPrint_StyleRule_IsApplied()
+        {
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                @media print { div { color: red; } }
+                </style></head><body><div id="el">text</div></body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("rgb(255, 0, 0)", el!.Color);
+        }
+
+        // ── @media screen ─────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task AtMediaScreen_StyleRule_IsNotApplied()
+        {
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                @media screen { div { color: blue; } }
+                </style></head><body><div id="el">text</div></body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("black", el!.Color);
+        }
+
+        // ── @media all ────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task AtMediaAll_StyleRule_IsApplied()
+        {
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                @media all { div { color: green; } }
+                </style></head><body><div id="el">text</div></body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("rgb(0, 128, 0)", el!.Color);
+        }
+
+        // ── @media only print ─────────────────────────────────────────────────
+
+        [Fact]
+        public async Task AtMediaOnlyPrint_StyleRule_IsApplied()
+        {
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                @media only print { div { color: red; } }
+                </style></head><body><div id="el">text</div></body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("rgb(255, 0, 0)", el!.Color);
+        }
+
+        // ── @media not print ──────────────────────────────────────────────────
+
+        [Fact]
+        public async Task AtMediaNotPrint_StyleRule_IsNotApplied()
+        {
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                @media not print { div { color: orange; } }
+                </style></head><body><div id="el">text</div></body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("black", el!.Color);
+        }
+
+        // ── @media not screen ─────────────────────────────────────────────────
+
+        [Fact]
+        public async Task AtMediaNotScreen_StyleRule_IsApplied()
+        {
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                @media not screen { div { color: purple; } }
+                </style></head><body><div id="el">text</div></body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("rgb(128, 0, 128)", el!.Color);
+        }
+
+        // ── print overrides screen ────────────────────────────────────────────
+
+        [Fact]
+        public async Task AtMediaPrint_OverridesAtMediaScreen_WhenBothPresent()
+        {
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                @media screen { div { color: blue; } }
+                @media print  { div { color: red;  } }
+                </style></head><body><div id="el">text</div></body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("rgb(255, 0, 0)", el!.Color);
+        }
+
+        // ── comma-separated list: print in the list ───────────────────────────
+
+        [Fact]
+        public async Task AtMediaPrintCommaScreen_StyleRule_IsApplied()
+        {
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                @media print, screen { div { color: green; } }
+                </style></head><body><div id="el">text</div></body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("rgb(0, 128, 0)", el!.Color);
+        }
+
+        // ── helpers ───────────────────────────────────────────────────────────
+
+        private static async Task<CssBox> BuildBoxTree(string html)
+        {
+            var adapter = new PdfSharpAdapter();
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            var size = new XSize(595, 842);
+            container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+            container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+            var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            return container.Root!;
+        }
+
+        private static CssBox? FindById(CssBox box, string id)
+        {
+            if (box.HtmlTag?.Attributes?.TryGetValue("id", out var boxId) == true
+                && string.Equals(boxId, id, StringComparison.OrdinalIgnoreCase))
+                return box;
+
+            foreach (var child in box.Boxes)
+            {
+                var found = FindById(child, id);
+                if (found is not null) return found;
+            }
+            return null;
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/CssData.cs
+++ b/src/PeachPDF/Html/Core/CssData.cs
@@ -80,7 +80,9 @@ namespace PeachPDF.Html.Core
                 {
                     foreach (var medium in mediaRule.Media)
                     {
-                        if (medium.Type != media) continue;
+                        var typeMatches = medium.Type == media || medium.Type == "all";
+                        var matches = medium.IsInverse ? !typeMatches : typeMatches;
+                        if (!matches) continue;
 
                         foreach (var rule in GetStyleRules(mediaRule.Rules.OfType<IStyleRule>(), box))
                         {


### PR DESCRIPTION
Implement partial @media handling for PDF rendering by evaluating `print` and `all` media types and honoring the `not` modifier during stylesheet rule selection. Add parser-level and integration tests covering media type parsing, `only`/`not`, comma-separated lists, and end-to-end style application behavior. Update CSS support docs to describe the new media-query behavior and limits (including ignored `screen` rules and unevaluated media features).