### PR TITLE
Let author display override UA table display

### DIFF
--- a/src/PeachPDF.Tests/Integration/AnonymousTableBoxIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/AnonymousTableBoxIntegrationTests.cs
@@ -123,16 +123,17 @@ namespace PeachPDF.Tests.Integration
         }
 
         [Fact]
-        public async Task MisparentedTableCell_WrappedInAnonymousRow_AtItsOriginalDocumentPosition()
+        public async Task MisparentedTableCell_WrappedInAnonymousRowThenTable_AtItsOriginalDocumentPosition()
         {
-            // Rule 3.1 (CorrectAnonymousTablesGenerateMissingParents): a `table-cell` box whose parent
-            // isn't a `table-row` must be wrapped in an anonymous `table-row`, positioned via
-            // SetBeforeBox at the cell's original index among its siblings - not appended at the end,
-            // which would silently reorder it after later, unrelated siblings. No `display:table`
-            // ancestor here deliberately - rule 3.1 fires purely off "table-cell whose parent isn't
-            // table-row", regardless of any table context; wrapping this in `display:table` would
-            // instead hit rule 2.1 first (a `table-cell` isn't a "proper child of table", only of
-            // table-row, so it groups into an anonymous row before rule 3.1 ever gets a chance to run).
+            // Two rules fire in sequence (CorrectAnonymousTablesGenerateMissingParents):
+            //   3.1 — a `table-cell` whose parent isn't a `table-row` is wrapped in an anonymous
+            //         `table-row` (both cells group into one, at cell1's original index);
+            //   3.2 — that anonymous `table-row`, now a proper table child under a non-table parent
+            //         (the body), is itself misparented and must be wrapped in an anonymous `table`.
+            // Both wrappers are positioned via SetBeforeBox at the run's original index among its
+            // siblings - not appended at the end, which would silently reorder it after later,
+            // unrelated siblings. No `display:table` ancestor here deliberately - rule 3.1 fires purely
+            // off "table-cell whose parent isn't table-row", regardless of any table context.
             var html = """
                 <!DOCTYPE html><html><head></head><body>
                   <div class="before"></div>
@@ -150,13 +151,20 @@ namespace PeachPDF.Tests.Integration
             var cell1 = FindByClass(root, "cell1")!;
             var cell2 = FindByClass(root, "cell2")!;
 
+            // 3.1: both cells share one anonymous table-row.
             var anonRow = cell1.ParentBox!;
             Assert.Equal(CssConstants.TableRow, anonRow.Display);
             Assert.Same(anonRow, cell2.ParentBox);
 
-            // The anonymous row must sit between "before" and "after" in document order, not after
+            // 3.2: the anonymous row is wrapped in an anonymous table (the table formatting context the
+            // stray cells require per CSS2.1 §17.2.1) — without it the row would render outside any table.
+            var anonTable = anonRow.ParentBox!;
+            Assert.Null(anonTable.HtmlTag);
+            Assert.Equal(CssConstants.Table, anonTable.Display);
+
+            // The synthesized table must sit between "before" and "after" in document order, not after
             // "after" (which is what a naive append-at-the-end would produce).
-            Assert.Equal(new[] { before, anonRow, after }, body.Boxes);
+            Assert.Equal(new[] { before, anonTable, after }, body.Boxes);
         }
 
         // ─── Helpers ─────────────────────────────────────────────────────────────

--- a/src/PeachPDF.Tests/Integration/TableDisplayOverrideTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableDisplayOverrideTests.cs
@@ -1,0 +1,116 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Utils;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// An author (or inline) <c>display</c> declaration on a table-tagged element must override the
+    /// UA-stylesheet <c>display: table-*</c> per the CSS cascade
+    /// (<see href="https://www.w3.org/TR/css-cascade-5/#cascade-origin">CSS Cascade 5 §6.3</see>) and
+    /// <see href="https://www.w3.org/TR/css-display-3/">CSS Display 3</see>. PeachPDF previously blocked
+    /// this via a deliberate gate (<c>DomParser.IsStyleOnElementAllowed</c>) that forced
+    /// <c>table</c>/<c>tr</c>/<c>td</c>/<c>th</c>/<c>thead</c>/<c>tbody</c> back to their default table
+    /// display. Removing that gate is what lets a CSS framework like Charts.css reset a semantic
+    /// <c>&lt;table&gt;</c> to <c>display:block</c>/<c>flex</c>. Everything downstream is already driven by
+    /// the computed <c>Display</c> value (anonymous-table fixup, layout-engine selection), so the override
+    /// flows through correctly.
+    /// </summary>
+    public class TableDisplayOverrideTests
+    {
+        [Theory]
+        [InlineData("block")]
+        [InlineData("flex")]
+        [InlineData("inline-block")]
+        [InlineData("none")]
+        public async Task InlineDisplay_OnTable_OverridesUaTableDisplay(string display)
+        {
+            var root = await BuildOnly($"""
+                <!DOCTYPE html><html><head></head><body>
+                <table class="t" style="display:{display}"></table>
+                </body></html>
+                """);
+
+            Assert.Equal(display, FindByClass(root, "t")!.Display);
+        }
+
+        [Fact]
+        public async Task InlineDisplayFlex_OnTableCell_OverridesTableCell()
+        {
+            var root = await BuildOnly("""
+                <!DOCTYPE html><html><head></head><body>
+                <table><tr><td class="c" style="display:flex"></td></tr></table>
+                </body></html>
+                """);
+
+            Assert.Equal(CssConstants.Flex, FindByClass(root, "c")!.Display);
+        }
+
+        [Fact]
+        public async Task StylesheetRule_ResetsWholeTableToBlock()
+        {
+            // The Charts.css reset shape: `table.x { display:block }` on the table plus a descendant
+            // rule resetting every table-internal element. Each must beat its UA table-* default.
+            var root = await BuildOnly("""
+                <!DOCTYPE html><html><head><style>
+                table.x { display: block }
+                table.x thead, table.x tbody, table.x tr, table.x th, table.x td { display: block }
+                </style></head><body>
+                <table class="x">
+                  <thead><tr><th class="h">H</th></tr></thead>
+                  <tbody><tr class="r"><td class="d">D</td></tr></tbody>
+                </table>
+                </body></html>
+                """);
+
+            Assert.Equal(CssConstants.Block, FindByClass(root, "x")!.Display);
+            Assert.Equal(CssConstants.Block, FindByClass(root, "r")!.Display);
+            Assert.Equal(CssConstants.Block, FindByClass(root, "d")!.Display);
+            Assert.Equal(CssConstants.Block, FindByClass(root, "h")!.Display);
+        }
+
+        [Fact]
+        public async Task TableWithoutOverride_StillDefaultsToTableDisplay()
+        {
+            // Guard: with no author override, the UA default still wins (the fix removes a gate, it does
+            // not change UA defaults).
+            var root = await BuildOnly("""
+                <!DOCTYPE html><html><head></head><body>
+                <table class="t"><tr class="r"><td class="d">D</td></tr></table>
+                </body></html>
+                """);
+
+            Assert.Equal(CssConstants.Table, FindByClass(root, "t")!.Display);
+            Assert.Equal(CssConstants.TableRow, FindByClass(root, "r")!.Display);
+            Assert.Equal(CssConstants.TableCell, FindByClass(root, "d")!.Display);
+        }
+
+        private static async Task<CssBox> BuildOnly(string html)
+        {
+            var adapter = new PdfSharpAdapter { PixelsPerPoint = 1.0 };
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            Assert.NotNull(container.Root);
+            return container.Root!;
+        }
+
+        private static CssBox? FindByClass(CssBox box, string className)
+        {
+            var val = box.HtmlTag?.TryGetAttribute("class", "");
+            if (val != null && val.Split(' ').Contains(className))
+                return box;
+
+            foreach (var child in box.Boxes)
+            {
+                var found = FindByClass(child, className);
+                if (found != null) return found;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/TableDisplayOverrideTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableDisplayOverrideTests.cs
@@ -2,6 +2,8 @@ using PeachPDF.Adapters;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Utils;
+using PeachPDF.PdfSharpCore.Drawing;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -86,6 +88,80 @@ namespace PeachPDF.Tests.Integration
             Assert.Equal(CssConstants.Table, FindByClass(root, "t")!.Display);
             Assert.Equal(CssConstants.TableRow, FindByClass(root, "r")!.Display);
             Assert.Equal(CssConstants.TableCell, FindByClass(root, "d")!.Display);
+        }
+
+        // --- Partial overrides: only a subset of the table's elements is reset (the common, natural case,
+        // and the one that regressed). A proper table child left under a now-non-table parent must still be
+        // wrapped in an anonymous table box (CSS2.1 §17.2.1 rule 3.2) so its content survives layout. These
+        // drive real layout (not just the parsed Display value) so content loss cannot hide. ---
+
+        [Theory]
+        [InlineData("""<table style="display:block"><tr><td class="d">CELL</td></tr></table>""")]
+        [InlineData("""<table><tr style="display:block"><td class="d">CELL</td></tr></table>""")]
+        [InlineData("""<table style="display:inline"><tr><td class="d">CELL</td></tr></table>""")]
+        public async Task PartialOverride_KeepsDescendantContent(string tableMarkup)
+        {
+            var (root, _) = await BuildAndLayout($"<!DOCTYPE html><html><body>{tableMarkup}</body></html>");
+
+            var words = CollectWords(root);
+            Assert.Contains("CELL", words);
+
+            // The proper table child under the non-table parent must have been re-wrapped in a synthesized
+            // (tag-less) anonymous table box so the table formatting context — and the content — is preserved.
+            Assert.Contains(EnumerateBoxes(root),
+                b => b.HtmlTag is null && b.Display is CssConstants.Table or CssConstants.InlineTable);
+        }
+
+        [Fact]
+        public async Task DisplayFlexTable_LaysChildrenOutAsAFlexContainer()
+        {
+            // A table reset to display:flex with two block children must lay them out side by side (distinct,
+            // increasing X), i.e. behave as a real flex container rather than a table.
+            var (root, _) = await BuildAndLayout("""
+                <!DOCTYPE html><html><head><style>
+                .row { display: flex }
+                .row > div { width: 40px; height: 20px }
+                </style></head><body>
+                <table class="row"><div class="a">A</div><div class="b">B</div></table>
+                </body></html>
+                """);
+
+            var a = FindByClass(root, "a")!;
+            var b = FindByClass(root, "b")!;
+
+            Assert.Equal(CssConstants.Flex, FindByClass(root, "row")!.Display);
+            Assert.True(b.Location.X > a.Location.X,
+                $"flex items should lay out left-to-right, but a.X={a.Location.X} b.X={b.Location.X}");
+            Assert.Equal(a.Location.Y, b.Location.Y, 3);
+        }
+
+        private static IEnumerable<CssBox> EnumerateBoxes(CssBox box)
+        {
+            yield return box;
+            foreach (var child in box.Boxes)
+                foreach (var descendant in EnumerateBoxes(child))
+                    yield return descendant;
+        }
+
+        private static List<string> CollectWords(CssBox box) =>
+            EnumerateBoxes(box).SelectMany(b => b.Words.Select(w => w.Text)).ToList();
+
+        private static async Task<(CssBox root, HtmlContainerInt container)> BuildAndLayout(string html)
+        {
+            var adapter = new PdfSharpAdapter { PixelsPerPoint = 1.0 };
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            var size = new XSize(595, 842);
+            container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+            container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+            var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            return (container.Root!, container);
         }
 
         private static async Task<CssBox> BuildOnly(string html)

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -1797,22 +1797,47 @@ namespace PeachPDF.Html.Core.Parse
 
             if (DomUtils.IsProperTableChild(box))
             {
-                var isMissingParent = box.ParentBox is null;
-                var isParentNotTable = box.ParentBox?.Display is not CssConstants.Table;
-                var isParentNotInlineTable = box.ParentBox?.Display is not CssConstants.InlineTable;
+                // CSS2.1 §17.2.1 rule 3.2 — whether a proper table child is misparented depends on the
+                // child's own type, not merely on whether it has a parent:
+                //   - a 'table-row' is misparented unless its parent is a row group box or a table/inline-table;
+                //   - a 'table-column' is misparented unless its parent is a table-column-group or a table/inline-table;
+                //   - a row group, 'table-column-group', or 'table-caption' is misparented unless its parent is a table/inline-table.
+                // (The prior condition AND-ed in "parent is null", which collapsed the whole test to
+                // "parent is null" and never wrapped a proper table child under a non-null, non-table
+                // parent — so e.g. a `<table style="display:block">`'s rows, or the anonymous row synthesized
+                // around cells under a `display:block` `<tr>`, lost their table box and silently dropped all
+                // content. That case only became reachable once author `display` could override table tags.)
+                var parent = box.ParentBox;
+                var parentIsTable = parent?.Display is CssConstants.Table or CssConstants.InlineTable;
 
-                var isMisparented = isMissingParent && isParentNotTable && isParentNotInlineTable;
+                var isMisparented = parent is null || box.Display switch
+                {
+                    CssConstants.TableRow => !parentIsTable && !parent.IsTableRowGroupBox,
+                    CssConstants.TableColumn => !parentIsTable && parent.Display is not CssConstants.TableColumnGroup,
+                    _ => !parentIsTable // row group, table-column-group, or table-caption
+                };
 
                 if (isMisparented)
                 {
-                    var parentDisplay = box.ParentBox is null || box.ParentBox.IsBlock ? CssConstants.Table : CssConstants.InlineTable;
+                    var originalParent = box.ParentBox;
+                    var parentDisplay = originalParent is null || originalParent.IsBlock ? CssConstants.Table : CssConstants.InlineTable;
 
                     var followingMatchingSiblings =
                         DomUtils.GetFollowingSiblings(box, DomUtils.IsProperTableChild, true)
                             .ToList();
 
-                    var tableBox = new CssBox(box.ParentBox, null);
+                    var tableBox = new CssBox(originalParent, null);
                     tableBox.Display = parentDisplay;
+
+                    // Position the synthesized table at the child's original index in the grandparent (the
+                    // constructor only appends it) — same as the SetBeforeBox in rules 2.1/2.3/3.1 — so it
+                    // takes the child's place in document order instead of drifting to the end once the child
+                    // is reparented into it. Skipped only when the child was the root (no parent to order in).
+                    if (originalParent is not null)
+                    {
+                        tableBox.SetBeforeBox(box);
+                    }
+
                     box.ParentBox = tableBox;
 
                     followingMatchingSiblings.ForEach(sib => sib.ParentBox = tableBox);

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -938,8 +938,7 @@ namespace PeachPDF.Html.Core.Parse
                 {
                     // A later plain value supersedes an earlier deferred var() value for the same property.
                     pendingVarProperties.Remove(prop.Name);
-                    if (IsStyleOnElementAllowed(box, prop.Name, value))
-                        CssUtils.SetPropertyValue(valueParser, box, prop.Name, value);
+                    CssUtils.SetPropertyValue(valueParser, box, prop.Name, value);
                 }
             }
         }
@@ -1043,14 +1042,14 @@ namespace PeachPDF.Html.Core.Parse
                     var longhandValue = longhand.HasValue && longhand.Value != CssConstants.Initial
                         ? longhand.Value
                         : CssDefaults.GetInitialValue(longhand.Name);
-                    if (longhandValue is not null && IsStyleOnElementAllowed(box, longhand.Name, longhandValue))
+                    if (longhandValue is not null)
                         CssUtils.SetPropertyValue(valueParser, box, longhand.Name, longhandValue);
                 }
 
                 return;
             }
 
-            if (reparsed is { HasValue: true } property && IsStyleOnElementAllowed(box, name, property.Value))
+            if (reparsed is { HasValue: true } property)
                 CssUtils.SetPropertyValue(valueParser, box, name, property.Value);
         }
 
@@ -1064,38 +1063,6 @@ namespace PeachPDF.Html.Core.Parse
             return CssDefaults.InheritedProperties.Contains(propName) && box.ParentBox != null
                 ? CssUtils.GetPropertyValue(box.ParentBox, propName)
                 : CssDefaults.GetInitialValue(propName);
-        }
-
-        /// <summary>
-        /// Check if the given style is allowed to be set on the given css box.<br/>
-        /// Used to prevent invalid CssBoxes creation like table with inline display style.
-        /// </summary>
-        /// <param name="box">the css box to assign css to</param>
-        /// <param name="key">the style key to check</param>
-        /// <param name="value">the style value to check</param>
-        /// <returns>true - style allowed, false - not allowed</returns>
-        private static bool IsStyleOnElementAllowed(CssBox box, string key, string value)
-        {
-            if (box.HtmlTag == null || key != HtmlConstants.Display) return true;
-
-            if (value is CssConstants.None)
-            {
-                return true;
-            }
-
-            return box.HtmlTag.Name.ToLowerInvariant() switch
-            {
-                HtmlConstants.Table => value == CssConstants.Table,
-                HtmlConstants.Tr => value == CssConstants.TableRow,
-                HtmlConstants.Tbody => value == CssConstants.TableRowGroup,
-                HtmlConstants.Thead => value == CssConstants.TableHeaderGroup,
-                HtmlConstants.Tfoot => value == CssConstants.TableFooterGroup,
-                HtmlConstants.Col => value == CssConstants.TableColumn,
-                HtmlConstants.Colgroup => value == CssConstants.TableColumnGroup,
-                HtmlConstants.Td or HtmlConstants.Th => value == CssConstants.TableCell,
-                HtmlConstants.Caption => value == CssConstants.TableCaption,
-                _ => true
-            };
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

An author (or inline) `display` declaration on a table-tagged element — `table`, `tr`, `td`, `th`, `thead`, `tbody`, `tfoot`, `caption`, `col`, `colgroup` — was silently dropped by a gate (`DomParser.IsStyleOnElementAllowed`) that forced these elements back to their UA default `display: table-*`, keeping only `display: none` as an exception.

This violates the CSS cascade ([CSS Cascade 5 §6.3](https://www.w3.org/TR/css-cascade-5/#cascade-origin)) and [CSS Display 3](https://www.w3.org/TR/css-display-3/): an author `display` declaration overrides the UA `display: table-*`. There is no spec basis for forcing table tags back to their default.

## Change

Remove the gate so the override wins by the normal cascade. This is safe because everything downstream is already driven by the **computed `Display` value**, not the tag name:
- the anonymous-table fixup passes (`CorrectAnonymousTables*`) key off `box.Display`;
- layout-engine selection (`CssBox.PerformLayoutImp`) picks flex/table/block by `Display`.

So a `td` set to `display: block`/`flex` is no longer treated as a table cell — which is what lets a pure-CSS charting framework (e.g. Charts.css) reset a semantic `<table>` into a flex layout.

## Why

This is the first of a stacked series enabling a Charts.css showcase. Without it, a `<table class="charts-css">` renders as a plain table instead of a chart.

## Tests

- New `TableDisplayOverrideTests`: inline and stylesheet `display` overrides on the table and each internal element (including a full Charts.css-style reset), plus a guard that the UA default still applies when there is no override.
- Full net8.0 suite green (4496 passed, 0 failed) — no table/Acid2/anonymous-table regressions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5W74ou6ZHgzScpiHjikGx)_