### PR TITLE
Redesign docs site: custom dark theme, peach logo, marketing landing page, and Support/Sponsorship/License pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,9 @@ Read these before making non-trivial changes in their area — they are the sour
 - [docs/html-css-support.md](docs/html-css-support.md) — full HTML/CSS compatibility matrix (elements, properties, selectors, at-rules, gaps, extensions, PDF metadata extraction, tagged PDF)
 - [docs/supported-svg-features.md](docs/supported-svg-features.md) — full SVG compatibility matrix (inline `<svg>` and standalone), rendered as real vector PDF content
 - [docs/usage-examples.md](docs/usage-examples.md) — copy-pasteable API usage (local HTML, MHTML, HTTP fetch, thread safety, fonts, enabling tagged PDF, ASP.NET Core/Azure Functions)
+- [docs/support.md](docs/support.md) — free (GitHub issues) and paid (Peach State Technologies) support options
+- [docs/sponsorship.md](docs/sponsorship.md) — GitHub Sponsors info; sponsors get paid support under the same terms as customers
+- [docs/license.md](docs/license.md) — BSD 3-Clause license text, third-party component licenses, license FAQ
 - [README.md](README.md) — package overview, install, quick start, fonts
 
 When you add or change user-facing features, update the relevant doc page (and its `README.md`/`docs/getting-started.md` cross-links) in the same change, rather than as a follow-up — this repo's convention (established by the SVG 1.0 coverage work) is docs land with the feature.

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -10,3 +10,5 @@
   url: /usage-examples.html
 - title: API Reference
   url: /api/
+- title: Support
+  url: /support.html

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -45,6 +45,9 @@
         {%- if site.data.version -%}
         <a href="https://github.com/jhaygood86/PeachPDF/releases/tag/v{{ site.data.version.current }}" rel="noopener" title="Release notes">v{{ site.data.version.current }}</a>
         {%- endif -%}
+        <a href="{{ '/support.html' | relative_url }}">Support</a>
+        <a href="{{ '/sponsorship.html' | relative_url }}">Sponsor</a>
+        <a href="{{ '/license.html' | relative_url }}">License</a>
         <a href="https://github.com/jhaygood86/PeachPDF" rel="noopener">GitHub</a>
         <a href="https://www.nuget.org/packages/PeachPDF" rel="noopener">NuGet</a>
       </span>

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -62,13 +62,13 @@ body {
 }
 
 .site-header-inner {
-  max-width: 60rem;
+  max-width: 70rem;
   margin-inline: auto;
   padding: 0 1.25rem;
   height: var(--header-h);
   display: flex;
   align-items: center;
-  gap: 1.5rem;
+  gap: 1.25rem;
 }
 
 .brand {
@@ -114,9 +114,9 @@ body {
 .site-nav a {
   color: var(--muted);
   text-decoration: none;
-  font-size: 0.9rem;
+  font-size: 0.875rem;
   font-weight: 500;
-  padding: 0.3rem 0.7rem;
+  padding: 0.3rem 0.6rem;
   border-radius: 999px;
   transition: color 0.15s, background-color 0.15s;
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -94,5 +94,6 @@ layout: default
 <section class="landing-cta">
   <h2>Ready to render?</h2>
   <code class="install-pill">dotnet add package PeachPDF</code>
-  <p>Free and open source. Available on <a href="https://www.nuget.org/packages/PeachPDF" rel="noopener">NuGet</a>, developed on <a href="https://github.com/jhaygood86/PeachPDF" rel="noopener">GitHub</a>.</p>
+  <p><a href="{{ '/license.html' | relative_url }}">Free and open source</a>. Available on <a href="https://www.nuget.org/packages/PeachPDF" rel="noopener">NuGet</a>, developed on <a href="https://github.com/jhaygood86/PeachPDF" rel="noopener">GitHub</a>.</p>
+  <p>Need help? Free community and paid <a href="{{ '/support.html' | relative_url }}">support options</a> are available.</p>
 </section>

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,0 +1,83 @@
+---
+layout: default
+---
+
+# License
+
+Usage of PeachPDF is **free and open source** under the terms of the **BSD 3-Clause license**. There is no cost, no royalty, and no separate commercial license — the same terms apply to everyone, whether or not you have a [paid support plan](support.md) or [sponsor the project](sponsorship.md).
+
+## License text
+
+```
+Copyright (c) 2009, José Manuel Menéndez Poo
+Copyright (c) 2013, Arthur Teplitzki
+Copyright (c) 2017-2025 Justin Haygood
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+  Neither the name of the menendezpoo.com, ArthurHub nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+## Third-party components
+
+Portions of PeachPDF are sourced from third parties and are licensed under alternative, BSD-compatible permissive license terms:
+
+| Functionality | Origin | License |
+|---|---|---|
+| CSS engine (parsing, CSS-OM) | Fork of [ExCSS](https://github.com/TylerBrinks/ExCSS) (Tyler Brinks) | [MIT](https://github.com/jhaygood86/PeachPDF/blob/main/src/PeachPDF/CSS/license.txt) |
+| PDF engine (document model, PDF writing) | Fork of [PDFsharp](https://github.com/empira/PDFsharp) (empira Software GmbH) | [MIT](https://github.com/jhaygood86/PeachPDF/blob/main/src/PeachPDF/PdfSharpCore/LICENSE.md) |
+| Core HTML rendering engine lineage | Derived from [HtmlRenderer](https://github.com/ArthurHub/HTML-Renderer) (José Manuel Menéndez Poo, Arthur Teplitzki) | BSD 3-Clause (the license above) |
+| Hyphenation pattern data (`hyphens: auto`) | CTAN's [hyph-utf8](https://ctan.org/pkg/hyph-utf8) package | A mix of permissive licenses including MIT and LPPL, plus BSD-style and public-domain patterns. Pattern files under copyleft (GPL/LGPL) or missing license terms are deliberately **not** shipped — see [`hyphens: auto` language coverage](html-css-support.md#hyphens-auto-language-coverage) |
+
+## License FAQ
+
+### Can I use PeachPDF in a commercial product?
+
+Yes. The BSD 3-Clause license permits commercial use with no fees or royalties. Closed-source, SaaS, internal tooling, shipped desktop software — all fine.
+
+### Do I have to open-source my application?
+
+No. BSD 3-Clause is a *permissive* license, not a copyleft one. Using, linking, or embedding PeachPDF places no requirements on your own code's license.
+
+### What am I required to do?
+
+If you redistribute PeachPDF's source code, keep the copyright notice, conditions, and disclaimer intact. If you redistribute it in binary form (which includes shipping an application that bundles it), reproduce the copyright notice, conditions, and disclaimer in your documentation and/or other distribution materials. Consuming the unmodified [NuGet package](https://www.nuget.org/packages/PeachPDF) already carries the project's license notices with it; most applications satisfy the binary-form requirement with an ordinary third-party-notices file or "about" screen entry.
+
+### Can I modify PeachPDF or maintain my own fork?
+
+Yes — modification and redistribution are explicitly permitted, under the same notice conditions above. Contributions back upstream are welcome but never required.
+
+### Can I use the authors' names to promote my product?
+
+No. The third clause forbids using the names of the copyright holders or contributors to endorse or promote derived products without prior written permission. Saying your product *uses* PeachPDF is fine; implying the authors *endorse* your product is not.
+
+### Is there a warranty?
+
+No — the software is provided "as is", without warranty of any kind, and the copyright holders are not liable for damages arising from its use. If you need guaranteed help, response times, or integration assistance, that's exactly what the [paid support plan](support.md#paid-support) is for.
+
+### Does buying paid support or sponsoring change the license?
+
+No. Support and [sponsorship](sponsorship.md) buy help and priority, not different license terms. Everyone uses PeachPDF under the same BSD 3-Clause license.

--- a/docs/sponsorship.md
+++ b/docs/sponsorship.md
@@ -6,6 +6,8 @@ If PeachPDF saves you time or ships in something you're proud of, you can [spons
 
 Sponsors who donate can get **paid support under the same terms** as customers who purchase a formal [paid support plan](support.md#paid-support) — direct email support, priority feature requests and bug fixes, and email-based consulting on how best to use and integrate PeachPDF into your application and workflow.
 
+Every **$25 donated** counts as **1 month of paid support for the sponsor only**. If you donate more than $25, you can choose how the extra applies — **additional developers** on your team or **additional months** of support — by emailing [justin@peachstatetechnologies.com](mailto:justin@peachstatetechnologies.com).
+
 If you'd like your sponsorship to come with support, email [justin@peachstatetechnologies.com](mailto:justin@peachstatetechnologies.com) after sponsoring and mention your GitHub username.
 
 Usage of PeachPDF is free either way — see the [License](license.md) page. Sponsorship is a thank-you, not a requirement.

--- a/docs/sponsorship.md
+++ b/docs/sponsorship.md
@@ -1,0 +1,11 @@
+# Sponsorship
+
+If PeachPDF saves you time or ships in something you're proud of, you can [sponsor jhaygood86 on GitHub](https://github.com/sponsors/jhaygood86) as a thank you. Sponsorship keeps the project's development sustainable — the compatibility matrices, the test suite, and the steady stream of new CSS and SVG coverage all take real time.
+
+## Sponsorship and paid support
+
+Sponsors who donate can get **paid support under the same terms** as customers who purchase a formal [paid support plan](support.md#paid-support) — direct email support, priority feature requests and bug fixes, and email-based consulting on how best to use and integrate PeachPDF into your application and workflow.
+
+If you'd like your sponsorship to come with support, email [justin@peachstatetechnologies.com](mailto:justin@peachstatetechnologies.com) after sponsoring and mention your GitHub username.
+
+Usage of PeachPDF is free either way — see the [License](license.md) page. Sponsorship is a thank-you, not a requirement.

--- a/docs/support.md
+++ b/docs/support.md
@@ -20,4 +20,4 @@ Paid support is provided by **Peach State Technologies**. Email [justin@peachsta
 
 ## Sponsorship as an alternative
 
-Prefer to support the project without a formal contract? [Sponsoring PeachPDF on GitHub](sponsorship.md) is an alternative to a formal support plan — sponsors who donate can get paid support under the same terms as customers who purchase one.
+Prefer to support the project without a formal contract? [Sponsoring PeachPDF on GitHub](sponsorship.md) is an alternative to a formal support plan — sponsors who donate can get paid support under the same terms as customers who purchase one, with every $25 donated counting as one month of support for the sponsor. See [Sponsorship](sponsorship.md) for the details.

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,0 +1,23 @@
+# Support
+
+PeachPDF itself is free and open source under the [BSD 3-Clause license](license.md) — support plans are for help using it, never for the right to use it.
+
+## Community support (free)
+
+Free support for **bug reports, feature requests, and other issues** is available on GitHub — open an issue at [github.com/jhaygood86/PeachPDF/issues](https://github.com/jhaygood86/PeachPDF/issues) and it will be triaged like everything else in the project.
+
+## Paid support
+
+Paid support is available for **$25/month per developer** or **$250/year per developer**, and includes:
+
+- **Direct email support** — a private channel straight to the maintainer, no public issue tracker required.
+- **Priority feature requests and bug fixes** — your reports move to the front of the queue.
+- **Email-based consulting** on how best to use and integrate PeachPDF into your application and workflow.
+
+For an additional cost, **custom development** to integrate PeachPDF into your product is also available.
+
+Paid support is provided by **Peach State Technologies**. Email [justin@peachstatetechnologies.com](mailto:justin@peachstatetechnologies.com) for more details.
+
+## Sponsorship as an alternative
+
+Prefer to support the project without a formal contract? [Sponsoring PeachPDF on GitHub](sponsorship.md) is an alternative to a formal support plan — sponsors who donate can get paid support under the same terms as customers who purchase one.


### PR DESCRIPTION
## Summary

Replaces the stock Cayman GitHub Pages theme with a fully custom, dark-mode-only design for https://peachpdf.net/, adds a marketing-style landing page, reorganizes doc content, and adds Support, Sponsorship, and License pages.

### Dark theme + peach logo
- Custom `docs/_layouts/default.html` + `docs/assets/css/style.css` design system: warm near-black palette, peach primary accent, dark green secondary accents (table headers, h2 rules, blockquotes, footer)
- Hand-authored peach SVG logo (`docs/assets/img/peach.svg`) in the masthead next to the **Peach**PDF gradient wordmark, also used as the favicon
- Sticky translucent header nav (data-driven via `docs/_data/nav.yml`, active-page highlighting incl. `/api/*` → API Reference), horizontally scrollable tables for the compat matrices, dark Rouge syntax palette, `scroll-margin-top` so deep links land clear of the sticky header
- CI-generated `docs/api/` pages pick up the layout automatically (single `default` layout + github-pages default plugin stack); no workflow changes needed for the theme itself

### Marketing landing page + content reorganization
- `docs/index.md` → `docs/index.html`: hero with glowing peach logo and gradient headline, CTA buttons, install pill, six-card feature grid, highlighted quick-start snippet, guide cards, closing CTA
- Old index reference content moved to a new `docs/getting-started.md` (nav's first entry)
- Fonts guide and an "Enabling tagged PDF (PDF/UA) output" example moved into Usage Examples (cross-linked to the HTML support page); PDF metadata extraction moved into HTML & CSS Support; all inbound links updated (`README.md`, compat page, `CLAUDE.md` doc map, `CONTRIBUTING.md`)

### Current version display
- `pages.yml` extracts `<PackageVersion>` from the csproj into git-ignored `docs/_data/version.yml` at build time (same grep `publish.yml` uses)
- Hero shows "Current version: vX.Y.Z — release notes" and the footer links vX.Y.Z on every page, both pointing at the GitHub release tag; renders nothing when the data file is absent (local builds)

### Support, Sponsorship, License pages
- **Support** (in top nav): free community support via GitHub issues; paid support from Peach State Technologies at $25/month or $250/year per developer (direct email support, priority features/bug fixes, email-based integration consulting; custom development at additional cost); sponsorship noted as an alternative
- **Sponsorship**: GitHub Sponsors for @jhaygood86; every $25 donated = 1 month of paid support for the sponsor, larger donations applicable to additional developers or months by email
- **License**: full BSD 3-Clause text, third-party component table (ExCSS + PdfSharpCore forks under MIT, hyph-utf8 hyphenation patterns under mixed permissive licenses incl. MIT/LPPL), and a license-terms FAQ
- All three linked from the footer on every page

### Notes
- `.gitignore`'s global `*.html` rule needed exceptions for `docs/_layouts/*.html` and `docs/index.html`; `docs/license.md` needs explicit front matter because `jekyll-optional-front-matter` excludes files named `license.md` by default
- Nothing deploys from this merge alone — the site goes live on the next release publish or a manual `workflow_dispatch` of `pages.yml`
- Verified locally by building with the github-pages gem (CI's plugin set) and screenshotting every key page at desktop and mobile widths with Chromium, including anchor landings, table scrolling, and title/link rewriting for the generated API pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJLnzj26dUWkxqmxNUHX9B

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJLnzj26dUWkxqmxNUHX9B)_