### PR TITLE
Fix double-counted table left margins

### DIFF
--- a/src/PeachPDF.TestHarness/showcases.json
+++ b/src/PeachPDF.TestHarness/showcases.json
@@ -1,0 +1,274 @@
+[
+  {
+    "slug": "gradients",
+    "category": "Backgrounds \u0026 Borders",
+    "title": "CSS Gradients",
+    "description": "linear-gradient, radial-gradient, and conic-gradient: directions, angles, multi-stop and hard-stop color lists, and CSS Color Level 4 interpolation spaces.",
+    "pdf": "gradients.pdf",
+    "html": "gradients.html"
+  },
+  {
+    "slug": "border_radius",
+    "category": "Backgrounds \u0026 Borders",
+    "title": "Border Radius",
+    "description": "border-radius from simple uniform rounding to per-corner and elliptical radii, on filled and bordered boxes.",
+    "pdf": "border_radius.pdf",
+    "html": "border_radius.html"
+  },
+  {
+    "slug": "background_origin_clip",
+    "category": "Backgrounds \u0026 Borders",
+    "title": "Background Origin \u0026 Clip",
+    "description": "background-origin and background-clip controlling where a background paints relative to the border, padding, and content boxes.",
+    "pdf": "background_origin_clip.pdf",
+    "html": "background_origin_clip.html"
+  },
+  {
+    "slug": "background_position_size",
+    "category": "Backgrounds \u0026 Borders",
+    "title": "Background Position \u0026 Size",
+    "description": "background-position and background-size combinations: keywords, lengths, percentages, cover, and contain.",
+    "pdf": "background_position_size.pdf",
+    "html": "background_position_size.html"
+  },
+  {
+    "slug": "list_style_image",
+    "category": "Lists \u0026 Generated Content",
+    "title": "List Style Image",
+    "description": "Custom list bullets supplied through list-style-image.",
+    "pdf": "list_style_image.pdf",
+    "html": "list_style_image.html"
+  },
+  {
+    "slug": "marker_styling",
+    "category": "Lists \u0026 Generated Content",
+    "title": "::marker Styling",
+    "description": "Styling list markers with the ::marker pseudo-element, including real per-item numbering via the list-item counter.",
+    "pdf": "marker_styling.pdf",
+    "html": "marker_styling.html"
+  },
+  {
+    "slug": "content_image",
+    "category": "Lists \u0026 Generated Content",
+    "title": "Generated Content Images",
+    "description": "Images inserted through the CSS content property on generated content.",
+    "pdf": "content_image.pdf",
+    "html": "content_image.html"
+  },
+  {
+    "slug": "paged_media",
+    "category": "Paged Media",
+    "title": "Paged Media",
+    "description": "@page rules with margin boxes, running headers and footers, and page counters.",
+    "pdf": "paged_media.pdf",
+    "html": "paged_media.html"
+  },
+  {
+    "slug": "paged_media_named_strings",
+    "category": "Paged Media",
+    "title": "Named Strings",
+    "description": "Running headers populated from document content with string-set and string().",
+    "pdf": "paged_media_named_strings.pdf",
+    "html": "paged_media_named_strings.html"
+  },
+  {
+    "slug": "paged_media_per_page_margins",
+    "category": "Paged Media",
+    "title": "Per-page Margins",
+    "description": "Page margins that vary from page to page using @page selectors.",
+    "pdf": "paged_media_per_page_margins.pdf",
+    "html": "paged_media_per_page_margins.html"
+  },
+  {
+    "slug": "paged_media_named_pages",
+    "category": "Paged Media",
+    "title": "Named Pages",
+    "description": "Routing content to differently-styled pages with named @page rules and the page property.",
+    "pdf": "paged_media_named_pages.pdf",
+    "html": "paged_media_named_pages.html"
+  },
+  {
+    "slug": "paged_media_margin_box_sizing",
+    "category": "Paged Media",
+    "title": "Margin Box Sizing",
+    "description": "Explicit width and height sizing of @page margin boxes.",
+    "pdf": "paged_media_margin_box_sizing.pdf",
+    "html": "paged_media_margin_box_sizing.html"
+  },
+  {
+    "slug": "flexbox",
+    "category": "Layout",
+    "title": "Flexbox",
+    "description": "Flexbox layout: direction, wrapping, justification, alignment, gaps, and flexible item sizing.",
+    "pdf": "flexbox.pdf",
+    "html": "flexbox.html"
+  },
+  {
+    "slug": "custom_properties",
+    "category": "CSS Values \u0026 Functions",
+    "title": "Custom Properties",
+    "description": "CSS custom properties resolved through var(), including fallbacks and cascading overrides.",
+    "pdf": "custom_properties.pdf",
+    "html": "custom_properties.html"
+  },
+  {
+    "slug": "transform",
+    "category": "Graphics \u0026 Effects",
+    "title": "Transforms",
+    "description": "CSS transforms - translate, rotate, scale, skew - with transform-origin control.",
+    "pdf": "transform.pdf",
+    "html": "transform.html"
+  },
+  {
+    "slug": "calc",
+    "category": "CSS Values \u0026 Functions",
+    "title": "calc() \u0026 Math Functions",
+    "description": "calc(), min(), max(), and clamp() expressions resolving against real box dimensions.",
+    "pdf": "calc.pdf",
+    "html": "calc.html"
+  },
+  {
+    "slug": "svg",
+    "category": "Graphics \u0026 Effects",
+    "title": "SVG",
+    "description": "Inline and embedded SVG rendered as true vector PDF content: shapes, paths, gradients, patterns, masks, and text.",
+    "pdf": "svg.pdf",
+    "html": "svg.html"
+  },
+  {
+    "slug": "opacity",
+    "category": "Graphics \u0026 Effects",
+    "title": "Opacity",
+    "description": "Element opacity composited as real group transparency over text, images, and nested content.",
+    "pdf": "opacity.pdf",
+    "html": "opacity.html"
+  },
+  {
+    "slug": "stacking_context",
+    "category": "Graphics \u0026 Effects",
+    "title": "Stacking Contexts",
+    "description": "z-index and stacking contexts: paint order across positioned, floated, and transformed boxes.",
+    "pdf": "stacking_context.pdf",
+    "html": "stacking_context.html"
+  },
+  {
+    "slug": "text_transform",
+    "category": "Typography \u0026 Text",
+    "title": "text-transform",
+    "description": "text-transform variants - uppercase, lowercase, capitalize - applied at render time.",
+    "pdf": "text_transform.pdf",
+    "html": "text_transform.html"
+  },
+  {
+    "slug": "multicol",
+    "category": "Layout",
+    "title": "Multi-column Layout",
+    "description": "CSS multi-column layout: column counts, widths, gaps, and column rules.",
+    "pdf": "multicol.pdf",
+    "html": "multicol.html"
+  },
+  {
+    "slug": "hyphenation_en_us",
+    "category": "Typography \u0026 Text",
+    "title": "Hyphenation \u2014 English (en-US)",
+    "description": "Automatic hyphenation (hyphens: auto) splitting long words at real, language-appropriate break points in a narrow justified column.",
+    "pdf": "hyphenation_en_us.pdf",
+    "html": "hyphenation_en_us.html"
+  },
+  {
+    "slug": "hyphenation_de_de",
+    "category": "Typography \u0026 Text",
+    "title": "Hyphenation \u2014 German (de-DE, reformed orthography default)",
+    "description": "Automatic hyphenation (hyphens: auto) splitting long words at real, language-appropriate break points in a narrow justified column.",
+    "pdf": "hyphenation_de_de.pdf",
+    "html": "hyphenation_de_de.html"
+  },
+  {
+    "slug": "hyphenation_fr",
+    "category": "Typography \u0026 Text",
+    "title": "Hyphenation \u2014 French (fr)",
+    "description": "Automatic hyphenation (hyphens: auto) splitting long words at real, language-appropriate break points in a narrow justified column.",
+    "pdf": "hyphenation_fr.pdf",
+    "html": "hyphenation_fr.html"
+  },
+  {
+    "slug": "hyphenation_ru",
+    "category": "Typography \u0026 Text",
+    "title": "Hyphenation \u2014 Russian (ru, Cyrillic script)",
+    "description": "Automatic hyphenation (hyphens: auto) splitting long words at real, language-appropriate break points in a narrow justified column.",
+    "pdf": "hyphenation_ru.pdf",
+    "html": "hyphenation_ru.html"
+  },
+  {
+    "slug": "tagged_pdf",
+    "category": "Standards \u0026 Accessibility",
+    "title": "Tagged PDF (PDF/UA)",
+    "description": "Accessible, tagged PDF output: a logical structure tree with headings, lists, tables, alt text, links, and tag-type overrides.",
+    "pdf": "tagged_pdf.pdf",
+    "html": "tagged_pdf.html"
+  },
+  {
+    "slug": "border_style",
+    "category": "Backgrounds \u0026 Borders",
+    "title": "Border Styles",
+    "description": "The full set of CSS border styles, from solid and dashed to groove, ridge, inset, and outset.",
+    "pdf": "border_style.pdf",
+    "html": "border_style.html"
+  },
+  {
+    "slug": "vertical_align",
+    "category": "Typography \u0026 Text",
+    "title": "Vertical Align",
+    "description": "vertical-align behaviors for inline content, from baseline and middle to explicit offsets.",
+    "pdf": "vertical_align.pdf",
+    "html": "vertical_align.html"
+  },
+  {
+    "slug": "letter_word_spacing",
+    "category": "Typography \u0026 Text",
+    "title": "Letter \u0026 Word Spacing",
+    "description": "letter-spacing and word-spacing adjustments across text runs.",
+    "pdf": "letter_word_spacing.pdf",
+    "html": "letter_word_spacing.html"
+  },
+  {
+    "slug": "first_letter",
+    "category": "Typography \u0026 Text",
+    "title": "::first-letter",
+    "description": "The ::first-letter pseudo-element: drop-cap style initial letter formatting.",
+    "pdf": "first_letter.pdf",
+    "html": "first_letter.html"
+  },
+  {
+    "slug": "first_line",
+    "category": "Typography \u0026 Text",
+    "title": "::first-line",
+    "description": "The ::first-line pseudo-element styling the first rendered line of a paragraph.",
+    "pdf": "first_line.pdf",
+    "html": "first_line.html"
+  },
+  {
+    "slug": "canvas_background",
+    "category": "Backgrounds \u0026 Borders",
+    "title": "Canvas Background",
+    "description": "CSS1 canvas background propagation: body and html backgrounds covering the full page.",
+    "pdf": "canvas_background.pdf",
+    "html": "canvas_background.html"
+  },
+  {
+    "slug": "font_resolution_showcase",
+    "category": "Typography \u0026 Text",
+    "title": "Font Resolution",
+    "description": "CSS font selection compliance: family matching, weight and style resolution, and fallback behavior.",
+    "pdf": "font_resolution_showcase.pdf",
+    "html": "font_resolution_showcase.html"
+  },
+  {
+    "slug": "acid2",
+    "category": "Standards \u0026 Accessibility",
+    "title": "Acid2",
+    "description": "The unmodified Acid2 test rendered by PeachPDF - the classic CSS compliance smiley.",
+    "pdf": "acid2.pdf",
+    "html": "acid2.html"
+  }
+]

--- a/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTableTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTableTests.cs
@@ -628,6 +628,53 @@ Assert.NotNull(tbody);
             Assert.Equal(1, footerProxies);
         }
 
+        [Fact]
+        public async Task TableLayout_FixedMarginLeft_IsNotDoubleCounted()
+        {
+            // Regression test: CssBox.PerformLayoutImp's Static/Relative branch already positions a
+            // display:table box at ClientLeft + ActualMarginLeft before dispatching into
+            // CssLayoutEngineTable.Layout, which used to unconditionally add
+            // GetActualMarginLeft(_tableBox, GetWidthSum()) again - for a fixed (non-auto)
+            // margin-left that second call returns the same non-zero value (GetWidthSum() only
+            // matters for the auto-margin centering case), so the table ended up shifted an extra
+            // margin-left's worth to the right. Caught on Acid2's own teeth row
+            // ("ul { display: table; margin: -1em 7em 0; }"), which rendered detached to the right
+            // of the chin instead of flush against it.
+            var html = "<html><body><div id='wrap'>" +
+                       "<table id='t' style='margin-left: 50px; margin-top: 0;'><tr><td>A</td></tr></table>" +
+                       "</div></body></html>";
+
+            var (rootBox, _) = await BuildCssBoxTree(html);
+            var wrap = FindById(rootBox, "wrap")!;
+            var table = FindTableBox(rootBox)!;
+
+            Assert.Equal(wrap.ClientLeft + 50, table.Location.X, precision: 3);
+        }
+
+        [Fact]
+        public async Task TableLayout_AutoMargins_CentersTable()
+        {
+            // Regression test for the deferred-centering branch left behind by the fix above:
+            // GetActualMarginLeft(_tableBox) returns 0 during the earlier Static/Relative pass
+            // (boxWidth: null, table width not known yet), so this box's margin-left:auto centering
+            // offset is entirely computed by CssLayoutEngineTable.Layout's own re-application, once
+            // GetWidthSum() is known - that path needs its own coverage, distinct from the
+            // fixed-margin case above.
+            var html = "<html><body><div id='wrap' style='width: 400px;'>" +
+                       "<table id='t' style='width: 100px; margin: 0 auto;'><tr><td>A</td></tr></table>" +
+                       "</div></body></html>";
+
+            var (rootBox, _) = await BuildCssBoxTree(html);
+            var wrap = FindById(rootBox, "wrap")!;
+            var table = FindTableBox(rootBox)!;
+
+            var wrapWidth = wrap.ClientRight - wrap.ClientLeft;
+            var tableWidth = table.ActualRight - table.Location.X;
+            var expectedX = wrap.ClientLeft + (wrapWidth - tableWidth) / 2;
+
+            Assert.Equal(expectedX, table.Location.X, precision: 3);
+        }
+
         #endregion
 
    #region Helper Methods
@@ -668,6 +715,22 @@ using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
   }
 
       return null;
+        }
+
+        private static CssBox? FindById(CssBox box, string id)
+        {
+            var val = box.HtmlTag?.TryGetAttribute("id", "");
+            if (val != null && val.Equals(id, System.StringComparison.OrdinalIgnoreCase))
+                return box;
+
+            foreach (var child in box.Boxes)
+            {
+                var result = FindById(child, id);
+                if (result != null)
+                    return result;
+            }
+
+            return null;
         }
 
         #endregion

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
@@ -168,10 +168,23 @@ namespace PeachPDF.Html.Core.Dom
             // While table width is larger than it should, and width is reducible
             EnforceMinimumSize();
 
-            _tableBox.Location = _tableBox.Location with
+            // CssBox.PerformLayoutImp's Static/Relative branch already positioned this box at
+            // ClientLeft + ActualMarginLeft before dispatching here (ActualMarginLeft calls
+            // GetActualMarginLeft with boxWidth: null). For a fixed (non-auto) margin-left that
+            // call already returns the final pixel value, so re-adding it below would double-count
+            // it - Acid2's own teeth row ("ul { margin: -1em 7em 0; }") landed 63pt too far right
+            // because of exactly this. Only 'margin-left: auto' (table centering, e.g.
+            // 'margin: 0 auto') genuinely needs a second pass here: GetActualMarginLeft
+            // intentionally returns 0 for an auto-margin table when boxWidth is null (the table's
+            // own shrink-to-fit width isn't known yet during the earlier pass), deferring the real
+            // centering offset - now that GetWidthSum() is known - to this point.
+            if (_tableBox.MarginLeft is CssConstants.Auto)
             {
-                X = _tableBox.Location.X + CssLayoutEngine.GetActualMarginLeft(_tableBox, GetWidthSum())
-            };
+                _tableBox.Location = _tableBox.Location with
+                {
+                    X = _tableBox.Location.X + CssLayoutEngine.GetActualMarginLeft(_tableBox, GetWidthSum())
+                };
+            }
 
             // Ensure there's no padding
             _tableBox.PaddingLeft = _tableBox.PaddingTop = _tableBox.PaddingRight = _tableBox.PaddingBottom = "0";


### PR DESCRIPTION
Prevent table layout from reapplying a fixed `margin-left` after `CssBox.PerformLayoutImp` has already positioned the table, while still keeping the deferred `margin: 0 auto` centering path for auto margins. Adds regression coverage for both fixed-margin and auto-centered tables, and updates the generated TestHarness showcase metadata.