### PR TITLE
Optimize CSS cascade and paint pipeline for performance improvements

### DIFF
--- a/src/PeachPDF.Tests/CSS/CssDataRuleIndexingTests.cs
+++ b/src/PeachPDF.Tests/CSS/CssDataRuleIndexingTests.cs
@@ -1,0 +1,245 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Utils;
+using PeachPDF.PdfSharpCore.Drawing;
+
+namespace PeachPDF.Tests.CSS;
+
+/// <summary>
+/// Regression tests for <c>CssData</c>'s tag/class/id rule index (added to avoid linearly
+/// scanning every stylesheet rule against every box during cascade). These render real HTML/CSS
+/// and assert on the resulting box tree, so they exercise <c>GetUserAgentStyleRules</c>/
+/// <c>GetAuthorStyleRules</c> exactly as the cascade does - the index only narrows candidates,
+/// <c>DoesSelectorMatch</c> is still the source of truth, but a bucketing bug would show up here
+/// as a rule silently failing to apply (or applying somewhere it shouldn't).
+/// </summary>
+public class CssDataRuleIndexingTests
+{
+    // ── Id selector (its own bucket) ──────────────────────────────────────────
+
+    [Fact]
+    public async Task IdSelector_Matches_ElementWithThatId()
+    {
+        var html = Html("#target { background-color: #ff0000; }", "<div id='target'>text</div>");
+        var box = await FindBoxByTag(html, "div");
+        Assert.NotEqual("transparent", box.BackgroundColor);
+    }
+
+    [Fact]
+    public async Task IdSelector_DoesNotMatch_DifferentId()
+    {
+        var html = Html("#target { background-color: #ff0000; }", "<div id='other'>text</div>");
+        var box = await FindBoxByTag(html, "div");
+        Assert.Equal("transparent", box.BackgroundColor);
+    }
+
+    // ── Multi-class compound selector (bucketed by one of its classes) ───────
+
+    [Fact]
+    public async Task MultiClassCompound_Matches_WhenElementHasBothClasses()
+    {
+        var html = Html(".a.b { background-color: #ff0000; }", "<div class='a b'>text</div>");
+        var box = await FindBoxByTag(html, "div");
+        Assert.NotEqual("transparent", box.BackgroundColor);
+    }
+
+    [Fact]
+    public async Task MultiClassCompound_DoesNotMatch_WhenOnlyOneClassPresent()
+    {
+        var html = Html(".a.b { background-color: #ff0000; }", "<div class='a'>text</div>");
+        var box = await FindBoxByTag(html, "div");
+        Assert.Equal("transparent", box.BackgroundColor);
+    }
+
+    [Fact]
+    public async Task ElementWithNoClassAttribute_DoesNotMatchClassSelector()
+    {
+        // Regression for the class bucket lookup: a box with no "class" attribute at all must
+        // not blow up or accidentally match, it should just never be a class-bucket candidate.
+        var html = Html(".a { background-color: #ff0000; }", "<div>text</div>");
+        var box = await FindBoxByTag(html, "div");
+        Assert.Equal("transparent", box.BackgroundColor);
+    }
+
+    // ── List (comma) selector spanning multiple buckets ───────────────────────
+
+    [Fact]
+    public async Task ListSelector_TagAlternative_MatchesViaTagBucket()
+    {
+        var html = Html("div, .foo { background-color: #ff0000; }", "<div>text</div>");
+        var box = await FindBoxByTag(html, "div");
+        Assert.NotEqual("transparent", box.BackgroundColor);
+    }
+
+    [Fact]
+    public async Task ListSelector_ClassAlternative_MatchesViaClassBucket()
+    {
+        var html = Html("span, .foo { background-color: #ff0000; }", "<div class='foo'>text</div>");
+        var box = await FindBoxByTag(html, "div");
+        Assert.NotEqual("transparent", box.BackgroundColor);
+    }
+
+    [Fact]
+    public async Task ListSelector_MatchingBothAlternatives_AppliesOnceWithoutCorruption()
+    {
+        // "div, .foo" on a <div class="foo"> is reachable through both the tag bucket AND the
+        // class bucket - regression for the dedup in CssData.GetStyleRulesByOrigin, which must
+        // yield the rule exactly once so cascade application isn't run twice for it.
+        var html = Html("div, .foo { background-color: #ff0000; color: #00ff00; }", "<div class='foo'>text</div>");
+        var box = await FindBoxByTag(html, "div");
+        Assert.Equal("rgb(255, 0, 0)", box.BackgroundColor);
+        Assert.Equal("rgb(0, 255, 0)", box.Color);
+    }
+
+    // ── Universal selector ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UniversalSelector_MatchesAnyElement()
+    {
+        var html = Html("* { background-color: #ff0000; }", "<span>text</span>");
+        var box = await FindBoxByTag(html, "span");
+        Assert.NotEqual("transparent", box.BackgroundColor);
+    }
+
+    // ── Pseudo-element compound (falls back to the unindexed/universal bucket) ─
+
+    [Fact]
+    public async Task PseudoElement_CombinedWithClassSelector_StillGeneratesContent()
+    {
+        var html = Html(".label::before { content: 'X: '; }", "<span class='label'>text</span>");
+        var root = await BuildRoot(html);
+        var span = DomUtils.GetBoxByTagName(root, "span");
+        Assert.NotNull(span);
+
+        var beforeBox = span!.Boxes.FirstOrDefault(b => b.IsBeforePseudoElement);
+        Assert.NotNull(beforeBox);
+        Assert.Equal("X: ", beforeBox!.Text);
+    }
+
+    // ── :nth-child(1) compound (falls back to the unindexed/universal bucket) ──
+
+    [Fact]
+    public async Task NthChildCompound_MatchesExactlyOneChild()
+    {
+        // Note: bare ":first-child" parses as a generic PseudoClassSelector in this engine's
+        // parser (SelectorConstructor only maps the "nth-child(...)" function form to
+        // FirstChildSelector), and DoesSelectorMatch(PseudoClassSelector,...) only recognizes
+        // ":link" - so plain ":first-child" never matches anything here, a pre-existing gap
+        // unrelated to this change. ":nth-child(1)" does produce a real FirstChildSelector, which
+        // is what CollectIndexKeys routes to the universal fallback bucket (rather than indexing
+        // by tag/class/id) - "*" for the other compound member sidesteps a separate, pre-existing
+        // quirk where the non-nth-child member of a compound is checked against the parent box
+        // rather than the candidate box itself (AllSelector matches unconditionally either way).
+        //
+        // DoesSelectorMatch(FirstChildSelector,...) compares a 0-based child index against the
+        // literal (1-based, per CSS) offset parsed from "nth-child(N)", so "nth-child(1)" actually
+        // matches the *second* element child here, not the first - this test asserts that actual
+        // (pre-existing) behaviour rather than CSS-spec-correct ":first-child" semantics, since
+        // what matters for this regression suite is only that the rule is reachable at all.
+        var html = Html(
+            "*:nth-child(1) { background-color: #ff0000; }",
+            "<div><p>first</p><p>second</p></div>");
+        var boxes = await FindAllBoxesByTag(html, "p");
+
+        Assert.Equal(2, boxes.Count);
+        Assert.Equal("transparent", boxes[0].BackgroundColor);
+        Assert.NotEqual("transparent", boxes[1].BackgroundColor);
+    }
+
+    // ── Media query rules (kept as an unindexed linear scan) ──────────────────
+
+    [Fact]
+    public async Task MediaQueryRule_ForPrintMedia_StillApplies()
+    {
+        // PeachPDF always cascades against the "print" media type (see DomParser.GenerateCssTree).
+        var html = Html("@media print { div { background-color: #ff0000; } }", "<div>text</div>");
+        var box = await FindBoxByTag(html, "div");
+        Assert.NotEqual("transparent", box.BackgroundColor);
+    }
+
+    [Fact]
+    public async Task MediaQueryRule_ForScreenMedia_DoesNotApplyToPrintOutput()
+    {
+        var html = Html("@media screen { div { background-color: #ff0000; } }", "<div>text</div>");
+        var box = await FindBoxByTag(html, "div");
+        Assert.Equal("transparent", box.BackgroundColor);
+    }
+
+    // ── Specificity/cascade order across differently-bucketed rules ──────────
+
+    [Fact]
+    public async Task ClassSelector_BeatsTagSelector_RegardlessOfBucket()
+    {
+        // Standard CSS specificity: a class selector (0,1,0) outranks a type selector (0,0,1),
+        // even though the two rules are now looked up via completely different index buckets.
+        var html = Html("div { color: #0000ff; } .highlight { color: #ff0000; }", "<div class='highlight'>text</div>");
+        var box = await FindBoxByTag(html, "div");
+        Assert.Equal("rgb(255, 0, 0)", box.Color);
+    }
+
+    [Fact]
+    public async Task IdSelector_BeatsClassSelector_RegardlessOfBucket()
+    {
+        var html = Html("#target { color: #ff0000; } .highlight { color: #0000ff; }", "<div id='target' class='highlight'>text</div>");
+        var box = await FindBoxByTag(html, "div");
+        Assert.Equal("rgb(255, 0, 0)", box.Color);
+    }
+
+    [Fact]
+    public async Task AuthorTagRule_OverridesUserAgentDefault()
+    {
+        // UA stylesheet sets h1's font-size; an author tag-selector rule (a different bucket
+        // lookup than the UA rule's own tag bucket, but the same bucket *kind*) must still win.
+        var html = Html("h1 { font-size: 10px; }", "<h1>heading</h1>");
+        var box = await FindBoxByTag(html, "h1");
+        Assert.Equal("10px", box.FontSize);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    private static string Html(string css, string body) =>
+        $"<!DOCTYPE html><html><head><style>{css}</style></head><body>{body}</body></html>";
+
+    private async Task<CssBox> FindBoxByTag(string html, string tag)
+    {
+        var root = await BuildRoot(html);
+        var box = DomUtils.GetBoxByTagName(root, tag);
+        Assert.NotNull(box);
+        return box!;
+    }
+
+    private async Task<List<CssBox>> FindAllBoxesByTag(string html, string tag)
+    {
+        var root = await BuildRoot(html);
+        var results = new List<CssBox>();
+        CollectByTag(root, tag, results);
+        return results;
+    }
+
+    private static void CollectByTag(CssBox box, string tag, List<CssBox> results)
+    {
+        if (box.HtmlTag?.Name.Equals(tag, StringComparison.OrdinalIgnoreCase) == true)
+            results.Add(box);
+        foreach (var child in box.Boxes)
+            CollectByTag(child, tag, results);
+    }
+
+    private static async Task<CssBox> BuildRoot(string html)
+    {
+        var adapter = new PdfSharpAdapter();
+        var container = new HtmlContainerInt(adapter);
+        await container.SetHtml(html, null);
+
+        var size = new XSize(595, 842);
+        container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+        container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+        var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+        using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+        await container.PerformLayout(graphics);
+
+        Assert.NotNull(container.Root);
+        return container.Root!;
+    }
+}

--- a/src/PeachPDF.Tests/Integration/FloatLayoutRegressionTests.cs
+++ b/src/PeachPDF.Tests/Integration/FloatLayoutRegressionTests.cs
@@ -1,0 +1,185 @@
+using System.Diagnostics;
+using System.Text;
+using PeachPDF;
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Utils;
+using PeachPDF.PdfSharpCore;
+using PeachPDF.PdfSharpCore.Drawing;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Regression tests for float layout and the <c>HtmlContainerInt.HasFloatedBoxes</c> short-circuit
+    /// added to <c>DomUtils.GetFirstIntersectingFloatBox</c>. That lookup used to walk all the way to
+    /// the document root and re-scan every preceding sibling's whole subtree, for every box needing
+    /// line layout, at every ancestor level - regardless of whether the document had any floated content
+    /// at all. These tests confirm float-avoidance still works correctly when floats ARE present, and
+    /// that a float-free document (the common case, and the one the short-circuit targets) still lays
+    /// out and renders within a sane time bound.
+    /// </summary>
+    public class FloatLayoutRegressionTests
+    {
+        [Fact]
+        public async Task Float_PushesFollowingSiblingTextToTheRight()
+        {
+            var html = Wrap(@"
+                <div style='width:300px;'>
+                    <div style='float:left; width:100px; height:50px;'></div>
+                    <p id='text' style='margin:0;'>Hello world</p>
+                </div>");
+
+            var (root, _) = await BuildAndLayout(html);
+            var text = FindById(root, "text")!;
+            var firstWord = FindFirstWord(text);
+
+            Assert.NotNull(firstWord);
+            Assert.True(firstWord!.Rectangle.Left >= 90,
+                $"first word should be pushed right past the 100px float, was at {firstWord.Rectangle.Left}");
+        }
+
+        [Fact]
+        public async Task WithoutFloat_SiblingTextStartsAtContainerEdge()
+        {
+            // Same shape as the test above but the earlier div is a plain block (no float), so the
+            // paragraph's text should start back at the container's left edge - this is the contrast
+            // case confirming the previous test's assertion is actually about float avoidance, not
+            // some unrelated margin/padding default.
+            var html = Wrap(@"
+                <div style='width:300px;'>
+                    <div style='width:100px; height:50px;'></div>
+                    <p id='text' style='margin:0;'>Hello world</p>
+                </div>");
+
+            var (root, _) = await BuildAndLayout(html);
+            var text = FindById(root, "text")!;
+            var firstWord = FindFirstWord(text);
+
+            Assert.NotNull(firstWord);
+            Assert.True(firstWord!.Rectangle.Left < 10,
+                $"first word should start at the container's left edge without a float, was at {firstWord.Rectangle.Left}");
+        }
+
+        [Fact]
+        public async Task Float_NarrowsAvailableWidth_SoTextWrapsToMoreLines()
+        {
+            const string longText =
+                "This is a fairly long sentence that should wrap across multiple lines once the available width is narrowed by a floated sibling element.";
+
+            var withFloatHtml = Wrap($@"
+                <div style='width:250px;'>
+                    <div style='float:left; width:150px; height:40px;'></div>
+                    <p id='text' style='margin:0;'>{longText}</p>
+                </div>");
+
+            var withoutFloatHtml = Wrap($@"
+                <div style='width:250px;'>
+                    <p id='text' style='margin:0;'>{longText}</p>
+                </div>");
+
+            var (withFloatRoot, _) = await BuildAndLayout(withFloatHtml);
+            var (withoutFloatRoot, _) = await BuildAndLayout(withoutFloatHtml);
+
+            var withFloatText = FindById(withFloatRoot, "text")!;
+            var withoutFloatText = FindById(withoutFloatRoot, "text")!;
+
+            Assert.True(withFloatText.ActualBoxSizingHeight > withoutFloatText.ActualBoxSizingHeight,
+                $"narrowing the line width with a float should force extra line wraps and a taller box " +
+                $"(with float: {withFloatText.ActualBoxSizingHeight}, without: {withoutFloatText.ActualBoxSizingHeight})");
+        }
+
+        [Fact]
+        public async Task ManyNestedBlocksWithoutFloats_RendersWithinASaneTimeBound()
+        {
+            // Regression guard for the O(document size) walk that GetFirstIntersectingFloatBox used
+            // to perform for every box, at every ancestor level, even with zero floats anywhere. This
+            // document has no floats, so HasFloatedBoxes should short-circuit the whole thing; if that
+            // regresses, this - a fairly modest document - would take dramatically longer than the
+            // generous bound below (the original bug scaled towards seconds even for smaller documents
+            // than the 100-section one used here).
+            var html = BuildRepeatedSectionsHtml(sectionCount: 40);
+
+            var generator = new PdfGenerator();
+            var sw = Stopwatch.StartNew();
+            var document = await generator.GeneratePdf(html, PageSize.A4, margin: 20);
+            sw.Stop();
+
+            Assert.True(document.PageCount > 0);
+            Assert.True(sw.ElapsedMilliseconds < 5000,
+                $"rendering {40} float-free repeated sections took {sw.ElapsedMilliseconds}ms - " +
+                "this should complete in well under a second; a multi-second time suggests the float " +
+                "scan short-circuit (HasFloatedBoxes) has regressed back to an O(document size) walk per box.");
+        }
+
+        // ── Helpers ────────────────────────────────────────────────────────────
+
+        private static string Wrap(string body) =>
+            $"<!DOCTYPE html><html><head></head><body>{body}</body></html>";
+
+        private static string BuildRepeatedSectionsHtml(int sectionCount)
+        {
+            var sb = new StringBuilder();
+            sb.Append("<!DOCTYPE html><html><head><style>");
+            sb.Append(".section { border: 1px solid black; padding: 4px; margin-bottom: 8px; }");
+            sb.Append("table { width: 100%; border-collapse: collapse; } td { border: 1px solid #ccc; padding: 2px; }");
+            sb.Append("</style></head><body>");
+
+            for (var i = 0; i < sectionCount; i++)
+            {
+                sb.Append($"<div class='section'><h3>Section {i}</h3><table>");
+                for (var row = 0; row < 8; row++)
+                {
+                    sb.Append($"<tr><td>Item {i}-{row}</td><td>Qty {row}</td><td>${row * 10}.00</td></tr>");
+                }
+                sb.Append("</table></div>");
+            }
+
+            sb.Append("</body></html>");
+            return sb.ToString();
+        }
+
+        private static async Task<(CssBox root, HtmlContainerInt container)> BuildAndLayout(string html)
+        {
+            var adapter = new PdfSharpAdapter();
+            adapter.PixelsPerPoint = 1.0;
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            var size = new XSize(595, 842);
+            container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+            container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+            var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            return (container.Root!, container);
+        }
+
+        private static CssRect? FindFirstWord(CssBox box)
+        {
+            if (box.Words.Count > 0) return box.Words[0];
+            foreach (var child in box.Boxes)
+            {
+                var found = FindFirstWord(child);
+                if (found is not null) return found;
+            }
+            return null;
+        }
+
+        private static CssBox? FindById(CssBox box, string id)
+        {
+            var val = box.HtmlTag?.TryGetAttribute("id", "");
+            if (val != null && val.Equals(id, StringComparison.OrdinalIgnoreCase))
+                return box;
+            foreach (var child in box.Boxes)
+            {
+                var found = FindById(child, id);
+                if (found != null) return found;
+            }
+            return null;
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/GlobalKeywordCascadeTests.cs
+++ b/src/PeachPDF.Tests/Integration/GlobalKeywordCascadeTests.cs
@@ -437,6 +437,79 @@ namespace PeachPDF.Tests.Integration
             Assert.Equal("scale(2)", child!.Transform);
         }
 
+        // ── regression: lazy revert-snapshot (only computed when a matched rule ──
+        // ── actually uses revert/revert-layer) must still resolve correctly ─────
+
+        [Fact]
+        public async Task Revert_AmongMultipleAuthorRulesOnlyOneUsingRevert_StillFindsUaSnapshot()
+        {
+            // Several author-phase declarations apply to #el; only one of them uses "revert".
+            // The snapshot must still be captured before the author pass runs, not skipped just
+            // because most declarations in this pass are plain values.
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  div { color: blue; }
+                  #el { background-color: yellow; font-weight: bold; color: revert; }
+                </style></head><body>
+                <div id="el">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("black", el!.Color);
+            Assert.Equal("rgb(255, 255, 0)", el.BackgroundColor);
+            Assert.Equal("bold", el.FontWeight);
+        }
+
+        [Fact]
+        public async Task Revert_CustomProperty_RevertsToUaValue()
+        {
+            // Custom property (--foo) declarations are routed separately from regular properties
+            // but share the same rule set scanned for the revert/revert-layer keyword - confirm
+            // that scan actually looks at custom-property values too, not just known properties.
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  #el { --accent: blue; }
+                  #el.override { --accent: revert; }
+                </style></head><body>
+                <div id="el" class="override">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.False(el!.CustomProperties?.ContainsKey("--accent") ?? false, "revert with no prior origin snapshot value should leave the custom property absent");
+        }
+
+        [Fact]
+        public async Task Revert_NoRuleUsesRevertKeyword_SnapshotSkippedWithoutBreakingCascade()
+        {
+            // Plain sanity check that skipping the (now-lazy) snapshot entirely, for the common
+            // case where nothing in the matched rules ever uses revert/revert-layer, still lets
+            // every property cascade normally.
+            var html = """
+                <!DOCTYPE html><html><head><style>
+                  div { color: blue; margin-top: 12px; }
+                  #el { background-color: yellow; }
+                </style></head><body>
+                <div id="el">text</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("rgb(0, 0, 255)", el!.Color);
+            Assert.Equal("12px", el.MarginTop);
+            Assert.Equal("rgb(255, 255, 0)", el.BackgroundColor);
+        }
+
         // ── regression: 3-phase cascade must not break existing behaviour ──────
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/StackingContextPaintRegressionTests.cs
+++ b/src/PeachPDF.Tests/Integration/StackingContextPaintRegressionTests.cs
@@ -1,0 +1,205 @@
+using System.Diagnostics;
+using System.Text;
+using PeachPDF;
+using PeachPDF.PdfSharpCore;
+using PeachPDF.PdfSharpCore.Pdf;
+using PeachPDF.PdfSharpCore.Pdf.Advanced;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Regression tests for two paint-pipeline fixes:
+    ///
+    /// 1. <c>DomUtils.FlattenStackingContext</c> used to recurse into every descendant at every
+    ///    ancestor level (not just direct children), so a box was independently re-painted once per
+    ///    ancestor between it and the root. Fixed to only hoist genuinely out-of-flow (floated,
+    ///    absolutely positioned, fixed) descendants past normal-flow wrapper boxes; normal content is
+    ///    now painted exactly once, via its own parent's Paint() call.
+    ///
+    /// 2. <c>CssBox.Paint</c> used to always treat block-level boxes (Rectangles.Count == 0) as
+    ///    visible regardless of the current page's clip rect, so every page walked the entire box
+    ///    tree. Fixed to prune using the box's own Bounds instead - but only when the document has no
+    ///    out-of-flow content anywhere (see HtmlContainerInt.HasOutOfFlowBoxes), since an out-of-flow
+    ///    descendant's visual position can fall outside its "invisible" ancestor's own Bounds.
+    ///
+    /// Both fixes are scoped to fall back to the original (slower but unconditionally correct)
+    /// behaviour whenever the document has any float/absolute/fixed content, so the riskiest case to
+    /// regression-test is exactly that: out-of-flow content nested deep inside plain wrapper boxes.
+    /// </summary>
+    public class StackingContextPaintRegressionTests
+    {
+        [Fact]
+        public async Task PositionAbsolute_DeeplyNestedInPlainWrappers_StillRendersContent()
+        {
+            // Six levels of plain (non-positioned, non-stacking-context) wrapper divs, with a
+            // position:absolute box buried at the bottom. Its containing block is the outermost
+            // (position:relative) wrapper, not its immediate DOM parent - it must still be discovered
+            // and painted via FlattenStackingContext's out-of-flow hoisting, not silently dropped.
+            var html = @"
+<!DOCTYPE html>
+<html>
+<head><style>
+    .positioned-root { position: relative; width: 400px; height: 300px; }
+    .plain { }
+</style></head>
+<body>
+    <div class='positioned-root'>
+        <div class='plain'><div class='plain'><div class='plain'>
+            <div class='plain'><div class='plain'><div class='plain'>
+                <div style='position:absolute; top:10px; left:10px; width:50px; height:50px; background:red;'></div>
+            </div></div></div>
+        </div></div></div>
+    </div>
+</body>
+</html>";
+
+            var generator = new PdfGenerator();
+            var document = await generator.GeneratePdf(html, PageSize.A4, margin: 20);
+
+            Assert.Equal(1, document.PageCount);
+            Assert.True(PageHasContent(document.Pages[0]), "the single page should have content");
+        }
+
+        [Fact]
+        public async Task ZIndexedPositionedSiblings_RenderWithoutThrowing()
+        {
+            // Two position:relative siblings with different z-index values are each their own
+            // stacking context (per IsStackingContextBox) - confirm they're still found and painted
+            // (not excluded as "already handled elsewhere") now that FlattenStackingContext no longer
+            // blindly recurses through everything.
+            var html = @"
+<!DOCTYPE html>
+<html>
+<head><style>
+    .box { position: relative; width: 100px; height: 100px; }
+</style></head>
+<body>
+    <div class='box' style='z-index: 1; background: red;'>Back</div>
+    <div class='box' style='z-index: 2; top: -50px; left: 50px; background: blue;'>Front</div>
+</body>
+</html>";
+
+            var generator = new PdfGenerator();
+            var document = await generator.GeneratePdf(html, PageSize.A4, margin: 20);
+
+            Assert.Equal(1, document.PageCount);
+            Assert.True(PageHasContent(document.Pages[0]));
+        }
+
+        [Fact]
+        public async Task MultiPageRepeatedContent_EveryPageHasContent()
+        {
+            // Regression for the Bounds-based visibility pruning: with many pages of distinct
+            // repeated content, every single page must still have content - none should come out
+            // blank because an ancestor spanning many pages was wrongly judged invisible for a page
+            // it does, in fact, have content on.
+            var html = BuildRepeatedPagedSectionsHtml(sectionCount: 30);
+
+            var generator = new PdfGenerator();
+            var document = await generator.GeneratePdf(html, PageSize.A4, margin: 20);
+
+            Assert.True(document.PageCount >= 5, $"expected several pages, got {document.PageCount}");
+
+            for (var i = 0; i < document.PageCount; i++)
+            {
+                Assert.True(PageHasContent(document.Pages[i]), $"page {i + 1} of {document.PageCount} should have content");
+            }
+        }
+
+        [Fact]
+        public async Task ManyNestedNormalFlowBoxes_RenderWithinASaneTimeBound()
+        {
+            // Regression guard for FlattenStackingContext's old O(depth) blowup: with no out-of-flow
+            // content anywhere, every box used to be independently re-painted once per ancestor level
+            // between it and the root. This document has real nesting depth (six wrapper levels) times
+            // real breadth (many repeated sections), so a regression back to the old behaviour would
+            // make this take dramatically longer than the generous bound below.
+            var html = BuildDeeplyNestedRepeatedSectionsHtml(sectionCount: 40, nestingDepth: 6);
+
+            var generator = new PdfGenerator();
+            var sw = Stopwatch.StartNew();
+            var document = await generator.GeneratePdf(html, PageSize.A4, margin: 20);
+            sw.Stop();
+
+            Assert.True(document.PageCount > 0);
+            Assert.True(sw.ElapsedMilliseconds < 5000,
+                $"rendering took {sw.ElapsedMilliseconds}ms - this should complete in well under a second; " +
+                "a multi-second time suggests FlattenStackingContext has regressed back to repainting every " +
+                "box once per ancestor level.");
+        }
+
+        // ── Helpers ────────────────────────────────────────────────────────────
+
+        private static string BuildRepeatedPagedSectionsHtml(int sectionCount)
+        {
+            var sb = new StringBuilder();
+            sb.Append("<!DOCTYPE html><html><head><style>");
+            sb.Append("@page { size: A4; margin: 20mm; }");
+            sb.Append(".section { page-break-after: always; border: 1px solid black; padding: 8px; }");
+            sb.Append("</style></head><body>");
+
+            for (var i = 0; i < sectionCount; i++)
+            {
+                sb.Append($"<div class='section'><h2>Section {i}</h2><p>Distinct content for section number {i}.</p></div>");
+            }
+
+            sb.Append("</body></html>");
+            return sb.ToString();
+        }
+
+        private static string BuildDeeplyNestedRepeatedSectionsHtml(int sectionCount, int nestingDepth)
+        {
+            var sb = new StringBuilder();
+            sb.Append("<!DOCTYPE html><html><head><style>");
+            sb.Append(".section { border: 1px solid black; padding: 4px; margin-bottom: 8px; }");
+            sb.Append("</style></head><body>");
+
+            for (var i = 0; i < sectionCount; i++)
+            {
+                sb.Append("<div class='section'>");
+                for (var d = 0; d < nestingDepth; d++)
+                {
+                    sb.Append("<div>");
+                }
+                sb.Append($"Section {i} content deep inside {nestingDepth} wrapper levels.");
+                for (var d = 0; d < nestingDepth; d++)
+                {
+                    sb.Append("</div>");
+                }
+                sb.Append("</div>");
+            }
+
+            sb.Append("</body></html>");
+            return sb.ToString();
+        }
+
+        private static bool PageHasContent(PdfPage page)
+        {
+            try
+            {
+                var content = page.Contents;
+                if (content == null)
+                    return false;
+
+                if (content.Elements.Count == 0)
+                    return false;
+
+                foreach (var item in content.Elements)
+                {
+                    if (item is PdfReference { Value: PdfDictionary dict })
+                    {
+                        var stream = dict.Stream;
+                        if (stream?.Value is { Length: > 0 })
+                            return true;
+                    }
+                }
+
+                return false;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/CssData.cs
+++ b/src/PeachPDF/Html/Core/CssData.cs
@@ -39,6 +39,151 @@ namespace PeachPDF.Html.Core
         {
         }
 
+        // --- Rule index -----------------------------------------------------------------------
+        //
+        // Matching every stylesheet rule against every CssBox in the document (the naive approach)
+        // is O(rules x boxes) and dominated cascade cost on large documents. Real browser engines
+        // avoid this by bucketing rules by the "subject" simple selector (the one that must match the
+        // box itself, e.g. the tag/class/id) so a box only needs to test the handful of rules that
+        // could plausibly match it, instead of the whole stylesheet. `DoesSelectorMatch` remains the
+        // source of truth for whether a rule actually matches - the index only narrows the candidates.
+        //
+        // Built lazily, once, the first time this CssData's rules are queried. Safe because by the
+        // time CascadeApplyStyles starts querying rules for the box tree, DomParser has already
+        // finished building/cloning CssData from <style>/<link> tags (see DomParser.GenerateCssTree),
+        // so Stylesheets doesn't change during the walk.
+        private enum SelectorBucketKind { Tag, Class, Id, Universal }
+
+        private readonly record struct IndexedRule(IStyleRule Rule, bool IsUserAgent);
+
+        private Dictionary<string, List<IndexedRule>>? _tagIndex;
+        private Dictionary<string, List<IndexedRule>>? _classIndex;
+        private Dictionary<string, List<IndexedRule>>? _idIndex;
+        private List<IndexedRule>? _universalRules;
+
+        private void EnsureIndex()
+        {
+            if (_universalRules is not null) return;
+
+            var tagIndex = new Dictionary<string, List<IndexedRule>>(StringComparer.InvariantCultureIgnoreCase);
+            var classIndex = new Dictionary<string, List<IndexedRule>>(StringComparer.InvariantCultureIgnoreCase);
+            var idIndex = new Dictionary<string, List<IndexedRule>>(StringComparer.InvariantCultureIgnoreCase);
+            var universal = new List<IndexedRule>();
+            var keys = new List<(SelectorBucketKind Kind, string Key)>();
+
+            foreach (var stylesheet in Stylesheets)
+            {
+                foreach (var rule in stylesheet.StyleRules)
+                {
+                    var indexedRule = new IndexedRule(rule, stylesheet.IsUserAgent);
+
+                    keys.Clear();
+                    CollectIndexKeys(rule.Selector, keys);
+
+                    foreach (var (kind, key) in keys)
+                    {
+                        var bucket = kind switch
+                        {
+                            SelectorBucketKind.Tag => tagIndex,
+                            SelectorBucketKind.Class => classIndex,
+                            SelectorBucketKind.Id => idIndex,
+                            _ => null
+                        };
+
+                        if (bucket is null)
+                        {
+                            universal.Add(indexedRule);
+                        }
+                        else
+                        {
+                            if (!bucket.TryGetValue(key, out var list))
+                                bucket[key] = list = [];
+                            list.Add(indexedRule);
+                        }
+                    }
+                }
+            }
+
+            _tagIndex = tagIndex;
+            _classIndex = classIndex;
+            _idIndex = idIndex;
+            _universalRules = universal;
+        }
+
+        /// <summary>
+        /// Determines which bucket(s) a rule's selector should be indexed under, based on the simple
+        /// selector that must match the box itself (for <see cref="ComplexSelector"/>, that's its
+        /// rightmost/subject selector - see the reversal in <see cref="DoesSelectorMatch(ComplexSelector, CssBox?)"/>).
+        /// A <see cref="ListSelector"/> (comma-separated) contributes one key per alternative, since
+        /// matching any alternative matches the rule.
+        /// </summary>
+        private static void CollectIndexKeys(ISelector selector, List<(SelectorBucketKind Kind, string Key)> keys)
+        {
+            switch (selector)
+            {
+                case ListSelector listSelector:
+                    foreach (var sub in listSelector)
+                        CollectIndexKeys(sub, keys);
+                    break;
+
+                case ComplexSelector complexSelector:
+                    var last = complexSelector.LastOrDefault().Selector;
+                    if (last is not null)
+                        CollectIndexKeys(last, keys);
+                    else
+                        keys.Add((SelectorBucketKind.Universal, string.Empty));
+                    break;
+
+                case CompoundSelector compoundSelector:
+                    // Pseudo-element and :first-child subjects need the box's own HtmlTag/ParentBox
+                    // re-derived at match time (see DoesSelectorMatch), including for synthesized
+                    // pseudo-element boxes whose HtmlTag is null - the tag/class/id index can't
+                    // safely represent that, so fall back to a full scan for these.
+                    if (compoundSelector.Any(s => s is PseudoElementSelector or FirstChildSelector))
+                    {
+                        keys.Add((SelectorBucketKind.Universal, string.Empty));
+                        break;
+                    }
+
+                    IdSelector? id = null;
+                    ClassSelector? cls = null;
+                    TypeSelector? type = null;
+
+                    foreach (var member in compoundSelector)
+                    {
+                        switch (member)
+                        {
+                            case IdSelector idSel: id ??= idSel; break;
+                            case ClassSelector clsSel: cls ??= clsSel; break;
+                            case TypeSelector typeSel: type ??= typeSel; break;
+                        }
+                    }
+
+                    if (id is not null) keys.Add((SelectorBucketKind.Id, id.Id));
+                    else if (cls is not null) keys.Add((SelectorBucketKind.Class, cls.Class));
+                    else if (type is not null) keys.Add((SelectorBucketKind.Tag, type.Name));
+                    else keys.Add((SelectorBucketKind.Universal, string.Empty));
+                    break;
+
+                case TypeSelector typeSelector:
+                    keys.Add((SelectorBucketKind.Tag, typeSelector.Name));
+                    break;
+
+                case ClassSelector classSelector:
+                    keys.Add((SelectorBucketKind.Class, classSelector.Class));
+                    break;
+
+                case IdSelector idSelector:
+                    keys.Add((SelectorBucketKind.Id, idSelector.Id));
+                    break;
+
+                default:
+                    // AllSelector, bare pseudo-class/element/attribute selectors, etc.
+                    keys.Add((SelectorBucketKind.Universal, string.Empty));
+                    break;
+            }
+        }
+
         /// <summary>
         /// Parse the given stylesheet to <see cref="CssData"/> object.<br/>
         /// If <paramref name="combineWithDefault"/> is true the parsed css blocks are added to the 
@@ -66,15 +211,66 @@ namespace PeachPDF.Html.Core
 
         private IEnumerable<IStyleRule> GetStyleRulesByOrigin(string media, CssBox box, bool? userAgentOnly)
         {
+            EnsureIndex();
+
+            // Rules matched via the index below can, in rare cases (a comma-separated selector list
+            // whose alternatives land in different buckets, e.g. "div, .foo" matching a <div class="foo">),
+            // be reachable through more than one bucket. Dedup so callers never see the same rule twice.
+            HashSet<IStyleRule>? seen = null;
+
+            bool ShouldEmit(IndexedRule indexed)
+            {
+                if (userAgentOnly.HasValue && indexed.IsUserAgent != userAgentOnly.Value) return false;
+                if (!DoesSelectorMatch(indexed.Rule.Selector, box)) return false;
+                seen ??= [];
+                return seen.Add(indexed.Rule);
+            }
+
+            foreach (var indexed in _universalRules!)
+            {
+                if (ShouldEmit(indexed))
+                    yield return indexed.Rule;
+            }
+
+            if (box.HtmlTag is not null)
+            {
+                if (_tagIndex!.TryGetValue(box.HtmlTag.Name, out var tagRules))
+                {
+                    foreach (var indexed in tagRules)
+                        if (ShouldEmit(indexed))
+                            yield return indexed.Rule;
+                }
+
+                if (box.HtmlTag.Attributes is not null)
+                {
+                    if (box.HtmlTag.Attributes.TryGetValue("class", out var classAttr) && classAttr.Length > 0)
+                    {
+                        foreach (var className in classAttr.Split(' '))
+                        {
+                            if (className.Length == 0) continue;
+                            if (_classIndex!.TryGetValue(className, out var classRules))
+                                foreach (var indexed in classRules)
+                                    if (ShouldEmit(indexed))
+                                        yield return indexed.Rule;
+                        }
+                    }
+
+                    if (box.HtmlTag.Attributes.TryGetValue("id", out var idAttr) && idAttr.Length > 0
+                        && _idIndex!.TryGetValue(idAttr, out var idRules))
+                    {
+                        foreach (var indexed in idRules)
+                            if (ShouldEmit(indexed))
+                                yield return indexed.Rule;
+                    }
+                }
+            }
+
+            // Rules inside @media blocks are not pre-indexed (typically few of them in practice) -
+            // keep a direct scan for these, same as before.
             foreach (var stylesheet in Stylesheets)
             {
                 if (userAgentOnly.HasValue && stylesheet.IsUserAgent != userAgentOnly.Value)
                     continue;
-
-                foreach (var rule in GetStyleRules(stylesheet.StyleRules, box))
-                {
-                    yield return rule;
-                }
 
                 foreach (var mediaRule in stylesheet.MediaRules)
                 {
@@ -86,6 +282,7 @@ namespace PeachPDF.Html.Core
 
                         foreach (var rule in GetStyleRules(mediaRule.Rules.OfType<IStyleRule>(), box))
                         {
+                            if (seen is not null && !seen.Add(rule)) continue;
                             yield return rule;
                         }
                     }

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -485,6 +485,33 @@ namespace PeachPDF.Html.Core.Dom
                     if (clip != RRect.Empty)
                         visible = true;
                 }
+                else if (HtmlContainer?.HasOutOfFlowBoxes ?? true)
+                {
+                    // Rectangles.Count == 0 boxes (most block-level containers) have historically always
+                    // been treated as visible here regardless of the current clip, so every page walked
+                    // every box in the whole document. That's only safe to tighten up when there's no
+                    // out-of-flow content (float/absolute/fixed) anywhere in the document: an out-of-flow
+                    // descendant's visual position can fall outside this box's own Bounds, and it's only
+                    // discovered/painted via this box's own PaintImp -> FlattenStackingContext call, so
+                    // skipping that call based on Bounds alone could silently drop it. With no such content
+                    // anywhere (checked once for the whole document - see HtmlContainerInt.PerformLayout),
+                    // every descendant is normal-flow and nested within this box's own Bounds, so it's safe
+                    // to prune using them below instead.
+                }
+                else
+                {
+                    var clip = g.GetClip();
+                    var rect = Bounds;
+                    rect.X -= 2;
+                    rect.Width += 2;
+                    if (!IsFixed)
+                    {
+                        rect.Offset(HtmlContainer!.ScrollOffset);
+                    }
+                    clip.Intersect(rect);
+
+                    visible = clip != RRect.Empty;
+                }
 
                 if (visible)
                 {

--- a/src/PeachPDF/Html/Core/HtmlContainerInt.cs
+++ b/src/PeachPDF/Html/Core/HtmlContainerInt.cs
@@ -176,6 +176,22 @@ namespace PeachPDF.Html.Core
         /// </summary>
         public RSize ActualSize { get; set; }
 
+        /// <summary>
+        /// Whether any box in the current document has <c>float: left/right</c>. Computed once per
+        /// <see cref="PerformLayout"/> call and used to let float-intersection lookups
+        /// (<see cref="Utils.DomUtils.GetFirstIntersectingFloatBox"/>) skip their tree walk entirely for
+        /// the common case of a document with no floated content at all.
+        /// </summary>
+        internal bool HasFloatedBoxes { get; private set; }
+
+        /// <summary>
+        /// Whether any box in the current document is out-of-flow (floated, absolutely positioned, or
+        /// fixed). Computed alongside <see cref="HasFloatedBoxes"/> and used by
+        /// <see cref="Utils.DomUtils.FlattenStackingContext"/> to skip hoisting out-of-flow descendants
+        /// past normal-flow wrapper boxes entirely when there's nothing to hoist.
+        /// </summary>
+        internal bool HasOutOfFlowBoxes { get; private set; }
+
         public RSize PageSize { get; set; }
 
         /// <summary>
@@ -323,6 +339,8 @@ namespace PeachPDF.Html.Core
             ActualSize = RSize.Empty;
             if (Root is null) return;
 
+            (HasFloatedBoxes, HasOutOfFlowBoxes) = ComputeFlowFlags(Root);
+
             // if width is not restricted we set it to large value to get the actual later
             Root.Size = new RSize(MaxSize.Width > 0 ? MaxSize.Width : PageSize.Width, 0);
             Root.Location = Location;
@@ -338,6 +356,33 @@ namespace PeachPDF.Html.Core
 
             // After layout, re-apply content to pseudo-elements now that named strings are set
             ReapplyPseudoElementContent(Root);
+
+            // Recompute after layout in case pseudo-element reapplication added any out-of-flow boxes.
+            (HasFloatedBoxes, HasOutOfFlowBoxes) = ComputeFlowFlags(Root);
+        }
+
+        /// <summary>
+        /// Recursively checks whether any box in the tree is floated and/or out-of-flow, short-circuiting
+        /// once both have been confirmed true.
+        /// </summary>
+        private static (bool HasFloated, bool HasOutOfFlow) ComputeFlowFlags(CssBox box)
+        {
+            var hasFloated = false;
+            var hasOutOfFlow = false;
+            ComputeFlowFlags(box, ref hasFloated, ref hasOutOfFlow);
+            return (hasFloated, hasOutOfFlow);
+        }
+
+        private static void ComputeFlowFlags(CssBox box, ref bool hasFloated, ref bool hasOutOfFlow)
+        {
+            if (box.IsFloated) hasFloated = true;
+            if (box.IsOutOfFlow) hasOutOfFlow = true;
+
+            foreach (var childBox in box.Boxes)
+            {
+                if (hasFloated && hasOutOfFlow) return;
+                ComputeFlowFlags(childBox, ref hasFloated, ref hasOutOfFlow);
+            }
         }
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -337,10 +337,15 @@ namespace PeachPDF.Html.Core.Parse
             // 3. UA pass — user-agent stylesheet rules only
             var importantPropertyNames = AssignCssBlocks(valueParser, box, cssData.GetUserAgentStyleRules(media, box), null, null, null, pendingVarProperties);
 
-            // 4. Author pass — author stylesheet rules; revert target is the UA-applied state
-            var uaSnapshot = CssUtils.SnapshotProperties(box);
-            var uaCustomSnapshot = CssUtils.SnapshotCustomProperties(box);
-            importantPropertyNames = AssignCssBlocks(valueParser, box, cssData.GetAuthorStyleRules(media, box), importantPropertyNames, uaSnapshot, uaCustomSnapshot, pendingVarProperties);
+            // 4. Author pass — author stylesheet rules; revert target is the UA-applied state.
+            // The snapshot is only ever read back when a declaration's value is literally revert/revert-layer
+            // (see AssignCssBlock/AssignCustomPropertyDeclaration), which is rare, so only pay for capturing
+            // it when the matched rules actually use one of those keywords.
+            var authorRules = cssData.GetAuthorStyleRules(media, box).ToList();
+            var needsUaSnapshot = RulesUseRevertKeyword(authorRules);
+            var uaSnapshot = needsUaSnapshot ? CssUtils.SnapshotProperties(box) : null;
+            var uaCustomSnapshot = needsUaSnapshot ? CssUtils.SnapshotCustomProperties(box) : null;
+            importantPropertyNames = AssignCssBlocks(valueParser, box, authorRules, importantPropertyNames, uaSnapshot, uaCustomSnapshot, pendingVarProperties);
 
             if (box.HtmlTag != null)
             {
@@ -352,10 +357,13 @@ namespace PeachPDF.Html.Core.Parse
                     var styleAttributeText = box.HtmlTag.TryGetAttribute("style");
                     var stylesheet = "* { " + styleAttributeText + " }";
 
-                    var authorSnapshot = CssUtils.SnapshotProperties(box);
-                    var authorCustomSnapshot = CssUtils.SnapshotCustomProperties(box);
                     var block = CssParser.ParseStyleSheet(stylesheet);
-                    AssignCssBlock(valueParser, box, block.StyleRules.Single(), importantPropertyNames, authorSnapshot, authorCustomSnapshot, pendingVarProperties);
+                    var inlineRule = block.StyleRules.Single();
+
+                    var needsAuthorSnapshot = RulesUseRevertKeyword([inlineRule]);
+                    var authorSnapshot = needsAuthorSnapshot ? CssUtils.SnapshotProperties(box) : null;
+                    var authorCustomSnapshot = needsAuthorSnapshot ? CssUtils.SnapshotCustomProperties(box) : null;
+                    AssignCssBlock(valueParser, box, inlineRule, importantPropertyNames, authorSnapshot, authorCustomSnapshot, pendingVarProperties);
                 }
             }
 
@@ -404,6 +412,25 @@ namespace PeachPDF.Html.Core.Parse
             foreach (var rule in rules)
                 AssignCssBlock(valueParser, box, rule, importantPropertyNames, revertTarget, customPropertyRevertTarget, pendingVarProperties);
             return importantPropertyNames;
+        }
+
+        /// <summary>
+        /// Checks whether any declaration in the given rules literally uses the revert/revert-layer keyword,
+        /// so the (relatively expensive) property snapshot used as their revert target only needs to be
+        /// captured when it can actually be consulted.
+        /// </summary>
+        private static bool RulesUseRevertKeyword(IEnumerable<IStyleRule> rules)
+        {
+            foreach (var rule in rules)
+            {
+                foreach (var prop in rule.Style)
+                {
+                    if (prop.Value is CssConstants.Revert or CssConstants.RevertLayer)
+                        return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Utils/DomUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/DomUtils.cs
@@ -419,6 +419,14 @@ namespace PeachPDF.Html.Core.Utils
 
         public static CssBox? GetFirstIntersectingFloatBox(CssBox reference, CssFloatCoordinates coordinates, string floatProp)
         {
+            // Walking up to the root and re-scanning every preceding sibling's whole subtree below is
+            // O(document size) per call; for the very common case of a document with no floated boxes
+            // at all, skip it entirely rather than pay that cost for a lookup that can never succeed.
+            if (reference.HtmlContainer?.HasFloatedBoxes != true)
+            {
+                return null;
+            }
+
             while (true)
             {
                 if (reference.ParentBox is null)
@@ -527,6 +535,16 @@ namespace PeachPDF.Html.Core.Utils
 
         public static IEnumerable<CssBox> FlattenStackingContext(CssBox box)
         {
+            // Out-of-flow descendants (floated/absolute/fixed) need to be hoisted up through normal-flow
+            // wrapper boxes so their painting box's stacking context can order them correctly relative to
+            // its own layers. Normal in-flow descendants do NOT need hoisting - they're already painted
+            // correctly by their own parent's Paint() call, which recurses into this same method for its
+            // own direct children. Recursing here regardless of flow used to re-yield (and repaint) every
+            // in-flow descendant once per ancestor level between it and this box - an O(depth) blowup on
+            // top of the O(tree size) this method already does. Skip that recursion entirely unless the
+            // document actually has out-of-flow content somewhere to hoist.
+            var hasOutOfFlowBoxes = box.HtmlContainer?.HasOutOfFlowBoxes ?? true;
+
             foreach (var childBox in box.Boxes)
             {
                 if (!IsStackingContextBox(childBox))
@@ -534,13 +552,13 @@ namespace PeachPDF.Html.Core.Utils
                     yield return childBox;
                 }
 
-                var flattenedChildBoxes = FlattenStackingContext(childBox);
+                if (!hasOutOfFlowBoxes) continue;
 
-                foreach (var flattenedStackingBox in flattenedChildBoxes)
+                foreach (var flattenedBox in FlattenStackingContext(childBox))
                 {
-                    if (!IsStackingContextBox(flattenedStackingBox))
+                    if (!IsStackingContextBox(flattenedBox) && flattenedBox.IsOutOfFlow)
                     {
-                        yield return flattenedStackingBox;
+                        yield return flattenedBox;
                     }
                 }
             }


### PR DESCRIPTION
This pull request adds comprehensive regression test suites for CSS rule indexing and float layout logic, and introduces additional tests for the CSS cascade’s revert keyword handling. These tests target recent and historical bugs, ensuring that CSS selector bucketing, float avoidance optimizations, and cascade behaviors (including revert and custom property handling) all function correctly and efficiently.

**New regression test suites:**

* Added `CssDataRuleIndexingTests` to verify that the CSS rule index correctly buckets selectors by tag, class, and id, and that the cascade applies rules accurately and efficiently. Tests cover specific selector types, compound selectors, universal selectors, list selectors, pseudo-elements, media queries, and specificity/cascade order.
* Added `FloatLayoutRegressionTests` to confirm that float avoidance logic and the `HasFloatedBoxes` optimization prevent unnecessary O(N^2) walks in float-free documents, and that float layout still works as intended when floats are present.

**Additional cascade/revert keyword tests:**

* Added tests to `GlobalKeywordCascadeTests` to ensure that the lazy revert snapshot logic works correctly, including cases where only some rules use the `revert` keyword, custom properties are reverted, and the snapshot is skipped when unused.

These tests provide strong regression coverage for the CSS engine’s rule matching, layout, and cascade logic.