### PR TITLE
Improve CSS Selector spec compliance

### DIFF
--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -402,13 +402,19 @@ Because PeachPDF renders a static PDF with no interactive or dynamic state, stat
 | `:nth-child(an+b)`, `:nth-last-child(an+b)` | Full "An+B" support, including `odd`/`even` keywords and negative steps (e.g. `:nth-child(-n+3)`) |
 | `:nth-of-type(an+b)`, `:nth-last-of-type(an+b)` | Same as above, counting only same-tag siblings |
 | `:nth-column(an+b)`, `:nth-last-column(an+b)` | Matches a table cell against its column position. Only accounts for `colspan` within the same row — a cell's column position does not account for `rowspan` carried over from earlier rows, since that bookkeeping only exists during layout, not at the point selectors are matched |
+| `:nth-child(an+b of S)`, `:nth-last-child(an+b of S)` | CSS Selectors Level 4 `of <selector>` extension — the An+B position is computed only among siblings matching `S`; `S` may be a comma-separated selector list |
+| `:not(S)` | Matches an element that does not match `S`. Nesting `:not()` inside `:not()` (e.g. `:not(:not(.foo))`) is rejected — the whole enclosing selector is invalid and the rule matches nothing |
+| `:is(S)`, `:matches(S)` | Matches an element that matches any selector in the (comma-separated, forgiving) list `S`. `:matches()` is the legacy alias for `:is()` |
+| `:has(S)` | Matches an element with a descendant matching `S`; `S` may be a comma-separated selector list. Only the default descendant relationship is supported — CSS4 leading-combinator forms (`:has(> S)`, `:has(+ S)`, `:has(~ S)`) are not supported and are silently discarded by the parser |
 | All others | Parsed but not matched — rules are silently ignored |
 
-Two known gaps in the structural pseudo-classes above:
-- The CSS Selectors Level 4 `of <selector>` extension (e.g. `:nth-child(2n+1 of .foo)`) is parsed but not matched — the whole rule is evaluated as if `of <selector>` were absent.
-- `:nth-column()`/`:nth-last-column()`'s same-row-only limitation described above.
+Known gap: `:nth-column()`/`:nth-last-column()`'s same-row-only limitation described above.
 
 State-based pseudo-classes other than `:link` (`:hover`, `:focus`, `:active`, `:checked`, `:disabled`, `:root`, `:empty`, etc.) are parsed but not applied.
+
+### Cascade & Specificity
+
+Rule application respects real CSS specificity, not just source order: for a given element, matching rules are applied in true document order, then stably re-sorted by specificity (inline style > ID count > class/attribute/pseudo-class count > type/pseudo-element count) so a higher-specificity rule always wins over a lower-specificity one regardless of which was declared first. Equal-specificity rules still resolve by source order (last one wins), and `!important` continues to take precedence over normal declarations, applied per-origin (author `!important` beats author normal; user-agent `!important` beats everything).
 
 ---
 

--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -390,15 +390,25 @@ Both the single-colon legacy syntax (`:before`, `:after`) and the modern double-
 
 ### Pseudo-classes
 
-Because PeachPDF renders a static PDF with no interactive or dynamic state, almost all pseudo-classes are parsed but not evaluated and will not match any elements.
+Because PeachPDF renders a static PDF with no interactive or dynamic state, state-based pseudo-classes are parsed but not evaluated and will not match any elements. The structural pseudo-classes (which depend only on an element's position in the document, not on interactive state) are fully supported, including the CSS "An+B" formula.
 
 | Pseudo-class | Notes |
 |--------------|-------|
 | `:link` | Matches `<a>` elements that have an `href` attribute |
-| `:nth-child(an+b)` | Partially supported: the step value `a` is ignored; only the offset `b` is checked against the element's position among siblings |
+| `:first-child`, `:last-child` | Equivalent to `:nth-child(1)` / `:nth-last-child(1)` |
+| `:only-child` | Matches an element with no other element siblings |
+| `:first-of-type`, `:last-of-type` | Equivalent to `:nth-of-type(1)` / `:nth-last-of-type(1)` |
+| `:only-of-type` | Matches an element with no other same-tag element siblings |
+| `:nth-child(an+b)`, `:nth-last-child(an+b)` | Full "An+B" support, including `odd`/`even` keywords and negative steps (e.g. `:nth-child(-n+3)`) |
+| `:nth-of-type(an+b)`, `:nth-last-of-type(an+b)` | Same as above, counting only same-tag siblings |
+| `:nth-column(an+b)`, `:nth-last-column(an+b)` | Matches a table cell against its column position. Only accounts for `colspan` within the same row — a cell's column position does not account for `rowspan` carried over from earlier rows, since that bookkeeping only exists during layout, not at the point selectors are matched |
 | All others | Parsed but not matched — rules are silently ignored |
 
-State-based pseudo-classes (`:hover`, `:focus`, `:active`, `:checked`, `:disabled`) and structural pseudo-classes (`:first-child`, `:last-child`, `:nth-of-type()`, `:not()`, etc.) are not applied.
+Two known gaps in the structural pseudo-classes above:
+- The CSS Selectors Level 4 `of <selector>` extension (e.g. `:nth-child(2n+1 of .foo)`) is parsed but not matched — the whole rule is evaluated as if `of <selector>` were absent.
+- `:nth-column()`/`:nth-last-column()`'s same-row-only limitation described above.
+
+State-based pseudo-classes other than `:link` (`:hover`, `:focus`, `:active`, `:checked`, `:disabled`, `:root`, `:empty`, etc.) are parsed but not applied.
 
 ---
 

--- a/src/PeachPDF.Tests/CSS/CssSpecificityOrderingTests.cs
+++ b/src/PeachPDF.Tests/CSS/CssSpecificityOrderingTests.cs
@@ -1,0 +1,96 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore.Drawing;
+
+namespace PeachPDF.Tests.CSS;
+
+/// <summary>
+/// Regression tests for CssData's cascade ordering: matched rules are now applied in
+/// (specificity ascending, true document order) rather than the old pure "whatever order rules
+/// were enumerated in" behavior, which didn't respect CSS specificity at all (a low-specificity
+/// rule declared later used to incorrectly beat a high-specificity rule declared earlier), and
+/// which additionally didn't preserve true source order across the plain-rule/@media boundary.
+/// </summary>
+public class CssSpecificityOrderingTests
+{
+    [Fact]
+    public async Task HigherSpecificityRule_WinsEvenWhenDeclaredEarlier()
+    {
+        // #el (id, highest specificity) is declared FIRST; div (type, lowest specificity) is
+        // declared SECOND. Under the old "pure source order" behavior, div (later) would
+        // incorrectly win. Specificity must decide this, not declaration order.
+        var html = Html("#el { color: #0000ff; } div { color: #ff0000; }", "<div id='el'>text</div>");
+        var box = await FindBoxByTag(html, "div");
+        Assert.Equal("rgb(0, 0, 255)", box.Color);
+    }
+
+    [Fact]
+    public async Task EqualSpecificity_SameOrigin_StillResolvesByLastDeclared()
+    {
+        var html = Html("div { color: #ff0000; } div { color: #0000ff; }", "<div>text</div>");
+        var box = await FindBoxByTag(html, "div");
+        Assert.Equal("rgb(0, 0, 255)", box.Color);
+    }
+
+    [Fact]
+    public async Task MediaRuleDeclaredEarlier_LosesToEqualSpecificityPlainRuleDeclaredLater()
+    {
+        // The @media print block (containing a "div" rule) appears FIRST in the source; a plain
+        // "div" rule appears SECOND. Both have identical (type-only) specificity, so true source
+        // order must decide - the old two-pass "all plain rules, then all media rules" enumeration
+        // didn't preserve this (it would treat the media rule as if it came after the plain rule,
+        // regardless of true position), so this would previously have picked the wrong winner.
+        var html = Html(
+            "@media print { div { color: #0000ff; } } div { color: #ff0000; }",
+            "<div>text</div>");
+        var box = await FindBoxByTag(html, "div");
+        Assert.Equal("rgb(255, 0, 0)", box.Color);
+    }
+
+    [Fact]
+    public async Task CommaListRule_UsesOnlyTheMatchedBranchsSpecificity_NotASum()
+    {
+        // The box matches ".a" (one class) but NOT "#b" (an id) in the list selector ".a, #b".
+        // The old buggy ListSelector.Specificity summed ALL alternatives (class + id), which would
+        // make this rule outrank ".a.c" (two classes) purely because of the unmatched "#b" branch's
+        // id specificity leaking in. The correct behavior only credits the branch that actually
+        // matched (".a" = one class), so ".a.c" (two classes) must win.
+        var html = Html(
+            ".a, #b { color: #0000ff; } .a.c { color: #ff0000; }",
+            "<div class='a c'>text</div>");
+        var box = await FindBoxByTag(html, "div");
+        Assert.Equal("rgb(255, 0, 0)", box.Color);
+    }
+
+    // ── Helpers (mirrors SelectorMatchingTests.cs conventions) ────────────────
+
+    private static string Html(string css, string body) =>
+        $"<!DOCTYPE html><html><head><style>{css}</style></head><body>{body}</body></html>";
+
+    private async Task<CssBox> FindBoxByTag(string html, string tag)
+    {
+        var root = await BuildRoot(html);
+        var box = PeachPDF.Html.Core.Utils.DomUtils.GetBoxByTagName(root, tag);
+        Assert.NotNull(box);
+        return box!;
+    }
+
+    private static async Task<CssBox> BuildRoot(string html)
+    {
+        var adapter = new PdfSharpAdapter();
+        var container = new HtmlContainerInt(adapter);
+        await container.SetHtml(html, null);
+
+        var size = new XSize(595, 842);
+        container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+        container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+        var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+        using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+        await container.PerformLayout(graphics);
+
+        Assert.NotNull(container.Root);
+        return container.Root!;
+    }
+}

--- a/src/PeachPDF.Tests/CSS/RelationalPseudoClassSelectorTests.cs
+++ b/src/PeachPDF.Tests/CSS/RelationalPseudoClassSelectorTests.cs
@@ -1,0 +1,187 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Utils;
+using PeachPDF.PdfSharpCore.Drawing;
+
+namespace PeachPDF.Tests.CSS;
+
+/// <summary>
+/// Regression tests for :not(), :is()/:matches(), and :has() - previously parsed successfully but
+/// permanently inert (rebuilt into a fake PseudoClassSelector that could only ever match ":link").
+/// :is() didn't parse at all before this change.
+/// </summary>
+public class RelationalPseudoClassSelectorTests
+{
+    // ── :not() ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Not_ExcludesElementsMatchingTheArgument()
+    {
+        var html = Html(
+            "p:not(.exclude) { background-color: #ff0000; }",
+            "<div><p class='exclude'>1</p><p>2</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(2, boxes.Count);
+        Assert.Equal("transparent", boxes[0].BackgroundColor);
+        Assert.NotEqual("transparent", boxes[1].BackgroundColor);
+    }
+
+    [Fact]
+    public async Task NotNot_IsRejectedAsInvalid_WholeRuleMatchesNothing()
+    {
+        // The parser has a pre-existing restriction against nesting :not() inside :not() (IsNested
+        // flag) - the whole enclosing selector becomes invalid, so the rule matches nothing at all,
+        // even for an element that would satisfy the (nonsensical) double-negation.
+        var html = Html(
+            "p:not(:not(.foo)) { background-color: #ff0000; }",
+            "<div><p class='foo'>1</p></div>");
+        var box = await FindBoxByTag(html, "p");
+        Assert.Equal("transparent", box.BackgroundColor);
+    }
+
+    // ── :is() / :matches() ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Is_MatchesEitherBranch()
+    {
+        var html = Html(
+            "p:is(.a, .b) { background-color: #ff0000; }",
+            "<div><p class='a'>1</p><p class='b'>2</p><p>3</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(3, boxes.Count);
+        Assert.NotEqual("transparent", boxes[0].BackgroundColor);
+        Assert.NotEqual("transparent", boxes[1].BackgroundColor);
+        Assert.Equal("transparent", boxes[2].BackgroundColor);
+    }
+
+    [Fact]
+    public async Task Matches_LegacyAliasBehavesTheSameAsIs()
+    {
+        var html = Html(
+            "p:matches(.a, .b) { background-color: #ff0000; }",
+            "<div><p class='a'>1</p><p>2</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(2, boxes.Count);
+        Assert.NotEqual("transparent", boxes[0].BackgroundColor);
+        Assert.Equal("transparent", boxes[1].BackgroundColor);
+    }
+
+    [Fact]
+    public async Task Is_SpecificityIsTheStaticMaxOfItsArguments_NotJustTheMatchedBranch()
+    {
+        // ":is(.a, #b)" must report specificity = max(.a, #b) = one-id, per spec - even though this
+        // box only matches via the ".a" branch (never #b). If :is()'s specificity were instead
+        // computed dynamically from only the matched branch (one-class), ".a.c" (two classes) would
+        // incorrectly outrank it; with the correct static-max (one-id) behavior, :is(...) wins.
+        var html = Html(
+            ":is(.a, #b) { color: #0000ff; } .a.c { color: #ff0000; }",
+            "<div class='a c'>text</div>");
+        var box = await FindBoxByTag(html, "div");
+        Assert.Equal("rgb(0, 0, 255)", box.Color);
+    }
+
+    // ── :has() ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Has_MatchesWhenADirectChildSatisfiesTheArgument()
+    {
+        var html = Html(
+            "div:has(.foo) { background-color: #ff0000; }",
+            "<div id='yes'><span class='foo'>x</span></div><div id='no'><span>x</span></div>");
+        var yes = await FindBoxById(html, "yes");
+        var no = await FindBoxById(html, "no");
+        Assert.NotEqual("transparent", yes.BackgroundColor);
+        Assert.Equal("transparent", no.BackgroundColor);
+    }
+
+    [Fact]
+    public async Task Has_MatchesWhenADeeplyNestedDescendantSatisfiesTheArgument()
+    {
+        var html = Html(
+            "div:has(.foo) { background-color: #ff0000; }",
+            "<div id='outer'><section><article><span class='foo'>deep</span></article></section></div>");
+        var outer = await FindBoxById(html, "outer");
+        Assert.NotEqual("transparent", outer.BackgroundColor);
+    }
+
+    [Fact]
+    public async Task Has_CommaSeparatedArgument_MatchesEitherBranch()
+    {
+        var html = Html(
+            "div:has(.a, .b) { background-color: #ff0000; }",
+            "<div id='yes'><span class='b'>x</span></div><div id='no'><span class='c'>x</span></div>");
+        var yes = await FindBoxById(html, "yes");
+        var no = await FindBoxById(html, "no");
+        Assert.NotEqual("transparent", yes.BackgroundColor);
+        Assert.Equal("transparent", no.BackgroundColor);
+    }
+
+    // ── Helpers (mirrors SelectorMatchingTests.cs conventions) ────────────────
+
+    private static string Html(string css, string body) =>
+        $"<!DOCTYPE html><html><head><style>{css}</style></head><body>{body}</body></html>";
+
+    private async Task<CssBox> FindBoxByTag(string html, string tag)
+    {
+        var root = await BuildRoot(html);
+        var box = DomUtils.GetBoxByTagName(root, tag);
+        Assert.NotNull(box);
+        return box!;
+    }
+
+    private async Task<List<CssBox>> FindAllBoxesByTag(string html, string tag)
+    {
+        var root = await BuildRoot(html);
+        var results = new List<CssBox>();
+        CollectByTag(root, tag, results);
+        return results;
+    }
+
+    private async Task<CssBox> FindBoxById(string html, string id)
+    {
+        var root = await BuildRoot(html);
+        var box = FindById(root, id);
+        Assert.NotNull(box);
+        return box!;
+    }
+
+    private static void CollectByTag(CssBox box, string tag, List<CssBox> results)
+    {
+        if (box.HtmlTag?.Name.Equals(tag, StringComparison.OrdinalIgnoreCase) == true)
+            results.Add(box);
+        foreach (var child in box.Boxes)
+            CollectByTag(child, tag, results);
+    }
+
+    private static CssBox? FindById(CssBox box, string id)
+    {
+        var val = box.HtmlTag?.TryGetAttribute("id", "");
+        if (val != null && val.Equals(id, StringComparison.OrdinalIgnoreCase))
+            return box;
+        foreach (var child in box.Boxes)
+        {
+            var found = FindById(child, id);
+            if (found != null) return found;
+        }
+        return null;
+    }
+
+    private static async Task<CssBox> BuildRoot(string html)
+    {
+        var adapter = new PdfSharpAdapter();
+        var container = new HtmlContainerInt(adapter);
+        await container.SetHtml(html, null);
+
+        var size = new XSize(595, 842);
+        container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+        container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+        var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+        using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+        await container.PerformLayout(graphics);
+
+        Assert.NotNull(container.Root);
+        return container.Root!;
+    }
+}

--- a/src/PeachPDF.Tests/CSS/StructuralPseudoClassSelectorTests.cs
+++ b/src/PeachPDF.Tests/CSS/StructuralPseudoClassSelectorTests.cs
@@ -1,0 +1,305 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Utils;
+using PeachPDF.PdfSharpCore.Drawing;
+
+namespace PeachPDF.Tests.CSS;
+
+/// <summary>
+/// Regression tests for the structural pseudo-class family: bare :first-child/:last-child/
+/// :only-child/:first-of-type/:last-of-type/:only-of-type (previously non-functional generic
+/// PseudoClassSelectors), :nth-child()/:nth-last-child()/:nth-of-type()/:nth-last-of-type()
+/// (previously off-by-one and missing from the matching switch), and :nth-column()/
+/// :nth-last-column() (previously missing from the matching switch entirely).
+/// </summary>
+public class StructuralPseudoClassSelectorTests
+{
+    // ── :first-child ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FirstChild_Matches_FirstElement()
+    {
+        var html = Html(":first-child { background-color: #ff0000; }", "<div><p>first</p><p>second</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(2, boxes.Count);
+        Assert.NotEqual("transparent", boxes[0].BackgroundColor);
+        Assert.Equal("transparent", boxes[1].BackgroundColor);
+    }
+
+    // ── :last-child ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LastChild_Matches_LastElement()
+    {
+        var html = Html(":last-child { background-color: #ff0000; }", "<div><p>first</p><p>second</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(2, boxes.Count);
+        Assert.Equal("transparent", boxes[0].BackgroundColor);
+        Assert.NotEqual("transparent", boxes[1].BackgroundColor);
+    }
+
+    // ── :only-child ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task OnlyChild_Matches_WhenNoSiblings()
+    {
+        var html = Html(":only-child { background-color: #ff0000; }", "<div><p>alone</p></div>");
+        var box = await FindBoxByTag(html, "p");
+        Assert.NotEqual("transparent", box.BackgroundColor);
+    }
+
+    [Fact]
+    public async Task OnlyChild_DoesNotMatch_WhenSiblingsPresent()
+    {
+        var html = Html(":only-child { background-color: #ff0000; }", "<div><p>first</p><p>second</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(2, boxes.Count);
+        Assert.All(boxes, b => Assert.Equal("transparent", b.BackgroundColor));
+    }
+
+    // ── :nth-child() — literal, formula, keywords, negative offset ────────────
+
+    [Fact]
+    public async Task NthChild_Literal_MatchesOnlyThatPosition()
+    {
+        var html = Html(":nth-child(2) { background-color: #ff0000; }", "<div><p>1</p><p>2</p><p>3</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(3, boxes.Count);
+        Assert.Equal("transparent", boxes[0].BackgroundColor);
+        Assert.NotEqual("transparent", boxes[1].BackgroundColor);
+        Assert.Equal("transparent", boxes[2].BackgroundColor);
+    }
+
+    [Fact]
+    public async Task NthChild_2n_MatchesEvenPositions()
+    {
+        var html = Html(":nth-child(2n) { background-color: #ff0000; }", "<div><p>1</p><p>2</p><p>3</p><p>4</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal("transparent", boxes[0].BackgroundColor);
+        Assert.NotEqual("transparent", boxes[1].BackgroundColor);
+        Assert.Equal("transparent", boxes[2].BackgroundColor);
+        Assert.NotEqual("transparent", boxes[3].BackgroundColor);
+    }
+
+    [Fact]
+    public async Task NthChild_2nPlus1_MatchesOddPositions()
+    {
+        var html = Html(":nth-child(2n+1) { background-color: #ff0000; }", "<div><p>1</p><p>2</p><p>3</p><p>4</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.NotEqual("transparent", boxes[0].BackgroundColor);
+        Assert.Equal("transparent", boxes[1].BackgroundColor);
+        Assert.NotEqual("transparent", boxes[2].BackgroundColor);
+        Assert.Equal("transparent", boxes[3].BackgroundColor);
+    }
+
+    [Fact]
+    public async Task NthChild_Odd_MatchesOddPositions()
+    {
+        var html = Html(":nth-child(odd) { background-color: #ff0000; }", "<div><p>1</p><p>2</p><p>3</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.NotEqual("transparent", boxes[0].BackgroundColor);
+        Assert.Equal("transparent", boxes[1].BackgroundColor);
+        Assert.NotEqual("transparent", boxes[2].BackgroundColor);
+    }
+
+    [Fact]
+    public async Task NthChild_Even_MatchesEvenPositions()
+    {
+        var html = Html(":nth-child(even) { background-color: #ff0000; }", "<div><p>1</p><p>2</p><p>3</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal("transparent", boxes[0].BackgroundColor);
+        Assert.NotEqual("transparent", boxes[1].BackgroundColor);
+        Assert.Equal("transparent", boxes[2].BackgroundColor);
+    }
+
+    [Fact]
+    public async Task NthChild_NegativeStep_MatchesFirstNPositions()
+    {
+        // "-n+3" matches positions 1, 2, 3 and nothing beyond.
+        var html = Html(":nth-child(-n+3) { background-color: #ff0000; }", "<div><p>1</p><p>2</p><p>3</p><p>4</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.NotEqual("transparent", boxes[0].BackgroundColor);
+        Assert.NotEqual("transparent", boxes[1].BackgroundColor);
+        Assert.NotEqual("transparent", boxes[2].BackgroundColor);
+        Assert.Equal("transparent", boxes[3].BackgroundColor);
+    }
+
+    [Fact]
+    public async Task NthLastChild_1_MatchesLastElement()
+    {
+        var html = Html(":nth-last-child(1) { background-color: #ff0000; }", "<div><p>1</p><p>2</p><p>3</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal("transparent", boxes[0].BackgroundColor);
+        Assert.Equal("transparent", boxes[1].BackgroundColor);
+        Assert.NotEqual("transparent", boxes[2].BackgroundColor);
+    }
+
+    // ── :first-of-type / :last-of-type / :only-of-type / :nth-of-type() ──────
+    // Mixed-tag siblings prove type-filtering isn't just reusing :nth-child's all-elements scope.
+
+    [Fact]
+    public async Task FirstOfType_Matches_FirstOfItsOwnTagOnly()
+    {
+        var html = Html("p:first-of-type { background-color: #ff0000; }", "<div><span>s</span><p>1</p><p>2</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(2, boxes.Count);
+        Assert.NotEqual("transparent", boxes[0].BackgroundColor);
+        Assert.Equal("transparent", boxes[1].BackgroundColor);
+    }
+
+    [Fact]
+    public async Task LastOfType_Matches_LastOfItsOwnTagOnly()
+    {
+        var html = Html("p:last-of-type { background-color: #ff0000; }", "<div><p>1</p><p>2</p><span>s</span></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(2, boxes.Count);
+        Assert.Equal("transparent", boxes[0].BackgroundColor);
+        Assert.NotEqual("transparent", boxes[1].BackgroundColor);
+    }
+
+    [Fact]
+    public async Task OnlyOfType_Matches_WhenNoOtherSiblingSharesTag()
+    {
+        var html = Html("p:only-of-type { background-color: #ff0000; }", "<div><span>s</span><p>1</p></div>");
+        var box = await FindBoxByTag(html, "p");
+        Assert.NotEqual("transparent", box.BackgroundColor);
+    }
+
+    [Fact]
+    public async Task OnlyOfType_DoesNotMatch_WhenAnotherSameTagSiblingExists()
+    {
+        var html = Html("p:only-of-type { background-color: #ff0000; }", "<div><p>1</p><p>2</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.All(boxes, b => Assert.Equal("transparent", b.BackgroundColor));
+    }
+
+    [Fact]
+    public async Task NthOfType_2_MatchesSecondOfItsOwnTagOnly()
+    {
+        var html = Html("p:nth-of-type(2) { background-color: #ff0000; }", "<div><span>s</span><p>1</p><span>s2</span><p>2</p><p>3</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(3, boxes.Count);
+        Assert.Equal("transparent", boxes[0].BackgroundColor);
+        Assert.NotEqual("transparent", boxes[1].BackgroundColor);
+        Assert.Equal("transparent", boxes[2].BackgroundColor);
+    }
+
+    [Fact]
+    public async Task NthLastOfType_1_MatchesLastOfItsOwnTagOnly()
+    {
+        var html = Html("p:nth-last-of-type(1) { background-color: #ff0000; }", "<div><p>1</p><span>s</span><p>2</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(2, boxes.Count);
+        Assert.Equal("transparent", boxes[0].BackgroundColor);
+        Assert.NotEqual("transparent", boxes[1].BackgroundColor);
+    }
+
+    // ── Compound forms ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TagPlusNthChild_MatchesOnlyMatchingTagAtThatPosition()
+    {
+        var html = Html("p:nth-child(2n+1) { background-color: #ff0000; }", "<div><p>1</p><span>2</span><p>3</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(2, boxes.Count);
+        Assert.NotEqual("transparent", boxes[0].BackgroundColor); // <p> at position 1 (odd) - matches
+        Assert.NotEqual("transparent", boxes[1].BackgroundColor); // <p> at position 3 (odd) - matches
+    }
+
+    [Fact]
+    public async Task ClassPlusFirstChild_MatchesOnlyWhenBothConditionsHold()
+    {
+        var html = Html(".item:first-child { background-color: #ff0000; }", "<div><p class='item'>1</p><p class='item'>2</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(2, boxes.Count);
+        Assert.NotEqual("transparent", boxes[0].BackgroundColor);
+        Assert.Equal("transparent", boxes[1].BackgroundColor);
+    }
+
+    [Fact]
+    public async Task ClassPlusFirstChild_DoesNotMatch_WhenFirstChildLacksClass()
+    {
+        var html = Html(".item:first-child { background-color: #ff0000; }", "<div><p>1</p><p class='item'>2</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(2, boxes.Count);
+        Assert.All(boxes, b => Assert.Equal("transparent", b.BackgroundColor));
+    }
+
+    // ── :nth-column() / :nth-last-column() ────────────────────────────────────
+
+    [Fact]
+    public async Task NthColumn_MatchesAnyOccupiedColumnOfAColspanCell()
+    {
+        // Row occupies 4 columns total: A=col0, B(colspan=2)=cols1-2, C=col3.
+        // nth-column(2) should match B, since one of its occupied columns is position 2.
+        var html = Html(
+            "td:nth-column(2) { background-color: #ff0000; }",
+            "<table><tr><td>A</td><td colspan='2'>B</td><td>C</td></tr></table>");
+        var boxes = await FindAllBoxesByTag(html, "td");
+        Assert.Equal(3, boxes.Count);
+        Assert.Equal("transparent", boxes[0].BackgroundColor); // A
+        Assert.NotEqual("transparent", boxes[1].BackgroundColor); // B
+        Assert.Equal("transparent", boxes[2].BackgroundColor); // C
+    }
+
+    [Fact]
+    public async Task NthLastColumn_1_MatchesLastColumnOnly()
+    {
+        var html = Html(
+            "td:nth-last-column(1) { background-color: #ff0000; }",
+            "<table><tr><td>A</td><td colspan='2'>B</td><td>C</td></tr></table>");
+        var boxes = await FindAllBoxesByTag(html, "td");
+        Assert.Equal(3, boxes.Count);
+        Assert.Equal("transparent", boxes[0].BackgroundColor); // A
+        Assert.Equal("transparent", boxes[1].BackgroundColor); // B
+        Assert.NotEqual("transparent", boxes[2].BackgroundColor); // C, the last of 4 columns
+    }
+
+    // ── Helpers (mirrors SelectorMatchingTests.cs conventions) ────────────────
+
+    private static string Html(string css, string body) =>
+        $"<!DOCTYPE html><html><head><style>{css}</style></head><body>{body}</body></html>";
+
+    private async Task<CssBox> FindBoxByTag(string html, string tag)
+    {
+        var root = await BuildRoot(html);
+        var box = DomUtils.GetBoxByTagName(root, tag);
+        Assert.NotNull(box);
+        return box!;
+    }
+
+    private async Task<List<CssBox>> FindAllBoxesByTag(string html, string tag)
+    {
+        var root = await BuildRoot(html);
+        var results = new List<CssBox>();
+        CollectByTag(root, tag, results);
+        return results;
+    }
+
+    private static void CollectByTag(CssBox box, string tag, List<CssBox> results)
+    {
+        if (box.HtmlTag?.Name.Equals(tag, StringComparison.OrdinalIgnoreCase) == true)
+            results.Add(box);
+        foreach (var child in box.Boxes)
+            CollectByTag(child, tag, results);
+    }
+
+    private static async Task<CssBox> BuildRoot(string html)
+    {
+        var adapter = new PdfSharpAdapter();
+        var container = new HtmlContainerInt(adapter);
+        await container.SetHtml(html, null);
+
+        var size = new XSize(595, 842);
+        container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+        container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+        var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+        using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+        await container.PerformLayout(graphics);
+
+        Assert.NotNull(container.Root);
+        return container.Root!;
+    }
+}

--- a/src/PeachPDF.Tests/CSS/StructuralPseudoClassSelectorTests.cs
+++ b/src/PeachPDF.Tests/CSS/StructuralPseudoClassSelectorTests.cs
@@ -256,6 +256,93 @@ public class StructuralPseudoClassSelectorTests
         Assert.NotEqual("transparent", boxes[2].BackgroundColor); // C, the last of 4 columns
     }
 
+    // ── CSS4 "of <selector>" extension (:nth-child()/:nth-last-child() only) ──
+
+    [Fact]
+    public async Task NthChildOfSelector_1_MatchesOnlyTheFirstMatchingSibling()
+    {
+        // Position is counted among the ".foo"-matching subset only, skipping non-".foo" siblings.
+        var html = Html(
+            ":nth-child(1 of .foo) { background-color: #ff0000; }",
+            "<div><p>1</p><p class='foo'>2</p><p>3</p><p class='foo'>4</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(4, boxes.Count);
+        Assert.Equal("transparent", boxes[0].BackgroundColor); // "1", not .foo
+        Assert.NotEqual("transparent", boxes[1].BackgroundColor); // "2", first .foo
+        Assert.Equal("transparent", boxes[2].BackgroundColor); // "3", not .foo
+        Assert.Equal("transparent", boxes[3].BackgroundColor); // "4", second .foo
+    }
+
+    [Fact]
+    public async Task NthChildOfSelector_2nPlus1_AppliesFormulaWithinTheFilteredSubset()
+    {
+        var html = Html(
+            ":nth-child(2n+1 of .foo) { background-color: #ff0000; }",
+            "<div><p>skip</p><p class='foo'>foo-1</p><p>skip</p><p class='foo'>foo-2</p><p class='foo'>foo-3</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(5, boxes.Count);
+        Assert.Equal("transparent", boxes[0].BackgroundColor); // "skip"
+        Assert.NotEqual("transparent", boxes[1].BackgroundColor); // "foo-1" - .foo position 1 (odd)
+        Assert.Equal("transparent", boxes[2].BackgroundColor); // "skip"
+        Assert.Equal("transparent", boxes[3].BackgroundColor); // "foo-2" - .foo position 2 (even)
+        Assert.NotEqual("transparent", boxes[4].BackgroundColor); // "foo-3" - .foo position 3 (odd)
+    }
+
+    [Fact]
+    public async Task NthLastChildOfSelector_1_MatchesTheLastMatchingSibling()
+    {
+        var html = Html(
+            ":nth-last-child(1 of .foo) { background-color: #ff0000; }",
+            "<div><p class='foo'>1</p><p>2</p><p class='foo'>3</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(3, boxes.Count);
+        Assert.Equal("transparent", boxes[0].BackgroundColor);
+        Assert.Equal("transparent", boxes[1].BackgroundColor);
+        Assert.NotEqual("transparent", boxes[2].BackgroundColor); // last .foo
+    }
+
+    [Fact]
+    public async Task NthChildOfSelector_ElementNotMatchingS_NeverMatchesRegardlessOfPosition()
+    {
+        // The structurally-first element doesn't itself have class "foo", so it can never satisfy
+        // ":nth-child(1 of .foo)" even though it's first among ALL children.
+        var html = Html(
+            ":nth-child(1 of .foo) { background-color: #ff0000; }",
+            "<div><p>first, not foo</p><p class='foo'>second, is foo</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(2, boxes.Count);
+        Assert.Equal("transparent", boxes[0].BackgroundColor);
+        Assert.NotEqual("transparent", boxes[1].BackgroundColor);
+    }
+
+    [Fact]
+    public async Task NthChildOfSelector_CommaSeparatedList_MatchesEitherBranch()
+    {
+        var html = Html(
+            ":nth-child(1 of .foo, .bar) { background-color: #ff0000; }",
+            "<div><p>skip</p><p class='bar'>first-of-either</p><p class='foo'>second-of-either</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+        Assert.Equal(3, boxes.Count);
+        Assert.Equal("transparent", boxes[0].BackgroundColor);
+        Assert.NotEqual("transparent", boxes[1].BackgroundColor); // first among .foo-or-.bar
+        Assert.Equal("transparent", boxes[2].BackgroundColor);
+    }
+
+    [Fact]
+    public async Task OfSelector_OnDisallowedFunction_InvalidatesTheWholeRule()
+    {
+        // The parser only allows "of S" on nth-child/nth-last-child - CSS spec has no such clause
+        // for nth-of-type/nth-last-of-type/nth-column/nth-last-column. Writing it anyway doesn't
+        // silently drop just the clause: it invalidates the entire enclosing selector (parses to
+        // UnknownSelector), so the whole rule matches nothing. Locking in this existing, correct
+        // parser behavior as a regression guard.
+        var html = Html(
+            "td:nth-of-type(1 of .foo) { background-color: #ff0000; }",
+            "<table><tr><td class='foo'>A</td></tr></table>");
+        var box = await FindBoxByTag(html, "td");
+        Assert.Equal("transparent", box.BackgroundColor);
+    }
+
     // ── Helpers (mirrors SelectorMatchingTests.cs conventions) ────────────────
 
     private static string Html(string css, string body) =>

--- a/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTableTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTableTests.cs
@@ -457,6 +457,11 @@ Assert.Equal(3, cells.Count);
      public async Task TableLayout_RespectsSpecifiedColumnWidths()
 {
    // Arrange
+   // Four (not three) unstyled-width columns: an even auto-layout split of 600px across 4 columns
+   // lands near 150px each, comfortably below the >=180 threshold below - so this can only pass if
+   // ":first-child" actually forced the first cell to ~200px, not by coincidentally landing in the
+   // same range as an inert rule's auto-layout split (which a 3-column table's ~200px/column average
+   // could not distinguish from a working rule).
 var html = @"
 <!DOCTYPE html>
 <html>
@@ -470,7 +475,7 @@ var html = @"
 <body>
     <table>
       <tbody>
-        <tr><td>Wide Cell</td><td>Auto</td><td>Auto</td></tr>
+        <tr><td>Wide Cell</td><td>Auto</td><td>Auto</td><td>Auto</td></tr>
    </tbody>
 </table>
 </body>
@@ -496,10 +501,13 @@ Assert.NotNull(tbody);
    var row = tbody.Boxes[0];
      var firstCell = row.Boxes[0];
     var firstCellWidth = firstCell.ActualRight - firstCell.Location.X;
+    var secondCell = row.Boxes[1];
+    var secondCellWidth = secondCell.ActualRight - secondCell.Location.X;
 
         // Assert
-    _output.WriteLine($"First cell width: {firstCellWidth}");
+    _output.WriteLine($"First cell width: {firstCellWidth}, second cell width: {secondCellWidth}");
      Assert.True(firstCellWidth >= 180, $"First cell should be approximately 200px wide (accounting for borders), but was {firstCellWidth}");
+     Assert.True(secondCellWidth < 160, $"Second cell should be narrower than the explicitly-widened first cell (proving the rule is selective, not applied to every column), but was {secondCellWidth}");
      }
 
         #endregion

--- a/src/PeachPDF.Tests/Integration/GlobalKeywordCascadeTests.cs
+++ b/src/PeachPDF.Tests/Integration/GlobalKeywordCascadeTests.cs
@@ -534,6 +534,57 @@ namespace PeachPDF.Tests.Integration
         }
 
         [Fact]
+        public async Task InlineImportant_BeatsAuthorImportantRule()
+        {
+            // Per spec, inline style sits at the top of its origin's !important tier too, same as
+            // it does for the normal tier - an inline !important declaration must beat an author
+            // stylesheet !important declaration for the same property.
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  div { color: blue !important; }
+                </style></head><body>
+                <div id="el" style="color: red !important">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("rgb(255, 0, 0)", el!.Color);
+        }
+
+        [Fact]
+        public async Task AuthorImportantRevert_RollsBackToInlineNormalValue_NotAllTheWayToUa()
+        {
+            // Documents a deliberate design choice in the 6-phase cascade restructure: an
+            // author-!important declaration's "revert" rolls back to the state right before ANY
+            // !important ran (which includes inline-normal's contribution), not all the way back to
+            // the UA-origin snapshot as a stricter per-origin reading of the spec might imply. This
+            // pins the behavior down so it can't drift silently - see the comment in
+            // DomParser.CascadeApplyStyles above the author-!important phase for the full rationale.
+            //
+            // Expected chain: UA has no color rule for div (stays at the initial "black") -> author-
+            // normal "div{color:blue}" applies -> inline-normal "color:green" applies on top -> the
+            // author-!important "revert" should land on "green" (the value right before any
+            // !important ran), not "blue" (author-normal-only) or "black" (UA-only).
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  div { color: blue; }
+                  #el { color: revert !important; }
+                </style></head><body>
+                <div id="el" style="color: green">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("rgb(0, 128, 0)", el!.Color);
+        }
+
+        [Fact]
         public async Task Regression_LaterAuthorRuleOverridesEarlierSameSpecificity()
         {
             // When two rules share the same specificity, source order decides: last wins.

--- a/src/PeachPDF/CSS/Enumerations/PseudoClassNames.cs
+++ b/src/PeachPDF/CSS/Enumerations/PseudoClassNames.cs
@@ -39,6 +39,7 @@ namespace PeachPDF.CSS
         public static readonly string Dir = "dir";
         public static readonly string Has = "has";
         public static readonly string Matches = "matches";
+        public static readonly string Is = "is";
         public static readonly string NthChild = "nth-child";
         public static readonly string NthLastChild = "nth-last-child";
         public static readonly string NthOfType = "nth-of-type";

--- a/src/PeachPDF/CSS/Factories/PseudoClassSelectorFactory.cs
+++ b/src/PeachPDF/CSS/Factories/PseudoClassSelectorFactory.cs
@@ -20,12 +20,6 @@ namespace PeachPDF.CSS
                 {
                     PseudoClassNames.Root,
                     PseudoClassNames.Scope,
-                    PseudoClassNames.OnlyType,
-                    PseudoClassNames.FirstOfType,
-                    PseudoClassNames.LastOfType,
-                    PseudoClassNames.OnlyChild,
-                    PseudoClassNames.FirstChild,
-                    PseudoClassNames.LastChild,
                     PseudoClassNames.Empty,
                     PseudoClassNames.AnyLink,
                     PseudoClassNames.Link,
@@ -63,6 +57,18 @@ namespace PeachPDF.CSS
                 PseudoElementSelectorFactory.Instance.Create(PseudoElementNames.FirstLine));
             selectors.Add(PseudoElementNames.FirstLetter,
                 PseudoElementSelectorFactory.Instance.Create(PseudoElementNames.FirstLetter));
+
+            // Structural pseudo-classes: bare idents are equivalent to their nth-*(1) function form
+            // (see CSS Selectors spec), so wire them to the same ChildSelector subtypes that
+            // "nth-child(...)" etc. produce, rather than a generic PseudoClassSelector with no
+            // positional semantics. Kind uses AllSelector.Create() (never null) to match the
+            // invariant ChildFunctionState<T>.Produce() upholds for the function-form parse path.
+            selectors.Add(PseudoClassNames.FirstChild, new FirstChildSelector().With(0, 1, AllSelector.Create()));
+            selectors.Add(PseudoClassNames.LastChild, new LastChildSelector().With(0, 1, AllSelector.Create()));
+            selectors.Add(PseudoClassNames.FirstOfType, new FirstTypeSelector().With(0, 1, AllSelector.Create()));
+            selectors.Add(PseudoClassNames.LastOfType, new LastTypeSelector().With(0, 1, AllSelector.Create()));
+            selectors.Add(PseudoClassNames.OnlyChild, new OnlyChildSelector());
+            selectors.Add(PseudoClassNames.OnlyType, new OnlyOfTypeSelector());
 
             return selectors;
         }

--- a/src/PeachPDF/CSS/Parser/SelectorConstructor.cs
+++ b/src/PeachPDF/CSS/Parser/SelectorConstructor.cs
@@ -57,7 +57,8 @@ namespace PeachPDF.CSS
                 {PseudoClassNames.Lang, _ => new LangFunctionState()},
                 {PseudoClassNames.Contains, _ => new ContainsFunctionState()},
                 {PseudoClassNames.Has, ctx => new HasFunctionState(ctx)},
-                {PseudoClassNames.Matches, ctx => new MatchesFunctionState(ctx)},
+                {PseudoClassNames.Matches, ctx => new MatchesFunctionState(ctx, PseudoClassNames.Matches)},
+                {PseudoClassNames.Is, ctx => new MatchesFunctionState(ctx, PseudoClassNames.Is)},
                 {PseudoClassNames.HostContext, ctx => new HostContextFunctionState(ctx)}
             }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
@@ -526,13 +527,7 @@ namespace PeachPDF.CSS
             {
                 var valid = _selector.IsValid;
                 var sel = _selector.GetResult();
-                if (valid)
-                {
-                    var code = PseudoClassNames.Not.StylesheetFunction(sel.Text);
-                    return PseudoClassSelector.Create( /*el => !sel.Match(el),*/ code);
-                }
-
-                return null;
+                return valid ? new NotSelector(sel) : null;
             }
 
             public override void Dispose()
@@ -567,13 +562,7 @@ namespace PeachPDF.CSS
                 var valid = _nested.IsValid;
                 var sel = _nested.GetResult();
 
-                if (!valid)
-                {
-                    return null;
-                }
-
-                var code = PseudoClassNames.Has.StylesheetFunction(sel.Text);
-                return PseudoClassSelector.Create( /*el => el.ChildNodes.QuerySelector(sel) != null,*/ code);
+                return valid ? new HasSelector(sel) : null;
             }
 
             public override void Dispose()
@@ -586,10 +575,12 @@ namespace PeachPDF.CSS
         private sealed class MatchesFunctionState : FunctionState
         {
             private readonly SelectorConstructor _selector;
+            private readonly string _keyword;
 
-            public MatchesFunctionState(SelectorConstructor parent)
+            public MatchesFunctionState(SelectorConstructor parent, string keyword)
             {
                 _selector = parent.CreateChild();
+                _keyword = keyword;
             }
 
             protected override bool OnToken(Token token)
@@ -608,14 +599,7 @@ namespace PeachPDF.CSS
             {
                 var valid = _selector.IsValid;
                 var sel = _selector.GetResult();
-                if (!valid)
-                {
-                    return null;
-                }
-
-                var code = PseudoClassNames.Matches.StylesheetFunction(sel.Text);
-                return PseudoClassSelector.Create( /*el => sel.Match(el),*/ code);
-
+                return valid ? new MatchesSelector(sel, _keyword) : null;
             }
 
             public override void Dispose()

--- a/src/PeachPDF/CSS/Selectors/ChildSelector.cs
+++ b/src/PeachPDF/CSS/Selectors/ChildSelector.cs
@@ -9,7 +9,7 @@ namespace PeachPDF.CSS
         private readonly string _name;
         public int Step { get; private set; }
         public int Offset { get; private set; }
-        protected ISelector Kind;
+        internal ISelector Kind { get; private set; }
 
         protected ChildSelector(string name)
         {

--- a/src/PeachPDF/CSS/Selectors/HasSelector.cs
+++ b/src/PeachPDF/CSS/Selectors/HasSelector.cs
@@ -1,0 +1,33 @@
+using System.IO;
+
+namespace PeachPDF.CSS
+{
+    /// <summary>
+    /// The relational pseudo-class ":has(S)" - matches an element that has a descendant matching S.
+    /// v1 only supports the default (descendant) relative-selector form; leading-combinator forms
+    /// like ":has(&gt; S)"/":has(+ S)"/":has(~ S)" are not supported (the parser silently discards a
+    /// leading combinator today - see SelectorConstructor.Insert(ISelector) - and fixing that touches
+    /// shared parsing code well beyond :has() itself, so it's an explicit, documented follow-up).
+    /// </summary>
+    internal sealed class HasSelector : StylesheetNode, ISelector
+    {
+        public HasSelector(ISelector inner)
+        {
+            Inner = inner;
+        }
+
+        public ISelector Inner { get; }
+
+        // Per spec, :has() takes the specificity of its most specific argument, same as :is()/:not().
+        public Priority Specificity => Inner.Specificity;
+
+        public string Text => this.ToCss();
+
+        public override void ToCss(TextWriter writer, IStyleFormatter formatter)
+        {
+            writer.Write(":has(");
+            writer.Write(Inner.Text);
+            writer.Write(')');
+        }
+    }
+}

--- a/src/PeachPDF/CSS/Selectors/ListSelector.cs
+++ b/src/PeachPDF/CSS/Selectors/ListSelector.cs
@@ -1,10 +1,23 @@
 using System.IO;
+using System.Linq;
 
 namespace PeachPDF.CSS
 {
     internal sealed class ListSelector : Selectors, ISelector
     {
         public bool IsInvalid { get; internal set; }
+
+        // A comma-separated selector list's specificity is NOT the sum of its alternatives (that's
+        // only correct for a CompoundSelector, whose members all apply to the SAME element at once).
+        // Per spec, when used as the "forgiving selector list" argument to :is()/:not()/:has(), it's
+        // the static max across all alternatives - regardless of which one (if any) actually matches
+        // a given element. When a ListSelector is a style rule's own top-level selector instead
+        // (".a, .b { }"), the spec treats it as shorthand for separate rules, so the specificity that
+        // matters there is whichever ONE alternative matched a given box - that per-match resolution
+        // is handled separately by CssData.GetMatchedSpecificity, which deliberately does not use this
+        // property for that case.
+        public override Priority Specificity =>
+            _selectors.Count == 0 ? Priority.Zero : _selectors.Max(s => s.Specificity);
 
         public override void ToCss(TextWriter writer, IStyleFormatter formatter)
         {

--- a/src/PeachPDF/CSS/Selectors/MatchesSelector.cs
+++ b/src/PeachPDF/CSS/Selectors/MatchesSelector.cs
@@ -1,0 +1,37 @@
+using System.IO;
+
+namespace PeachPDF.CSS
+{
+    /// <summary>
+    /// The ":matches(S)"/":is(S)" pseudo-class - matches an element that matches ANY selector in S.
+    /// Both keywords share this same class (":is()" is the modern name, ":matches()" the legacy
+    /// alias); <see cref="Keyword"/> just controls how it round-trips back to CSS text.
+    /// </summary>
+    internal sealed class MatchesSelector : StylesheetNode, ISelector
+    {
+        public MatchesSelector(ISelector inner, string keyword)
+        {
+            Inner = inner;
+            Keyword = keyword;
+        }
+
+        public ISelector Inner { get; }
+
+        public string Keyword { get; }
+
+        // Per spec, :is()/:matches() take the specificity of their most specific argument (the
+        // static max, via ListSelector's own Specificity, when Inner is a comma-separated list).
+        public Priority Specificity => Inner.Specificity;
+
+        public string Text => this.ToCss();
+
+        public override void ToCss(TextWriter writer, IStyleFormatter formatter)
+        {
+            writer.Write(':');
+            writer.Write(Keyword);
+            writer.Write('(');
+            writer.Write(Inner.Text);
+            writer.Write(')');
+        }
+    }
+}

--- a/src/PeachPDF/CSS/Selectors/NotSelector.cs
+++ b/src/PeachPDF/CSS/Selectors/NotSelector.cs
@@ -1,0 +1,30 @@
+using System.IO;
+
+namespace PeachPDF.CSS
+{
+    /// <summary>
+    /// The negation pseudo-class ":not(S)" - matches an element that does NOT match S.
+    /// </summary>
+    internal sealed class NotSelector : StylesheetNode, ISelector
+    {
+        public NotSelector(ISelector inner)
+        {
+            Inner = inner;
+        }
+
+        public ISelector Inner { get; }
+
+        // Per spec, :not() takes the specificity of its argument (the most specific selector in a
+        // comma-separated argument, via ListSelector's own static-max Specificity).
+        public Priority Specificity => Inner.Specificity;
+
+        public string Text => this.ToCss();
+
+        public override void ToCss(TextWriter writer, IStyleFormatter formatter)
+        {
+            writer.Write(":not(");
+            writer.Write(Inner.Text);
+            writer.Write(')');
+        }
+    }
+}

--- a/src/PeachPDF/CSS/Selectors/OnlyChildSelector.cs
+++ b/src/PeachPDF/CSS/Selectors/OnlyChildSelector.cs
@@ -1,0 +1,10 @@
+namespace PeachPDF.CSS
+{
+    internal sealed class OnlyChildSelector : SelectorBase
+    {
+        public OnlyChildSelector()
+            : base(Priority.OneClass, $"{PseudoClassNames.Separator}{PseudoClassNames.OnlyChild}")
+        {
+        }
+    }
+}

--- a/src/PeachPDF/CSS/Selectors/OnlyOfTypeSelector.cs
+++ b/src/PeachPDF/CSS/Selectors/OnlyOfTypeSelector.cs
@@ -1,0 +1,10 @@
+namespace PeachPDF.CSS
+{
+    internal sealed class OnlyOfTypeSelector : SelectorBase
+    {
+        public OnlyOfTypeSelector()
+            : base(Priority.OneClass, $"{PseudoClassNames.Separator}{PseudoClassNames.OnlyType}")
+        {
+        }
+    }
+}

--- a/src/PeachPDF/CSS/Selectors/Selectors.cs
+++ b/src/PeachPDF/CSS/Selectors/Selectors.cs
@@ -13,7 +13,7 @@ namespace PeachPDF.CSS
             _selectors = new List<ISelector>();
         }
 
-        public Priority Specificity
+        public virtual Priority Specificity
         {
             get
             {

--- a/src/PeachPDF/Html/Core/CssData.cs
+++ b/src/PeachPDF/Html/Core/CssData.cs
@@ -66,36 +66,81 @@ namespace PeachPDF.Html.Core
 
         private IEnumerable<IStyleRule> GetStyleRulesByOrigin(string media, CssBox box, bool? userAgentOnly)
         {
+            var matched = new List<IStyleRule>();
+
             foreach (var stylesheet in Stylesheets)
             {
                 if (userAgentOnly.HasValue && stylesheet.IsUserAgent != userAgentOnly.Value)
                     continue;
 
-                foreach (var rule in GetStyleRules(stylesheet.StyleRules, box))
-                {
-                    yield return rule;
-                }
+                CollectMatchingRulesInOrder(stylesheet.Rules, media, box, matched);
+            }
 
-                foreach (var mediaRule in stylesheet.MediaRules)
-                {
-                    foreach (var medium in mediaRule.Media)
-                    {
-                        var typeMatches = medium.Type == media || medium.Type == "all";
-                        var matches = medium.IsInverse ? !typeMatches : typeMatches;
-                        if (!matches) continue;
+            // Stable sort: equal-specificity rules keep the true document order CollectMatchingRulesInOrder
+            // produced them in, giving correct source-order tiebreaking without any extra index field.
+            return matched.OrderBy(rule => GetMatchedSpecificity(rule.Selector, box));
+        }
 
-                        foreach (var rule in GetStyleRules(mediaRule.Rules.OfType<IStyleRule>(), box))
+        /// <summary>
+        /// Walks a rule list in true document order, expanding matching <c>@media</c> blocks in place
+        /// (rather than the old two-pass "all plain rules, then all media rules" approach, which didn't
+        /// preserve real source order across that boundary) so the caller's stable specificity-sort has
+        /// a genuinely ordered sequence to break ties with.
+        /// </summary>
+        private static void CollectMatchingRulesInOrder(IEnumerable<IRule> rules, string media, CssBox box, List<IStyleRule> matched)
+        {
+            foreach (var rule in rules)
+            {
+                switch (rule)
+                {
+                    case IStyleRule styleRule:
+                        if (DoesSelectorMatch(styleRule.Selector, box))
+                            matched.Add(styleRule);
+                        break;
+
+                    case IMediaRule mediaRule:
+                        var mediaMatches = false;
+                        foreach (var medium in mediaRule.Media)
                         {
-                            yield return rule;
+                            var typeMatches = medium.Type == media || medium.Type == "all";
+                            if (medium.IsInverse ? !typeMatches : typeMatches)
+                            {
+                                mediaMatches = true;
+                                break;
+                            }
                         }
-                    }
+
+                        if (mediaMatches)
+                            CollectMatchingRulesInOrder(mediaRule.Rules, media, box, matched);
+                        break;
                 }
             }
         }
 
-        private static IEnumerable<IStyleRule> GetStyleRules(IEnumerable<IStyleRule> styleRules, CssBox box)
+        /// <summary>
+        /// The effective specificity of a matched rule's selector for cascade-ordering purposes,
+        /// relative to a specific matched box. This deliberately differs from calling
+        /// <c>selector.Specificity</c> directly for a top-level <see cref="ListSelector"/> (comma-
+        /// separated rule selector, e.g. "h1, h2 {}"): per spec a selector list used as a whole
+        /// rule's selector is cascade-equivalent to separate rules, so the specificity that governs
+        /// THIS box's cascade is whichever one alternative actually matched it - not every
+        /// alternative's static max (which is what <see cref="ListSelector.Specificity"/> reports,
+        /// correctly, for its OTHER use as an argument to :is()/:not()/:has()). One level of
+        /// ListSelector-checking is sufficient since the grammar can't nest one directly inside
+        /// another top-level list.
+        /// </summary>
+        private static Priority GetMatchedSpecificity(ISelector selector, CssBox? box)
         {
-            return styleRules.Where(rule => DoesSelectorMatch(rule.Selector, box));
+            if (selector is ListSelector list)
+            {
+                return list
+                    .Where(s => DoesSelectorMatch(s, box))
+                    .Select(s => s.Specificity)
+                    .DefaultIfEmpty(Priority.Zero)
+                    .Max();
+            }
+
+            return selector.Specificity;
         }
 
         private static bool DoesSelectorMatch(ISelector selector, CssBox? box)
@@ -121,6 +166,9 @@ namespace PeachPDF.Html.Core
                 ChildSelector childSelector => DoesSelectorMatch(childSelector, box),
                 OnlyChildSelector onlyChildSelector => DoesSelectorMatch(onlyChildSelector, box),
                 OnlyOfTypeSelector onlyOfTypeSelector => DoesSelectorMatch(onlyOfTypeSelector, box),
+                NotSelector notSelector => DoesSelectorMatch(notSelector, box),
+                MatchesSelector matchesSelector => DoesSelectorMatch(matchesSelector, box),
+                HasSelector hasSelector => DoesSelectorMatch(hasSelector, box),
                 _ => false
             };
         }
@@ -378,6 +426,13 @@ namespace PeachPDF.Html.Core
                     b.HtmlTag!.Name.Equals(box.HtmlTag.Name, StringComparison.InvariantCultureIgnoreCase));
             }
 
+            // CSS4 "of <selector>" extension (:nth-child(An+B of S)/:nth-last-child(An+B of S)).
+            // Kind defaults to AllSelector (matches unconditionally) whenever no "of" clause was
+            // written, and the parser only ever allows a non-default Kind on FirstChildSelector/
+            // LastChildSelector - so this filter is always a no-op for the four other subtypes.
+            // Applying it unconditionally is simpler than special-casing which subtypes can have it.
+            siblingBoxes = siblingBoxes.Where(b => DoesSelectorMatch(childSelector.Kind, b));
+
             var siblings = siblingBoxes.ToList();
             var index = siblings.IndexOf(box);
             if (index < 0)
@@ -497,6 +552,38 @@ namespace PeachPDF.Html.Core
             return parentBox.Boxes.Count(b =>
                 b.HtmlTag is not null &&
                 b.HtmlTag.Name.Equals(box.HtmlTag.Name, StringComparison.InvariantCultureIgnoreCase)) == 1;
+        }
+
+        private static bool DoesSelectorMatch(NotSelector notSelector, CssBox? box)
+        {
+            return box is not null && !DoesSelectorMatch(notSelector.Inner, box);
+        }
+
+        private static bool DoesSelectorMatch(MatchesSelector matchesSelector, CssBox? box)
+        {
+            return DoesSelectorMatch(matchesSelector.Inner, box);
+        }
+
+        private static bool DoesSelectorMatch(HasSelector hasSelector, CssBox? box)
+        {
+            return box is not null && HasDescendantMatch(box, hasSelector.Inner);
+        }
+
+        /// <summary>
+        /// Recursively searches box's descendants (at any depth) for one matching inner, short-
+        /// circuiting on the first hit - mirrors the shape of DomUtils.GetBoxById/GetBoxByTagName.
+        /// Backs :has()'s default (descendant) relative-selector form; leading-combinator forms
+        /// (":has(&gt; x)"/"+"/"~") aren't supported - see HasSelector's doc comment.
+        /// </summary>
+        private static bool HasDescendantMatch(CssBox box, ISelector inner)
+        {
+            foreach (var child in box.Boxes)
+            {
+                if (DoesSelectorMatch(inner, child)) return true;
+                if (HasDescendantMatch(child, inner)) return true;
+            }
+
+            return false;
         }
 
         private static bool DoesSelectorMatch(ComplexSelector complexSelector, CssBox? box)

--- a/src/PeachPDF/Html/Core/CssData.cs
+++ b/src/PeachPDF/Html/Core/CssData.cs
@@ -118,7 +118,9 @@ namespace PeachPDF.Html.Core
                 AttrBeginsSelector attrBeginsSelector => DoesSelectorMatch(attrBeginsSelector, box),
                 AttrEndsSelector attrEndsSelector => DoesSelectorMatch(attrEndsSelector, box),
                 AttrHyphenSelector attrHyphenSelector => DoesSelectorMatch(attrHyphenSelector, box),
-                FirstChildSelector firstChildSelector => DoesSelectorMatch(firstChildSelector, box),
+                ChildSelector childSelector => DoesSelectorMatch(childSelector, box),
+                OnlyChildSelector onlyChildSelector => DoesSelectorMatch(onlyChildSelector, box),
+                OnlyOfTypeSelector onlyOfTypeSelector => DoesSelectorMatch(onlyOfTypeSelector, box),
                 _ => false
             };
         }
@@ -136,7 +138,11 @@ namespace PeachPDF.Html.Core
 
             var lastSelector = compoundSelector.Last();
 
-            if (lastSelector is not PseudoElementSelector or FirstChildSelector)
+            // Structural pseudo-classes (ChildSelector subtypes, OnlyChildSelector, OnlyOfTypeSelector)
+            // are matched against `box` itself here, same as every other compound member - their own
+            // DoesSelectorMatch overload re-derives sibling scope from `box` as needed, so no special
+            // handling is required for them beyond the plain path below.
+            if (lastSelector is not PseudoElementSelector)
                 return compoundSelector.All(selector => DoesSelectorMatch(selector, box));
 
             if (lastSelector is PseudoElementSelector pseudoElementSelector)
@@ -181,17 +187,6 @@ namespace PeachPDF.Html.Core
                             break;
                         }
                 }
-            }
-
-            if (lastSelector is FirstChildSelector firstChildSelector)
-            {
-                var referenceBox = DomUtils.GetNearestParentElementBox(box);
-
-                var isMatchWithoutNthChildElement = compoundSelector
-                    .Where(x => x is not FirstChildSelector)
-                    .All(selector => DoesSelectorMatch(selector, referenceBox));
-
-                return isMatchWithoutNthChildElement && DoesSelectorMatch(firstChildSelector, box);
             }
 
             return false;
@@ -347,7 +342,135 @@ namespace PeachPDF.Html.Core
             }
         }
 
-        private static bool DoesSelectorMatch(FirstChildSelector firstChildSelector, CssBox? box)
+        /// <summary>
+        /// Matches the six structural "An+B" pseudo-classes (:nth-child, :nth-last-child,
+        /// :nth-of-type, :nth-last-of-type, :nth-column, :nth-last-column - including their bare-ident
+        /// forms like :first-child, which are wired to Step=0/Offset=1 by PseudoClassSelectorFactory).
+        /// Each variant differs only in (a) which sibling scope to count within and (b) whether to
+        /// count from the start or the end; the actual "does this position satisfy An+B" test is
+        /// shared via <see cref="MatchesAnPlusB"/>.
+        /// </summary>
+        private static bool DoesSelectorMatch(ChildSelector childSelector, CssBox? box)
+        {
+            if (box?.HtmlTag is null)
+            {
+                return false;
+            }
+
+            switch (childSelector)
+            {
+                case FirstColumnSelector or LastColumnSelector:
+                    return DoesColumnSelectorMatch(childSelector, box, fromEnd: childSelector is LastColumnSelector);
+            }
+
+            var parentBox = DomUtils.GetNearestParentElementBox(box);
+            if (parentBox is null)
+            {
+                return false;
+            }
+
+            IEnumerable<CssBox> siblingBoxes = parentBox.Boxes.Where(b => b.HtmlTag is not null);
+
+            var sameTypeOnly = childSelector is FirstTypeSelector or LastTypeSelector;
+            if (sameTypeOnly)
+            {
+                siblingBoxes = siblingBoxes.Where(b =>
+                    b.HtmlTag!.Name.Equals(box.HtmlTag.Name, StringComparison.InvariantCultureIgnoreCase));
+            }
+
+            var siblings = siblingBoxes.ToList();
+            var index = siblings.IndexOf(box);
+            if (index < 0)
+            {
+                return false;
+            }
+
+            var fromEndPosition = childSelector is LastChildSelector or LastTypeSelector;
+            var position = fromEndPosition ? siblings.Count - index : index + 1;
+
+            return MatchesAnPlusB(position, childSelector.Step, childSelector.Offset);
+        }
+
+        /// <summary>
+        /// Matches :nth-column()/:nth-last-column() against the cell's occupied column position(s)
+        /// within its own row. Only accounts for colspan of preceding cells in the SAME row - unlike
+        /// <see cref="Dom.CssLayoutEngineTable"/>'s column bookkeeping (which additionally accounts for
+        /// rowspan carried over from earlier rows via placeholder boxes inserted during layout), this
+        /// runs during cascade, before layout, when that placeholder bookkeeping doesn't exist yet.
+        /// A colspan-N cell occupies N columns; per spec this matches if ANY occupied column position
+        /// satisfies the An+B formula, not just the cell's starting column.
+        /// </summary>
+        private static bool DoesColumnSelectorMatch(ChildSelector childSelector, CssBox box, bool fromEnd)
+        {
+            var row = box.ParentBox;
+            if (row is null)
+            {
+                return false;
+            }
+
+            var cellsInRow = row.Boxes.Where(b => b.HtmlTag is not null).ToList();
+            var columnIndex = 0;
+            var totalColumns = 0;
+            var found = false;
+
+            foreach (var cell in cellsInRow)
+            {
+                if (cell == box)
+                {
+                    columnIndex = totalColumns;
+                    found = true;
+                }
+
+                totalColumns += GetColSpan(cell);
+            }
+
+            if (!found)
+            {
+                return false;
+            }
+
+            var boxSpan = GetColSpan(box);
+            for (var column = columnIndex; column < columnIndex + boxSpan; column++)
+            {
+                var position = fromEnd ? totalColumns - column : column + 1;
+                if (MatchesAnPlusB(position, childSelector.Step, childSelector.Offset))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Reads a box's "colspan" HTML attribute (default 1 if absent/invalid). Deliberately
+        /// duplicated from <see cref="Dom.CssLayoutEngineTable"/>'s private equivalent rather than
+        /// shared - this runs at cascade time, before the layout-phase state that method's column
+        /// bookkeeping otherwise depends on exists.
+        /// </summary>
+        private static int GetColSpan(CssBox box)
+        {
+            var value = box.GetAttribute("colspan", "1");
+            return !int.TryParse(value, out var colSpan) || colSpan < 1 ? 1 : colSpan;
+        }
+
+        /// <summary>
+        /// The standard CSS "An+B" existence test: does there exist a non-negative integer n such that
+        /// position == step*n + offset? position is always the 1-based index within whatever sibling
+        /// scope the caller has already resolved.
+        /// </summary>
+        private static bool MatchesAnPlusB(int position, int step, int offset)
+        {
+            if (step == 0)
+            {
+                return position == offset;
+            }
+
+            var diff = position - offset;
+            return diff % step == 0 && (step > 0 ? diff >= 0 : diff <= 0);
+        }
+
+        private static bool DoesSelectorMatch(OnlyChildSelector _, CssBox? box)
         {
             if (box?.HtmlTag is null)
             {
@@ -355,14 +478,25 @@ namespace PeachPDF.Html.Core
             }
 
             var parentBox = DomUtils.GetNearestParentElementBox(box);
+            return parentBox is not null && parentBox.Boxes.Count(b => b.HtmlTag is not null) == 1;
+        }
 
+        private static bool DoesSelectorMatch(OnlyOfTypeSelector _, CssBox? box)
+        {
+            if (box?.HtmlTag is null)
+            {
+                return false;
+            }
+
+            var parentBox = DomUtils.GetNearestParentElementBox(box);
             if (parentBox is null)
             {
                 return false;
             }
 
-            var currentIndex = parentBox.Boxes.Where(b => b.HtmlTag is not null).ToList();
-            return currentIndex.IndexOf(box) == firstChildSelector.Offset;
+            return parentBox.Boxes.Count(b =>
+                b.HtmlTag is not null &&
+                b.HtmlTag.Name.Equals(box.HtmlTag.Name, StringComparison.InvariantCultureIgnoreCase)) == 1;
         }
 
         private static bool DoesSelectorMatch(ComplexSelector complexSelector, CssBox? box)

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -334,32 +334,82 @@ namespace PeachPDF.Html.Core.Parse
             // FINAL custom property values regardless of which phase declared them.
             var pendingVarProperties = new Dictionary<string, string>();
 
-            // 3. UA pass — user-agent stylesheet rules only
-            var importantPropertyNames = AssignCssBlocks(valueParser, box, cssData.GetUserAgentStyleRules(media, box), null, null, null, pendingVarProperties);
+            // Matched rules are already sorted by CssData (specificity ascending, then true source
+            // order) - materialize each origin once so both the normal and important passes below
+            // reuse the same matched/sorted list instead of re-querying CssData twice per origin.
+            var uaRules = cssData.GetUserAgentStyleRules(media, box).ToList();
+            var authorRules = cssData.GetAuthorStyleRules(media, box).ToList();
 
-            // 4. Author pass — author stylesheet rules; revert target is the UA-applied state
+            // Cascade precedence (lowest to highest, i.e. applied in this order so "last write wins"
+            // naturally produces the correct winner): UA-normal, Author-normal (inline-normal wins
+            // ties within this tier), Author-!important (inline-!important wins ties within this
+            // tier), UA-!important (per spec, origin order REVERSES for !important, so it's applied -
+            // and wins - last). Each phase's revert/revert-layer target is a snapshot of the box's
+            // state immediately before that phase ran - generalizing the pre-existing (and already
+            // tested) "revert = state right before this phase" model uniformly across all six phases,
+            // rather than a stricter, more formally origin-pure model.
+
+            // 3. UA normal
+            AssignCssBlocks(valueParser, box, uaRules, importantPass: false, null, null, pendingVarProperties);
             var uaSnapshot = CssUtils.SnapshotProperties(box);
             var uaCustomSnapshot = CssUtils.SnapshotCustomProperties(box);
-            importantPropertyNames = AssignCssBlocks(valueParser, box, cssData.GetAuthorStyleRules(media, box), importantPropertyNames, uaSnapshot, uaCustomSnapshot, pendingVarProperties);
 
+            // 4. Author normal
+            AssignCssBlocks(valueParser, box, authorRules, importantPass: false, uaSnapshot, uaCustomSnapshot, pendingVarProperties);
+            var authorNormalSnapshot = CssUtils.SnapshotProperties(box);
+            var authorNormalCustomSnapshot = CssUtils.SnapshotCustomProperties(box);
+
+            IStyleRule? inlineRule = null;
             if (box.HtmlTag != null)
             {
                 TranslateAttributes(box.HtmlTag, box);
 
-                // 5. Inline styles; revert target is the author-applied state
                 if (box.HtmlTag.HasAttribute("style"))
                 {
                     var styleAttributeText = box.HtmlTag.TryGetAttribute("style");
                     var stylesheet = "* { " + styleAttributeText + " }";
-
-                    var authorSnapshot = CssUtils.SnapshotProperties(box);
-                    var authorCustomSnapshot = CssUtils.SnapshotCustomProperties(box);
                     var block = CssParser.ParseStyleSheet(stylesheet);
-                    AssignCssBlock(valueParser, box, block.StyleRules.Single(), importantPropertyNames, authorSnapshot, authorCustomSnapshot, pendingVarProperties);
+                    inlineRule = block.StyleRules.Single();
                 }
             }
 
-            // 6. Resolve var() references now that every custom property's final cascaded value is known
+            // 5. Inline normal; revert target is the author-normal-applied state (unchanged from
+            // before this restructure)
+            var inlineNormalSnapshot = authorNormalSnapshot;
+            var inlineNormalCustomSnapshot = authorNormalCustomSnapshot;
+            if (inlineRule is not null)
+            {
+                AssignCssBlock(valueParser, box, inlineRule, importantPass: false, authorNormalSnapshot, authorNormalCustomSnapshot, pendingVarProperties);
+                inlineNormalSnapshot = CssUtils.SnapshotProperties(box);
+                inlineNormalCustomSnapshot = CssUtils.SnapshotCustomProperties(box);
+            }
+
+            // 6. Author !important. Note: this means an author-!important "revert" can roll back to
+            // a value inline *normal* style just set, not all the way back to the UA snapshot - a
+            // deliberate choice for mechanical consistency with the rest of this "snapshot = state
+            // right before this phase" model, rather than a stricter per-origin reading of the spec.
+            // The built-in UA stylesheet has no !important rules, so this combination (revert inside
+            // an author-!important declaration, interacting with a preceding inline-normal value) is
+            // untested territory in real usage; documenting it here rather than resolving it silently.
+            AssignCssBlocks(valueParser, box, authorRules, importantPass: true, inlineNormalSnapshot, inlineNormalCustomSnapshot, pendingVarProperties);
+            var authorImportantSnapshot = CssUtils.SnapshotProperties(box);
+            var authorImportantCustomSnapshot = CssUtils.SnapshotCustomProperties(box);
+
+            // 7. Inline !important
+            var afterInlineImportantSnapshot = authorImportantSnapshot;
+            var afterInlineImportantCustomSnapshot = authorImportantCustomSnapshot;
+            if (inlineRule is not null)
+            {
+                AssignCssBlock(valueParser, box, inlineRule, importantPass: true, authorImportantSnapshot, authorImportantCustomSnapshot, pendingVarProperties);
+                afterInlineImportantSnapshot = CssUtils.SnapshotProperties(box);
+                afterInlineImportantCustomSnapshot = CssUtils.SnapshotCustomProperties(box);
+            }
+
+            // 8. UA !important - applied globally last so it wins over everything else, per spec's
+            // origin reversal for the !important tier.
+            AssignCssBlocks(valueParser, box, uaRules, importantPass: true, afterInlineImportantSnapshot, afterInlineImportantCustomSnapshot, pendingVarProperties);
+
+            // 9. Resolve var() references now that every custom property's final cascaded value is known
             ResolveDeferredVarProperties(valueParser, box, pendingVarProperties);
 
             // Correct current color
@@ -389,25 +439,29 @@ namespace PeachPDF.Html.Core.Parse
         }
 
         /// <summary>
-        /// Assigns the given css style rules to the given css box.
+        /// Assigns the given css style rules to the given css box, applying only the declarations
+        /// whose <c>!important</c> flag matches <paramref name="importantPass"/>.
         /// </summary>
-        private static HashSet<string> AssignCssBlocks(
+        private static void AssignCssBlocks(
             CssValueParser valueParser,
             CssBox box,
             IEnumerable<IStyleRule> rules,
-            HashSet<string>? importantPropertyNames,
+            bool importantPass,
             IReadOnlyDictionary<string, string?>? revertTarget,
             IReadOnlyDictionary<string, string>? customPropertyRevertTarget,
             Dictionary<string, string> pendingVarProperties)
         {
-            importantPropertyNames ??= [];
             foreach (var rule in rules)
-                AssignCssBlock(valueParser, box, rule, importantPropertyNames, revertTarget, customPropertyRevertTarget, pendingVarProperties);
-            return importantPropertyNames;
+                AssignCssBlock(valueParser, box, rule, importantPass, revertTarget, customPropertyRevertTarget, pendingVarProperties);
         }
 
         /// <summary>
-        /// Assigns the given css style block properties to the given css box.
+        /// Assigns the given css style block properties to the given css box, applying only the
+        /// declarations whose <c>!important</c> flag matches <paramref name="importantPass"/> (the
+        /// caller is expected to call this once per origin per pass - see <see cref="CascadeApplyStyles"/>
+        /// - so that within a properly-ordered sequence of calls, "last write wins" alone produces the
+        /// spec-correct result without needing to track which property names were already locked by an
+        /// earlier !important declaration).
         /// Handles all five CSS global keywords: inherit, initial, unset, revert, revert-layer.
         /// Custom property declarations (--foo) are routed to <see cref="AssignCustomPropertyDeclaration"/> instead,
         /// since those keywords mean something different for an open-ended, case-sensitive property store.
@@ -417,7 +471,7 @@ namespace PeachPDF.Html.Core.Parse
         /// <param name="valueParser">the css value parser to use</param>
         /// <param name="box">the css box to assign css to</param>
         /// <param name="stylesheetRule">the stylesheet rule to assign</param>
-        /// <param name="importantPropertyNames">Carries the property names that have been marked important so they don't get re-applied</param>
+        /// <param name="importantPass">true to apply only <c>!important</c> declarations, false to apply only normal ones</param>
         /// <param name="revertTarget">Property snapshot representing the prior cascade origin, used for revert/revert-layer</param>
         /// <param name="customPropertyRevertTarget">Case-sensitive custom-property snapshot for revert/revert-layer</param>
         /// <param name="pendingVarProperties">Accumulates regular declarations whose value contains var(...), keyed by property name</param>
@@ -425,16 +479,19 @@ namespace PeachPDF.Html.Core.Parse
             CssValueParser valueParser,
             CssBox box,
             IStyleRule stylesheetRule,
-            HashSet<string> importantPropertyNames,
+            bool importantPass,
             IReadOnlyDictionary<string, string?>? revertTarget,
             IReadOnlyDictionary<string, string>? customPropertyRevertTarget,
             Dictionary<string, string> pendingVarProperties)
         {
             foreach (var prop in stylesheetRule.Style)
             {
+                if (prop.IsImportant != importantPass)
+                    continue;
+
                 if (PropertyFactory.IsCustomPropertyName(prop.Name))
                 {
-                    AssignCustomPropertyDeclaration(box, prop, importantPropertyNames, customPropertyRevertTarget);
+                    AssignCustomPropertyDeclaration(box, prop, customPropertyRevertTarget);
                     continue;
                 }
 
@@ -456,12 +513,6 @@ namespace PeachPDF.Html.Core.Parse
                             : CssDefaults.GetInitialValue(prop.Name),
                     _ => prop.Value
                 };
-
-                if (importantPropertyNames.Contains(prop.Name.ToLowerInvariant()))
-                    continue;
-
-                if (prop.IsImportant)
-                    importantPropertyNames.Add(prop.Name.ToLowerInvariant());
 
                 if (value is null) continue;
 
@@ -491,12 +542,8 @@ namespace PeachPDF.Html.Core.Parse
         private static void AssignCustomPropertyDeclaration(
             CssBox box,
             IProperty prop,
-            HashSet<string> importantPropertyNames,
             IReadOnlyDictionary<string, string>? customPropertyRevertTarget)
         {
-            if (importantPropertyNames.Contains(prop.Name)) return; // case-sensitive: no ToLowerInvariant
-            if (prop.IsImportant) importantPropertyNames.Add(prop.Name);
-
             var rawValue = prop.Value switch
             {
                 CssConstants.Inherit or CssConstants.Unset // custom properties are always inherited


### PR DESCRIPTION
This pull request adds comprehensive support for advanced CSS selector features in PeachPDF, including full CSS specificity ordering and relational pseudo-classes. It updates documentation to reflect these capabilities and introduces new regression test suites to ensure correct behavior for selector specificity and relational pseudo-classes like `:not()`, `:is()`, and `:has()`.

**Selector Matching and Specificity Improvements:**

* Updated documentation in `docs/html-css-support.md` to clarify support for structural pseudo-classes and to document that CSS rule application now respects true CSS specificity, including handling of `!important` and source order for equal specificity.
* Added `CssSpecificityOrderingTests.cs` to verify that CSS rules are applied in correct specificity order, including cases involving media queries and selector lists. These tests ensure that higher-specificity selectors win, source order is respected for equal specificity, and selector list specificity is correctly computed.

**Relational Pseudo-class Support:**

* Added `RelationalPseudoClassSelectorTests.cs` to test and confirm support for relational pseudo-classes: `:not()` (including invalid nesting), `:is()`, `:matches()` (legacy alias), and `:has()`. These tests cover correct matching behavior, specificity calculation, and handling of comma-separated selector lists.