### PR TITLE
Implement :root pseudo-class matching

### DIFF
--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -449,6 +449,7 @@ Because PeachPDF renders a static PDF with no interactive or dynamic state, stat
 | Pseudo-class | Notes |
 |--------------|-------|
 | `:link` | Matches `<a>` elements that have an `href` attribute |
+| `:root` | Matches the document's root element (the `<html>` element) |
 | `:first-child`, `:last-child` | Equivalent to `:nth-child(1)` / `:nth-last-child(1)` |
 | `:only-child` | Matches an element with no other element siblings |
 | `:first-of-type`, `:last-of-type` | Equivalent to `:nth-of-type(1)` / `:nth-last-of-type(1)` |
@@ -464,7 +465,7 @@ Because PeachPDF renders a static PDF with no interactive or dynamic state, stat
 
 Known gap: `:nth-column()`/`:nth-last-column()`'s same-row-only limitation described above.
 
-State-based pseudo-classes other than `:link` (`:hover`, `:focus`, `:active`, `:checked`, `:disabled`, `:root`, `:empty`, etc.) are parsed but not applied.
+State-based pseudo-classes other than `:link` (`:hover`, `:focus`, `:active`, `:checked`, `:disabled`, `:empty`, etc.) are parsed but not applied.
 
 ### Cascade & Specificity
 

--- a/src/PeachPDF.Tests/CSS/StructuralPseudoClassSelectorTests.cs
+++ b/src/PeachPDF.Tests/CSS/StructuralPseudoClassSelectorTests.cs
@@ -58,6 +58,46 @@ public class StructuralPseudoClassSelectorTests
         Assert.All(boxes, b => Assert.Equal("transparent", b.BackgroundColor));
     }
 
+    // ── :root ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Root_Matches_HtmlElement()
+    {
+        var html = Html(":root { background-color: #ff0000; }", "<p>content</p>");
+        var box = await FindBoxByTag(html, "html");
+        Assert.NotEqual("transparent", box.BackgroundColor);
+    }
+
+    [Fact]
+    public async Task Root_DoesNotMatch_BodyOrDescendants()
+    {
+        var html = Html(":root { background-color: #ff0000; }", "<div><p>content</p></div>");
+        var body = await FindBoxByTag(html, "body");
+        var div = await FindBoxByTag(html, "div");
+        Assert.Equal("transparent", body.BackgroundColor);
+        Assert.Equal("transparent", div.BackgroundColor);
+    }
+
+    [Fact]
+    public async Task Root_CompoundWithTypeSelector_StillMatches()
+    {
+        var html = Html("html:root { background-color: #ff0000; }", "<p>content</p>");
+        var box = await FindBoxByTag(html, "html");
+        Assert.NotEqual("transparent", box.BackgroundColor);
+    }
+
+    [Fact]
+    public async Task Root_Specificity_OutranksTypeSelector_RegardlessOfSourceOrder()
+    {
+        // ":root" is (0,0,1,0), "html" is (0,0,0,1) - :root must win the cascade even though it's
+        // declared after "html", where a naive source-order-only cascade would pick "html"'s blue.
+        var html = Html(
+            "html { background-color: #0000ff; } :root { background-color: #ff0000; }",
+            "<p>content</p>");
+        var box = await FindBoxByTag(html, "html");
+        Assert.Equal("rgb(255, 0, 0)", box.BackgroundColor);
+    }
+
     // ── :nth-child() — literal, formula, keywords, negative offset ────────────
 
     [Fact]

--- a/src/PeachPDF/Html/Core/CssData.cs
+++ b/src/PeachPDF/Html/Core/CssData.cs
@@ -618,6 +618,13 @@ namespace PeachPDF.Html.Core
 
         private static bool DoesSelectorMatch(PseudoClassSelector pseudoClassSelector, CssBox? box)
         {
+            if (pseudoClassSelector.Class == PseudoClassNames.Root)
+            {
+                return box?.HtmlTag is not null
+                    && box.HtmlTag.Name.Equals("html", StringComparison.OrdinalIgnoreCase)
+                    && DomUtils.GetNearestParentElementBox(box) is null;
+            }
+
             return pseudoClassSelector.Class == "link" && box is not null && box.IsClickable;
         }
 


### PR DESCRIPTION
Add runtime support for the `:root` pseudo-class in selector matching by treating the document root `<html>` element as the only match. This updates structural pseudo-class tests to cover root-only matching, compound selectors, and specificity behavior in the cascade, and updates the HTML/CSS support docs to mark `:root` as supported and remove it from the unsupported state-based pseudo-class list.