### PR TITLE
Add "Why PeachPDF?" page with library comparison table to docs site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -423,3 +423,4 @@ FodyWeavers.xsd
 !/docs/_layouts/*.html
 !/docs/index.html
 !/docs/showcase.html
+!/docs/why-peachpdf.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ Pure .NET HTML → PDF rendering library. No external process dependency (no Pup
 Read these before making non-trivial changes in their area — they are the source of truth, not this file:
 
 - [docs/index.html](docs/index.html) — doc site marketing-style landing page (hero, feature cards, guide cards)
+- [docs/why-peachpdf.html](docs/why-peachpdf.html) — "Why PeachPDF?" marketing page: HTML/CSS-as-the-API pitch, free/open-source pitch, comparison table vs other .NET PDF libraries (IronPDF, PuppeteerSharp, DinkToPdf, wkhtmltopdf, Prince, QuestPDF, PDFsharp/MigraDoc, Aspose)
 - [docs/showcase.html](docs/showcase.html) — feature showcase gallery; cards (thumbnail + PDF + HTML-source links) are driven by `site.data.showcases`, which pages.yml generates at site build time by running the TestHarness (`docs/showcase/` and `docs/_data/showcases.json` are gitignored build output, never source)
 - [docs/getting-started.md](docs/getting-started.md) — install, quick start, thread safety / guide index
 - [docs/architecture.md](docs/architecture.md) — how HTML becomes a PDF: parser, DOM, CSS, layout, painting, PDF renderer

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -1,3 +1,5 @@
+- title: Why PeachPDF
+  url: /why-peachpdf.html
 - title: Getting Started
   url: /getting-started.html
 - title: Architecture

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -320,6 +320,19 @@ h4 {
   margin-top: 1.5rem;
 }
 
+.card-grid + .landing-lede,
+table + .landing-lede,
+.table-breakout + .landing-lede {
+  margin-top: 1.5rem;
+}
+
+/* Let a wide table use more than the content column on large screens,
+   centered on the page; the table's own overflow-x still handles the rest. */
+.table-breakout {
+  width: max(100%, min(100vw - 3rem, 78rem));
+  margin-inline: calc((100% - max(100%, min(100vw - 3rem, 78rem))) / 2);
+}
+
 .card {
   background: var(--surface);
   border: 1px solid var(--border);

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,7 @@ layout: default
   <p class="hero-sub">PeachPDF renders HTML, CSS, and SVG straight to vector PDF — entirely in-process. No headless browsers. No native dependencies. Anywhere .NET runs.</p>
   <div class="hero-ctas">
     <a class="btn btn-primary" href="{{ '/getting-started.html' | relative_url }}">Get started</a>
+    <a class="btn btn-ghost" href="{{ '/why-peachpdf.html' | relative_url }}">Why PeachPDF?</a>
     <a class="btn btn-ghost" href="https://github.com/jhaygood86/PeachPDF" rel="noopener">View on GitHub</a>
   </div>
   <code class="install-pill">dotnet add package PeachPDF</code>
@@ -43,6 +44,7 @@ layout: default
       <p>Web fonts via <code>@font-face</code>, fonts loaded from a stream, system font discovery on every platform, and browser-grade weight/style/stretch matching with faux-bold and faux-italic synthesis.</p>
     </div>
   </div>
+  <p class="landing-lede">See how PeachPDF <a href="{{ '/why-peachpdf.html' | relative_url }}">compares to other .NET PDF libraries</a> →</p>
 </section>
 
 <section class="landing-section landing-code">
@@ -64,6 +66,10 @@ layout: default
 <section class="landing-section">
   <h2 class="landing-h2">Dig into the docs</h2>
   <div class="card-grid guide-grid">
+    <a class="card card-link" href="{{ '/why-peachpdf.html' | relative_url }}">
+      <h3>Why PeachPDF?</h3>
+      <p>How it compares to IronPDF, Puppeteer, wkhtmltopdf, QuestPDF, and friends — and why HTML is the right input format.</p>
+    </a>
     <a class="card card-link" href="{{ '/getting-started.html' | relative_url }}">
       <h3>Getting Started</h3>
       <p>Install the package, render your first PDF, and get the thread-safety model right from the start.</p>

--- a/docs/why-peachpdf.html
+++ b/docs/why-peachpdf.html
@@ -1,0 +1,164 @@
+---
+layout: default
+title: Why PeachPDF?
+---
+<section class="landing-section">
+  <h1 class="landing-h2">Why PeachPDF?</h1>
+  <p class="landing-lede">Because you already know how to build documents — you've been doing it in HTML and CSS for years. PeachPDF turns that knowledge into professional vector PDFs, entirely in-process, completely free.</p>
+</section>
+
+<section class="landing-section">
+  <h2 class="landing-h2">The skills you already have are the API</h2>
+  <p class="landing-lede">Most PDF libraries ask you to learn their world. PeachPDF meets you in yours.</p>
+  <div class="card-grid">
+    <div class="card">
+      <h3>No new API to learn</h3>
+      <p>Describe your invoice, report, or contract in HTML and CSS — not in a proprietary document object model or a fluent builder API you'll only ever use for PDFs. If you can write a web page, you can already write a PeachPDF document.</p>
+    </div>
+    <div class="card">
+      <h3>No manual layout</h3>
+      <p>No coordinate math, no measuring strings to see where the next line goes, no hand-rolled pagination. The layout engine handles text flow, tables, flexbox, page breaks, and running headers and footers — you say what the document is, not where every piece sits.</p>
+    </div>
+    <div class="card">
+      <h3>Design tooling you already own</h3>
+      <p>Iterate on your template in a browser, keep it in version control as plain HTML, and hand it to anyone who knows the web. Designers can restyle a document without ever reading C#.</p>
+    </div>
+    <div class="card">
+      <h3>Graphics without a graphics API</h3>
+      <p>Charts, logos, seals, and diagrams go in as inline or standalone <code>&lt;svg&gt;</code> and come out as true vector PDF content — crisp at any zoom, never rasterized, no drawing code required.</p>
+    </div>
+  </div>
+  <p class="landing-lede">See exactly what's supported in the <a href="{{ '/html-css-support.html' | relative_url }}">HTML &amp; CSS compatibility matrix</a> and the <a href="{{ '/supported-svg-features.html' | relative_url }}">SVG feature list</a>.</p>
+</section>
+
+<section class="landing-section">
+  <h2 class="landing-h2">Free and open source — actually</h2>
+  <p class="landing-lede">No asterisks. No trial watermarks. No surprises at renewal time.</p>
+  <div class="card-grid">
+    <div class="card">
+      <h3>BSD-3-Clause licensed</h3>
+      <p>One of the most permissive licenses there is. Use PeachPDF in commercial products, closed-source products, SaaS platforms — anywhere — with no obligation beyond keeping the license notice.</p>
+    </div>
+    <div class="card">
+      <h3>No license keys or fees</h3>
+      <p>No per-developer seats, no per-server pricing, no revenue thresholds that flip a "community" license into an invoice once your business grows. The library is unconditionally free for everyone.</p>
+    </div>
+    <div class="card">
+      <h3>Developed in the open</h3>
+      <p>Every line of source is on <a href="https://github.com/jhaygood86/PeachPDF" rel="noopener">GitHub</a>. Read it, audit it, debug into it, fork it. Optional <a href="{{ '/support.html' | relative_url }}">paid support</a> and <a href="{{ '/sponsorship.html' | relative_url }}">sponsorship</a> exist for teams that want them — the library never depends on either.</p>
+    </div>
+  </div>
+  <p class="landing-lede">Read the full <a href="{{ '/license.html' | relative_url }}">license and FAQ</a>.</p>
+</section>
+
+<section class="landing-section">
+  <h2 class="landing-h2">How PeachPDF compares</h2>
+  <p class="landing-lede">The .NET HTML-to-PDF landscape splits three ways: wrap a browser, wrap a native binary, or make you lay out the PDF in code. PeachPDF takes a fourth path — a real HTML/CSS layout engine written in managed .NET.</p>
+  <div class="table-breakout">
+  <table>
+    <thead>
+      <tr>
+        <th>Library</th>
+        <th>License &amp; cost</th>
+        <th>HTML &amp; CSS input</th>
+        <th>How it renders</th>
+        <th>Native / external dependencies</th>
+        <th>Containers &amp; serverless</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>PeachPDF</strong></td>
+        <td>Free — BSD-3-Clause</td>
+        <td>✅ HTML, CSS, and SVG</td>
+        <td>Own layout engine, fully in-process</td>
+        <td>None — pure managed .NET</td>
+        <td>Excellent — no browser, no native binaries, works in trimmed and AOT deployments</td>
+        <td>Actively developed</td>
+      </tr>
+      <tr>
+        <td>IronPDF</td>
+        <td>Commercial — paid per developer</td>
+        <td>✅ Chromium-grade</td>
+        <td>Embedded Chromium renderer</td>
+        <td>Ships Chromium native binaries with the package</td>
+        <td>Works, but images grow by hundreds of MB</td>
+        <td>Actively developed</td>
+      </tr>
+      <tr>
+        <td>PuppeteerSharp</td>
+        <td>Free — MIT</td>
+        <td>✅ Chrome-grade</td>
+        <td>Drives a headless Chrome in a separate process</td>
+        <td>Downloads a full Chromium build (hundreds of MB)</td>
+        <td>Hard — browser install, sandbox flags, and extra memory in every image</td>
+        <td>Actively developed</td>
+      </tr>
+      <tr>
+        <td>DinkToPdf</td>
+        <td>Free — MIT</td>
+        <td>⚠️ 2012-era WebKit; no flexbox or modern CSS</td>
+        <td>Wraps the native <code>libwkhtmltox</code> library</td>
+        <td>Per-platform native library you deploy yourself</td>
+        <td>Fragile — native loading issues and long-standing thread-safety problems</td>
+        <td>Dormant — no releases in years</td>
+      </tr>
+      <tr>
+        <td>wkhtmltopdf</td>
+        <td>Free — LGPL</td>
+        <td>⚠️ 2012-era WebKit; no flexbox or modern CSS</td>
+        <td>External command-line process</td>
+        <td>Native binary installed on the host</td>
+        <td>Possible, but you're baking an archived tool into new images</td>
+        <td>Archived — deprecated by its maintainers</td>
+      </tr>
+      <tr>
+        <td>Prince (PrinceXML)</td>
+        <td>Commercial — paid per server</td>
+        <td>✅ Excellent, best-in-class paged-media CSS</td>
+        <td>External native process</td>
+        <td>Native binary installed on the host</td>
+        <td>Works, but every container counts as a licensed server</td>
+        <td>Actively developed</td>
+      </tr>
+      <tr>
+        <td>QuestPDF</td>
+        <td>Free under $1M annual revenue, paid above</td>
+        <td>❌ None — code-first fluent C# API</td>
+        <td>Own engine drawing through SkiaSharp</td>
+        <td>SkiaSharp native binaries</td>
+        <td>Good, but every layout is C# code your developers maintain</td>
+        <td>Actively developed</td>
+      </tr>
+      <tr>
+        <td>PDFsharp / MigraDoc</td>
+        <td>Free — MIT</td>
+        <td>❌ None — drawing and document object model</td>
+        <td>Direct PDF drawing; you position content</td>
+        <td>None</td>
+        <td>Good, but all layout is manual</td>
+        <td>Actively developed</td>
+      </tr>
+      <tr>
+        <td>Aspose.PDF</td>
+        <td>Commercial — paid per developer</td>
+        <td>⚠️ HTML conversion with partial CSS fidelity</td>
+        <td>Own converter inside a large general-purpose PDF suite</td>
+        <td>Large closed-source library</td>
+        <td>Works</td>
+        <td>Actively developed</td>
+      </tr>
+    </tbody>
+  </table>
+  </div>
+  <p class="landing-lede">Licensing and pricing details are as of this writing and change over time — always check each vendor's site before deciding.</p>
+  <p class="landing-lede"><strong>Where PeachPDF isn't the right fit:</strong> it doesn't execute JavaScript, and pixel-perfect Chrome parity isn't the goal — if your documents are rendered by client-side scripts, a browser-based tool is the honest recommendation. For everything else, the <a href="{{ '/html-css-support.html' | relative_url }}">compatibility matrix</a> tells you exactly what you get.</p>
+</section>
+
+<section class="landing-cta">
+  <h2>Ready to render?</h2>
+  <code class="install-pill">dotnet add package PeachPDF</code>
+  <p><a href="{{ '/getting-started.html' | relative_url }}">Get started</a> in a few lines, or browse the <a href="{{ '/showcase.html' | relative_url }}">feature showcase</a> to see real output first.</p>
+  <p>Available on <a href="https://www.nuget.org/packages/PeachPDF" rel="noopener">NuGet</a>, developed on <a href="https://github.com/jhaygood86/PeachPDF" rel="noopener">GitHub</a>.</p>
+</section>


### PR DESCRIPTION
New docs/why-peachpdf.html marketing page covering three pillars: build
PDFs with the HTML/CSS/SVG knowledge you already have (no proprietary
API, no manual layout), fully free BSD-3-Clause open source, and a
comparison table against IronPDF, PuppeteerSharp, DinkToPdf, wkhtmltopdf,
Prince, QuestPDF, PDFsharp/MigraDoc, and Aspose.PDF across licensing,
HTML/CSS input, rendering approach, native dependencies,
container/serverless fit, and maintenance status.

Linked from the top nav (first entry), a hero CTA button on the landing
page, a "see how it compares" tie-in under the landing feature cards,
and a new first card in the "Dig into the docs" grid. Adds a
.table-breakout utility so the wide comparison table can use up to 78rem
on large screens while page-level horizontal overflow stays contained,
and spacing for a landing-lede that follows a card grid or table.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W72JcedHiXSH6YNPtK9TUf