### PR TITLE
Add comprehensive documentation and XML comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,25 @@
 # PeachPDF
 Peach PDF is a pure .NET HTML -> PDF rendering library. This library does not depend on Puppeter, wkhtmltopdf, or any other process to render the HTML to PDF. As a result, this should work in virtually any environment where .NET 8+ works. As a side benefit of being pure .NET, performance improvements in future .NET versions immediately benefit this library. 
 
+## Features
+
+- CSS custom properties (`--foo`) and `var()`, including fallbacks and inheritance
+- CSS math functions: `calc()`, `min()`, `max()`, `clamp()`
+- 2D and 3D CSS transforms (`translate`, `scale`, `rotate`, `skew`, `matrix`, and their variants)
+- Flexbox layout (CSS Flexbox Level 1)
+- All five CSS-wide keywords: `inherit`, `initial`, `unset`, `revert`, `revert-layer`
+- Gradients (`linear-gradient`, `radial-gradient`, `conic-gradient`, and repeating variants) with CSS Color Level 4 interpolation
+- CSS Paged Media: `@page` rules, named pages, margin boxes, and running headers/footers via `string-set`/`string()`
+- Automatic PDF metadata extraction from HTML `<title>` and `<meta>` elements
+- Web fonts (`@font-face`), custom fonts loaded from a stream, and system font discovery
+
+See [HTML & CSS Support](https://peachpdf.net/html-css-support.html) for the full compatibility matrix.
+
 ## PeachPDF Requirements
 
-- .NET 8
+- .NET 8 or .NET 10
 
-_Note: This package depends on PeachPDF.PdfSharpCore which has its own license, but the end result is still open source_
+_Note: This package embeds a fork of PdfSharpCore directly in its source tree; that fork carries its own license (see `src/PeachPDF/PdfSharpCore/LICENSE.md`), but the end result is still open source_
 
 ## Installing PeachPDF
 

--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -713,10 +713,10 @@ The following CSS features are not supported:
 - **Grid** — `display: grid` and all grid properties
 - **3D perspective** — the `perspective()` transform function, and the `perspective`/`perspective-origin`/`transform-style`/`backface-visibility` properties
 - **Transitions and animations** — `transition`, `animation`, `@keyframes`
-- **Filters and effects** — `filter`, `backdrop-filter`, `mix-blend-mode`, `opacity`
-- **`background` shorthand** — use individual `background-*` properties
-- **`letter-spacing`**
-- **`text-transform`** — `uppercase`, `lowercase`, `capitalize`
+- **Filters and effects** — `filter`, `backdrop-filter`, `mix-blend-mode` (not parsed at all)
+- **`opacity`** — parsed and accepted but has no effect
+- **`letter-spacing`** — parsed and accepted but has no effect
+- **`text-transform`** — `uppercase`, `lowercase`, `capitalize`; parsed and accepted but has no effect
 - **`text-shadow`**
 - **`word-wrap` / `overflow-wrap`**
 - **`outline`** and `outline-*` properties

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,22 +1,35 @@
 # PeachPDF
-Peach PDF is a pure .NET HTML -> PDF rendering library. This library does not depend on Puppeter, wkhtmltopdf, or any other process to render the HTML to PDF. As a result, this should work in virtually any environment where .NET 8+ works. As a side benefit of being pure .NET, performance improvements in future .NET versions immediately benefit this library. 
 
-## PeachPDF Requirements
+PeachPDF is a pure .NET HTML → PDF rendering library. It doesn't shell out to Puppeteer, wkhtmltopdf, or any other external process — everything from HTML parsing to PDF output runs in-process, so it works in virtually any environment where .NET runs (containers, serverless, trimmed/AOT deployments) and benefits automatically from future .NET performance improvements.
 
-- .NET 8
+Targets .NET 8 and .NET 10.
 
-## Installing PeachPDF
+## Features
 
-Install the PeachPDF package from nuget.org
+- CSS custom properties (`--foo`) and `var()`, including fallbacks and inheritance
+- CSS math functions: `calc()`, `min()`, `max()`, `clamp()`
+- 2D and 3D CSS transforms, and Flexbox layout (CSS Flexbox Level 1)
+- All five CSS-wide keywords: `inherit`, `initial`, `unset`, `revert`, `revert-layer`
+- Gradients with CSS Color Level 4 interpolation
+- CSS Paged Media: `@page` rules, named pages, margin boxes, and running headers/footers
+- Automatic PDF metadata extraction from HTML `<title>` and `<meta>` elements
+- Web fonts (`@font-face`), custom fonts loaded from a stream, and system font discovery
+
+## Guides
+
+- **[Architecture](architecture.md)** — how PeachPDF converts HTML to PDF: the HTML parser, DOM model, CSS parser, layout engine, painting layer, and PDF renderer.
+- **[HTML & CSS Support](html-css-support.md)** — the full compatibility matrix of supported HTML elements, CSS properties, selectors, and at-rules, including notes on gaps and PeachPDF-specific extensions.
+- **[Usage Examples](usage-examples.md)** — copy-pasteable examples: local HTML strings, MHTML files, HTTP fetching, shared CSS contexts, saving to disk, and returning PDFs from ASP.NET Core (controllers and Minimal APIs) and Azure Functions.
+
+## Quick Start
+
+Install the PeachPDF package from nuget.org:
 
 ```
 dotnet add package PeachPDF
 ```
 
-## Using PeachPDF
-
-### Simple example
-Simple example to render PDF to a Stream. All images and assets must be local to the file on the file system or in data: URIs
+Render HTML to a PDF stream. All images and assets must be local to the file system or in `data:` URIs:
 
 ```csharp
 PdfGenerateConfig pdfConfig = new(){
@@ -32,47 +45,7 @@ var document = await generator.GeneratePdf(html, pdfConfig);
 document.Save(stream);
 ```
 
-### Rendering an MHTML file
-
-You can generate PDF documents using self contained MHTML files (what Chrome calls "single page documents") by using the included MimeKitNetworkLoader
-
-```csharp
-PdfGenerateConfig pdfConfig = new(){
-  PageSize = PageSize.Letter,
-  PageOrientation = PageOrientation.Portrait,
-  NetworkLoader = new MimeKitNetworkLoader(File.OpenRead("example.mhtml"))
-};
-
-PdfGenerator generator = new();
-
-var stream = new MemoryStream();
-
-// Passing null to GeneratePdf will load the HTML from the provided network loader instance instead
-var document = await generator.GeneratePdf(null, pdfConfig);
-document.Save(stream);
-```
-
-### Rendering HTML from a URI
-
-You can also render HTML from the Internet to a PDF
-
-```csharp
-HttpClient httpClient = new();
-
-PdfGenerateConfig pdfConfig = new(){
-  PageSize = PageSize.Letter,
-  PageOrientation = PageOrientation.Portrait,
-  NetworkLoader = new HttpClientNetworkLoader(httpClient, new Uri("https://www.example.com"))
-};
-
-PdfGenerator generator = new();
-
-var stream = new MemoryStream();
-
-// Passing null to GeneratePdf will load the HTML from the provided network loader instance instead
-var document = await generator.GeneratePdf(null, pdfConfig);
-document.Save(stream);
-```
+For more usage examples — rendering self-contained MHTML files, fetching HTML from a remote URI, sharing a parsed CSS context across renders, saving to disk, and returning PDFs from ASP.NET Core or Azure Functions endpoints — see [Usage Examples](usage-examples.md).
 
 ## PDF Metadata
 
@@ -106,14 +79,6 @@ Example:
 </body>
 </html>
 ```
-
-## Architecture
-
-See [Architecture](architecture.md) for an overview of how PeachPDF converts HTML to PDF, covering the HTML parser, DOM model, CSS parser, layout engine, painting layer, and PDF renderer.
-
-## HTML & CSS Support
-
-See [HTML & CSS Support](html-css-support.md) for a full list of supported HTML elements and CSS properties, including notes on gaps and PeachPDF-specific extensions.
 
 ## Fonts
 

--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -1,0 +1,244 @@
+# Usage Examples
+
+This page collects practical, copy-pasteable examples for common PeachPDF scenarios, including hosting it behind an HTTP endpoint. For the full list of supported HTML elements and CSS properties, see [HTML & CSS Support](html-css-support.md); for how the rendering pipeline works internally, see [Architecture](architecture.md).
+
+All examples assume:
+
+```csharp
+using PeachPDF;
+using PeachPDF.Network;
+```
+
+## Contents
+
+- [Rendering HTML from a local string](#rendering-html-from-a-local-string)
+- [Rendering an MHTML file](#rendering-an-mhtml-file)
+- [Fetching HTML over HTTP](#fetching-html-over-http)
+- [Sharing a parsed CSS context across renders](#sharing-a-parsed-css-context-across-renders)
+- [Saving a PDF to a file](#saving-a-pdf-to-a-file)
+- [ASP.NET Core controller endpoint](#aspnet-core-controller-endpoint)
+- [ASP.NET Core Minimal API endpoint](#aspnet-core-minimal-api-endpoint)
+- [Azure Functions (isolated worker) HTTP handler](#azure-functions-isolated-worker-http-handler)
+
+## Rendering HTML from a local string
+
+The simplest case: render an in-memory HTML string to a PDF stream. All images and assets must be local to the file system or in `data:` URIs, since no `NetworkLoader` is configured.
+
+```csharp
+var html = "<html><body><h1>Hello, PeachPDF</h1></body></html>";
+
+var pdfConfig = new PdfGenerateConfig
+{
+    PageSize = PageSize.Letter,
+    PageOrientation = PageOrientation.Portrait
+};
+
+var generator = new PdfGenerator();
+
+var stream = new MemoryStream();
+var document = await generator.GeneratePdf(html, pdfConfig);
+document.Save(stream);
+```
+
+## Rendering an MHTML file
+
+Self-contained MHTML archives (what Chrome calls "single page documents") bundle the HTML plus every referenced image, stylesheet, and font into one file. `MimeKitNetworkLoader` resolves all of those references from the archive, so nothing is fetched from disk or the network.
+
+```csharp
+using var mhtmlStream = File.OpenRead("example.mhtml");
+
+var pdfConfig = new PdfGenerateConfig
+{
+    PageSize = PageSize.Letter,
+    PageOrientation = PageOrientation.Portrait,
+    NetworkLoader = new MimeKitNetworkLoader(mhtmlStream)
+};
+
+var generator = new PdfGenerator();
+
+var stream = new MemoryStream();
+
+// Passing null to GeneratePdf loads the HTML from the configured NetworkLoader instead
+var document = await generator.GeneratePdf(null, pdfConfig);
+document.Save(stream);
+```
+
+## Fetching HTML over HTTP
+
+`HttpClientNetworkLoader` fetches the root document and every referenced resource (stylesheets, images) through a caller-supplied `HttpClient`, so you control headers, authentication, proxies, and timeouts.
+
+```csharp
+var httpClient = new HttpClient();
+
+var pdfConfig = new PdfGenerateConfig
+{
+    PageSize = PageSize.Letter,
+    PageOrientation = PageOrientation.Portrait,
+    NetworkLoader = new HttpClientNetworkLoader(httpClient, new Uri("https://www.example.com"))
+};
+
+var generator = new PdfGenerator();
+
+var stream = new MemoryStream();
+
+// Passing null to GeneratePdf loads the HTML from the configured NetworkLoader instead
+var document = await generator.GeneratePdf(null, pdfConfig);
+document.Save(stream);
+```
+
+Loading images via relative paths falls back to the local file system unless the configured `NetworkLoader` has an appropriate `BaseUri` (as above), or the HTML has a `<base href>` element.
+
+## Sharing a parsed CSS context across renders
+
+If you're rendering many documents against the same stylesheet — for example, a batch of invoices that all use one company template — parse the CSS once with `PdfGenerator.ParseStyleSheet` and reuse the resulting `PeachPdfCssContent` instead of re-parsing the same CSS for every document.
+
+```csharp
+const string css = """
+    body { font-family: Arial, sans-serif; }
+    h1 { color: #2c3e50; }
+    .total { font-weight: bold; }
+    """;
+
+var generator = new PdfGenerator();
+
+// combineWithDefault: true (the default) merges this stylesheet on top of the
+// W3 user-agent defaults; false replaces the defaults entirely.
+var sharedCssData = await generator.ParseStyleSheet(css, combineWithDefault: true);
+
+var pdfConfig = new PdfGenerateConfig
+{
+    PageSize = PageSize.Letter,
+    PageOrientation = PageOrientation.Portrait
+};
+
+foreach (var invoiceHtml in invoiceHtmlDocuments)
+{
+    var document = await generator.GeneratePdf(invoiceHtml, pdfConfig, sharedCssData);
+
+    using var fileStream = File.Create($"invoice-{Guid.NewGuid()}.pdf");
+    document.Save(fileStream);
+}
+```
+
+Reusing `sharedCssData` this way avoids re-parsing identical CSS on every iteration; the same `PdfGenerator` instance can also be reused across renders (font mappings and loaded fonts persist on it).
+
+## Saving a PDF to a file
+
+`PeachPdfDocument.Save` writes to any `Stream`, so saving directly to disk just means opening a file stream instead of a `MemoryStream`:
+
+```csharp
+var html = "<html><body><h1>Hello, PeachPDF</h1></body></html>";
+var pdfConfig = new PdfGenerateConfig { PageSize = PageSize.Letter };
+
+var generator = new PdfGenerator();
+var document = await generator.GeneratePdf(html, pdfConfig);
+
+using var fileStream = File.Create("output.pdf");
+document.Save(fileStream);
+```
+
+## ASP.NET Core controller endpoint
+
+Render to a `MemoryStream`, rewind it, and return it with `File()` so ASP.NET Core streams it to the client with the right content type. `BuildInvoiceHtml` below stands in for whatever HTML-generation logic you use (a Razor template, a string builder, etc.) — the PDF-specific part is everything after `var html = ...`.
+
+```csharp
+using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("reports")]
+public class ReportsController : ControllerBase
+{
+    [HttpGet("invoice/{id:int}")]
+    public async Task<IActionResult> GetInvoice(int id)
+    {
+        var html = await BuildInvoiceHtml(id);
+
+        var pdfConfig = new PdfGenerateConfig
+        {
+            PageSize = PageSize.Letter,
+            PageOrientation = PageOrientation.Portrait
+        };
+
+        var generator = new PdfGenerator();
+        var document = await generator.GeneratePdf(html, pdfConfig);
+
+        var stream = new MemoryStream();
+        document.Save(stream);
+        stream.Position = 0;
+
+        return File(stream, "application/pdf", $"invoice-{id}.pdf");
+    }
+}
+```
+
+## ASP.NET Core Minimal API endpoint
+
+The same approach works with `Results.File`, mapped on the `WebApplication` built in `Program.cs`:
+
+```csharp
+app.MapGet("/reports/invoice/{id:int}", async (int id) =>
+{
+    var html = await BuildInvoiceHtml(id);
+
+    var pdfConfig = new PdfGenerateConfig
+    {
+        PageSize = PageSize.Letter,
+        PageOrientation = PageOrientation.Portrait
+    };
+
+    var generator = new PdfGenerator();
+    var document = await generator.GeneratePdf(html, pdfConfig);
+
+    var stream = new MemoryStream();
+    document.Save(stream);
+    stream.Position = 0;
+
+    return Results.File(stream, "application/pdf", $"invoice-{id}.pdf");
+});
+```
+
+## Azure Functions (isolated worker) HTTP handler
+
+`HttpResponseData.Body` is itself a writable `Stream`, so `PeachPdfDocument.Save` can write straight to the response body with no intermediate buffer.
+
+```csharp
+using System.Net;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+public class GenerateInvoicePdf
+{
+    private readonly ILogger _logger;
+
+    public GenerateInvoicePdf(ILoggerFactory loggerFactory)
+    {
+        _logger = loggerFactory.CreateLogger<GenerateInvoicePdf>();
+    }
+
+    [Function("GenerateInvoicePdf")]
+    public async Task<HttpResponseData> Run(
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "invoice/{id:int}")] HttpRequestData req,
+        int id)
+    {
+        var html = await BuildInvoiceHtml(id);
+
+        var pdfConfig = new PdfGenerateConfig
+        {
+            PageSize = PageSize.Letter,
+            PageOrientation = PageOrientation.Portrait
+        };
+
+        var generator = new PdfGenerator();
+        var document = await generator.GeneratePdf(html, pdfConfig);
+
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        response.Headers.Add("Content-Type", "application/pdf");
+        response.Headers.Add("Content-Disposition", $"attachment; filename=invoice-{id}.pdf");
+
+        document.Save(response.Body);
+
+        return response;
+    }
+}
+```

--- a/src/PeachPDF/HtmlRenderErrorType.cs
+++ b/src/PeachPDF/HtmlRenderErrorType.cs
@@ -1,18 +1,53 @@
 namespace PeachPDF
 {
     /// <summary>
-    /// Enum of possible error types that can be reported.
+    /// The pipeline phase a <see cref="HtmlRenderException"/> was raised from. Set on <see cref="HtmlRenderException.RenderErrorType"/>.
     /// </summary>
     public enum HtmlRenderErrorType
     {
+        /// <summary>
+        /// An error that doesn't fit one of the more specific categories below.
+        /// </summary>
         General = 0,
+
+        /// <summary>
+        /// The stylesheet (author, inline, or <c>@import</c>ed) could not be parsed or loaded.
+        /// </summary>
         CssParsing = 1,
+
+        /// <summary>
+        /// The HTML document could not be parsed.
+        /// </summary>
         HtmlParsing = 2,
+
+        /// <summary>
+        /// An image referenced by the document (<c>&lt;img&gt;</c>, <c>background-image</c>, <c>list-style-image</c>) could not be loaded or decoded.
+        /// </summary>
         Image = 3,
+
+        /// <summary>
+        /// An error occurred while painting a box to the PDF page.
+        /// </summary>
         Paint = 4,
+
+        /// <summary>
+        /// An error occurred while computing layout (position/size) for a box.
+        /// </summary>
         Layout = 5,
+
+        /// <summary>
+        /// Reserved; not currently raised by PeachPDF. Inherited from this engine's interactive-viewer origins, where it covered keyboard/mouse input handling.
+        /// </summary>
         KeyboardMouse = 6,
+
+        /// <summary>
+        /// Reserved; not currently raised by PeachPDF. Inherited from this engine's interactive-viewer origins, where it covered <c>&lt;iframe&gt;</c> navigation.
+        /// </summary>
         Iframe = 7,
+
+        /// <summary>
+        /// Reserved; not currently raised by PeachPDF. Inherited from this engine's interactive-viewer origins, where it covered right-click context menu handling.
+        /// </summary>
         ContextMenu = 8,
     }
 }

--- a/src/PeachPDF/HtmlRenderException.cs
+++ b/src/PeachPDF/HtmlRenderException.cs
@@ -4,8 +4,18 @@ using System;
 
 namespace PeachPDF
 {
+    /// <summary>
+    /// Thrown when HTML/CSS parsing, layout, or painting fails while a <see cref="PdfGenerator"/> method is
+    /// rendering a document. <see cref="RenderErrorType"/> identifies which pipeline phase raised it.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="renderErrorType">The pipeline phase the error occurred in.</param>
+    /// <param name="innerException">Optional: the underlying exception that caused this error, if any.</param>
     public class HtmlRenderException(string message, HtmlRenderErrorType renderErrorType, Exception? innerException = null) : Exception(message, innerException)
     {
+        /// <summary>
+        /// The pipeline phase this error occurred in.
+        /// </summary>
         public HtmlRenderErrorType RenderErrorType { get; } = renderErrorType;
 
     }

--- a/src/PeachPDF/Network/DataUriNetworkLoader.cs
+++ b/src/PeachPDF/Network/DataUriNetworkLoader.cs
@@ -6,15 +6,27 @@ using System.Threading.Tasks;
 
 namespace PeachPDF.Network
 {
+    /// <summary>
+    /// The default <see cref="RNetworkLoader"/> used when <see cref="PeachPDF.PdfGenerateConfig.NetworkLoader"/>
+    /// is left unset. Resolves only <c>data:</c> URIs; any other resource URI (remote stylesheets, remote
+    /// images, HTTP(S) sources) is silently skipped. This is the safest default for server-side environments
+    /// where network access must be opted into explicitly rather than assumed.
+    /// </summary>
     public class DataUriNetworkLoader : RNetworkLoader
     {
+        /// <inheritdoc/>
         public override RUri? BaseUri => null;
 
+        /// <summary>
+        /// Not supported by this loader — the HTML string must always be passed directly to
+        /// <c>PdfGenerator.GeneratePdf</c>/<c>AddPdfPages</c> rather than loaded via a network loader.
+        /// </summary>
         public override Task<string> GetPrimaryContents()
         {
             return null!;
         }
 
+        /// <inheritdoc/>
         public override Task<RNetworkResponse?> GetResourceStream(RUri uri)
         {
             if (uri.Scheme is not "data") return Task.FromResult<RNetworkResponse?>(null);

--- a/src/PeachPDF/Network/HttpClientNetworkLoader.cs
+++ b/src/PeachPDF/Network/HttpClientNetworkLoader.cs
@@ -8,16 +8,31 @@ using System.Threading.Tasks;
 
 namespace PeachPDF.Network
 {
+    /// <summary>
+    /// An <see cref="RNetworkLoader"/> that fetches the root HTML document and every resource it references
+    /// (stylesheets, images) over HTTP(S) using a caller-supplied <see cref="HttpClient"/>. The caller controls
+    /// the <see cref="HttpClient"/>'s lifetime, so custom headers, authentication, proxies, timeouts, and
+    /// <see cref="HttpMessageHandler"/> chains are all supported without any PeachPDF-specific API.
+    /// </summary>
+    /// <param name="httpClient">The client used to fetch the root document and all referenced resources.</param>
+    /// <param name="primaryContentsUri">The URI of the root HTML document; also used as <see cref="BaseUri"/> for resolving relative references.</param>
     public class HttpClientNetworkLoader(HttpClient httpClient, Uri? primaryContentsUri) : RNetworkLoader
     {
+        /// <summary>
+        /// Creates a loader for the root document at <paramref name="primaryContentsUri"/>.
+        /// </summary>
+        /// <param name="httpClient">The client used to fetch the root document and all referenced resources.</param>
+        /// <param name="primaryContentsUri">The URI of the root HTML document; also used as <see cref="BaseUri"/> for resolving relative references.</param>
         public HttpClientNetworkLoader(HttpClient httpClient, string primaryContentsUri)
             : this(httpClient, new Uri(primaryContentsUri))
         {
 
         }
 
+        /// <inheritdoc/>
         public override RUri? BaseUri => primaryContentsUri != null ? new RUri(primaryContentsUri) : null;
 
+        /// <inheritdoc/>
         public override async Task<string> GetPrimaryContents()
         {
             if (BaseUri is null)
@@ -36,6 +51,7 @@ namespace PeachPDF.Network
             return await streamReader.ReadToEndAsync();
         }
 
+        /// <inheritdoc/>
         public override async Task<RNetworkResponse?> GetResourceStream(RUri uri)
         {
             var response = await httpClient.GetAsync(uri.Uri);

--- a/src/PeachPDF/Network/MimeKitNetworkLoader.cs
+++ b/src/PeachPDF/Network/MimeKitNetworkLoader.cs
@@ -7,19 +7,31 @@ using System.Threading.Tasks;
 
 namespace PeachPDF.Network
 {
+    /// <summary>
+    /// An <see cref="RNetworkLoader"/> backed by a self-contained MHTML archive (what Chrome calls a "single
+    /// page document"). The root HTML and every resource it references (stylesheets, images, fonts) are read
+    /// from the archive's MIME parts, matched by their <c>Content-Location</c>, so no network or file-system
+    /// access is needed to render the document.
+    /// </summary>
     public class MimeKitNetworkLoader : RNetworkLoader
     {
         private readonly Task<MimeMessage> _messageTask;
         private MimeMessage? _message = null;
 
+        /// <inheritdoc/>
         public override RUri? BaseUri => null;
 
+        /// <summary>
+        /// Creates a loader that reads the MHTML archive from <paramref name="stream"/>.
+        /// </summary>
+        /// <param name="stream">A stream positioned at the start of a MIME/MHTML archive. The caller owns the stream.</param>
         public MimeKitNetworkLoader(Stream stream)
         {
             MimeParser parser = new(stream);
             _messageTask = parser.ParseMessageAsync();
         }
 
+        /// <inheritdoc/>
         public override async Task<string> GetPrimaryContents()
         {
             _message ??= await _messageTask;
@@ -27,6 +39,7 @@ namespace PeachPDF.Network
             return _message.HtmlBody ?? string.Empty;
         }
 
+        /// <inheritdoc/>
         public override async Task<RNetworkResponse?> GetResourceStream(RUri uri)
         {
             _message ??= await _messageTask;

--- a/src/PeachPDF/Network/RNetworkLoader.cs
+++ b/src/PeachPDF/Network/RNetworkLoader.cs
@@ -2,10 +2,34 @@
 
 namespace PeachPDF.Network
 {
+    /// <summary>
+    /// Controls how PeachPDF loads the root HTML document and every external resource it references
+    /// (stylesheets, images). Set an instance on <see cref="PeachPDF.PdfGenerateConfig.NetworkLoader"/> to
+    /// integrate PeachPDF with a custom resource source (a cloud blob store, a bundler manifest, an in-memory
+    /// dictionary, etc.). PeachPDF ships three concrete implementations: <see cref="DataUriNetworkLoader"/>
+    /// (the default when none is configured), <see cref="MimeKitNetworkLoader"/> for MHTML archives, and
+    /// <see cref="HttpClientNetworkLoader"/> for HTTP(S) sources. <c>data:</c> URIs are always handled
+    /// internally regardless of which loader is configured.
+    /// </summary>
     public abstract class RNetworkLoader
     {
+        /// <summary>
+        /// Returns the root HTML document as a string. Called once at the start of rendering when <c>null</c>
+        /// is passed as the HTML argument to a <c>PdfGenerator.GeneratePdf</c>/<c>AddPdfPages</c> overload.
+        /// </summary>
         public abstract Task<string> GetPrimaryContents();
+
+        /// <summary>
+        /// Returns the content of an external resource (a stylesheet or image) referenced by the document, or
+        /// <c>null</c> if the resource cannot be resolved.
+        /// </summary>
+        /// <param name="uri">The resource URI, resolved against <see cref="BaseUri"/> or a <c>&lt;base href&gt;</c> element if relative.</param>
         public abstract Task<RNetworkResponse?> GetResourceStream(RUri uri);
+
+        /// <summary>
+        /// The document's base URL, used to resolve relative <c>href</c>, <c>src</c>, and CSS <c>url()</c>
+        /// references. If <c>null</c>, relative references are resolved against the local file system.
+        /// </summary>
         public abstract RUri? BaseUri { get; }
     }
 }

--- a/src/PeachPDF/Network/RNetworkResponse.cs
+++ b/src/PeachPDF/Network/RNetworkResponse.cs
@@ -3,5 +3,13 @@ using System.IO;
 
 namespace PeachPDF.Network
 {
+    /// <summary>
+    /// The result of resolving a resource URI via <see cref="RNetworkLoader.GetResourceStream"/>.
+    /// </summary>
+    /// <param name="ResourceStream">The resource's content stream, or <c>null</c> if the resource has no body.</param>
+    /// <param name="ResponseHeaders">
+    /// HTTP-style response headers for the resource, if any. For stylesheet resources, PeachPDF inspects this
+    /// for a <c>Content-Type</c> header and only accepts the body as CSS when it is <c>text/css</c>.
+    /// </param>
     public record RNetworkResponse(Stream? ResourceStream, Dictionary<string, string[]>? ResponseHeaders);
 }

--- a/src/PeachPDF/Network/RUri.cs
+++ b/src/PeachPDF/Network/RUri.cs
@@ -3,6 +3,12 @@ using System;
 
 namespace PeachPDF.Network
 {
+    /// <summary>
+    /// Wraps <see cref="System.Uri"/> for use throughout PeachPDF's resource-loading pipeline, adding
+    /// special-case handling for <c>data:</c> URIs (which <see cref="System.Uri"/> can parse but, on older
+    /// target frameworks, cannot round-trip correctly through <see cref="AbsoluteUri"/>) and helpers for
+    /// resolving a relative URI against a base URI.
+    /// </summary>
     public class RUri
     {
         private Uri? _uri { get; }
@@ -10,6 +16,10 @@ namespace PeachPDF.Network
         private string? _originalUri { get; }
 #endif
 
+        /// <summary>
+        /// Parses <paramref name="uriString"/> as either an absolute or relative URI.
+        /// </summary>
+        /// <param name="uriString">The URI string to parse.</param>
         public RUri(string uriString)
         {
             ArgumentNullException.ThrowIfNull(uriString, nameof(uriString));
@@ -28,6 +38,11 @@ namespace PeachPDF.Network
 #endif
         }
 
+        /// <summary>
+        /// Parses <paramref name="uriString"/> as the given <paramref name="uriKind"/>.
+        /// </summary>
+        /// <param name="uriString">The URI string to parse.</param>
+        /// <param name="uriKind">Whether the string is known to be absolute, relative, or either.</param>
         public RUri(string uriString, UriKind uriKind)
         {
 #if NET10_0_OR_GREATER
@@ -44,44 +59,96 @@ namespace PeachPDF.Network
 #endif
         }
 
+        /// <summary>
+        /// Resolves <paramref name="uri"/> against <paramref name="baseUri"/>, the same way a relative
+        /// <c>href</c>/<c>src</c>/<c>url()</c> reference is resolved against a document's base URL.
+        /// </summary>
+        /// <param name="baseUri">The base URI to resolve against.</param>
+        /// <param name="uri">The (typically relative) URI to resolve.</param>
         public RUri(RUri baseUri, RUri uri)
         {
             _uri = new Uri(baseUri.Uri, uri.Uri);
         }
 
+        /// <summary>
+        /// Resolves <paramref name="uri"/> against <paramref name="baseUri"/>, the same way a relative
+        /// <c>href</c>/<c>src</c>/<c>url()</c> reference is resolved against a document's base URL.
+        /// </summary>
+        /// <param name="baseUri">The base URI to resolve against.</param>
+        /// <param name="uri">The (typically relative) URI string to resolve.</param>
         public RUri(RUri baseUri, string uri)
         {
             _uri = new Uri(baseUri.Uri, uri);
         }
 
+        /// <summary>
+        /// Wraps an existing <see cref="System.Uri"/> instance.
+        /// </summary>
+        /// <param name="uri">The URI to wrap.</param>
         public RUri(Uri uri)
         {
             _uri = uri;
         }
 
 #if NET10_0_OR_GREATER
+        /// <summary>
+        /// The underlying <see cref="System.Uri"/>.
+        /// </summary>
         public Uri Uri => _uri!;
 
+        /// <summary>
+        /// The URI scheme (e.g. <c>https</c>, <c>file</c>, <c>data</c>).
+        /// </summary>
         public string Scheme => _uri!.Scheme;
 
+        /// <summary>
+        /// The fully escaped absolute URI string.
+        /// </summary>
         public string AbsoluteUri => _uri!.AbsoluteUri;
 
+        /// <summary>
+        /// The original, unescaped URI string as it was parsed.
+        /// </summary>
         public string OriginalString => _uri!.OriginalString;
 
+        /// <summary>
+        /// Whether this instance represents an absolute URI.
+        /// </summary>
         public bool IsAbsoluteUri => _uri!.IsAbsoluteUri;
 
+        /// <summary>
+        /// Whether this URI refers to a local file.
+        /// </summary>
         public bool IsFile => _uri!.IsFile;
 #else
+        /// <summary>
+        /// The underlying <see cref="System.Uri"/>.
+        /// </summary>
         public Uri Uri => _uri ?? new Uri(_originalUri!);
 
+        /// <summary>
+        /// The URI scheme (e.g. <c>https</c>, <c>file</c>, <c>data</c>).
+        /// </summary>
         public string Scheme => _uri is not null ? _uri.Scheme : _originalUri!.Split(":")[0];
 
+        /// <summary>
+        /// The fully escaped absolute URI string.
+        /// </summary>
         public string AbsoluteUri => _uri is not null ? _uri.AbsoluteUri : _originalUri!;
 
+        /// <summary>
+        /// The original, unescaped URI string as it was parsed.
+        /// </summary>
         public string OriginalString => _uri is not null ? _uri.OriginalString : _originalUri!;
 
+        /// <summary>
+        /// Whether this instance represents an absolute URI.
+        /// </summary>
         public bool IsAbsoluteUri => _uri?.IsAbsoluteUri ?? true;
 
+        /// <summary>
+        /// Whether this URI refers to a local file.
+        /// </summary>
         public bool IsFile => _uri?.IsFile ?? false;
 #endif
     }

--- a/src/PeachPDF/PdfGenerator.cs
+++ b/src/PeachPDF/PdfGenerator.cs
@@ -31,7 +31,10 @@ using System.Threading.Tasks;
 namespace PeachPDF
 {
     /// <summary>
-    /// TODO:a add doc
+    /// Renders HTML (and optionally CSS) into a PDF document entirely in-process, with no external
+    /// browser or process dependency. This is the main entry point for PeachPDF: use one of the
+    /// <c>GeneratePdf</c> overloads to create a new <see cref="PeachPdfDocument"/>, or one of the
+    /// <c>AddPdfPages</c> overloads to append rendered pages to an existing one.
     /// </summary>
     public class PdfGenerator
     {

--- a/src/PeachPDF/PeachPDF.csproj
+++ b/src/PeachPDF/PeachPDF.csproj
@@ -3,7 +3,10 @@
 		<AssemblyName>PeachPDF</AssemblyName>
 		<PackageId>PeachPDF</PackageId>
 		<PackageVersion>0.9.1</PackageVersion>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<IncludeSymbols>true</IncludeSymbols>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
 		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -31,6 +34,9 @@
 	</ItemGroup>
 	<ItemGroup>
 		<InternalsVisibleTo Include="PeachPDF.Tests" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 	<Target Name="GeneratePeachPdfProductInfo" BeforeTargets="BeforeBuild">
 		<WriteLinesToFile

--- a/src/PeachPDF/PeachPdfCssContent.cs
+++ b/src/PeachPDF/PeachPdfCssContent.cs
@@ -2,6 +2,11 @@ using PeachPDF.Html.Core;
 
 namespace PeachPDF
 {
+    /// <summary>
+    /// An opaque, pre-parsed stylesheet produced by <see cref="PdfGenerator.ParseStyleSheet"/>. Pass an instance
+    /// to a <c>GeneratePdf</c>/<c>AddPdfPages</c> overload's <c>cssData</c> parameter to reuse the same parsed CSS
+    /// across multiple renders instead of re-parsing identical stylesheet text on every call.
+    /// </summary>
     public class PeachPdfCssContent
     {
         private readonly CssData _cssData;

--- a/src/PeachPDF/PeachPdfDocument.cs
+++ b/src/PeachPDF/PeachPdfDocument.cs
@@ -3,6 +3,10 @@ using System.IO;
 
 namespace PeachPDF;
 
+/// <summary>
+/// A PDF document produced by <see cref="PdfGenerator"/>. Instances are created by calling one of the
+/// <c>PdfGenerator.GeneratePdf</c> overloads and are written out with <see cref="Save"/>.
+/// </summary>
 public class PeachPdfDocument
 {
     private readonly PdfDocument _document;
@@ -14,10 +18,17 @@ public class PeachPdfDocument
 
     internal PdfDocument PdfDocument => _document;
 
+    /// <summary>
+    /// The number of pages currently in the document.
+    /// </summary>
     public int PageCount => _document.PageCount;
 
     internal PdfPages Pages => _document.Pages;
 
+    /// <summary>
+    /// Writes the completed PDF to the given stream.
+    /// </summary>
+    /// <param name="stream">The destination stream. The caller owns the stream and is responsible for disposing it.</param>
     public void Save(Stream stream)
     {
         _document.Save(stream);


### PR DESCRIPTION
Add extensive XML documentation comments to public types and members for improved IntelliSense support, including detailed summaries for HtmlRenderException, RNetworkLoader implementations, and PdfGenerator. Create new usage-examples.md guide with copy-pasteable examples for common scenarios (local HTML, MHTML, HTTP fetching, ASP.NET Core endpoints, Azure Functions). Update README.md and docs/index.md with clearer feature descriptions and guides structure. Update docs/html-css-support.md to clarify parsing vs. rendering behavior for certain properties. Enable XML documentation file generation in PeachPDF.csproj and set CS1591 as error to enforce documentation on public APIs.