### PR TITLE
Fix docs deploy never triggering after NuGet release

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,7 @@ name: Deploy GitHub Pages
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,6 +54,12 @@ jobs:
           --generate-notes \
           $PRERELEASE_FLAG
 
+    - name: Trigger docs deploy
+      if: steps.version.outputs.prerelease != 'true'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: gh workflow run pages.yml --ref main
+
     - name: Build
       run: dotnet build src/PeachPDF/PeachPDF.csproj --configuration Release
 


### PR DESCRIPTION
release events created via the workflow's default GITHUB_TOKEN don't trigger other workflows, so pages.yml's `release: published` trigger was silently never firing. publish.yml now explicitly dispatches pages.yml (workflow_dispatch is exempt from that restriction) after creating a non-prerelease release.