### PR TITLE
Align @page margin-box images per box alignment (fix #140)

### DIFF
--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -748,7 +748,7 @@ Margin boxes are sub-rules of `@page` that place text inside the page margins (o
 | `counter(pages)` | `content: counter(pages)` | Total page count |
 | `string(name)` | `content: string(chapter)` | Named string captured via `string-set`; see below |
 | Mixed | `content: "Page " counter(page) " of " counter(pages)` | Concatenated |
-| `url(...)` | `content: url("logo.svg")` | An image (raster or SVG, incl. `data:` URIs) — useful for a logo in a running header. Rendered at natural size, anchored to the box's top-left, clipped to the box. Not combinable with text/counter/string content in the same declaration |
+| `url(...)` | `content: url("logo.svg")` | An image (raster or SVG, incl. `data:` URIs) — useful for a logo in a running header. Rendered at natural size, aligned within the box by the box's `text-align`/`vertical-align` (same as text content: the default follows the box's position — e.g. `@top-right` end-aligned, `@top-center` centered — and an explicit `text-align`/`vertical-align` applies), clipped to the box. Not combinable with text/counter/string content in the same declaration |
 | Gradient function | `content: linear-gradient(to right, red, blue)` | `linear-gradient()`/`radial-gradient()`/`conic-gradient()` (and their `repeating-` forms), filling the box |
 | `none` | `content: none` | Suppresses the box (useful in `:first` to hide the header on the cover page) |
 

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -953,6 +953,49 @@ await SaveShowcaseAsync("paged_media", "Paged Media", "Paged Media",
     "url() logo image in a margin box (@top-left-corner).",
     pagedMediaHtml, new PdfGenerateConfig { PageSize = PageSize.A4 });
 
+// ─── CSS Paged Media showcase — margin-box image alignment ─────────────────
+
+// A margin box's image content follows the box's alignment exactly as text does (CSS Paged
+// Media Level 3 §7.2): the default follows the box's position - @top-left flush left, @top-center
+// centered, @top-right flush right - and an explicit text-align applies. The same peach logo is
+// dropped into each of the three top boxes with no per-box width, so its horizontal placement is
+// driven purely by alignment; the bottom row adds an explicit text-align: right override.
+var marginImageAlignHtml = """
+    <!DOCTYPE html>
+    <html>
+    <head>
+    <style>
+    @page {
+      size: A4 portrait;
+      margin: 22mm 20mm 22mm 20mm;
+      @top-left    { content: url('{{PEACH_DATA_URI}}'); }
+      @top-center  { content: url('{{PEACH_DATA_URI}}'); }
+      @top-right   { content: url('{{PEACH_DATA_URI}}'); }
+      @bottom-left { content: url('{{PEACH_DATA_URI}}'); text-align: right; }
+      @bottom-right { content: "explicit text-align: right \2192"; font: 8pt Arial; color: #888; vertical-align: middle; }
+    }
+    body { font: 11pt Arial, sans-serif; color: #333; margin: 0; }
+    h1 { font-size: 20pt; margin: 0 0 12pt; }
+    p  { margin: 0 0 8pt; line-height: 1.6; }
+    </style>
+    </head>
+    <body>
+      <h1>Margin-box image alignment</h1>
+      <p>The peach logo appears three times across the top margin: flush to the left in
+      <code>@top-left</code>, centered in <code>@top-center</code>, and flush to the right in
+      <code>@top-right</code> &mdash; each placed purely by the margin box's default alignment,
+      with no explicit box width.</p>
+      <p>In the bottom-left box the logo carries an explicit <code>text-align: right</code>, so it
+      hugs the right edge of its box instead of its default left.</p>
+    </body>
+    </html>
+    """.Replace("{{PEACH_DATA_URI}}", peachDataUri);
+
+await SaveShowcaseAsync("margin_box_image_alignment", "Paged Media", "Margin-box Image Alignment",
+    "An image in a @page margin box follows the box's alignment like text does: default from the " +
+    "box position (@top-left/@top-center/@top-right) plus an explicit text-align override.",
+    marginImageAlignHtml, new PdfGenerateConfig { PageSize = PageSize.A4 });
+
 // ─── CSS Paged Media showcase — named strings (string-set / string()) ──────
 
 var namedStringsHtml = """
@@ -3368,17 +3411,17 @@ var catalogHtml = $$"""
     }
     /* Book-style running furniture, mirrored between left- and right-hand pages:
        the product name sits at the top on the matching (outside) side, aligned to
-       that edge; the company logo (a real image in a margin box) sits at top-center
-       with the box width pinned to the image so it truly centers; the folio sits in
-       the inside (gutter) bottom corner */
+       that edge; the company logo (a real image in a margin box) sits at top-center,
+       centered within the box by the margin box's own default alignment (no explicit
+       box width needed); the folio sits in the inside (gutter) bottom corner */
     @page :right {
       @top-right { content: string(item-name); font: italic 8.5pt Georgia, serif; color: #666; }
-      @top-center { content: url("{{catalogLogoDataUri}}"); width: 20px; }
+      @top-center { content: url("{{catalogLogoDataUri}}"); }
       @bottom-left { content: counter(page); font: 9pt Georgia, serif; color: #8a5a3b; }
     }
     @page :left {
       @top-left { content: string(item-name); font: italic 8.5pt Georgia, serif; color: #666; }
-      @top-center { content: url("{{catalogLogoDataUri}}"); width: 20px; }
+      @top-center { content: url("{{catalogLogoDataUri}}"); }
       @bottom-right { content: counter(page); font: 9pt Georgia, serif; color: #8a5a3b; }
     }
     @page :first {

--- a/src/PeachPDF.Tests/Integration/MarginBoxRendererImageTests.cs
+++ b/src/PeachPDF.Tests/Integration/MarginBoxRendererImageTests.cs
@@ -88,6 +88,117 @@ namespace PeachPDF.Tests.Integration
             Assert.InRange(y, 800, 841.89);
         }
 
+        // ─── Issue #140: margin-box images follow the box's alignment ──────────
+        //
+        // A margin box's image content must be placed within the box the same way its text content
+        // is: per CSS Paged Media Level 3 §7.2 the box's default text-align follows its position
+        // (@top-right end-aligned, @top-center centered) and an explicit text-align applies. Before
+        // the fix a margin-box image was always hard-anchored at the box's content-start (left edge),
+        // ignoring both the default and any explicit alignment. These assert the actual `cm ... Do`
+        // translation (a substring match alone can't tell a right-aligned image from a left-aligned
+        // one), parsing the x coordinate exactly as the top-left test above does.
+
+        private static (double X, double Y) GetImagePlacement(string pdfText)
+        {
+            var match = Regex.Match(pdfText, @"[\d.]+ 0 0 [\d.]+ (\d+\.\d+) (\d+\.\d+) cm /\w+ Do");
+            Assert.True(match.Success, "Expected an axis-aligned image `cm ... Do` placement in the content stream.");
+            return (
+                double.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture),
+                double.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture));
+        }
+
+        [Fact]
+        public async Task RasterUrlContent_TopRight_ImageFlushToRightContentEdge()
+        {
+            var pdfText = await GetPdfText($"@top-right {{ content: url(\"data:image/png;base64,{PngBase64}\"); }}");
+
+            var (x, _) = GetImagePlacement(pdfText);
+
+            // A4 = 595.28pt wide, 20mm ≈ 56.69pt margins → right content edge ≈ 538.58pt. The
+            // 1x1 PNG is 0.75pt wide, so a right-aligned image's left edge lands at ≈537.8, NOT
+            // ~2/3 across the page (where the @top-right box merely begins).
+            Assert.InRange(x, 534, 539);
+        }
+
+        [Fact]
+        public async Task RasterUrlContent_TopCenter_ImageHorizontallyCentered()
+        {
+            var pdfText = await GetPdfText($"@top-center {{ content: url(\"data:image/png;base64,{PngBase64}\"); }}");
+
+            var (x, _) = GetImagePlacement(pdfText);
+
+            // Centered image: its left edge sits half its own 0.75pt width left of the page centre
+            // (595.28 / 2 ≈ 297.64), i.e. ≈297.3 — not the left edge of the centre box (~217).
+            Assert.InRange(x, 295, 300);
+        }
+
+        [Fact]
+        public async Task RasterUrlContent_ExplicitTextAlignRight_OverridesInferredCenter()
+        {
+            // text-align:right on a box whose inferred default is center (@top-center) must move the
+            // image to the right edge of the centre box (contentLeft + tL + tC ≈ 377.9), proving the
+            // explicit value reaches images, not just the position-inferred default.
+            var pdfText = await GetPdfText(
+                $"@top-center {{ content: url(\"data:image/png;base64,{PngBase64}\"); text-align: right; }}");
+
+            var (x, _) = GetImagePlacement(pdfText);
+
+            Assert.InRange(x, 374, 379);
+        }
+
+        [Fact]
+        public async Task RasterUrlContent_ExplicitTextAlignRight_OverridesInferredLeft()
+        {
+            // The mirror case: text-align:right on a box whose inferred default is left (@top-left)
+            // must push the image to the right edge of the left box (contentLeft + tL ≈ 217.3),
+            // rather than staying at the box's left content-start (≈56.7) where it defaults.
+            var pdfText = await GetPdfText(
+                $"@top-left {{ content: url(\"data:image/png;base64,{PngBase64}\"); text-align: right; }}");
+
+            var (x, _) = GetImagePlacement(pdfText);
+
+            Assert.InRange(x, 214, 219);
+        }
+
+        // Vertical alignment: like text, a margin-box image defaults to vertical-align: middle
+        // (centered in the margin band) and honors an explicit top/bottom. PDF's y-axis runs
+        // bottom-up, so a larger y is nearer the top of the page. The top row's boxes are the full
+        // top-margin height (20mm ≈ 56.69pt) tall; a 0.75pt-tall image lands near the page top
+        // (y ≈ 841.1) for `top`, mid-band (y ≈ 813.2) for the middle default, and near the band's
+        // bottom (y ≈ 785.2) for `bottom`.
+
+        [Fact]
+        public async Task RasterUrlContent_DefaultVerticalAlign_CentersInMarginBand()
+        {
+            var pdfText = await GetPdfText($"@top-center {{ content: url(\"data:image/png;base64,{PngBase64}\"); }}");
+
+            var (_, y) = GetImagePlacement(pdfText);
+
+            Assert.InRange(y, 810, 816);
+        }
+
+        [Fact]
+        public async Task RasterUrlContent_VerticalAlignTop_AnchorsToBandTop()
+        {
+            var pdfText = await GetPdfText(
+                $"@top-center {{ content: url(\"data:image/png;base64,{PngBase64}\"); vertical-align: top; }}");
+
+            var (_, y) = GetImagePlacement(pdfText);
+
+            Assert.InRange(y, 839, 841.89);
+        }
+
+        [Fact]
+        public async Task RasterUrlContent_VerticalAlignBottom_AnchorsToBandBottom()
+        {
+            var pdfText = await GetPdfText(
+                $"@top-center {{ content: url(\"data:image/png;base64,{PngBase64}\"); vertical-align: bottom; }}");
+
+            var (_, y) = GetImagePlacement(pdfText);
+
+            Assert.InRange(y, 783, 788);
+        }
+
         [Fact]
         public async Task SvgUrlContent_RendersAsVectorContentNotRasterImage()
         {

--- a/src/PeachPDF.Tests/Integration/MarginBoxRendererImageTests.cs
+++ b/src/PeachPDF.Tests/Integration/MarginBoxRendererImageTests.cs
@@ -305,4 +305,85 @@ namespace PeachPDF.Tests.Integration
             return (adapter, container);
         }
     }
+
+    /// <summary>
+    /// Regression tests for the margin-box <b>text</b> alignment corrected alongside issue #140.
+    /// <c>MarginBoxRenderer.ResolveAlignment</c> is shared between the text
+    /// (<c>BuildStringFormat</c>) and image paths; before the fix its
+    /// <c>?? InferAlignment</c> fallback was dead code (an unset <c>text-align</c> reads as
+    /// <see cref="string.Empty"/>, not <c>null</c>), so every margin box's text was centered within
+    /// its box regardless of position. Per CSS Paged Media Level 3 §7.2 an unset <c>text-align</c>
+    /// must follow the box's position (<c>@top-left</c> start-aligned, <c>@top-right</c> end-aligned,
+    /// <c>@top-center</c> centered). These assert the actual <c>Td</c> x-translation of the running
+    /// header text (a single margin box per case, so its <c>Td</c> is absolute), guarding the text
+    /// path directly rather than only via the image tests.
+    /// </summary>
+    public class MarginBoxRendererTextAlignmentTests
+    {
+        private static async Task<string> GetPdfText(string marginBoxCss)
+        {
+            var html = $$"""
+                <!DOCTYPE html><html><head><style>
+                @page { size: A4; margin: 20mm; {{marginBoxCss}} }
+                </style></head><body><p>body</p></body></html>
+                """;
+
+            var generator = new PdfGenerator();
+            var config = new PdfGenerateConfig { PageSize = PageSize.A4, CompressContentStreams = false };
+            var doc = await generator.GeneratePdf(html, config);
+            var ms = new MemoryStream();
+            doc.Save(ms);
+            return Encoding.Latin1.GetString(ms.ToArray());
+        }
+
+        // The running header text lands high on an A4 page (y ≈ 809.8, well above the body's
+        // y ≈ 762.9); a single margin box emits exactly one `x y Td <glyphs> Tj` whose x is the
+        // absolute left edge of the (aligned) text. PeachPDF uses CID fonts, so the shown text is
+        // hex glyph ids - we key off the y band, not the (unreadable) glyph bytes.
+        private static double GetHeaderTextX(string pdfText)
+        {
+            var match = Regex.Match(pdfText, @"(\d+\.\d+) (8\d\d\.\d+) Td <[0-9A-Fa-f]+> Tj");
+            Assert.True(match.Success, "Expected a running-header `x y Td <...> Tj` text placement in the top band.");
+            return double.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
+        }
+
+        [Fact]
+        public async Task TopLeftDefault_TextIsFlushLeft()
+        {
+            // The key regression guard: before the ResolveAlignment fix this text was centered in the
+            // left box (x ≈ 137); it must now start flush at the left content edge (20mm ≈ 56.69pt).
+            var x = GetHeaderTextX(await GetPdfText("@top-left { content: \"X\"; }"));
+
+            Assert.InRange(x, 54, 62);
+        }
+
+        [Fact]
+        public async Task TopRightDefault_TextIsRightAligned()
+        {
+            // Right-aligned within the rightmost box: the text's right edge meets the right content
+            // edge (≈538.6pt), so its left edge sits distinctly to the right of centre.
+            var x = GetHeaderTextX(await GetPdfText("@top-right { content: \"X\"; }"));
+
+            Assert.InRange(x, 520, 539);
+        }
+
+        [Fact]
+        public async Task TopCenterDefault_TextIsCentered()
+        {
+            // Centered on the page (595.28 / 2 ≈ 297.6), so the text's left edge sits just left of it.
+            var x = GetHeaderTextX(await GetPdfText("@top-center { content: \"X\"; }"));
+
+            Assert.InRange(x, 285, 297);
+        }
+
+        [Fact]
+        public async Task ExplicitTextAlignRight_OverridesInferredLeft()
+        {
+            // text-align:right on a @top-left box (inferred default left) pushes the text to the right
+            // edge of the left box (contentLeft + tL ≈ 217.3), well right of its flush-left default.
+            var x = GetHeaderTextX(await GetPdfText("@top-left { content: \"X\"; text-align: right; }"));
+
+            Assert.InRange(x, 205, 218);
+        }
+    }
 }

--- a/src/PeachPDF/Html/Core/Dom/MarginBoxRenderer.cs
+++ b/src/PeachPDF/Html/Core/Dom/MarginBoxRenderer.cs
@@ -67,7 +67,8 @@ namespace PeachPDF.Html.Core.Dom
                 var image = await ResolveContentImage(contentValue, adapter, htmlContainer, imageCache);
                 if (image != null)
                 {
-                    PaintImage(g, image, rect, adapter, htmlContainer);
+                    var position = ResolveImagePosition(marginRule.Style, boxName);
+                    PaintImage(g, image, rect, position, adapter, htmlContainer);
                     continue;
                 }
 
@@ -127,17 +128,19 @@ namespace PeachPDF.Html.Core.Dom
         /// <summary>
         /// Paints a margin box's image content via the same <see cref="CssImagePainter"/>/
         /// <see cref="BackgroundImageDrawHandler"/> pipeline used for in-flow <c>content: url(...)</c>
-        /// (<see cref="CssBox.PaintContentImage"/>) - natural size, anchored at the box's top-left,
-        /// clipped to the box, no repeat, matching that established convention for authored content
-        /// images. <paramref name="g"/> paints in raw, unshrunk PDF-point space (see <see cref="BuildFont"/>'s
+        /// (<see cref="CssBox.PaintContentImage"/>) - natural size, aligned within the box per
+        /// <paramref name="positionList"/> (a CSS <c>background-position</c> value derived from the
+        /// box's resolved <c>text-align</c>/<c>vertical-align</c>, so an image follows the same
+        /// alignment its text content would - CSS Paged Media Level 3 §7.2), clipped to the box, no
+        /// repeat. <paramref name="g"/> paints in raw, unshrunk PDF-point space (see <see cref="BuildFont"/>'s
         /// own doc comment), so it's wrapped in a <see cref="GraphicsAdapter"/> with the rect
         /// pre-multiplied by <c>PixelsPerPoint</c> to cancel that adapter's own division back out.
         /// <paramref name="htmlContainer"/>'s root box stands in for the (non-existent, for a margin
         /// box) owning <c>CssBox</c> that <see cref="BackgroundLayerResolver"/> needs for potential
-        /// em/rem length resolution - unreachable for the fixed "left top"/"auto" values used here, but
+        /// em/rem length resolution - unreachable for the keyword position/"auto" values used here, but
         /// a real, already-laid-out box is a safe, defensible fallback if that ever changes.
         /// </summary>
-        private static void PaintImage(XGraphics g, CssImage image, XRect rect, RAdapter adapter, HtmlContainerInt htmlContainer)
+        private static void PaintImage(XGraphics g, CssImage image, XRect rect, string positionList, RAdapter adapter, HtmlContainerInt htmlContainer)
         {
             // Root is only ever null before the document's initial layout, which has already run by
             // the time page rendering (and so margin-box painting) begins - null here would mean
@@ -151,7 +154,7 @@ namespace PeachPDF.Html.Core.Dom
 
             CssImagePainter.Paint(graphicsAdapter, image, layerIndex: 0, isFirst: true,
                 originRect: paintRect, clipRect: paintRect, roundedClipPath: null,
-                positionList: "left top", sizeList: CssConstants.Auto, repeatList: "no-repeat",
+                positionList: positionList, sizeList: CssConstants.Auto, repeatList: "no-repeat",
                 attachmentList: CssConstants.Scroll, viewportRect: paintRect, box: rootBox,
                 drawBrush: brush =>
                 {
@@ -508,9 +511,45 @@ namespace PeachPDF.Html.Core.Dom
 
         private static (string TextAlign, string VerticalAlign) ResolveAlignment(StyleDeclaration style, string boxName)
         {
-            var textAlign = style.TextAlign?.ToLowerInvariant() ?? InferAlignment(boxName);
-            var verticalAlign = style.VerticalAlign?.ToLowerInvariant() ?? "middle";
+            // StyleDeclaration.TextAlign/VerticalAlign return string.Empty (not null) for an unset
+            // property, so a null-coalescing fallback never fires - an unset text-align must fall
+            // through to the box's position-inferred default (CSS Paged Media Level 3 §7.2), not an
+            // empty string. Check for empty explicitly.
+            var textAlign = string.IsNullOrWhiteSpace(style.TextAlign)
+                ? InferAlignment(boxName)
+                : style.TextAlign.ToLowerInvariant();
+            var verticalAlign = string.IsNullOrWhiteSpace(style.VerticalAlign)
+                ? "middle"
+                : style.VerticalAlign.ToLowerInvariant();
             return (textAlign, verticalAlign);
+        }
+
+        /// <summary>
+        /// Translates a margin box's resolved <c>(text-align, vertical-align)</c> - the same alignment
+        /// its text content uses (defaulting from the box's position per CSS Paged Media Level 3 §7.2,
+        /// via <see cref="ResolveAlignment"/>/<see cref="InferAlignment"/>) - into a CSS
+        /// <c>background-position</c> string, so <c>&lt;image&gt;</c>-valued <c>content</c> is placed
+        /// within the box exactly as text would be, instead of always at the box's content-start.
+        /// Mirror of <see cref="BuildStringFormat"/> for the image paint path.
+        /// </summary>
+        private static string ResolveImagePosition(StyleDeclaration style, string boxName)
+        {
+            var (textAlign, verticalAlign) = ResolveAlignment(style, boxName);
+
+            var horizontal = textAlign switch
+            {
+                "left" => "left",
+                "right" => "right",
+                _ => "center",
+            };
+            var vertical = verticalAlign switch
+            {
+                "top" => "top",
+                "bottom" => "bottom",
+                _ => "center",
+            };
+
+            return $"{horizontal} {vertical}";
         }
 
         private static XStringFormat BuildStringFormat(StyleDeclaration style, string boxName)


### PR DESCRIPTION
Fixes #140.

## Problem

An image in a `@page` margin box (`content: url(...)`) was always painted at the box's content-start (top-left), ignoring the box's alignment, while text content already followed `text-align`/`vertical-align`. Per CSS Paged Media Level 3 §7.2 a margin box's default `text-align` follows its position (`@top-right` end-aligned, `@top-center` centered) and an explicit `text-align` applies — images should follow the same rules as text.

## Fix

`MarginBoxRenderer.PaintImage` now takes a `background-position` derived from the box's resolved alignment (new `ResolveImagePosition` helper, a mirror of `BuildStringFormat`) instead of a hardcoded `"left top"`, so the existing image paint pipeline (`CssImagePainter` → `BackgroundImageDrawHandler` → `BackgroundLayerResolver.ResolvePosition`) places the image within the box exactly as text is placed.

This also fixes a latent bug in the shared `ResolveAlignment`: `StyleDeclaration.TextAlign`/`VerticalAlign` return `string.Empty` (not `null`) when unset, so the `?? InferAlignment` fallback was dead code and the per-position default never applied. An unset `text-align` now correctly falls through to the position-inferred default for **both** text and image content — so margin-box text is edge-aligned per its position as the spec requires (previously it was always centered within its box). No existing test asserted the old centered-text behavior, and the full suite stays green.

## Verification

- Full suite passes (0 failures); 11 new positional regression tests (image + text, horizontal + vertical + explicit `text-align`/`vertical-align` overrides), asserting the actual `cm ... Do` / `Td ... Tj` translations rather than substrings.
- 100% diff coverage on changed lines.
- Rasterized the new showcase with both PDFium and MuPDF — they agree exactly: `@top-left`/`@top-center`/`@top-right` render flush-left / centered / flush-right, and an explicit `text-align: right` hugs the box's right edge.

## Docs & showcase

- `docs/html-css-support.md`: the `url(...)` margin-box content row now documents that image content is aligned within the box per `text-align`/`vertical-align` (default from the box position), not anchored top-left.
- `src/PeachPDF.TestHarness/Program.cs`: added a "Margin-box Image Alignment" showcase demonstrating the three horizontal alignments plus an explicit override, and removed the now-unnecessary explicit box-width workaround from the print-catalog logo (it still centers correctly).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuwW9RZrC4o7TBEoGBBGYX)_