### PR TITLE
Generate API docs in Pages build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,6 +21,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Generate API reference
+        run: dotnet build src/PeachPDF/PeachPDF.csproj --configuration Release -p:TargetFramework=net10.0 -p:DisableDefaultDocumentation=false
+
       - uses: actions/configure-pages@v5
 
       - uses: actions/jekyll-build-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -406,3 +406,6 @@ FodyWeavers.xsd
 *.pdf
 /coverage-report
 /coverage
+
+# Auto-generated API reference (built by pages.yml via DefaultDocumentation; not source)
+/docs/api/

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ Targets .NET 8 and .NET 10.
 - **[Architecture](architecture.md)** — how PeachPDF converts HTML to PDF: the HTML parser, DOM model, CSS parser, layout engine, painting layer, and PDF renderer.
 - **[HTML & CSS Support](html-css-support.md)** — the full compatibility matrix of supported HTML elements, CSS properties, selectors, and at-rules, including notes on gaps and PeachPDF-specific extensions.
 - **[Usage Examples](usage-examples.md)** — copy-pasteable examples: local HTML strings, MHTML files, HTTP fetching, shared CSS contexts, saving to disk, and returning PDFs from ASP.NET Core (controllers and Minimal APIs) and Azure Functions.
+- **[API Reference](api/index.md)** — generated reference for every public type and member, always in sync with the latest source.
 
 ## Quick Start
 

--- a/src/PeachPDF/PdfGenerator.cs
+++ b/src/PeachPDF/PdfGenerator.cs
@@ -68,11 +68,10 @@ namespace PeachPDF
         }
 
         /// <summary>
-        /// Parse the given stylesheet to <see cref="CssData"/> object.<br/>
-        /// If <paramref name="combineWithDefault"/> is true the parsed css blocks are added to the 
-        /// default css data (as defined by W3), merged if class name already exists. If false only the data in the given stylesheet is returned.
+        /// Parses the given stylesheet into a reusable <see cref="PeachPdfCssContent"/> object.<br/>
+        /// If <paramref name="combineWithDefault"/> is true the parsed css blocks are added to the
+        /// default css data (as defined by the <see href="http://www.w3.org/TR/CSS21/sample.html">CSS 2.1 default stylesheet for HTML</see>), merged if class name already exists. If false only the data in the given stylesheet is returned.
         /// </summary>
-        /// <seealso cref="http://www.w3.org/TR/CSS21/sample.html"/>
         /// <param name="stylesheet">the stylesheet source to parse</param>
         /// <param name="combineWithDefault">true - combine the parsed css data with default css data, false - return only the parsed css data</param>
         /// <returns>the parsed css data</returns>

--- a/src/PeachPDF/PeachPDF.csproj
+++ b/src/PeachPDF/PeachPDF.csproj
@@ -7,6 +7,11 @@
 		<IncludeSymbols>true</IncludeSymbols>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
+		<!-- Off by default so ordinary local `dotnet build` runs stay fast; CI passes -p:DisableDefaultDocumentation=false to regenerate docs/api/. -->
+		<DisableDefaultDocumentation Condition="'$(DisableDefaultDocumentation)' == ''">true</DisableDefaultDocumentation>
+		<DefaultDocumentationFolder>$(MSBuildProjectDirectory)/../../docs/api</DefaultDocumentationFolder>
+		<DefaultDocumentationGeneratedAccessModifiers>Public</DefaultDocumentationGeneratedAccessModifiers>
+		<DefaultDocumentationFileNameFactory>Name</DefaultDocumentationFileNameFactory>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
 		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -21,6 +26,7 @@
 		<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>
 	<ItemGroup>
+		<PackageReference Include="DefaultDocumentation" Version="1.2.5" PrivateAssets="all" IncludeAssets="build" />
 		<PackageReference Include="MimeKit" Version="4.17.0" />
 		<PackageReference Include="StbImageSharp" Version="2.30.15" />
 		<PackageReference Include="StbImageWriteSharp" Version="1.16.7" />
@@ -39,10 +45,7 @@
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 	<Target Name="GeneratePeachPdfProductInfo" BeforeTargets="BeforeBuild">
-		<WriteLinesToFile
-			File="$(IntermediateOutputPath)PeachPdfProductInfo.g.cs"
-			Lines="namespace PeachPDF { internal static class PeachPdfProductInfo { public const string Generator = &quot;PeachPDF $(PackageVersion)&quot;%3B } }"
-			Overwrite="true" />
+		<WriteLinesToFile File="$(IntermediateOutputPath)PeachPdfProductInfo.g.cs" Lines="namespace PeachPDF { internal static class PeachPdfProductInfo { public const string Generator = &quot;PeachPDF $(PackageVersion)&quot;%3B } }" Overwrite="true" />
 		<ItemGroup>
 			<Compile Include="$(IntermediateOutputPath)PeachPdfProductInfo.g.cs" />
 		</ItemGroup>


### PR DESCRIPTION
Add DefaultDocumentation to the PeachPDF project and wire the Pages workflow to build the API reference for net10.0. Update the docs home page to link to the generated reference and ignore the generated docs/api output in source control.