### PR TITLE
Add contribution and third-party license docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@ CI enforces 90% diff coverage on PRs (`diff-cover` against the PR base, via `.gi
 dotnet test --collect:"XPlat Code Coverage" --settings PeachPDF.Tests/coverlet.runsettings --results-directory coverage
 ```
 
+Before considering any non-trivial code change complete, run the command above and check diff coverage on the lines you changed. If new/changed code falls short of the 90% diff-coverage threshold CI enforces, add tests to close the gap before finishing — don't leave it for CI to catch.
+
 Avoid writing tests against `PdfSharpCore.Fonts.FontFactory` (and OpenType neighbors) without care — it caches resolved fonts in `static readonly Dictionary` fields shared process-wide, and xUnit's parallel test-class execution makes new tests here a real order-dependent-flakiness risk against the rest of the suite.
 
 ## Testing conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to PeachPDF
+
+Thanks for your interest in contributing. This document covers how to build, test, and submit changes.
+
+## Getting started
+
+- The solution is at `src/PeachPDF.sln`. PeachPDF targets .NET 8 and .NET 10.
+- All `dotnet` CLI commands below assume your working directory is `src/` — the projects (and their relative paths in this doc) are rooted there.
+
+## Building and testing
+
+Run the test suite with a single target framework:
+
+```
+dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0
+```
+
+`PeachPDF.Tests` multi-targets net8.0 and net10.0. A bare `dotnet test` (no `--framework`) builds and runs the full suite (3000+ tests) twice in one invocation, which roughly doubles local build/test time — always pass `--framework net8.0` for routine local runs. Only add an explicit net10.0 run if you suspect a net10.0-specific issue.
+
+To run a subset of tests:
+
+```
+dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~Svg"
+```
+
+## Code coverage
+
+CI enforces **90% diff coverage** on pull requests — the coverage of lines you actually changed, not the whole codebase — via `diff-cover` against the PR base branch (see `.github/workflows/test.yml` and `src/PeachPDF.Tests/coverlet.runsettings`, Cobertura format).
+
+Reproduce this locally before opening or updating a PR:
+
+```
+dotnet test --collect:"XPlat Code Coverage" --settings PeachPDF.Tests/coverlet.runsettings --results-directory coverage
+```
+
+If your changed lines fall short of 90%, add tests to close the gap rather than relying on CI to catch it — a red diff-coverage check is one of the more common reasons a PR stalls in review.
+
+## Testing conventions
+
+- **A passing test that only checks PDF content-stream substrings (`/SMask`, `Tj`, `/ShadingType`, etc.) is not proof a feature renders correctly.** A token can be fully present while the actual composed/positioned result is visually broken or blank. For anything touching PDF graphics state — soft masks, patterns, clip paths, gradients, transparency groups, transforms — prefer structural/adjacency assertions (e.g. regex-checking that a `gs` and the `Do` it modifies appear on the same `cm` line), or better, rasterize the output and look at it.
+- **Rasterize with two renderers, not one**, when verifying transparency/soft-mask/blend-mode output. MuPDF is unusually lenient about transparency-group conformance and can render content "correctly" that a stricter, more representative engine (PDFium — Chrome/Edge's engine) refuses. Agreement between both is real evidence; a single MuPDF render that looks right is not.
+- When implementing a new SVG or CSS **paint** feature, a parser-level "did it parse into the right enum/value" test is not sufficient on its own — add an integration test that would fail if the feature were a complete no-op at render time.
+- **Layout engine changes** (`CssLayoutEngine`/`CssLayoutEngineFlex`/`CssLayoutEngineTable`/`CssLayoutEngineColumns`, `CssBox.PerformLayoutImp`) need unit tests that assert the relevant `CssBox`'s properties after layout (`Location`, `ActualRight`/`ActualBottom`, etc.), not just that layout completes without throwing. Assert on every box the change affects, including children when the change affects child placement. See the harness pattern in `FlexboxIntegrationTests.cs`/`MulticolLayoutIntegrationTests.cs`: build a `HtmlContainerInt` + `PdfSharpAdapter`, call `PerformLayout` directly, then walk the box tree by id/class and assert positions/sizes.
+- **Painting changes** need unit tests that confirm the actual sequence of calls made to the `RGraphics` adapter layer, not just that painting completes or that some token shows up in the final PDF. Use a test-only `RGraphics` mock (see `SpyGraphics` in `TransformIntegrationTests.cs`, `RecordingGraphics` in `CssLayoutEngineTablePageBreakTests.cs`) that records each invocation, then assert on the recording. When order across different call types matters, record into a single ordered log.
+- Avoid writing tests against `PdfSharpCore.Fonts.FontFactory` (and OpenType neighbors) without care — it caches resolved fonts in `static readonly Dictionary` fields shared process-wide, and xUnit's parallel test-class execution makes new tests here a real order-dependent-flakiness risk.
+
+## Documentation
+
+When you add or change a user-facing feature, update the relevant doc page in the same PR — not as a follow-up:
+
+- [docs/architecture.md](docs/architecture.md) — how HTML becomes a PDF
+- [docs/html-css-support.md](docs/html-css-support.md) — HTML/CSS compatibility matrix
+- [docs/supported-svg-features.md](docs/supported-svg-features.md) — SVG compatibility matrix
+- [docs/usage-examples.md](docs/usage-examples.md) — API usage examples
+- [README.md](README.md) / [docs/index.md](docs/index.md) — cross-link new features from these where relevant
+
+If a change gives PeachPDF a new visible rendering capability, add or update a showcase in `src/PeachPDF.TestHarness/Program.cs` in the same change. Several real rendering-correctness bugs (paint-order issues, broken masks, no-op gradient spread methods) were only caught by visually exercising a showcase, not by automated tests alone.
+
+## Architecture conventions
+
+- Don't write two independent parsers for the same CSS value grammar across layers. If both the CSS-OM/parsing layer and a later render/resolution layer need to understand a value's grammar, extract it into one shared internal class both call (e.g. `CalcParser`, `BackgroundPositionGrammar`/`BackgroundSizeGrammar`). Only the final numeric resolution that genuinely depends on runtime-only information should differ between layers.
+- The `Html/Adapters` layer (`RGraphics`/`RAdapter`/`RPen`/etc.) is the abstraction boundary between layout/paint logic and the concrete PDF backend (`PdfSharpCore`). New rendering primitives get added here first, then implemented in `GraphicsAdapter`/`XGraphics`/`XGraphicsPdfRenderer`. If you add a new abstract `RGraphics` member, update the test-only mocks (`SpyGraphics`, `RecordingGraphics`) too.
+- Before building new PDF-writing infrastructure (patterns, soft masks, shadings), check whether `PdfSharpCore` already has an unused primitive for it — `XForm`/`PdfFormXObject`, `PdfTilingPattern`, `PdfSoftMask` have all been found pre-existing-but-uncalled at various points.
+
+## Pull requests
+
+- CI runs the test suite on `windows-latest`, `ubuntu-latest`, and `macos-latest` against both .NET 8 and .NET 10, and enforces the 90% diff-coverage gate described above.
+- `@jhaygood86` is the default code owner for the entire repository and will be requested for review automatically.
+- Keep PRs scoped to one change; include tests and doc updates in the same PR rather than as follow-ups.
+
+## Third-party components
+
+PeachPDF embeds a few third-party components directly in its source tree, each under its own license — see [THIRD-PARTY-LICENSES.md](THIRD-PARTY-LICENSES.md) for the full list (currently: an embedded PdfSharpCore fork, an adapted ExCSS-derived CSS parser, and bundled hyph-utf8 hyphenation pattern data). If your change touches one of those subtrees, make sure it stays consistent with that component's original license terms.

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -1,0 +1,198 @@
+# Third-Party Licenses
+
+PeachPDF is MIT-licensed (see [LICENSE](LICENSE)), but it embeds and adapts a small number of third-party components directly in its source tree, each carrying its own license terms. This document collects those licenses, alongside where each component lives in the repo, so they aren't just scattered `LICENSE`/`license.txt` files a reader has to go hunting for.
+
+## PdfSharpCore (embedded fork)
+
+- **Location:** [`src/PeachPDF/PdfSharpCore/`](src/PeachPDF/PdfSharpCore/)
+- **License file:** [`src/PeachPDF/PdfSharpCore/LICENSE.md`](src/PeachPDF/PdfSharpCore/LICENSE.md)
+- **License:** MIT
+
+```
+## MIT License
+
+Copyright (c) 2001-2024 empira Software GmbH, Troisdorf (Cologne Area), Germany
+Copyright (c) 2017-2025 Justin Haygood
+
+http://docs.pdfsharp.net
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+```
+
+## ExCSS (CSS parser, adapted in-tree)
+
+- **Location:** [`src/PeachPDF/CSS/`](src/PeachPDF/CSS/)
+- **License file:** [`src/PeachPDF/CSS/license.txt`](src/PeachPDF/CSS/license.txt)
+- **License:** MIT
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2024 Tyler Brinks
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## Hyphenation patterns (hyph-utf8 / CTAN)
+
+- **Location:** [`src/PeachPDF/Text/Resources/Patterns/`](src/PeachPDF/Text/Resources/Patterns/) — one Brotli-compressed `hyph-<tag>.txt.br` file per language (73 files)
+- **Upstream source:** the `hyph-utf8` package from CTAN, mirrored at [github.com/hyphenation/tex-hyphen](https://github.com/hyphenation/tex-hyphen)
+- **Regeneration/provenance script:** [`tools/Update-HyphenationPatterns.ps1`](tools/Update-HyphenationPatterns.ps1), pinned to a specific upstream commit for reproducibility
+
+Each language's original `hyph-<tag>.tex` source carries its own copyright and license notice (these patterns are contributed independently, by different authors, over several decades). `tools/Update-HyphenationPatterns.ps1` bundles **only permissively-licensed pattern sets** (MIT/LPPL/BSD-style/public-domain) and skips any whose resolved license is GPL/LGPL-family or unstated (see the script's `Test-PermissiveLicense` function) — consistent with PeachPDF's own MIT license. Each compressed pattern file also carries this same notice inline in its decompressed text header, alongside its title, copyright holder, and a source/retrieval-date/commit stamp.
+
+The table below groups the 73 bundled languages by their exact license text, so each distinct notice is reproduced once rather than 73 times. Language tags correspond to `hyph-<tag>.txt.br` in the Patterns directory above.
+
+> This is a point-in-time snapshot of what the pinned upstream commit contained when generated. If `tools/Update-HyphenationPatterns.ps1` is re-run against a newer commit, upstream files may have changed license text (or license status), and this section should be regenerated to match.
+
+### MIT (standard boilerplate)
+
+26 languages: `as, be, bn, cu, cy, da, et, fr, fur, ga, gu, hi, it, kn, la-x-classic, la-x-liturgic, lt, ml, mn-cyrl, mr, pms, rm, sl, ta, te, tk`
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+### MIT (standard boilerplate, typographic quotation marks around "AS IS" only)
+
+2 languages: `af, es`
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+### MIT (standard boilerplate, typographic quotation marks)
+
+12 languages: `cop, de-1901, de-1996, de-ch-1901, en-gb, la, oc, or, pa, pi, sq, zh-latn-pinyin`
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+### MIT (by reference)
+
+6 languages: `el-monoton, el-polyton, fi-x-school, grc, ka, nl`
+
+> MIT — https://opensource.org/licenses/MIT
+
+1 language: `sk`
+
+> MIT — http://www.opensource.org/licenses/MIT
+
+1 language: `mul-ethi`
+
+> This file is available under the terms of the MIT licence. Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+### LaTeX Project Public License (LPPL)
+
+4 languages: `ca, eo, sh-cyrl, sh-latn`
+
+> LPPL 1 or later — https://latex-project.org/lppl/
+
+1 language: `tr`
+
+> LPPL 1 or later — https://latex-project.org/lppl/lppl-1-0.html
+
+1 language: `uk`
+
+> LPPL — https://latex-project.org/lppl/
+
+1 language: `sv`
+
+> LPPL 1.2 or later
+
+1 language: `ru`
+
+> LPPL 1.2 or later — https://latex-project.org/lppl/
+
+1 language: `is`
+
+> LPPL 1.2 or later — http://www.latex-project.org/lppl.txt
+
+1 language: `ia`
+
+> LPPL 1.3 — https://latex-project.org/lppl/
+
+1 language: `kmr`
+
+> LPPL 1.3 — https://latex-project.org/lppl/lppl-1-3.html
+
+1 language: `th`
+
+> LPPL 1.3 or later — https://latex-project.org/lppl/
+
+1 language: `hsb`
+
+> LPPL 1.3 or later — http://www.latex-project.org/lppl.txt
+
+### BSD-style "Data Files" license
+
+2 languages: `eu, hr`
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this file and any associated documentation (the "Data Files") to deal in the Data Files without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, and/or sell copies of the Data Files, and to permit persons to whom the Data Files are furnished to do so, provided that (a) this copyright and permission notice appear with all copies of the Data Files, (b) this copyright and permission notice appear in associated documentation, and (c) there is clear notice in each modified Data File as well as in the documentation associated with the Data File(s) that the data has been modified. THE DATA FILES ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA FILES. Except as contained in this notice, the name of a copyright holder shall not be used in advertising or otherwise to promote the sale, use or other dealings in these Data Files without prior written authorization of the copyright holder.
+
+1 language: `pt`
+
+> Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. * Neither the name of the University of Campinas, of the University of Minho nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL PEDRO J. DE REZENDE OR J.JOAO DIAS ALMEIDA BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+1 language: `bg`
+
+> This software may be used, modified, copied, distributed, and sold, both in source and binary form provided that the above copyright notice and these terms are retained. The name of the author may not be used to endorse or promote products derived from this software without prior permission. THIS SOFTWARE IS PROVIDES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE.
+
+### Public domain / unlicensed / freely-distributable
+
+2 languages: `nb, nn`
+
+> Copying and distribution of this file, with or without modification, are permitted in any medium without royalty, provided the copyright notice and this notice are preserved.
+
+1 language: `en-us`
+
+> Copying and distribution of this file, with or without modification, are permitted in any medium without royalty provided the copyright notice and this notice are preserved.
+
+1 language: `pl`
+
+> This macro file belongs to the public domain under the conditions specified by the author of TeX: “Macro files like PLAIN.TEX should not be changed in any way, except with respect to preloaded fonts, unless the changes are authorized by the authors of the macros.” — Donald E. Knuth
+
+1 language: `kk`
+
+> Public domain
+
+1 language: `fi`
+
+> Patterns may be freely distributed
+
+1 language: `gl`
+
+> Unlicence — https://unlicense.org/
+
+1 language: `sa`
+
+> You may freely use, copy, modify and/or distribute this file.


### PR DESCRIPTION
Introduces CONTRIBUTING.md with clear contributor guidance on build/test workflow, mandatory net8.0 test targeting, 90% diff-coverage expectations, testing conventions, documentation/update requirements, and PR expectations. Adds THIRD-PARTY-LICENSES.md to centralize license details for embedded components (PdfSharpCore fork, ExCSS-derived parser, and bundled hyphenation patterns), including provenance and per-license grouping. Also updates CLAUDE.md to reinforce checking local diff coverage before considering non-trivial changes complete.