### PR TITLE
Keep brush (gradient) strokes opaque and reset their color space (fix #134)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ If a new or changed feature gives PeachPDF a new visible capability, add a new s
 - `src/PeachPDF.TestHarness/` — a runnable showcase app for visually exercising features (`Program.cs`).
 - `src/PeachPDF.Benchmarks/` — BenchmarkDotNet project.
 - Working directory for `dotnet build`/`dotnet test` is `src/` — if a shell session resets to repo root, commands silently fail with "Project file does not exist"; always confirm you're in `src/` first.
+- If the .NET SDK is missing (e.g. a fresh sandboxed/web session), install it with `apt` — `sudo apt-get install -y dotnet-sdk-10.0` (add `aspnetcore-runtime-8.0` so the net8.0 target framework can run). The `dot.net/v1/dotnet-install.sh` route is blocked in this environment (the Microsoft CDN host returns 403 through the egress proxy), so apt is the working path. `global.json` pins SDK 10.0.100 (rollForward `latestFeature`), which the apt `dotnet-sdk-10.0` (10.0.1xx) satisfies.
 
 ## Critical: `dotnet test` invocation
 

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -1945,6 +1945,11 @@ var svgHtml = "<!DOCTYPE html><html><head>" + SvgShowcaseCss + "</head><body>" +
             $"""<svg viewBox="0 0 100 100" width="80" height="80"><polygon points="{StarPoints}" fill="none" stroke="#c0392b" stroke-width="3"/></svg>""",
             "fill=\"none\" stroke=\"#c0392b\"")
     ) +
+    Row(
+        SvgSwatch("gradient stroke (rounded rect + ellipse)",
+            """<svg viewBox="0 0 100 100" width="80" height="80"><defs><linearGradient id="gs1" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#c0392b"/><stop offset="1" stop-color="#2980b9"/></linearGradient></defs><rect x="10" y="12" width="80" height="34" rx="8" fill="none" stroke="url(#gs1)" stroke-width="6"/><ellipse cx="50" cy="72" rx="38" ry="20" fill="none" stroke="url(#gs1)" stroke-width="6"/></svg>""",
+            "stroke=\"url(#gradient)\" on a rounded rect and an ellipse - a gradient stroke sharing a page with solid strokes")
+    ) +
 
     "<h2>5 — Group Opacity &amp; Transforms</h2>" +
     Row(

--- a/src/PeachPDF.Tests/Integration/SvgGradientStrokeAlphaTests.cs
+++ b/src/PeachPDF.Tests/Integration/SvgGradientStrokeAlphaTests.cs
@@ -1,0 +1,128 @@
+using PeachPDF.PdfSharpCore;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Regression coverage for issue #134: a brush-backed stroke pen (SVG stroke="url(#gradient)")
+    /// carries no meaningful pen.Color - its constructor leaves Color at the default transparent
+    /// black (alpha 0). RealizePen used pen.Color.A to drive the stroke's constant alpha /CA, so a
+    /// gradient stroke emitted right after any opaque solid stroke got /CA 0 and became invisible.
+    /// </summary>
+    public class SvgGradientStrokeAlphaTests
+    {
+        private static async Task<string> GetPdfText(string svg)
+        {
+            var html = $"<!DOCTYPE html><html><head><style>body {{ margin: 0; }}</style></head><body>{svg}</body></html>";
+            var generator = new PdfGenerator();
+            var config = new PdfGenerateConfig { PageSize = PageSize.A4, CompressContentStreams = false };
+            config.SetMargins(20);
+            var doc = await generator.GeneratePdf(html, config);
+            var ms = new MemoryStream();
+            doc.Save(ms);
+            return Encoding.Latin1.GetString(ms.ToArray());
+        }
+
+        // The issue's minimal repro shape: an opaque solid stroke immediately followed by a gradient
+        // (brush) stroke - the ordering that poisoned the realized stroke alpha to 0.
+        private const string SolidThenGradientSvg =
+            "<svg width=\"300\" height=\"120\" viewBox=\"0 0 300 120\" xmlns=\"http://www.w3.org/2000/svg\">" +
+            "<defs><linearGradient id=\"g\" x1=\"0\" y1=\"0\" x2=\"1\" y2=\"1\">" +
+            "<stop offset=\"0\" stop-color=\"#c00\"/><stop offset=\"1\" stop-color=\"#00c\"/></linearGradient></defs>" +
+            "<rect x=\"10\" y=\"10\" width=\"120\" height=\"100\" fill=\"none\" stroke=\"#0a0\" stroke-width=\"8\"/>" +
+            "<ellipse cx=\"230\" cy=\"60\" rx=\"60\" ry=\"50\" fill=\"none\" stroke=\"url(#g)\" stroke-width=\"8\"/>" +
+            "</svg>";
+
+        [Fact]
+        public async Task GradientStrokeAfterOpaqueStroke_DoesNotZeroTheStrokeAlpha()
+        {
+            var pdfText = await GetPdfText(SolidThenGradientSvg);
+
+            // Every stroke here is fully opaque, so no ExtGState may set the constant stroke alpha to
+            // zero. Parse the actual ExtGState objects and assert none carries "/CA 0" - a zeroed /CA
+            // is exactly what made the gradient stroke invisible.
+            foreach (Match obj in Regex.Matches(pdfText, @"\d+ 0 obj(.*?)endobj", RegexOptions.Singleline))
+            {
+                var body = obj.Groups[1].Value;
+                if (!body.Contains("/ExtGState"))
+                    continue;
+
+                var ca = Regex.Match(body, @"/CA\s+([0-9.]+)");
+                if (ca.Success)
+                    Assert.NotEqual(0.0, double.Parse(ca.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture));
+            }
+        }
+
+        [Fact]
+        public async Task GradientStrokeAfterOpaqueStroke_StillEmitsItsShadingPatternStroke()
+        {
+            var pdfText = await GetPdfText(SolidThenGradientSvg);
+
+            // The opaque solid stroke establishes its DeviceRGB color, then the gradient stroke must
+            // switch to the shading pattern and paint through it (SCN) - both must be present, and in
+            // that order, for the trigger condition to actually be exercised.
+            var solidStrokeIndex = pdfText.IndexOf(" RG\n", StringComparison.Ordinal);
+            var patternStrokeIndex = pdfText.IndexOf("/Pattern CS", StringComparison.Ordinal);
+
+            Assert.True(solidStrokeIndex >= 0, "expected the opaque solid stroke to realize a DeviceRGB stroke color");
+            Assert.True(patternStrokeIndex >= 0, "expected the gradient stroke to realize a shading pattern");
+            Assert.True(solidStrokeIndex < patternStrokeIndex, "the solid stroke must precede the gradient stroke to reproduce the bug");
+            Assert.Contains(" SCN\n", pdfText);
+            Assert.Contains("/ShadingType", pdfText);
+        }
+
+        [Fact]
+        public async Task SolidStrokeAfterGradientStroke_ReestablishesItsOwnColor()
+        {
+            // A gradient stroke switches the stroke color space to /Pattern. A following solid stroke
+            // must re-emit its own DeviceRGB color (RG) so it strokes in that color rather than silently
+            // reusing the previous shape's shading pattern (which rendered a "black" stroke as the
+            // gradient). This mirrors how the fill side already handles a solid fill after a pattern fill.
+            var svg =
+                "<svg width=\"300\" height=\"120\" viewBox=\"0 0 300 120\" xmlns=\"http://www.w3.org/2000/svg\">" +
+                "<defs><linearGradient id=\"g\" x1=\"0\" y1=\"0\" x2=\"1\" y2=\"0\">" +
+                "<stop offset=\"0\" stop-color=\"#c00\"/><stop offset=\"1\" stop-color=\"#00c\"/></linearGradient></defs>" +
+                "<ellipse cx=\"70\" cy=\"60\" rx=\"50\" ry=\"45\" fill=\"none\" stroke=\"url(#g)\" stroke-width=\"8\"/>" +
+                "<rect x=\"170\" y=\"15\" width=\"110\" height=\"90\" fill=\"none\" stroke=\"#000\" stroke-width=\"8\"/>" +
+                "</svg>";
+
+            var pdfText = await GetPdfText(svg);
+
+            // The gradient stroke's pattern is set up first...
+            var patternStrokeIndex = pdfText.IndexOf("/Pattern CS", StringComparison.Ordinal);
+            Assert.True(patternStrokeIndex >= 0, "expected the gradient stroke to realize a shading pattern");
+
+            // ...and after it, the black solid stroke must re-establish a DeviceRGB stroke color (RG),
+            // so it is not left stroking in the /Pattern color space.
+            var solidStrokeIndex = pdfText.IndexOf(" RG\n", patternStrokeIndex, StringComparison.Ordinal);
+            Assert.True(solidStrokeIndex > patternStrokeIndex,
+                "a solid stroke following a gradient stroke must re-emit its RG color, not reuse the pattern");
+        }
+
+        [Fact]
+        public async Task SemiTransparentGradientStrokeAfterOpaqueStroke_KeepsItsSoftMaskAlpha()
+        {
+            // A gradient with a translucent stop still carries real transparency via its own soft-mask
+            // ExtGState (a /SMask), which must survive - the fix only stops pen.Color from driving the
+            // constant /CA, it must not suppress genuine gradient transparency.
+            var svg =
+                "<svg width=\"300\" height=\"120\" viewBox=\"0 0 300 120\" xmlns=\"http://www.w3.org/2000/svg\">" +
+                "<defs><linearGradient id=\"g\" x1=\"0\" y1=\"0\" x2=\"1\" y2=\"0\">" +
+                "<stop offset=\"0\" stop-color=\"#c00\" stop-opacity=\"0.2\"/><stop offset=\"1\" stop-color=\"#00c\"/></linearGradient></defs>" +
+                "<rect x=\"10\" y=\"10\" width=\"120\" height=\"100\" fill=\"none\" stroke=\"#0a0\" stroke-width=\"8\"/>" +
+                "<ellipse cx=\"230\" cy=\"60\" rx=\"60\" ry=\"50\" fill=\"none\" stroke=\"url(#g)\" stroke-width=\"12\"/>" +
+                "</svg>";
+
+            var pdfText = await GetPdfText(svg);
+
+            Assert.Contains("/SMask", pdfText);
+            Assert.DoesNotContain("/CA 0\n", pdfText);
+        }
+    }
+}

--- a/src/PeachPDF/PdfSharpCore/Drawing.Pdf/PdfGraphicsState.cs
+++ b/src/PeachPDF/PdfSharpCore/Drawing.Pdf/PdfGraphicsState.cs
@@ -198,7 +198,11 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             }
             else if (colorMode != PdfColorMode.Cmyk)
             {
-                if (_realizedStrokeColor.Rgb != color.Rgb)
+                // The IsEmpty guard mirrors the fill side (RealizeFillColor): after a brush/pattern
+                // stroke the tracked color is reset to Empty, and a following solid stroke must then
+                // re-emit its DeviceRGB color to switch the stroke color space back out of /Pattern -
+                // otherwise it would silently keep stroking with the previous shape's shading pattern.
+                if (_realizedStrokeColor.IsEmpty || _realizedStrokeColor.Rgb != color.Rgb)
                 {
                     _renderer.Append(PdfEncoders.ToString(color, PdfColorMode.Rgb));
                     _renderer.Append(" RG\n");
@@ -213,17 +217,30 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
                 }
             }
 
-            if (_renderer.Owner.Version >= 14 && (_realizedStrokeColor.A != color.A || _realizedStrokeOverPrint != overPrint))
+            // A pen that strokes with a brush (e.g. an SVG stroke="url(#gradient)") carries no
+            // meaningful pen.Color: the brush constructor leaves it at the default transparent black,
+            // so color.A is 0. The brush itself supplies the stroke's color, and any real transparency
+            // rides the brush's own soft-mask ExtGState (see RealizeBrush), so the constant stroke
+            // alpha must stay fully opaque. Driving /CA from color.A here would emit /CA 0 and make the
+            // whole brush stroke invisible whenever the previously realized stroke alpha wasn't already
+            // 0 (e.g. right after any opaque solid stroke).
+            double strokeAlpha = pen.Brush != null ? 1.0 : color.A;
+
+            if (_renderer.Owner.Version >= 14 && (_realizedStrokeColor.A != strokeAlpha || _realizedStrokeOverPrint != overPrint))
             {
-                PdfExtGState extGState = _renderer.Owner.ExtGStateTable.GetExtGStateStroke(color.A, overPrint);
+                PdfExtGState extGState = _renderer.Owner.ExtGStateTable.GetExtGStateStroke(strokeAlpha, overPrint);
                 string gs = _renderer.Resources.AddExtGState(extGState);
                 _renderer.AppendFormatString("{0} gs\n", gs);
 
                 // Must create transparency group.
-                if (_renderer._page != null && color.A < 1)
+                if (_renderer._page != null && strokeAlpha < 1)
                     _renderer._page.TransparencyUsed = true;
             }
-            _realizedStrokeColor = color;
+            // A brush stroke switched the stroke color space to /Pattern and painted through the brush;
+            // invalidate the tracked stroke color (as RealizeBrush already does for the fill side) so a
+            // following solid stroke re-establishes its own DeviceRGB/CMYK color instead of reusing this
+            // pattern. Solid strokes keep tracking their realized color for the dedup above.
+            _realizedStrokeColor = pen.Brush != null ? XColor.Empty : color;
             _realizedStrokeOverPrint = overPrint;
         }
 


### PR DESCRIPTION
A pen that strokes with a brush - an SVG stroke="url(#gradient)" - carries no
meaningful pen.Color: the XPen brush constructor leaves Color at the default
transparent black (alpha 0). RealizePen drove the PDF constant stroke alpha /CA
from pen.Color.A, so a gradient stroke emitted right after any opaque solid
stroke got /CA 0 and rendered completely invisible. This is the reported
"stroked <ellipse> omits its stroke" symptom: in the repro the ellipse's
gradient stroke follows an opaque solid-stroked rect, which had set the realized
stroke alpha to 1, so the ellipse's /CA 0 zeroed it out. A gradient stroke
rendered in isolation was unaffected, which is why it looked ellipse-specific.

Fix: for a brush-backed pen the constant stroke alpha stays fully opaque (1.0);
the brush supplies the stroke color, and any genuine gradient transparency is
carried by the brush's own soft-mask /SMask ExtGState (see RealizeBrush /
PdfShading.BuildAlphaExtGStateIfNeeded), independent of /CA.

Also fixes a sibling defect in the same method: a solid stroke following a
gradient stroke reused the gradient's /Pattern color space (a "black" stroke
painted as the gradient) because the tracked stroke color was never invalidated
after a pattern stroke. Now RealizePen invalidates _realizedStrokeColor after a
brush stroke and re-emits the DeviceRGB stroke color when the tracked color is
empty - mirroring what the fill side (RealizeFillColor / RealizeBrush) already
does.

Verified by rasterizing the repro in both PDFium and MuPDF. Adds
SvgGradientStrokeAlphaTests covering: no /CA 0 for an opaque gradient stroke
after a solid stroke, the shading pattern is still emitted, a semi-transparent
gradient stroke keeps its soft-mask alpha, and a solid stroke after a gradient
re-establishes its own color. Adds a gradient-stroke showcase swatch.

Fixes #134