### PR TITLE
Add CSS custom properties and var() support

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -270,10 +270,11 @@ Before style cascading begins, `CascadeApplyPageStyles` reads `@page` rules from
 3. **Matching rules** — `CssData.GetStyleRules` yields every `IStyleRule` from every stylesheet (filtered to the `print` media type) whose selector matches the current box.
 4. **`!important` tracking** — property names marked `!important` are recorded in a `HashSet<string>`. Subsequent rules cannot overwrite them.
 5. **`inherit` / `initial` keywords** — resolved at assignment time: `inherit` reads the property value from the parent box; `initial` reads from `CssDefaults.InitialValues`.
-6. **Presentational attributes** — `TranslateAttributes` maps HTML attributes such as `align`, `width`, `border`, `bgcolor`, `valign`, `cellspacing`, and `cellpadding` to their CSS equivalents so they participate in the cascade.
-7. **Inline `style` attribute** — parsed on the fly and applied last (with highest author specificity).
-8. **`currentColor`** — `CssUtils.ApplyCurrentColor` resolves any `currentColor` keyword references.
-9. **Text decoration propagation** — because `text-decoration` does not inherit through the CSS `inherit` mechanism but does visually propagate to inline children, it is explicitly copied down to child boxes that contain actual text.
+6. **Custom properties and `var()`** — `--foo` declarations are kept in a per-box dictionary, cloned (not shared) from the parent at inheritance time so a child's local override never leaks to its parent or siblings. Regular declarations whose value contains `var()` are deferred until the box's entire cascade (UA, author, inline) has finished, then resolved in one pass via a graph-based, memoized, cycle-safe substitution against the box's final custom-property values — this makes resolution correct regardless of declaration order and safely short-circuits cyclic references (`--a: var(--b); --b: var(--a);`) instead of looping.
+7. **Presentational attributes** — `TranslateAttributes` maps HTML attributes such as `align`, `width`, `border`, `bgcolor`, `valign`, `cellspacing`, and `cellpadding` to their CSS equivalents so they participate in the cascade.
+8. **Inline `style` attribute** — parsed on the fly and applied last (with highest author specificity).
+9. **`currentColor`** — `CssUtils.ApplyCurrentColor` resolves any `currentColor` keyword references.
+10. **Text decoration propagation** — because `text-decoration` does not inherit through the CSS `inherit` mechanism but does visually propagate to inline children, it is explicitly copied down to child boxes that contain actual text.
 
 ### Post-styling corrections
 

--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -637,6 +637,35 @@ All five keywords can be combined with `!important`.
 
 ---
 
+## CSS Custom Properties
+
+PeachPDF supports [CSS custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) (`--foo: value`) and the [`var()`](https://developer.mozilla.org/en-US/docs/Web/CSS/var) function, including inheritance, fallback values, and interaction with the CSS-wide keywords above.
+
+```css
+.card {
+  --brand-color: #2c3e50;
+  background: var(--brand-color);
+  border: 1px solid var(--accent-color, #333); /* fallback used since --accent-color is undefined */
+}
+```
+
+| Feature | Support | Notes |
+|---------|---------|-------|
+| Declaration (`--name: value`) | Full | Custom property names are case-sensitive (`--Foo` and `--foo` are distinct) and accept almost any token sequence as a value |
+| `var(--name)` | Full | Substituted with the custom property's cascaded value before the containing declaration is applied |
+| `var(--name, fallback)` | Full | The fallback (which may itself contain `var()`, including further fallbacks) is used when `--name` is undefined |
+| Inheritance | Full | Custom properties are always inherited, regardless of whether the property they're used in is normally inherited |
+| Shorthand properties | Full | `var()` inside a shorthand (e.g. `margin: var(--a) var(--b)`) is resolved before the shorthand is expanded into its longhands |
+| `inherit` / `unset` on a custom property | Full | Pulls the parent element's value, since custom properties are always inherited |
+| `initial` on a custom property | Full | Clears the property to the guaranteed-invalid value (absent) |
+| `revert` / `revert-layer` on a custom property | Full | Restores the value from the previous cascade origin, same as for built-in properties |
+| Cyclic references | Handled | A custom property that references itself, directly or through a chain (`--a: var(--b); --b: var(--a);`), resolves to the guaranteed-invalid value instead of looping |
+| `@property` (typed/registered custom properties) | Not supported | All custom properties are untyped |
+
+When a `var()` reference can't be resolved and no fallback is given, the containing declaration falls back the same way `unset` does: to the parent's value for an inherited property, or to the property's initial value otherwise.
+
+---
+
 ## Unsupported CSS Features
 
 The following CSS features are not supported:
@@ -645,7 +674,6 @@ The following CSS features are not supported:
 - **Transforms** — `transform`, `transform-origin`
 - **Transitions and animations** — `transition`, `animation`, `@keyframes`
 - **Filters and effects** — `filter`, `backdrop-filter`, `mix-blend-mode`, `opacity`
-- **CSS variables** — `var()` and `--custom-properties`
 - **`calc()` expressions**
 - **`background` shorthand** — use individual `background-*` properties
 - **`letter-spacing`**

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -1032,3 +1032,129 @@ Console.WriteLine("Saved test_flexbox.pdf");
 File.Delete("test_flexbox.html");
 File.WriteAllText("test_flexbox.html", flexHtml);
 Console.WriteLine("Saved test_flexbox.html");
+
+// ─── CSS Custom Properties (var()) showcase ─────────────────────────────────
+
+static string VarSwatch(string desc, string boxCss, string valueLabel, string cssLabel) =>
+    "<td>" +
+    $"<div class=\"vbox\" style=\"{boxCss}\">Aa</div>" +
+    $"<div class=\"desc\">{desc}</div>" +
+    $"<div class=\"val\">{valueLabel}</div>" +
+    $"<div class=\"css\">{cssLabel}</div>" +
+    "</td>";
+
+const string VarCss = """
+    <style>
+    @page { size: a4; margin: 15mm }
+    body { font: 8.5pt Arial, sans-serif; margin: 0 }
+    h1 { font-size: 15pt; margin: 0 0 0.3em }
+    h2 { font-size: 10pt; margin: 0.9em 0 0.3em; padding-bottom: 2px; border-bottom: 1px solid #999 }
+    p.intro { margin: 0 0 0.7em; color: #555; font-size: 7.5pt }
+    table.sw { border-collapse: collapse; width: 100%; margin-bottom: 0.3em }
+    table.sw td { padding: 3px; vertical-align: top; width: 25% }
+    .vbox { height: 44px; display: flex; align-items: center; justify-content: center; font: bold 9pt Arial; margin-bottom: 3px }
+    .desc { font-size: 7pt; font-weight: bold; color: #444; margin-bottom: 1px }
+    .val { font-size: 6pt; font-family: monospace; color: #b8860b; font-weight: bold; margin-bottom: 2px; word-break: break-all }
+    .css { font-size: 5.5pt; color: #666; line-height: 1.3; word-break: break-all }
+    .card { border-radius: 8px; padding: 14px }
+    .card h3 { margin: 0 0 6px; font-size: 11pt }
+    .card p { margin: 0 0 8px; font-size: 8pt; line-height: 1.4 }
+    .card button { border: none; border-radius: 4px; padding: 6px 14px; font: bold 8pt Arial }
+    .cardval { font-size: 6pt; font-family: monospace; color: #b8860b; font-weight: bold; margin-bottom: 2px }
+    </style>
+    """;
+
+var varHtml = "<!DOCTYPE html><html><head>" + VarCss + "</head><body>" +
+
+    "<h1>CSS Custom Properties &amp; var() Test Page</h1>" +
+
+    "<h2>1 — Basic Declaration &amp; Usage</h2>" +
+    "<p class=\"intro\">--main-bg, --main-color and --main-border are declared once on the surrounding container and consumed via var() on each box.</p>" +
+    "<div style=\"--main-bg: #2c3e50; --main-color: white; --main-border: 3px solid #1a252f;\">" +
+    Row(
+        VarSwatch("background + color + border", "background: var(--main-bg); color: var(--main-color); border: var(--main-border);", "--main-bg: #2c3e50 · --main-color: white · --main-border: 3px solid #1a252f", "background: var(--main-bg); color: var(--main-color); border: var(--main-border)"),
+        VarSwatch("reused for border only", "border: var(--main-border); color: var(--main-bg); background: white;", "--main-border: 3px solid #1a252f", "border: var(--main-border)"),
+        VarSwatch("reused for text color", "color: var(--main-bg); border: 1px solid #ccc; background: white;", "--main-bg: #2c3e50", "color: var(--main-bg)"),
+        VarSwatch("literal (no var, for comparison)", "background: #2c3e50; color: white; border: 3px solid #1a252f;", "(no custom property used)", "background: #2c3e50 (literal)")
+    ) +
+    "</div>" +
+
+    "<h2>2 — Fallback Values</h2>" +
+    "<p class=\"intro\">Each box references a custom property that was never declared; the fallback (second argument to var()) is used instead.</p>" +
+    Row(
+        VarSwatch("color fallback", "background: var(--undefined-bg, #8e44ad); color: white;", "--undefined-bg: (not declared) → fallback #8e44ad", "background: var(--undefined-bg, #8e44ad)"),
+        VarSwatch("length fallback", "background: #16a085; color: white; padding: var(--undefined-padding, 16px);", "--undefined-padding: (not declared) → fallback 16px", "padding: var(--undefined-padding, 16px)"),
+        VarSwatch("nested fallback chain", "background: var(--undefined-a, var(--undefined-b, #d35400)); color: white;", "--undefined-a, --undefined-b: (not declared) → fallback #d35400", "var(--a, var(--b, #d35400))"),
+        VarSwatch("no fallback (uses initial)", "background: var(--totally-undefined); border: 1px dashed #999;", "--totally-undefined: (not declared) → initial value", "background: var(--totally-undefined)")
+    ) +
+
+    "<h2>3 — Inheritance &amp; Local Override</h2>" +
+    "<p class=\"intro\">--accent is declared once on the outer container. The second box overrides it locally; the override does not leak to its siblings.</p>" +
+    "<div style=\"--accent: #2980b9;\">" +
+    Row(
+        VarSwatch("inherited (no override)", "background: var(--accent); color: white;", "--accent: #2980b9 (inherited)", "background: var(--accent) → inherited"),
+        VarSwatch("local override", "--accent: #c0392b; background: var(--accent); color: white;", "--accent: #c0392b (local override)", "--accent: #c0392b (local)"),
+        VarSwatch("sibling still inherits original", "background: var(--accent); color: white;", "--accent: #2980b9 (inherited, unaffected)", "background: var(--accent) → unaffected"),
+        VarSwatch("--accent: unset (still inherits)", "--accent: unset; background: var(--accent); color: white;", "--accent: #2980b9 (via unset → inherit)", "--accent: unset; background: var(--accent)")
+    ) +
+    "</div>" +
+
+    "<h2>4 — Cyclic References Resolve Safely</h2>" +
+    "<p class=\"intro\">Per spec, a custom property that references itself (directly or through a chain) becomes invalid instead of looping forever; a fallback or the property's initial value is used.</p>" +
+    Row(
+        VarSwatch("direct cycle, with fallback", "--loop-a: var(--loop-b); --loop-b: var(--loop-a); background: var(--loop-a, #7f8c8d); color: white;", "--loop-a ↔ --loop-b: cyclic → invalid → fallback #7f8c8d", "--loop-a: var(--loop-b); --loop-b: var(--loop-a); background: var(--loop-a, #7f8c8d)"),
+        VarSwatch("self-reference — always invalid", "--self: var(--self, #e74c3c); background: var(--self); border: 1px dashed #999;", "--self: self-referential → invalid (the fallback inside --self's OWN definition does not rescue it — matches Chrome/Firefox)", "--self: var(--self, #e74c3c); background: var(--self) (no fallback here)"),
+        VarSwatch("one-directional chain (not cyclic)", "--chain-a: var(--chain-b); --chain-b: #27ae60; background: var(--chain-a); color: white;", "--chain-a → --chain-b: #27ae60 (resolved, not cyclic)", "--a: var(--b); --b: #27ae60 → resolves"),
+        VarSwatch("multi-hop chain", "--x1: var(--x2); --x2: var(--x3); --x3: #f39c12; background: var(--x1); color: white;", "--x1 → --x2 → --x3: #f39c12 (resolved)", "--x1→--x2→--x3: #f39c12")
+    ) +
+
+    "<h2>5 — Real-World Example: Themeable Card Component</h2>" +
+    "<p class=\"intro\">The same card markup and CSS rules render two different themes purely by changing custom property values on the wrapping element — no duplicated rules.</p>" +
+    """
+    <style>
+    .card {
+      --card-bg: white;
+      --card-fg: #222;
+      --card-accent: #2c3e50;
+      --card-muted: #666;
+      background: var(--card-bg);
+      color: var(--card-fg);
+      border: 1px solid var(--card-accent);
+    }
+    .card h3 { color: var(--card-accent); }
+    .card p { color: var(--card-muted); }
+    .card button { background: var(--card-accent); color: var(--card-bg); }
+    </style>
+    """ +
+    "<table class=\"sw\"><tr>" +
+    "<td style=\"width:50%\">" +
+        "<div class=\"card\">" +
+            "<h3>Light Theme</h3>" +
+            "<p>This card uses the component's default custom property values.</p>" +
+            "<button>Learn More</button>" +
+        "</div>" +
+        "<div class=\"cardval\">--card-bg: white · --card-fg: #222 · --card-accent: #2c3e50 · --card-muted: #666 (defaults)</div>" +
+    "</td>" +
+    "<td style=\"width:50%\">" +
+        "<div class=\"card\" style=\"--card-bg: #1a1a2e; --card-fg: #eee; --card-accent: #e94560; --card-muted: #aaa;\">" +
+            "<h3>Dark Theme</h3>" +
+            "<p>Same markup and rules — only the custom property values differ.</p>" +
+            "<button>Learn More</button>" +
+        "</div>" +
+        "<div class=\"cardval\">--card-bg: #1a1a2e · --card-fg: #eee · --card-accent: #e94560 · --card-muted: #aaa (overridden inline)</div>" +
+    "</td>" +
+    "</tr></table>" +
+
+    "</body></html>";
+
+var varStream = new MemoryStream();
+var varDocument = await generator.GeneratePdf(varHtml, pdfConfig);
+varDocument.Save(varStream);
+
+File.Delete("test_custom_properties.pdf");
+File.WriteAllBytes("test_custom_properties.pdf", varStream.ToArray());
+Console.WriteLine("Saved test_custom_properties.pdf");
+
+File.Delete("test_custom_properties.html");
+File.WriteAllText("test_custom_properties.html", varHtml);
+Console.WriteLine("Saved test_custom_properties.html");

--- a/src/PeachPDF.Tests/CSS/PropertyTests/CustomPropertyTests.cs
+++ b/src/PeachPDF.Tests/CSS/PropertyTests/CustomPropertyTests.cs
@@ -1,0 +1,120 @@
+using PeachPDF.CSS;
+using System.Linq;
+using Xunit;
+
+namespace PeachPDF.Tests.CSS.PropertyTests
+{
+    /// <summary>
+    /// Unit tests verifying that the CSS module correctly parses custom properties (--foo) and
+    /// tolerates the var() function inside any property's value. Cascade-level resolution of
+    /// var() is tested separately in Integration/CustomPropertiesIntegrationTests.cs.
+    /// </summary>
+    public class CustomPropertyTests : CssConstructionFunctions
+    {
+        [Fact]
+        public void CustomProperty_SimpleValue_ParsesAndRoundTrips()
+        {
+            var property = ParseDeclaration("--main-color: red");
+            Assert.Equal("--main-color", property.Name);
+            Assert.IsType<CustomProperty>(property);
+            Assert.True(property.HasValue);
+            Assert.Equal("red", property.Value);
+        }
+
+        [Fact]
+        public void CustomProperty_ArbitraryTokenSoup_NeverFailsToParse()
+        {
+            var property = ParseDeclaration("--x: 1px solid   red , foo(bar)");
+            Assert.Equal("--x", property.Name);
+            Assert.IsType<CustomProperty>(property);
+            Assert.True(property.HasValue);
+        }
+
+        [Fact]
+        public void CustomProperty_WithVarReference_RoundTripsLiterally()
+        {
+            var property = ParseDeclaration("--b: var(--a, blue)");
+            Assert.Equal("--b", property.Name);
+            Assert.True(property.HasValue);
+            Assert.Contains("var(--a, blue)", property.Value);
+        }
+
+        [Fact]
+        public void CustomProperty_NameIsCaseSensitive()
+        {
+            var lower = ParseDeclaration("--foo: 1px");
+            var upper = ParseDeclaration("--Foo: 2px");
+            Assert.Equal("--foo", lower.Name);
+            Assert.Equal("--Foo", upper.Name);
+        }
+
+        [Fact]
+        public void CustomProperty_MultiHyphenatedName_ParsesAsSingleIdentifier()
+        {
+            var property = ParseDeclaration("--foo-bar-baz: 1px");
+            Assert.Equal("--foo-bar-baz", property.Name);
+        }
+
+        [Fact]
+        public void ColorProperty_WithVarFunction_DoesNotFailToParse()
+        {
+            var property = ParseDeclaration("color: var(--main-color, red)");
+            Assert.Equal("color", property.Name);
+            Assert.True(property.HasValue);
+            Assert.Contains("var(--main-color, red)", property.Value);
+        }
+
+        [Fact]
+        public void MarginProperty_WithMultipleVarFunctions_DoesNotFailToParse()
+        {
+            var property = ParseDeclaration("margin: var(--a) var(--b)");
+            Assert.Equal("margin", property.Name);
+            Assert.True(property.HasValue);
+        }
+
+        [Fact]
+        public void MarginShorthandInStyleSheet_WithVar_KeepsShorthandWholeUntilCascadeTime()
+        {
+            // Shorthand-to-longhand expansion happens at parse time (StyleDeclaration.SetShorthand);
+            // a var() reference can't be split into per-longhand slices until it's resolved per-element,
+            // so the shorthand must survive intact for CssUtils.SetPropertyValue to expand post-substitution.
+            var sheet = ParseStyleSheet("* { margin: var(--a) var(--b); }");
+            var rule = sheet.StyleRules.Single();
+            var names = rule.Style.Select(p => p.Name).ToArray();
+            Assert.Equal(new[] { "margin" }, names);
+        }
+
+        [Fact]
+        public void Property_WithNestedVarInsideOtherFunction_DoesNotFailToParse()
+        {
+            var property = ParseDeclaration("background-image: linear-gradient(var(--c1), var(--c2))");
+            Assert.Equal("background-image", property.Name);
+            Assert.True(property.HasValue);
+        }
+
+        // ── Lexer regression coverage for the -- identifier-start fix ──────────
+
+        [Fact]
+        public void HtmlCommentClose_StillTokenizesAsCdc_NotAffectedByDashFix()
+        {
+            var stylesheet = ParseStyleSheet("<!-- .a { color: red; } -->");
+            Assert.NotEmpty(stylesheet.StyleRules);
+        }
+
+        [Fact]
+        public void VendorPrefixedProperty_StillParsesAsUnknownSingleHyphenIdent()
+        {
+            var property = ParseDeclaration("-webkit-transform: none", includeUnknownDeclarations: true);
+            Assert.Equal("-webkit-transform", property.Name);
+        }
+
+        [Fact]
+        public void NegativeLength_StillParsesCorrectly()
+        {
+            var property = ParseDeclaration("margin-top: -5px");
+            Assert.Equal("margin-top", property.Name);
+            Assert.True(property.HasValue);
+            Assert.Equal("-5px", property.Value);
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/CustomPropertiesIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/CustomPropertiesIntegrationTests.cs
@@ -1,0 +1,480 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore.Drawing;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Integration tests for CSS custom properties (--foo) and the var() function at the
+    /// cascade-resolution level: inheritance, fallback, cycle detection, revert/revert-layer,
+    /// and interaction with the existing 3-phase cascade and !important machinery.
+    /// </summary>
+    public class CustomPropertiesIntegrationTests
+    {
+        [Fact]
+        public async Task Var_UsedOnDescendant_AppliesInheritedCustomPropertyValue()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="parent" style="--main-color: red">
+                  <span id="child" style="color: var(--main-color)">text</span>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var child = FindById(root, "child");
+
+            Assert.NotNull(child);
+            // Custom properties bypass the typed ColorProperty converter (var() can't be resolved until
+            // cascade time), so the value round-trips as literal text rather than being normalized to rgb().
+            Assert.Equal("red", child!.Color);
+        }
+
+        [Fact]
+        public async Task CustomProperty_InheritsThroughMultipleLevelsWithoutRedeclaration()
+        {
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  .theme { --brand-color: green; }
+                </style></head><body>
+                <div id="parent" class="theme">
+                  <div id="mid">
+                    <span id="child" style="color: var(--brand-color)">text</span>
+                  </div>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var child = FindById(root, "child");
+
+            Assert.NotNull(child);
+            Assert.Equal("green", child!.Color);
+        }
+
+        [Fact]
+        public async Task CustomProperty_ChildOverride_DoesNotMutateParentOrSibling()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="parent" style="--x: red">
+                  <div id="childA" style="--x: blue; color: var(--x)">a</div>
+                  <span id="childB" style="color: var(--x)">b</span>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var childA = FindById(root, "childA");
+            var childB = FindById(root, "childB");
+
+            Assert.NotNull(childA);
+            Assert.NotNull(childB);
+            Assert.Equal("blue", childA!.Color);
+            Assert.Equal("red", childB!.Color);
+        }
+
+        [Fact]
+        public async Task Var_WithFallback_UsedWhenCustomPropertyUndefined()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="el" style="margin-top: var(--undefined-spacing, 10px)">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("10px", el!.MarginTop);
+        }
+
+        [Fact]
+        public async Task Var_WithoutFallback_UndefinedInheritedProperty_FallsBackLikeInherit()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="parent" style="color: purple">
+                  <span id="child" style="color: var(--undefined)">text</span>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var child = FindById(root, "child");
+
+            Assert.NotNull(child);
+            Assert.Equal("rgb(128, 0, 128)", child!.Color);
+        }
+
+        [Fact]
+        public async Task Var_WithoutFallback_UndefinedNonInheritedProperty_FallsBackLikeInitial()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="parent" style="margin-top: 40px">
+                  <div id="child" style="margin-top: var(--undefined)">text</div>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var child = FindById(root, "child");
+
+            Assert.NotNull(child);
+            Assert.Equal("0", child!.MarginTop);
+        }
+
+        [Fact]
+        public async Task Var_MultipleOccurrencesInOneShorthandValue_ShorthandExpansionStillWorks()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="el" style="--a: 10px; --b: 20px; margin: var(--a) var(--b)">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("10px", el!.MarginTop);
+            Assert.Equal("10px", el.MarginBottom);
+            Assert.Equal("20px", el.MarginLeft);
+            Assert.Equal("20px", el.MarginRight);
+        }
+
+        [Fact]
+        public async Task Var_NestedFallback_ResolvesInnerReferenceFirst()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="el" style="--b: green; --c: var(--a, var(--b, red)); color: var(--c)">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("green", el!.Color);
+        }
+
+        [Fact]
+        public async Task Var_FallbackContainingFunctionWithCommas_SplitsOnlyAtTopLevel()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="el" style="--x: var(--undefined, rgb(1, 2, 3)); background-color: var(--x)">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Contains("rgb(1, 2, 3)", el!.BackgroundColor);
+        }
+
+        [Fact]
+        public async Task Content_WithLiteralVarTextInQuotes_IsNotMisinterpretedAsAReference()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="el" style='content: "var(--not-a-reference)"'>text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("\"var(--not-a-reference)\"", el!.Content);
+        }
+
+        [Fact]
+        public async Task MultiHopCyclicCustomProperties_ResolveAsGuaranteedInvalid_WithoutHanging()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="parent" style="color: purple">
+                  <div id="el" style="--a: var(--b); --b: var(--c); --c: var(--a); color: var(--a)">text</div>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            // color is inherited; a cyclic (guaranteed-invalid) var() reference falls back like "unset" would.
+            Assert.Equal("rgb(128, 0, 128)", el!.Color);
+        }
+
+        [Fact]
+        public async Task SelfReferencingCustomProperty_IsGuaranteedInvalid_EvenWithOwnFallback()
+        {
+            // Per the CSS Custom Properties spec, writing var(--self, ...) inside --self's own
+            // definition is a self-reference regardless of the fallback: --self must become
+            // permanently guaranteed-invalid, matching real browsers (Chrome, Firefox) — the fallback
+            // does NOT rescue it. A consumer with no fallback of its own therefore also gets nothing.
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="parent" style="color: purple">
+                  <div id="el" style="--self: var(--self, orange); color: var(--self)">text</div>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("rgb(128, 0, 128)", el!.Color);
+        }
+
+        [Fact]
+        public async Task OneDirectionalChain_IsNotTreatedAsCyclic_ResolvesCorrectly()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="el" style="--a: var(--b); --b: blue; color: var(--a)">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("blue", el!.Color);
+        }
+
+        [Fact]
+        public async Task Revert_CustomPropertyInInlineStyle_RestoresAuthorPhaseValue()
+        {
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  #el { --theme-color: blue; }
+                </style></head><body>
+                <div id="el" style="--theme-color: revert; color: var(--theme-color)">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("blue", el!.Color);
+        }
+
+        [Fact]
+        public async Task RevertLayer_CustomPropertyInInlineStyle_BehavesLikeRevert()
+        {
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  #el { --theme-color: blue; }
+                </style></head><body>
+                <div id="el" style="--theme-color: revert-layer; color: var(--theme-color)">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("blue", el!.Color);
+        }
+
+        [Fact]
+        public async Task Inherit_CustomPropertyDeclaration_PullsParentValue()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="parent" style="--x: red">
+                  <span id="child" style="--x: inherit; color: var(--x)">text</span>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var child = FindById(root, "child");
+
+            Assert.NotNull(child);
+            Assert.Equal("red", child!.Color);
+        }
+
+        [Fact]
+        public async Task Initial_CustomPropertyDeclaration_ClearsInheritedValue()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="parent" style="--x: red">
+                  <span id="child" style="--x: initial; color: var(--x, blue)">text</span>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var child = FindById(root, "child");
+
+            Assert.NotNull(child);
+            Assert.Equal("blue", child!.Color);
+        }
+
+        [Fact]
+        public async Task CustomProperty_NamesAreCaseSensitive()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="el" style="--Foo: blue; --foo: red; color: var(--Foo); background-color: var(--foo)">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("blue", el!.Color);
+            Assert.Equal("red", el.BackgroundColor);
+        }
+
+        [Fact]
+        public async Task DeferredVarProperty_OverriddenByLaterPlainValue_UsesPlainValue()
+        {
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  div { --x: green; color: var(--x); }
+                  #el { color: blue; }
+                </style></head><body>
+                <div id="el">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("rgb(0, 0, 255)", el!.Color);
+        }
+
+        [Fact]
+        public async Task DeferredVarProperty_OverriddenByLaterVarValue_UsesLatestValue()
+        {
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  div { --a: green; color: var(--a); }
+                  #el { --b: blue; color: var(--b); }
+                </style></head><body>
+                <div id="el">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("blue", el!.Color);
+        }
+
+        [Fact]
+        public async Task CurrentColor_SourcedThroughCustomProperty_ResolvesCorrectly()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="el" style="color: red; --x: currentcolor; background-color: var(--x)">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("rgb(255, 0, 0)", el!.BackgroundColor);
+        }
+
+        [Fact]
+        public async Task Var_UsedInBackgroundShorthand_AppliesResolvedColor()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="el" style="--bg: #8e44ad; background: var(--bg)">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("rgb(142, 68, 173)", el!.BackgroundColor);
+        }
+
+        [Fact]
+        public async Task Var_WithFallbackInBackgroundShorthand_AppliesFallbackColor()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="el" style="background: var(--undefined-bg, #8e44ad)">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("rgb(142, 68, 173)", el!.BackgroundColor);
+        }
+
+        [Fact]
+        public async Task Var_WithNestedFallbackChainInBackgroundShorthand_AppliesFinalFallbackColor()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="el" style="background: var(--undefined-a, var(--undefined-b, #d35400))">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("rgb(211, 84, 0)", el!.BackgroundColor);
+        }
+
+        // ── helpers ───────────────────────────────────────────────────────────
+
+        private static async Task<CssBox> BuildBoxTree(string html)
+        {
+            var adapter = new PdfSharpAdapter();
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            var size = new XSize(595, 842);
+            container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+            container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+            var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            return container.Root!;
+        }
+
+        private static CssBox? FindById(CssBox box, string id)
+        {
+            if (box.HtmlTag?.Attributes?.TryGetValue("id", out var boxId) == true
+                && string.Equals(boxId, id, StringComparison.OrdinalIgnoreCase))
+                return box;
+
+            foreach (var child in box.Boxes)
+            {
+                var found = FindById(child, id);
+                if (found is not null) return found;
+            }
+            return null;
+        }
+    }
+}

--- a/src/PeachPDF/CSS/Enumerations/FunctionNames.cs
+++ b/src/PeachPDF/CSS/Enumerations/FunctionNames.cs
@@ -49,5 +49,6 @@ namespace PeachPDF.CSS
         public static readonly string Hwb = "hwb";
         public static readonly string ConicGradient = "conic-gradient";
         public static readonly string RepeatingConicGradient = "repeating-conic-gradient";
+        public static readonly string Var = "var";
     }
 }

--- a/src/PeachPDF/CSS/Extensions/ValueExtensions.cs
+++ b/src/PeachPDF/CSS/Extensions/ValueExtensions.cs
@@ -485,6 +485,20 @@ namespace PeachPDF.CSS
             return string.Join(string.Empty, value.Select(m => m.ToValue()));
         }
 
+        public static bool ContainsFunction(this IEnumerable<Token> tokens, string functionName)
+        {
+            foreach (var token in tokens)
+            {
+                if (token is FunctionToken function &&
+                    (function.Data.Isi(functionName) || function.ArgumentTokens.ContainsFunction(functionName)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public static Color? ToColor(this IEnumerable<Token> value)
         {
             var element = value.OnlyOrDefault();

--- a/src/PeachPDF/CSS/Factories/PropertyFactory.cs
+++ b/src/PeachPDF/CSS/Factories/PropertyFactory.cs
@@ -364,7 +364,17 @@ namespace PeachPDF.CSS
 
         public Property Create(string name)
         {
-            return CreateLonghand(name) ?? CreateShorthand(name);
+            return CreateLonghand(name) ?? CreateShorthand(name) ?? CreateCustomProperty(name);
+        }
+
+        private static Property CreateCustomProperty(string name)
+        {
+            return IsCustomPropertyName(name) ? new CustomProperty(name) : null;
+        }
+
+        internal static bool IsCustomPropertyName(string name)
+        {
+            return name is { Length: > 2 } && name[0] == '-' && name[1] == '-';
         }
 
         public Property CreateFont(string name)

--- a/src/PeachPDF/CSS/Model/StyleDeclaration.cs
+++ b/src/PeachPDF/CSS/Model/StyleDeclaration.cs
@@ -276,6 +276,15 @@ namespace PeachPDF.CSS
 
         private void SetShorthand(ShorthandProperty shorthand)
         {
+            if (shorthand.DeclaredValue.Original.ContainsFunction(FunctionNames.Var))
+            {
+                // A var() reference can't be split into per-longhand slices here — the referenced custom
+                // property's value is only known per-element, at cascade time. Keep the shorthand
+                // declaration whole so cascade-time substitution + shorthand expansion can handle it once resolved.
+                SetLonghand(shorthand);
+                return;
+            }
+
             var properties = PropertyFactory.Instance.CreateLonghandsFor(shorthand.Name);
             shorthand.Export(properties);
 

--- a/src/PeachPDF/CSS/Parser/Lexer.cs
+++ b/src/PeachPDF/CSS/Parser/Lexer.cs
@@ -101,10 +101,19 @@ namespace PeachPDF.CSS
                             if (c1.IsNameStart()) return IdentStart(current);
                             if (c1 == Symbols.ReverseSolidus && !c2.IsLineBreak() && c2 != Symbols.EndOfFile)
                                 return IdentStart(current);
-                            if (c1 != Symbols.Minus || c2 != Symbols.GreaterThan) return NewDelimiter(current);
 
-                            Advance(2);
-                            return NewCloseComment();
+                            if (c1 == Symbols.Minus)
+                            {
+                                if (c2 == Symbols.GreaterThan)
+                                {
+                                    Advance(2);
+                                    return NewCloseComment();
+                                }
+
+                                return IdentStart(current);
+                            }
+
+                            return NewDelimiter(current);
                         }
 
                         Back();
@@ -458,7 +467,7 @@ namespace PeachPDF.CSS
             if (current == Symbols.Minus)
             {
                 current = GetNext();
-                if (current.IsNameStart() || IsValidEscape(current))
+                if (current.IsNameStart() || current == Symbols.Minus || IsValidEscape(current))
                 {
                     StringBuffer.Append(Symbols.Minus);
                     return IdentRest(current);

--- a/src/PeachPDF/CSS/Parser/StylesheetComposer.cs
+++ b/src/PeachPDF/CSS/Parser/StylesheetComposer.cs
@@ -631,8 +631,19 @@ namespace PeachPDF.CSS
                         // Example 2: "margin: 5px !important; text-align:center; margin-left: 3px;";
                         if (sourceProperty is ShorthandProperty shorthandProperty)
                         {
-                            resolvedProperties = PropertyFactory.Instance.CreateLonghandsFor(shorthandProperty.Name);
-                            shorthandProperty.Export(resolvedProperties);
+                            if (shorthandProperty.DeclaredValue.Original.ContainsFunction(FunctionNames.Var))
+                            {
+                                // A var() reference can't be split into per-longhand slices at parse time —
+                                // the referenced custom property's value is only known per-element, at cascade
+                                // time. Keep the shorthand declaration whole so cascade-time substitution +
+                                // shorthand expansion (CssUtils.SetPropertyValue) can handle it once resolved.
+                                resolvedProperties = new Property[] { shorthandProperty };
+                            }
+                            else
+                            {
+                                resolvedProperties = PropertyFactory.Instance.CreateLonghandsFor(shorthandProperty.Name);
+                                shorthandProperty.Export(resolvedProperties);
+                            }
                         }
 
                         foreach (var resolvedProperty in resolvedProperties)

--- a/src/PeachPDF/CSS/StyleProperties/CustomProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/CustomProperty.cs
@@ -1,0 +1,14 @@
+#nullable disable
+
+namespace PeachPDF.CSS
+{
+    internal sealed class CustomProperty : Property
+    {
+        internal CustomProperty(string name)
+            : base(name)
+        {
+        }
+
+        internal override IValueConverter Converter => Converters.Any;
+    }
+}

--- a/src/PeachPDF/CSS/StyleProperties/Property.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Property.cs
@@ -24,7 +24,9 @@ namespace PeachPDF.CSS
 
         internal bool TrySetValue(TokenValue newTokenValue)
         {
-            var value = Converter.Convert(newTokenValue ?? TokenValue.Initial);
+            var tokenValue = newTokenValue ?? TokenValue.Initial;
+            var converter = tokenValue.ContainsFunction(FunctionNames.Var) ? Converters.Any : Converter;
+            var value = converter.Convert(tokenValue);
 
             if (value == null) return false;
             DeclaredValue = value;

--- a/src/PeachPDF/Html/Core/Dom/CssBoxProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBoxProperties.cs
@@ -52,6 +52,12 @@ namespace PeachPDF.Html.Core.Dom
         private string _textIndent = "0";
         private string _wordSpacing = "normal";
 
+        /// <summary>
+        /// Specified (not var()-resolved) values of this box's CSS custom properties (--foo), keyed by
+        /// their case-sensitive name. Lazily created; null when no custom property has been declared or inherited.
+        /// </summary>
+        internal Dictionary<string, string>? CustomProperties;
+
         #endregion
 
 
@@ -1238,6 +1244,12 @@ namespace PeachPDF.Html.Core.Dom
         protected void InheritStyle(CssBox? p, bool everything)
         {
             if (p == null) return;
+
+            // Custom properties are always inherited, regardless of the `everything` special case.
+            // Cloned (not shared) so a child's local override never mutates the parent's or a sibling's dictionary.
+            CustomProperties = p.CustomProperties is { Count: > 0 }
+                ? new Dictionary<string, string>(p.CustomProperties)
+                : null;
 
             BorderSpacing = p.BorderSpacing;
             BorderCollapse = p.BorderCollapse;

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -22,6 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace PeachPDF.Html.Core.Parse
@@ -327,12 +328,18 @@ namespace PeachPDF.Html.Core.Parse
             // 2. Inherit inheritable properties from parent
             box.InheritStyle();
 
+            // Regular property declarations whose value contains var(...) are deferred here and resolved
+            // once, after the whole cascade (all phases below) has finished, so var() sees this box's
+            // FINAL custom property values regardless of which phase declared them.
+            var pendingVarProperties = new Dictionary<string, string>();
+
             // 3. UA pass — user-agent stylesheet rules only
-            var importantPropertyNames = AssignCssBlocks(valueParser, box, cssData.GetUserAgentStyleRules(media, box), null, null);
+            var importantPropertyNames = AssignCssBlocks(valueParser, box, cssData.GetUserAgentStyleRules(media, box), null, null, null, pendingVarProperties);
 
             // 4. Author pass — author stylesheet rules; revert target is the UA-applied state
             var uaSnapshot = CssUtils.SnapshotProperties(box);
-            importantPropertyNames = AssignCssBlocks(valueParser, box, cssData.GetAuthorStyleRules(media, box), importantPropertyNames, uaSnapshot);
+            var uaCustomSnapshot = CssUtils.SnapshotCustomProperties(box);
+            importantPropertyNames = AssignCssBlocks(valueParser, box, cssData.GetAuthorStyleRules(media, box), importantPropertyNames, uaSnapshot, uaCustomSnapshot, pendingVarProperties);
 
             if (box.HtmlTag != null)
             {
@@ -345,10 +352,14 @@ namespace PeachPDF.Html.Core.Parse
                     var stylesheet = "* { " + styleAttributeText + " }";
 
                     var authorSnapshot = CssUtils.SnapshotProperties(box);
+                    var authorCustomSnapshot = CssUtils.SnapshotCustomProperties(box);
                     var block = CssParser.ParseStyleSheet(stylesheet);
-                    AssignCssBlock(valueParser, box, block.StyleRules.Single(), importantPropertyNames, authorSnapshot);
+                    AssignCssBlock(valueParser, box, block.StyleRules.Single(), importantPropertyNames, authorSnapshot, authorCustomSnapshot, pendingVarProperties);
                 }
             }
+
+            // 6. Resolve var() references now that every custom property's final cascaded value is known
+            ResolveDeferredVarProperties(valueParser, box, pendingVarProperties);
 
             // Correct current color
             CssUtils.ApplyCurrentColor(box, valueParser);
@@ -384,32 +395,48 @@ namespace PeachPDF.Html.Core.Parse
             CssBox box,
             IEnumerable<IStyleRule> rules,
             HashSet<string>? importantPropertyNames,
-            IReadOnlyDictionary<string, string?>? revertTarget)
+            IReadOnlyDictionary<string, string?>? revertTarget,
+            IReadOnlyDictionary<string, string>? customPropertyRevertTarget,
+            Dictionary<string, string> pendingVarProperties)
         {
             importantPropertyNames ??= [];
             foreach (var rule in rules)
-                AssignCssBlock(valueParser, box, rule, importantPropertyNames, revertTarget);
+                AssignCssBlock(valueParser, box, rule, importantPropertyNames, revertTarget, customPropertyRevertTarget, pendingVarProperties);
             return importantPropertyNames;
         }
 
         /// <summary>
         /// Assigns the given css style block properties to the given css box.
         /// Handles all five CSS global keywords: inherit, initial, unset, revert, revert-layer.
+        /// Custom property declarations (--foo) are routed to <see cref="AssignCustomPropertyDeclaration"/> instead,
+        /// since those keywords mean something different for an open-ended, case-sensitive property store.
+        /// Regular declarations whose value contains var(...) are deferred into <paramref name="pendingVarProperties"/>
+        /// rather than applied immediately — see <see cref="ResolveDeferredVarProperties"/> for why.
         /// </summary>
         /// <param name="valueParser">the css value parser to use</param>
         /// <param name="box">the css box to assign css to</param>
         /// <param name="stylesheetRule">the stylesheet rule to assign</param>
         /// <param name="importantPropertyNames">Carries the property names that have been marked important so they don't get re-applied</param>
         /// <param name="revertTarget">Property snapshot representing the prior cascade origin, used for revert/revert-layer</param>
+        /// <param name="customPropertyRevertTarget">Case-sensitive custom-property snapshot for revert/revert-layer</param>
+        /// <param name="pendingVarProperties">Accumulates regular declarations whose value contains var(...), keyed by property name</param>
         private static void AssignCssBlock(
             CssValueParser valueParser,
             CssBox box,
             IStyleRule stylesheetRule,
             HashSet<string> importantPropertyNames,
-            IReadOnlyDictionary<string, string?>? revertTarget = null)
+            IReadOnlyDictionary<string, string?>? revertTarget,
+            IReadOnlyDictionary<string, string>? customPropertyRevertTarget,
+            Dictionary<string, string> pendingVarProperties)
         {
             foreach (var prop in stylesheetRule.Style)
             {
+                if (PropertyFactory.IsCustomPropertyName(prop.Name))
+                {
+                    AssignCustomPropertyDeclaration(box, prop, importantPropertyNames, customPropertyRevertTarget);
+                    continue;
+                }
+
                 var value = prop.Value switch
                 {
                     CssConstants.Inherit when box.ParentBox != null
@@ -435,9 +462,341 @@ namespace PeachPDF.Html.Core.Parse
                 if (prop.IsImportant)
                     importantPropertyNames.Add(prop.Name.ToLowerInvariant());
 
-                if (value is not null && IsStyleOnElementAllowed(box, prop.Name, value))
-                    CssUtils.SetPropertyValue(valueParser, box, prop.Name, value);
+                if (value is null) continue;
+
+                if (value.Contains("var(", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Overwrites any earlier pending entry for this name (last write wins).
+                    pendingVarProperties[prop.Name] = value;
+                }
+                else
+                {
+                    // A later plain value supersedes an earlier deferred var() value for the same property.
+                    pendingVarProperties.Remove(prop.Name);
+                    if (IsStyleOnElementAllowed(box, prop.Name, value))
+                        CssUtils.SetPropertyValue(valueParser, box, prop.Name, value);
+                }
             }
+        }
+
+        /// <summary>
+        /// Assigns a single custom property (--foo) declaration to the box's custom-property store.
+        /// Unlike regular properties, custom properties are always inherited, their names are case-sensitive,
+        /// and their global keywords resolve against the custom-property dictionary rather than the fixed,
+        /// known-property switch used by <see cref="AssignCssBlock"/>. The stored value is left unresolved
+        /// (it may itself contain var(...)) — resolution happens once, later, in <see cref="ResolveDeferredVarProperties"/>,
+        /// which is what makes multi-hop var() graph resolution correct regardless of declaration order.
+        /// </summary>
+        private static void AssignCustomPropertyDeclaration(
+            CssBox box,
+            IProperty prop,
+            HashSet<string> importantPropertyNames,
+            IReadOnlyDictionary<string, string>? customPropertyRevertTarget)
+        {
+            if (importantPropertyNames.Contains(prop.Name)) return; // case-sensitive: no ToLowerInvariant
+            if (prop.IsImportant) importantPropertyNames.Add(prop.Name);
+
+            var rawValue = prop.Value switch
+            {
+                CssConstants.Inherit or CssConstants.Unset // custom properties are always inherited
+                    => box.ParentBox?.CustomProperties != null &&
+                       box.ParentBox.CustomProperties.TryGetValue(prop.Name, out var pv)
+                        ? pv
+                        : null,
+                CssConstants.Initial
+                    => null, // guaranteed-invalid value => property becomes absent
+                CssConstants.Revert or CssConstants.RevertLayer
+                    => customPropertyRevertTarget != null &&
+                       customPropertyRevertTarget.TryGetValue(prop.Name, out var rv)
+                        ? rv
+                        : null,
+                _ => prop.Value
+            };
+
+            box.CustomProperties ??= new Dictionary<string, string>();
+            if (rawValue is not null)
+                box.CustomProperties[prop.Name] = rawValue;
+            else
+                box.CustomProperties.Remove(prop.Name);
+        }
+
+        /// <summary>
+        /// Result of attempting to resolve every var() reference in a declaration's value. Success is false
+        /// only when a reference is "guaranteed-invalid" (no matching custom property, no fallback, or a
+        /// cyclic reference) — per spec this invalidates the whole value, not just the failing substring.
+        /// </summary>
+        private readonly record struct VarResolution(bool Success, string? Value);
+
+        /// <summary>
+        /// Resolves every regular property deferred during the cascade's three phases (see
+        /// <see cref="AssignCssBlock"/>) now that this box's custom properties reflect their FINAL cascaded
+        /// (though not yet var()-resolved) values. Resolution is graph-based and memoized per box via a shared
+        /// `resolvedCache`/`resolving`/`cyclic` triple, so multi-hop cyclic references (e.g. --a: var(--b);
+        /// --b: var(--c); --c: var(--a);) are detected correctly regardless of which pending property triggers
+        /// the lookup first.
+        /// </summary>
+        private static void ResolveDeferredVarProperties(CssValueParser valueParser, CssBox box, Dictionary<string, string> pendingVarProperties)
+        {
+            if (pendingVarProperties.Count == 0) return;
+
+            var resolvedCache = new Dictionary<string, string>();
+            var resolving = new HashSet<string>();
+            var cyclic = new HashSet<string>();
+
+            foreach (var (name, rawValue) in pendingVarProperties)
+            {
+                var result = SubstituteVarReferences(box, rawValue, resolvedCache, resolving, cyclic);
+                var finalValue = result.Success ? result.Value : GetGuaranteedInvalidFallback(box, name);
+
+                if (finalValue is not null)
+                    ApplyResolvedPropertyValue(valueParser, box, name, finalValue);
+            }
+        }
+
+        /// <summary>
+        /// Applies a fully var()-resolved property value to the box. Shorthand properties (e.g. "background")
+        /// are re-parsed through the real CSS-OM shorthand converter and expanded into longhands here, because
+        /// unlike margin/padding/border/font/flex/list-style, not every shorthand has a "whole string" case in
+        /// <see cref="CssUtils.SetPropertyValue"/> — that switch normally only ever receives longhands, since
+        /// shorthands are expanded into them at parse time (<c>StyleDeclaration.SetShorthand</c>), a step
+        /// var()-containing shorthands deliberately skip (see <c>StylesheetComposer.FillDeclarations</c>)
+        /// because they can't be split into per-longhand slices until their var() references are resolved,
+        /// which has only just happened here.
+        /// </summary>
+        private static void ApplyResolvedPropertyValue(CssValueParser valueParser, CssBox box, string name, string value)
+        {
+            if (PropertyFactory.Instance.CreateShorthand(name) is not null)
+            {
+                var reparsed = StylesheetParser.Default.ParseDeclaration($"{name}: {value}");
+                if (reparsed is ShorthandProperty { HasValue: true } shorthand)
+                {
+                    var longhands = PropertyFactory.Instance.CreateLonghandsFor(name);
+                    shorthand.Export(longhands);
+
+                    foreach (var longhand in longhands)
+                    {
+                        if (longhand.HasValue && IsStyleOnElementAllowed(box, longhand.Name, longhand.Value))
+                            CssUtils.SetPropertyValue(valueParser, box, longhand.Name, longhand.Value);
+                    }
+
+                    return;
+                }
+            }
+
+            if (IsStyleOnElementAllowed(box, name, value))
+                CssUtils.SetPropertyValue(valueParser, box, name, value);
+        }
+
+        /// <summary>
+        /// Resolves every var(...) occurrence in <paramref name="value"/> to plain text. Quote-aware (so
+        /// `content: "var(--x)"` is left untouched) and paren-depth-aware (so a fallback containing nested
+        /// commas, e.g. `var(--a, var(--b, red))` or a fallback with a comma-taking function, splits correctly).
+        /// </summary>
+        private static VarResolution SubstituteVarReferences(CssBox box, string value, Dictionary<string, string> resolvedCache, HashSet<string> resolving, HashSet<string> cyclic)
+        {
+            if (value.IndexOf("var(", StringComparison.OrdinalIgnoreCase) < 0)
+                return new VarResolution(true, value);
+
+            var sb = new StringBuilder();
+            var i = 0;
+            while (i < value.Length)
+            {
+                if (TryMatchVarCall(value, i, out var argsStart, out var callEnd))
+                {
+                    var (name, fallback) = SplitFirstTopLevelComma(value, argsStart, callEnd - 1);
+
+                    if (TryResolveCustomProperty(box, name, resolvedCache, resolving, cyclic, out var found))
+                    {
+                        sb.Append(found);
+                    }
+                    else if (fallback != null)
+                    {
+                        var fallbackResult = SubstituteVarReferences(box, fallback, resolvedCache, resolving, cyclic);
+                        if (!fallbackResult.Success) return new VarResolution(false, null);
+                        sb.Append(fallbackResult.Value);
+                    }
+                    else
+                    {
+                        return new VarResolution(false, null); // guaranteed-invalid
+                    }
+
+                    i = callEnd;
+                }
+                else if (value[i] is '"' or '\'')
+                {
+                    var quoteEnd = SkipQuotedString(value, i);
+                    sb.Append(value, i, quoteEnd - i);
+                    i = quoteEnd;
+                }
+                else
+                {
+                    sb.Append(value[i]);
+                    i++;
+                }
+            }
+
+            return new VarResolution(true, sb.ToString());
+        }
+
+        /// <summary>
+        /// Recursive + memoized: resolves box.CustomProperties[name]'s own var() references first (so a custom
+        /// property may reference another custom property, in any declaration order), using `resolving` as a
+        /// visited-set for cycle detection across the whole reference graph for this box.
+        /// <paramref name="cyclic"/> permanently marks a property that was found to (directly or transitively)
+        /// reference itself. This is distinct from a plain "not found" — per the CSS spec, a property that
+        /// references itself is guaranteed-invalid regardless of any fallback written inside that same
+        /// reference (e.g. `--self: var(--self, red);` must NOT resolve to "red": writing var(--self, ...)
+        /// inside --self's own definition is a self-reference, full stop, matching real browsers). Without
+        /// this permanent marker, the fallback used to locally satisfy the mid-cycle lookup would get cached
+        /// as if it were --self's legitimately resolved value.
+        /// </summary>
+        private static bool TryResolveCustomProperty(CssBox box, string name, Dictionary<string, string> resolvedCache, HashSet<string> resolving, HashSet<string> cyclic, out string? value)
+        {
+            if (cyclic.Contains(name))
+            {
+                value = null;
+                return false;
+            }
+
+            if (resolvedCache.TryGetValue(name, out value)) return true;
+
+            if (box.CustomProperties == null || !box.CustomProperties.TryGetValue(name, out var rawValue))
+            {
+                value = null;
+                return false;
+            }
+
+            if (!resolving.Add(name))
+            {
+                cyclic.Add(name); // name is referenced while already being resolved — a cycle
+                value = null;
+                return false;
+            }
+
+            var result = SubstituteVarReferences(box, rawValue, resolvedCache, resolving, cyclic);
+            resolving.Remove(name);
+
+            if (cyclic.Contains(name) || !result.Success)
+            {
+                cyclic.Add(name);
+                value = null;
+                return false;
+            }
+
+            resolvedCache[name] = value = result.Value!;
+            return true;
+        }
+
+        /// <summary>
+        /// Matches a case-insensitive "var(" starting at <paramref name="start"/> and scans forward for the
+        /// matching close paren. On success, <paramref name="argsStart"/> is the index of the first argument
+        /// character and <paramref name="callEnd"/> is the index just past the closing paren.
+        /// </summary>
+        private static bool TryMatchVarCall(string value, int start, out int argsStart, out int callEnd)
+        {
+            argsStart = 0;
+            callEnd = 0;
+
+            if (start + 4 > value.Length) return false;
+            if (string.Compare(value, start, "var(", 0, 4, StringComparison.OrdinalIgnoreCase) != 0) return false;
+
+            var depth = 1;
+            var i = start + 4;
+            while (i < value.Length)
+            {
+                var c = value[i];
+                if (c is '"' or '\'')
+                {
+                    i = SkipQuotedString(value, i);
+                    continue;
+                }
+
+                if (c == '(') depth++;
+                else if (c == ')')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        argsStart = start + 4;
+                        callEnd = i + 1;
+                        return true;
+                    }
+                }
+
+                i++;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Splits a var() argument list at the first top-level (paren-depth 0, outside quotes) comma.
+        /// The text before it is the custom property name (trimmed); everything after — commas and all —
+        /// is the fallback, per spec.
+        /// </summary>
+        private static (string Name, string? Fallback) SplitFirstTopLevelComma(string value, int start, int end)
+        {
+            var depth = 0;
+            var i = start;
+            while (i < end)
+            {
+                var c = value[i];
+                if (c is '"' or '\'')
+                {
+                    i = SkipQuotedString(value, i);
+                    continue;
+                }
+
+                if (c == '(') depth++;
+                else if (c == ')') depth--;
+                else if (c == ',' && depth == 0)
+                {
+                    var name = value[start..i].Trim();
+                    var fallback = value[(i + 1)..end].Trim();
+                    return (name, fallback.Length > 0 ? fallback : null);
+                }
+
+                i++;
+            }
+
+            return (value[start..end].Trim(), null);
+        }
+
+        /// <summary>
+        /// Advances past a quoted string literal starting at <paramref name="start"/> (which must point at the
+        /// opening quote), honoring backslash escapes so an escaped quote doesn't end the string early.
+        /// Returns the index just past the closing quote (or the string's end, if unterminated).
+        /// </summary>
+        private static int SkipQuotedString(string value, int start)
+        {
+            var quote = value[start];
+            var i = start + 1;
+            while (i < value.Length)
+            {
+                if (value[i] == '\\' && i + 1 < value.Length)
+                {
+                    i += 2;
+                    continue;
+                }
+
+                if (value[i] == quote)
+                    return i + 1;
+
+                i++;
+            }
+
+            return i;
+        }
+
+        /// <summary>
+        /// The value a property falls back to when a var() reference in it is guaranteed-invalid — reuses
+        /// the exact same expression as the `unset` keyword arm in <see cref="AssignCssBlock"/>, for consistency.
+        /// </summary>
+        private static string? GetGuaranteedInvalidFallback(CssBox box, string propName)
+        {
+            return CssDefaults.InheritedProperties.Contains(propName) && box.ParentBox != null
+                ? CssUtils.GetPropertyValue(box.ParentBox, propName)
+                : CssDefaults.GetInitialValue(propName);
         }
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Utils/CssUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/CssUtils.cs
@@ -205,6 +205,16 @@ namespace PeachPDF.Html.Core.Utils
         }
 
         /// <summary>
+        /// Snapshots this box's custom property values, for use as the revert/revert-layer target of a
+        /// later cascade phase. Custom property names are case-sensitive, unlike <see cref="SnapshotProperties"/>'s
+        /// known-property snapshot, so this uses a separate, ordinal-case-sensitive dictionary.
+        /// </summary>
+        public static Dictionary<string, string>? SnapshotCustomProperties(CssBox box)
+        {
+            return box.CustomProperties is { Count: > 0 } ? new Dictionary<string, string>(box.CustomProperties) : null;
+        }
+
+        /// <summary>
         /// Set CSS box property value by the CSS name.<br/>
         /// Used as a mapping between CSS property and the class property.
         /// </summary>


### PR DESCRIPTION
Implement end-to-end support for CSS custom properties (`--*`) and `var()` across parsing and cascade resolution. The cascade now stores inherited custom-property dictionaries per box, defers `var()`-containing declarations until final cascade state, resolves references with fallback handling and cycle detection, and applies resolved shorthand/longhand values safely. Also updates lexer/property creation for custom-property names, adds extensive unit and integration coverage, and documents the new support (including architecture notes and feature docs), plus a test harness showcase page.