### PR TITLE
Fix showcase font loading to use base directory instead of cwd

### DIFF
--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -3517,7 +3517,7 @@ await SaveShowcaseAsync("print_catalog", "Real-World Documents", "Print Catalog"
 // for the digit range (U+0030-0039), so digits render in it while letters in the same run fall back to
 // the serif family - a per-character split within one text run, honoring the unicode-range descriptor.
 var monoDigitsFontUri = "data:font/truetype;base64," +
-    Convert.ToBase64String(File.ReadAllBytes("LiberationMono-Regular.ttf"));
+    Convert.ToBase64String(File.ReadAllBytes(Path.Combine(AppContext.BaseDirectory, "LiberationMono-Regular.ttf")));
 var unicodeRangeHtml = $$"""
     <html>
     <head>
@@ -3551,7 +3551,7 @@ await SaveShowcaseAsync("unicode_range", "Fonts & Text", "@font-face unicode-ran
 // subset of Noto Emoji) renders its glyf outlines. Color-glyph tables (COLR/CBDT/sbix) are not
 // composited - outlines only.
 var emojiFontUri = "data:font/truetype;base64," +
-    Convert.ToBase64String(File.ReadAllBytes("NotoEmoji-Regular.ttf"));
+    Convert.ToBase64String(File.ReadAllBytes(Path.Combine(AppContext.BaseDirectory, "NotoEmoji-Regular.ttf")));
 var emojiRow = string.Join(" ", new[] { 0x1F600, 0x1F60A, 0x1F602, 0x1F44D, 0x1F389, 0x1F680, 0x2764 }
     .Select(char.ConvertFromUtf32));
 var grinning = char.ConvertFromUtf32(0x1F600);


### PR DESCRIPTION
## Summary
- The docs-site pages.yml workflow's "Generate feature showcases" step crashed (https://github.com/jhaygood86/PeachPDF/actions/runs/29807433840/job/88560814475) with `FileNotFoundException` for `LiberationMono-Regular.ttf`
- `unicode_range` and `emoji` showcases loaded their bundled `.ttf` fonts via bare relative paths (`File.ReadAllBytes("LiberationMono-Regular.ttf")` / `"NotoEmoji-Regular.ttf"`), which only resolve when the working directory happens to be the build output directory
- The workflow invokes `dotnet run --project ...` from the repo root ($GITHUB_WORKSPACE), so those relative paths pointed at the wrong location and crashed the process (exit 134) before the showcase JSON could be written
- Fixed both to resolve via `AppContext.BaseDirectory`, matching the existing pattern already used for loading `acid2.html` in the same file

## Test plan
- [x] Ran `dotnet run --project PeachPDF.TestHarness/PeachPDF.TestHarness.csproj --configuration Release --framework net10.0 -- <tmp dir>` from the repo root (mirroring the CI invocation) — completes successfully, generating all 40 showcases including `unicode_range.pdf` and `emoji.pdf`