### PR TITLE
Add margin-box image content rendering

### DIFF
--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -710,6 +710,8 @@ Margin boxes are sub-rules of `@page` that place text inside the page margins (o
 | `counter(pages)` | `content: counter(pages)` | Total page count |
 | `string(name)` | `content: string(chapter)` | Named string captured via `string-set`; see below |
 | Mixed | `content: "Page " counter(page) " of " counter(pages)` | Concatenated |
+| `url(...)` | `content: url("logo.svg")` | An image (raster or SVG, incl. `data:` URIs) — useful for a logo in a running header. Rendered at natural size, anchored to the box's top-left, clipped to the box. Not combinable with text/counter/string content in the same declaration |
+| Gradient function | `content: linear-gradient(to right, red, blue)` | `linear-gradient()`/`radial-gradient()`/`conic-gradient()` (and their `repeating-` forms), filling the box |
 | `none` | `content: none` | Suppresses the box (useful in `:first` to hide the header on the cover page) |
 
 **Supported style properties in margin boxes:**

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -891,6 +891,7 @@ var pagedMediaHtml = """
     @page {
       size: A4 portrait;
       margin: 25mm 20mm 25mm 20mm;
+      @top-left-corner { content: url('{{PEACH_DATA_URI}}'); }
       @top-left   { content: "Acme Corp"; font-size: 8pt; font-family: Arial; color: #555; }
       @top-center { content: "Annual Report 2025"; font-size: 8pt; font-family: Arial; font-weight: bold; }
       @top-right  { content: "Confidential"; font-size: 8pt; font-family: Arial; color: #cc0000; }
@@ -944,10 +945,11 @@ var pagedMediaHtml = """
 
     </body>
     </html>
-    """;
+    """.Replace("{{PEACH_DATA_URI}}", peachDataUri);
 
 await SaveShowcaseAsync("paged_media", "Paged Media", "Paged Media",
-    "@page rules with margin boxes, running headers and footers, and page counters.",
+    "@page rules with margin boxes, running headers and footers, and page counters, including a " +
+    "url() logo image in a margin box (@top-left-corner).",
     pagedMediaHtml, new PdfGenerateConfig { PageSize = PageSize.A4 });
 
 // ─── CSS Paged Media showcase — named strings (string-set / string()) ──────

--- a/src/PeachPDF.Tests/Integration/MarginBoxRendererImageTests.cs
+++ b/src/PeachPDF.Tests/Integration/MarginBoxRendererImageTests.cs
@@ -1,0 +1,193 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Entities;
+using PeachPDF.PdfSharpCore;
+using PeachPDF.PdfSharpCore.Drawing;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Regression tests for issue #127: a margin box's <c>content: url(...)</c> (per CSS Paged Media
+    /// Level 3 §7, a margin box's <c>content</c> accepts an <c>&lt;image&gt;</c> value, not just
+    /// text/counter/string content) rendered nothing - <see cref="MarginBoxRenderer"/> only ever
+    /// interpreted <c>content</c> as text/counter/string tokens. Fixed by detecting image content
+    /// (mirroring <see cref="CssContentEngine.ApplyContent"/>'s own first-token detection) and
+    /// painting it through the same <see cref="PeachPDF.Html.Core.Handlers.CssImagePainter"/>/
+    /// <see cref="PeachPDF.Html.Core.Handlers.BackgroundImageDrawHandler"/> pipeline already used for
+    /// in-flow <c>content: url(...)</c> (<c>::before</c>/<c>::after</c>).
+    /// </summary>
+    public class MarginBoxRendererImageTests
+    {
+        private const string PngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+        private const string SvgMarkup = """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" width="20" height="20">
+              <circle cx="10" cy="10" r="8" fill="#C97B4A"/>
+            </svg>
+            """;
+
+        private static string SvgDataUri(string markup) =>
+            "data:image/svg+xml;base64," + Convert.ToBase64String(Encoding.UTF8.GetBytes(markup));
+
+        private static async Task<string> GetPdfText(string marginBoxCss)
+        {
+            var html = $$"""
+                <!DOCTYPE html><html><head><style>
+                @page { size: A4; margin: 20mm; {{marginBoxCss}} }
+                </style></head><body><p>content</p></body></html>
+                """;
+
+            var generator = new PdfGenerator();
+            var config = new PdfGenerateConfig { PageSize = PageSize.A4, CompressContentStreams = false };
+            var doc = await generator.GeneratePdf(html, config);
+            var ms = new MemoryStream();
+            doc.Save(ms);
+            return Encoding.Latin1.GetString(ms.ToArray());
+        }
+
+        [Fact]
+        public async Task RasterUrlContent_RendersAsImageXObject()
+        {
+            var pdfText = await GetPdfText($"@top-left {{ content: url(\"data:image/png;base64,{PngBase64}\"); }}");
+
+            Assert.Contains("/Subtype /Image", pdfText);
+        }
+
+        [Fact]
+        public async Task RasterUrlContent_PositionedInsideTopLeftMarginBox_NotElsewhereOnPage()
+        {
+            // A structural/positional check, not just a substring match (per this repo's own testing
+            // conventions: a content-stream token can be present while the actual painted position is
+            // wrong or off-page) - the image's `cm` placement must land inside the top-left margin box
+            // (just right of the 20mm left margin, near the top of the page), not e.g. centered on the
+            // page or clipped away to (0,0).
+            var pdfText = await GetPdfText($"@top-left {{ content: url(\"data:image/png;base64,{PngBase64}\"); }}");
+
+            var match = Regex.Match(pdfText, @"1 0 0 1 (\d+\.\d+) (\d+\.\d+) cm /\w+ Do");
+            Assert.True(match.Success, "Expected an untransformed image `cm ... Do` placement in the content stream.");
+
+            var x = double.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
+            var y = double.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture);
+
+            // 20mm ≈ 56.69pt left margin; PDF's y-axis runs bottom-up, so "near the top of the page"
+            // (A4 = 841.89pt tall) means a y close to the page height, not close to 0.
+            Assert.InRange(x, 50, 70);
+            Assert.InRange(y, 800, 841.89);
+        }
+
+        [Fact]
+        public async Task SvgUrlContent_RendersAsVectorContentNotRasterImage()
+        {
+            var pdfText = await GetPdfText($"@top-left {{ content: url('{SvgDataUri(SvgMarkup)}'); }}");
+
+            // Same CssImagePainter/CreateTile path as background-image/list-style-image/::before
+            // content images - real vector curve operators, never a rasterized /Image XObject.
+            Assert.DoesNotContain("/Subtype /Image", pdfText);
+            Assert.Contains(" c\n", pdfText);
+        }
+
+        [Fact]
+        public async Task ImageContent_SiblingTextMarginBox_StillRendersText()
+        {
+            // The exact shape of issue #127's repro: an image margin box alongside a text one on the
+            // same page - the image must not suppress or break its sibling's own text rendering.
+            var pdfText = await GetPdfText($$"""
+                @top-left { content: url("data:image/png;base64,{{PngBase64}}"); }
+                @top-center { content: "TOP CENTER TEXT"; }
+                """);
+
+            Assert.Contains("/Subtype /Image", pdfText);
+            Assert.Contains("Tj", pdfText);
+        }
+
+        [Fact]
+        public async Task TextContent_StillWorksAfterImageDetectionAdded()
+        {
+            var pdfText = await GetPdfText("@top-left { content: \"hello\"; }");
+
+            Assert.Contains("Tj", pdfText);
+            Assert.DoesNotContain("/Subtype /Image", pdfText);
+        }
+
+        [Fact]
+        public async Task MissingUrlContent_RendersWithoutCrash()
+        {
+            var pdfText = await GetPdfText("@top-left { content: url('nonexistent.png'); }");
+
+            Assert.NotEmpty(pdfText);
+        }
+
+        [Fact]
+        public async Task LinearGradientContent_RendersShading()
+        {
+            var pdfText = await GetPdfText("@top-left { content: linear-gradient(to right, red, blue); width: 40px; height: 20px; }");
+
+            Assert.Contains("/ShadingType", pdfText);
+        }
+
+        // ─── Direct ResolveContentImage unit tests ─────────────────────────────
+
+        [Fact]
+        public async Task ResolveContentImage_UrlContent_ReturnsLoadedImage()
+        {
+            var (adapter, container) = await NewContainer();
+            var cache = new Dictionary<string, CssImage?>();
+
+            var image = await MarginBoxRenderer.ResolveContentImage(
+                $"url(\"data:image/png;base64,{PngBase64}\")", adapter, container, cache);
+
+            var url = Assert.IsType<CssImage.Url>(image);
+            Assert.NotNull(url.Image);
+        }
+
+        [Fact]
+        public async Task ResolveContentImage_TextContent_ReturnsNull()
+        {
+            var (adapter, container) = await NewContainer();
+            var cache = new Dictionary<string, CssImage?>();
+
+            var image = await MarginBoxRenderer.ResolveContentImage("\"hello\"", adapter, container, cache);
+
+            Assert.Null(image);
+        }
+
+        [Fact]
+        public async Task ResolveContentImage_RepeatedCall_ReturnsCachedInstance()
+        {
+            var (adapter, container) = await NewContainer();
+            var cache = new Dictionary<string, CssImage?>();
+            var contentValue = $"url(\"data:image/png;base64,{PngBase64}\")";
+
+            var first = await MarginBoxRenderer.ResolveContentImage(contentValue, adapter, container, cache);
+            var second = await MarginBoxRenderer.ResolveContentImage(contentValue, adapter, container, cache);
+
+            Assert.Same(first, second);
+        }
+
+        private static async Task<(PdfSharpAdapter adapter, HtmlContainerInt container)> NewContainer()
+        {
+            var adapter = new PdfSharpAdapter { PixelsPerPoint = 1.0 };
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml("<html><body><p>content</p></body></html>", null);
+
+            var size = new XSize(595, 842);
+            container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+            container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+            var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            await container.PerformLayout(graphics);
+
+            return (adapter, container);
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssContentEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssContentEngine.cs
@@ -106,7 +106,13 @@ namespace PeachPDF.Html.Core.Dom
             cssBox.Text = contentText.ToString();
         }
 
-        private static bool IsGradientFunctionName(string name) =>
+        /// <summary>
+        /// Shared with <see cref="MarginBoxRenderer.ResolveContentImage"/> - a margin box's own
+        /// <c>content</c> accepts the same <c>&lt;image&gt;</c> value grammar (CSS Paged Media Level 3
+        /// §7), so both places must agree on which function names count as image content rather than
+        /// re-deriving the list independently.
+        /// </summary>
+        internal static bool IsGradientFunctionName(string name) =>
             name is "linear-gradient" or "repeating-linear-gradient"
                  or "radial-gradient" or "repeating-radial-gradient"
                  or "conic-gradient" or "repeating-conic-gradient";

--- a/src/PeachPDF/Html/Core/Dom/MarginBoxRenderer.cs
+++ b/src/PeachPDF/Html/Core/Dom/MarginBoxRenderer.cs
@@ -4,6 +4,7 @@ using PeachPDF.CSS;
 using PeachPDF.Html.Adapters;
 using PeachPDF.Html.Adapters.Entities;
 using PeachPDF.Html.Core.Entities;
+using PeachPDF.Html.Core.Handlers;
 using PeachPDF.Html.Core.Parse;
 using PeachPDF.Html.Core.Utils;
 using PeachPDF.PdfSharpCore.Drawing;
@@ -11,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace PeachPDF.Html.Core.Dom
 {
@@ -27,7 +29,7 @@ namespace PeachPDF.Html.Core.Dom
         /// <c>font-size</c>/<c>font-weight</c>/<c>font-style</c> — per CSS Paged Media, margin boxes
         /// inherit these from their page context.
         /// </summary>
-        public static void Render(
+        public static async Task Render(
             XGraphics g,
             XSize pageSize,
             double marginLeft,
@@ -40,7 +42,9 @@ namespace PeachPDF.Html.Core.Dom
             double pageY,
             IReadOnlyList<NamedString> namedStrings,
             RAdapter adapter,
-            StyleDeclaration? pageStyle)
+            StyleDeclaration? pageStyle,
+            HtmlContainerInt htmlContainer,
+            Dictionary<string, CssImage?> imageCache)
         {
             foreach (var marginRule in margins)
             {
@@ -54,12 +58,19 @@ namespace PeachPDF.Html.Core.Dom
                     contentValue.Equals("normal", StringComparison.OrdinalIgnoreCase))
                     continue;
 
-                var text = ResolveContent(contentValue, pageNumber, totalPages, pageY, pageSize.Height - marginTop - marginBottom, namedStrings);
-                if (text == null)
-                    continue;
-
                 var rect = GetMarginBoxRect(boxName, pageSize, marginLeft, marginTop, marginRight, marginBottom, margins);
                 if (rect.Width <= 0 || rect.Height <= 0)
+                    continue;
+
+                var image = await ResolveContentImage(contentValue, adapter, htmlContainer, imageCache);
+                if (image != null)
+                {
+                    PaintImage(g, image, rect, adapter, htmlContainer);
+                    continue;
+                }
+
+                var text = ResolveContent(contentValue, pageNumber, totalPages, pageY, pageSize.Height - marginTop - marginBottom, namedStrings);
+                if (text == null)
                     continue;
 
                 var font = BuildFont(marginRule.Style, pageStyle, adapter);
@@ -68,6 +79,79 @@ namespace PeachPDF.Html.Core.Dom
 
                 g.DrawString(text, font, brush, rect, format);
             }
+        }
+
+        /// <summary>
+        /// Detects and resolves an <c>&lt;image&gt;</c>-valued <c>content</c> (a bare <c>url()</c>, or
+        /// one of the gradient functions) on a margin box - per CSS Paged Media Level 3 §7, a margin
+        /// box's <c>content</c> accepts an <c>&lt;image&gt;</c> value, not just text/counter/string
+        /// content. Mirrors the same first-token image detection <see cref="CssContentEngine.ApplyContent"/>
+        /// uses for in-flow <c>content</c> (an image value makes the whole declaration an image, not
+        /// text to append to) via the shared <see cref="CssContentEngine.IsGradientFunctionName"/>.
+        /// Loaded images are cached by their raw declaration text across the whole document render,
+        /// since the same margin-box rule (and so the same image) repeats identically on every page.
+        /// </summary>
+        internal static async Task<CssImage?> ResolveContentImage(
+            string contentValue,
+            RAdapter adapter,
+            HtmlContainerInt htmlContainer,
+            Dictionary<string, CssImage?> imageCache)
+        {
+            var tokens = CssValueParser.GetCssTokens(contentValue);
+            if (tokens.Count == 0)
+                return null;
+
+            var first = tokens[0];
+            var isImageContent = first is UrlToken ||
+                (first is FunctionToken ft && CssContentEngine.IsGradientFunctionName(ft.Data));
+            if (!isImageContent)
+                return null;
+
+            if (imageCache.TryGetValue(contentValue, out var cached))
+                return cached;
+
+            var image = new CssValueParser(adapter).ParseImage(contentValue);
+            if (image != null)
+                await image.EnsureLoadedAsync(htmlContainer);
+
+            imageCache[contentValue] = image;
+            return image;
+        }
+
+        /// <summary>
+        /// Paints a margin box's image content via the same <see cref="CssImagePainter"/>/
+        /// <see cref="BackgroundImageDrawHandler"/> pipeline used for in-flow <c>content: url(...)</c>
+        /// (<see cref="CssBox.PaintContentImage"/>) - natural size, anchored at the box's top-left,
+        /// clipped to the box, no repeat, matching that established convention for authored content
+        /// images. <paramref name="g"/> paints in raw, unshrunk PDF-point space (see <see cref="BuildFont"/>'s
+        /// own doc comment), so it's wrapped in a <see cref="GraphicsAdapter"/> with the rect
+        /// pre-multiplied by <c>PixelsPerPoint</c> to cancel that adapter's own division back out.
+        /// <paramref name="htmlContainer"/>'s root box stands in for the (non-existent, for a margin
+        /// box) owning <c>CssBox</c> that <see cref="BackgroundLayerResolver"/> needs for potential
+        /// em/rem length resolution - unreachable for the fixed "left top"/"auto" values used here, but
+        /// a real, already-laid-out box is a safe, defensible fallback if that ever changes.
+        /// </summary>
+        private static void PaintImage(XGraphics g, CssImage image, XRect rect, RAdapter adapter, HtmlContainerInt htmlContainer)
+        {
+            // Root is only ever null before the document's initial layout, which has already run by
+            // the time page rendering (and so margin-box painting) begins - null here would mean
+            // there's no laid-out document at all to be generating a PDF page for.
+            if (htmlContainer.Root is not { } rootBox)
+                return;
+
+            var pixelsPerPoint = (adapter as PdfSharpAdapter)?.PixelsPerPoint ?? 1.0;
+            using var graphicsAdapter = new GraphicsAdapter(adapter, g, pixelsPerPoint);
+            var paintRect = new RRect(rect.X * pixelsPerPoint, rect.Y * pixelsPerPoint, rect.Width * pixelsPerPoint, rect.Height * pixelsPerPoint);
+
+            CssImagePainter.Paint(graphicsAdapter, image, layerIndex: 0, isFirst: true,
+                originRect: paintRect, clipRect: paintRect, roundedClipPath: null,
+                positionList: "left top", sizeList: CssConstants.Auto, repeatList: "no-repeat",
+                attachmentList: CssConstants.Scroll, viewportRect: paintRect, box: rootBox,
+                drawBrush: brush =>
+                {
+                    graphicsAdapter.DrawRectangle(brush, paintRect.X, paintRect.Y, paintRect.Width, paintRect.Height);
+                    brush.Dispose();
+                });
         }
 
         private static string? ResolveContent(
@@ -385,10 +469,16 @@ namespace PeachPDF.Html.Core.Dom
             return null;
         }
 
-        private static XStringFormat BuildStringFormat(StyleDeclaration style, string boxName)
+        private static (string TextAlign, string VerticalAlign) ResolveAlignment(StyleDeclaration style, string boxName)
         {
             var textAlign = style.TextAlign?.ToLowerInvariant() ?? InferAlignment(boxName);
             var verticalAlign = style.VerticalAlign?.ToLowerInvariant() ?? "middle";
+            return (textAlign, verticalAlign);
+        }
+
+        private static XStringFormat BuildStringFormat(StyleDeclaration style, string boxName)
+        {
+            var (textAlign, verticalAlign) = ResolveAlignment(style, boxName);
 
             return (textAlign, verticalAlign) switch
             {

--- a/src/PeachPDF/PdfGenerator.cs
+++ b/src/PeachPDF/PdfGenerator.cs
@@ -260,6 +260,12 @@ namespace PeachPDF
             // paint pass suppressed (see SuppressOwnBackgroundPaint), so it isn't painted twice.
             var canvasBackgroundBox = ResolveCanvasBackground(container.HtmlContainerInt.Root);
 
+            // Margin-box `content: url(...)` images (see MarginBoxRenderer.ResolveContentImage) are
+            // cached by declaration text across the whole document, since the same margin rule - and
+            // so the same image - repeats identically on every page; without this a multi-hundred-page
+            // document would re-decode (or re-fetch, for a network image) the same logo once per page.
+            var marginBoxImageCache = new Dictionary<string, CssImage?>();
+
             // Create a PDF page for each page-slot that would actually show something, per CSS Paged
             // Media Level 3 §3.2 ("User agents SHOULD avoid generating a large number of
             // content-empty pages") - e.g. Acid2's own "100em" margins on "#top"/".picture" are
@@ -357,7 +363,7 @@ namespace PeachPDF
 
                 if (applicableMargins.Count > 0)
                 {
-                    MarginBoxRenderer.Render(
+                    await MarginBoxRenderer.Render(
                         g,
                         orgPageSize,
                         mL,
@@ -370,9 +376,14 @@ namespace PeachPDF
                         pageY,
                         container.NamedStrings,
                         _pdfSharpAdapter,
-                        applicablePageStyle);
+                        applicablePageStyle,
+                        container.HtmlContainerInt,
+                        marginBoxImageCache);
                 }
             }
+
+            foreach (var cachedImage in marginBoxImageCache.Values)
+                cachedImage?.Dispose();
 
             // Finalizes /ParentTree page-keyed entries before HandleLinks (which, when tagging is
             // enabled, appends further annotation-keyed entries to the same tree - see


### PR DESCRIPTION
Implemented support for @page margin-box `content` values that are images (`url(...)` and gradient functions), not just text/counters/strings. `MarginBoxRenderer` now detects and resolves image content, paints it through the existing CSS image pipeline, and is invoked asynchronously from `PdfGenerator` with a per-document cache to avoid repeated image decode/fetch across pages (with proper disposal after rendering). Also exposed shared gradient-name detection in `CssContentEngine`, added integration coverage for raster/SVG/gradient/caching behavior, and updated docs and the paged-media showcase to demonstrate a margin-box logo via `content: url(...)`.

Fixes #127 