### PR TITLE
Document .NET support policy and compare it across libraries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
     # Doc-only PRs shouldn't pay for the full test suite, but this job is a required
     # status check — a trigger-level `paths:` filter would leave it stuck pending and
     # block the merge. So the job always runs; the heavy steps below are gated on
-    # whether anything under src/ (or this workflow) actually changed, and the job
-    # still reports success when they're skipped.
+    # whether anything under src/ actually changed, and the job still reports success
+    # when they're skipped.
     - name: Detect source changes
       uses: dorny/paths-filter@v3
       id: changes
@@ -37,7 +37,6 @@ jobs:
         filters: |
           src:
             - 'src/**'
-            - '.github/workflows/test.yml'
 
     - name: Setup .NET
       if: steps.changes.outputs.src == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,22 @@ jobs:
       with:
         fetch-depth: 0
 
+    # Doc-only PRs shouldn't pay for the full test suite, but this job is a required
+    # status check — a trigger-level `paths:` filter would leave it stuck pending and
+    # block the merge. So the job always runs; the heavy steps below are gated on
+    # whether anything under src/ (or this workflow) actually changed, and the job
+    # still reports success when they're skipped.
+    - name: Detect source changes
+      uses: dorny/paths-filter@v3
+      id: changes
+      with:
+        filters: |
+          src:
+            - 'src/**'
+            - '.github/workflows/test.yml'
+
     - name: Setup .NET
+      if: steps.changes.outputs.src == 'true'
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
@@ -33,32 +48,37 @@ jobs:
           10.0.x
 
     - name: Setup Python
+      if: steps.changes.outputs.src == 'true'
       uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 
     - name: Install fonts (Linux)
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && steps.changes.outputs.src == 'true'
       run: sudo apt-get update && sudo apt-get install -y fontconfig fonts-liberation fonts-dejavu-core
 
     - name: Install diff-cover and ReportGenerator
+      if: steps.changes.outputs.src == 'true'
       run: |
         pip install diff-cover
         dotnet tool install --global dotnet-reportgenerator-globaltool
 
     - name: Restore
+      if: steps.changes.outputs.src == 'true'
       run: dotnet restore src/PeachPDF.Tests/PeachPDF.Tests.csproj
 
     - name: Build
+      if: steps.changes.outputs.src == 'true'
       run: dotnet build src/PeachPDF.Tests/PeachPDF.Tests.csproj --no-restore --configuration Release
 
     # The TestHarness is the showcase generator for the docs site (pages.yml); nothing
     # else builds it in CI, so compile it here to catch breaks before release day.
     - name: Build TestHarness (showcase generator)
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && steps.changes.outputs.src == 'true'
       run: dotnet build src/PeachPDF.TestHarness/PeachPDF.TestHarness.csproj --configuration Release
 
     - name: Install Playwright browsers
+      if: steps.changes.outputs.src == 'true'
       run: |
         $playwrightScript = Get-ChildItem -Path src/PeachPDF.Tests/bin/Release -Filter playwright.ps1 -Recurse | Select-Object -First 1 -ExpandProperty FullName
         if ($IsLinux) {
@@ -68,14 +88,15 @@ jobs:
         }
 
     - name: Test
+      if: steps.changes.outputs.src == 'true'
       run: dotnet test src/PeachPDF.Tests/PeachPDF.Tests.csproj --no-build --configuration Release --logger "trx;LogFileName=test-results.trx" --collect:"XPlat Code Coverage" --settings src/PeachPDF.Tests/coverlet.runsettings --results-directory coverage
 
     - name: Generate HTML coverage report
-      if: always()
+      if: always() && steps.changes.outputs.src == 'true'
       run: reportgenerator -reports:coverage/**/coverage.cobertura.xml -targetdir:coverage-report -reporttypes:Html
 
     - name: Diff coverage gate (PRs only)
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' && steps.changes.outputs.src == 'true'
       run: |
         git fetch origin ${{ github.base_ref }}
         $coverageFiles = (Get-ChildItem -Path coverage -Filter coverage.cobertura.xml -Recurse | ForEach-Object FullName)
@@ -83,14 +104,14 @@ jobs:
 
     - name: Upload test results
       uses: actions/upload-artifact@v4
-      if: always()
+      if: always() && steps.changes.outputs.src == 'true'
       with:
         name: test-results-${{ matrix.os }}
         path: src/PeachPDF.Tests/**/*.trx
 
     - name: Upload coverage reports
       uses: actions/upload-artifact@v4
-      if: always()
+      if: always() && steps.changes.outputs.src == 'true'
       with:
         name: coverage-reports-${{ matrix.os }}
         path: |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See [HTML & CSS Support](https://peachpdf.net/html-css-support.html) for the ful
 
 ## PeachPDF Requirements
 
-- .NET 8 or .NET 10
+- .NET 8 or newer (every currently-supported .NET version, per [Microsoft's .NET support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core))
 
 _Note: This package embeds a fork of PdfSharpCore directly in its source tree; that fork carries its own license (see `src/PeachPDF/PdfSharpCore/LICENSE.md`), but the end result is still open source_
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 PeachPDF is a pure .NET HTML → PDF rendering library. It doesn't shell out to Puppeteer, wkhtmltopdf, or any other external process — everything from HTML parsing to PDF output runs in-process, so it works in virtually any environment where .NET runs (containers, serverless, trimmed/AOT deployments) and benefits automatically from future .NET performance improvements.
 
-Targets .NET 8 and .NET 10.
+**.NET support.** PeachPDF runs on every currently-supported version of .NET — **.NET 8 and newer** — following [Microsoft's .NET support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core). The NuGet package builds against the Long-Term-Support targets (`net8.0` and `net10.0`); the Standard-Term-Support releases in between (such as .NET 9) aren't separate build targets but are fully supported — the `net8.0` build runs on them unchanged.
 
 ## Quick Start
 

--- a/docs/why-peachpdf.html
+++ b/docs/why-peachpdf.html
@@ -55,13 +55,17 @@ title: Why PeachPDF?
       <h3>Developed in the open</h3>
       <p>Every line of source is on <a href="https://github.com/jhaygood86/PeachPDF" rel="noopener">GitHub</a>. Read it, audit it, debug into it, fork it. Optional <a href="{{ '/support.html' | relative_url }}">paid support</a> and <a href="{{ '/sponsorship.html' | relative_url }}">sponsorship</a> exist for teams that want them — the library never depends on either.</p>
     </div>
+    <div class="card">
+      <h3>Runs on every supported .NET</h3>
+      <p>PeachPDF supports <strong>.NET 8 and newer</strong>, in step with <a href="https://dotnet.microsoft.com/platform/support/policy/dotnet-core" rel="noopener">Microsoft's own .NET support policy</a>, and is ready for trimmed and AOT-compiled deployments. When a new .NET lands, PeachPDF is there — no legacy runtime shims to carry.</p>
+    </div>
   </div>
   <p class="landing-lede">Read the full <a href="{{ '/license.html' | relative_url }}">license and FAQ</a>.</p>
 </section>
 
 <section class="landing-section">
   <h2 class="landing-h2">How PeachPDF compares</h2>
-  <p class="landing-lede">The .NET HTML-to-PDF landscape splits three ways: wrap a browser, wrap a native binary, or make you lay out the PDF in code. PeachPDF takes a fourth path — a real HTML/CSS layout engine written in managed .NET.</p>
+  <p class="landing-lede">The .NET HTML-to-PDF landscape splits three ways: wrap a browser, wrap a native binary, or make you lay out the PDF in code. PeachPDF takes a fourth path — a real HTML/CSS layout engine written in managed .NET. The <strong>.NET runtime support</strong> column shows which runtimes each targets.</p>
   <div class="table-breakout">
   <table>
     <thead>
@@ -72,6 +76,7 @@ title: Why PeachPDF?
         <th>How it renders</th>
         <th>Accessible (tagged) PDF</th>
         <th>Native / external dependencies</th>
+        <th>.NET runtime support</th>
         <th>Containers &amp; serverless</th>
         <th>Status</th>
       </tr>
@@ -84,6 +89,7 @@ title: Why PeachPDF?
         <td>Own layout engine, fully in-process</td>
         <td>✅ Optional tagged output with a structure tree; tag mapping customizable per element via CSS (<code>-peachpdf-pdf-tag-type</code>, including <code>none</code> for decorative content)</td>
         <td>None — pure managed .NET</td>
+        <td>✅ .NET 8 and newer — every currently-supported .NET version</td>
         <td>Excellent — no browser, no native binaries, works in trimmed and AOT deployments</td>
         <td>Actively developed</td>
       </tr>
@@ -94,6 +100,7 @@ title: Why PeachPDF?
         <td>Embedded Chromium renderer</td>
         <td>⚠️ PDF/A and PDF/UA export options; no per-element tag control</td>
         <td>Ships Chromium native binaries with the package</td>
+        <td>.NET Framework 4.6.2+, .NET Standard 2.0, .NET Core / .NET 5–10</td>
         <td>Works, but images grow by hundreds of MB</td>
         <td>Actively developed</td>
       </tr>
@@ -104,6 +111,7 @@ title: Why PeachPDF?
         <td>Drives a headless Chrome in a separate process</td>
         <td>⚠️ Chrome can emit tagged PDFs; no tag customization</td>
         <td>Downloads a full Chromium build (hundreds of MB)</td>
+        <td>.NET Standard 2.0 and .NET 8+</td>
         <td>Hard — browser install, sandbox flags, and extra memory in every image</td>
         <td>Actively developed</td>
       </tr>
@@ -114,6 +122,7 @@ title: Why PeachPDF?
         <td>Wraps the native <code>libwkhtmltox</code> library</td>
         <td>❌ Untagged output</td>
         <td>Per-platform native library you deploy yourself</td>
+        <td>.NET Standard 2.0 / .NET Core (dormant)</td>
         <td>Fragile — native loading issues and long-standing thread-safety problems</td>
         <td>Dormant — no releases in years</td>
       </tr>
@@ -124,6 +133,7 @@ title: Why PeachPDF?
         <td>External command-line process</td>
         <td>❌ Untagged output</td>
         <td>Native binary installed on the host</td>
+        <td>Language-agnostic external CLI</td>
         <td>Possible, but you're baking an archived tool into new images</td>
         <td>Archived — deprecated by its maintainers</td>
       </tr>
@@ -134,6 +144,7 @@ title: Why PeachPDF?
         <td>External native process</td>
         <td>✅ Strong tagged / PDF-UA support with CSS tag customization</td>
         <td>Native binary installed on the host</td>
+        <td>Language-agnostic external process</td>
         <td>Works, but every container counts as a licensed server</td>
         <td>Actively developed</td>
       </tr>
@@ -144,6 +155,7 @@ title: Why PeachPDF?
         <td>Own engine drawing through SkiaSharp</td>
         <td>⚠️ PDF/A and PDF/UA conformance in recent versions, from code-first layouts</td>
         <td>SkiaSharp native binaries</td>
+        <td>.NET Framework 4.x, .NET Standard 2.0, .NET 6+</td>
         <td>Good, but every layout is C# code your developers maintain</td>
         <td>Actively developed</td>
       </tr>
@@ -154,6 +166,7 @@ title: Why PeachPDF?
         <td>Direct PDF drawing; you position content</td>
         <td>⚠️ Tagged / PDF-UA output via <code>UAManager</code> in recent versions; structure marked up in code</td>
         <td>None</td>
+        <td>.NET Framework 4.6.2+, .NET Standard 2.0, .NET 6+</td>
         <td>Good, but all layout is manual</td>
         <td>Actively developed</td>
       </tr>
@@ -164,6 +177,7 @@ title: Why PeachPDF?
         <td>Own converter inside a large general-purpose PDF suite</td>
         <td>✅ Tagged PDF via a programmatic tagging API</td>
         <td>Large closed-source library</td>
+        <td>.NET Framework, .NET Standard 2.0, .NET 6+</td>
         <td>Works</td>
         <td>Actively developed</td>
       </tr>


### PR DESCRIPTION
- Add a Microsoft-aligned .NET support policy (.NET 8 and newer, every
  currently-supported version) to getting-started.md and README, replacing
  the narrower "targets .NET 8 and .NET 10" wording.
- Why PeachPDF?: add a "Runs on every supported .NET" card and a
  ".NET runtime support" column to the library comparison table.
- CI: gate the test job's heavy steps on whether src/ (or the workflow
  itself) changed, so doc-only PRs still report a green required check
  without running the full suite.