### PR TITLE
Preserve both positions of a two-position gradient color stop

### DIFF
--- a/src/PeachPDF.Tests/CSS/Gradient.cs
+++ b/src/PeachPDF.Tests/CSS/Gradient.cs
@@ -311,6 +311,39 @@ namespace PeachPDF.Tests.CSS
             Assert.False(backgroundImage.IsInitial);
         }
 
+        [Theory]
+        // <color-stop-length> = <length-percentage>{1,2} (CSS Images 4 §3.5.1). Both positions must survive
+        // serialization: the render layer (CssValueParser.ParseLinearGradient) reads the property's value
+        // and expands two positions into two stops, so dropping one here collapsed the solid band. This
+        // asserts the non-lossy value directly - the LinearGradientIntegrationTests only check that a
+        // stitching function is present, which is true with or without the dropped position.
+        [InlineData("background-image: linear-gradient(red 0 50%, blue 50% 100%)",
+            "linear-gradient(rgb(255, 0, 0) 0 50%, rgb(0, 0, 255) 50% 100%)")]
+        [InlineData("background-image: linear-gradient(90deg, red 0 8px, blue)",
+            "linear-gradient(90deg, rgb(255, 0, 0) 0 8px, rgb(0, 0, 255))")]
+        [InlineData("background-image: radial-gradient(red 0 8px, blue)",
+            "radial-gradient(rgb(255, 0, 0) 0 8px, rgb(0, 0, 255))")]
+        public void GradientTwoPositionColorStopRoundTrips(string snippet, string expected)
+        {
+            var property = ParseDeclaration(snippet);
+            Assert.IsType<BackgroundImageProperty>(property);
+            var backgroundImage = (BackgroundImageProperty)property;
+            Assert.True(backgroundImage.HasValue);
+            Assert.Equal(expected, backgroundImage.Value);
+        }
+
+        [Theory]
+        // Single-position and no-position stops, plus a bare-position colour hint, are unaffected; three
+        // positions on one stop and two bare positions with no colour remain invalid.
+        [InlineData("background-image: linear-gradient(red 50%, blue)", true)]
+        [InlineData("background-image: linear-gradient(red, 25%, blue)", true)]
+        [InlineData("background-image: linear-gradient(red 0 25% 50%, blue)", false)]
+        [InlineData("background-image: linear-gradient(0 50%, blue)", false)]
+        public void GradientColorStopValidity(string snippet, bool valid)
+        {
+            var property = ParseDeclaration(snippet);
+            Assert.Equal(valid, ((BackgroundImageProperty)property).HasValue);
+        }
     }
 }
 

--- a/src/PeachPDF.Tests/Integration/LinearGradientIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/LinearGradientIntegrationTests.cs
@@ -106,12 +106,17 @@ namespace PeachPDF.Tests.Integration
         [Fact]
         public async Task HardStopShorthand_ExpandsToTwoStops()
         {
-            // red 0 50%, blue 50% 100% — each stop with two positions should expand
+            // "red 0 50%, blue 50% 100%" expands to four stops (red@0, red@50%, blue@50%, blue@100%),
+            // producing a hard colour edge at 50%. A merely-present /FunctionType is not enough to prove
+            // that: if either stop's first position is dropped the value collapses to "red 50%, blue 100%",
+            // a single smooth interpolation with no stitching, which still emits a /FunctionType. Assert the
+            // stitching structure instead - a type-3 function whose /Bounds place a coincident pair at the
+            // 0.5 hard edge - so the test actually fails if a position is lost.
             var pdfText = await GetPdfText(GradientHtml("background-image: linear-gradient(to right, red 0 50%, blue 50% 100%);"));
 
             Assert.Contains("/ShadingType", pdfText);
-            // Two-position shorthand expands to 4 stops, requiring a stitching function
-            Assert.Contains("/FunctionType", pdfText);
+            Assert.Contains("/FunctionType 3", pdfText);
+            Assert.Matches(@"/Bounds\s*\[\s*0?\.5\s+0?\.5\s*\]", pdfText);
         }
 
         // ── Phase A: color hints ──────────────────────────────────────────

--- a/src/PeachPDF/CSS/ValueConverters/GradientConverter.cs
+++ b/src/PeachPDF/CSS/ValueConverters/GradientConverter.cs
@@ -39,19 +39,32 @@ namespace PeachPDF.CSS
         private static IPropertyValue ToGradientStop(List<Token> value)
         {
             var color = default(IPropertyValue);
-            var position = default(IPropertyValue);
+            var firstPosition = default(IPropertyValue);
+            var secondPosition = default(IPropertyValue);
             var items = value.ToItems();
 
             if (items.Count != 0)
             {
-                position = LengthOrPercentConverter.Convert(items[items.Count - 1]);
+                firstPosition = LengthOrPercentConverter.Convert(items[items.Count - 1]);
 
-                if (position != null)
+                if (firstPosition != null) items.RemoveAt(items.Count - 1);
+            }
+
+            // <color-stop-length> = <length-percentage>{1,2} (CSS Images 4 §3.5.1): a stop may carry two
+            // positions, equivalent to two same-colour stops, one at each position. Parsing right-to-left,
+            // the position taken above is the second (rightmost); a position immediately before it is the
+            // first. Both are kept, in source order, so the value round-trips as authored - the render
+            // layer (CssValueParser.ParseLinearGradient) reads the property's serialized value and already
+            // expands two positions into two stops, so dropping one here collapsed the solid band it draws.
+            if (firstPosition != null && items.Count != 0)
+            {
+                var earlier = LengthOrPercentConverter.Convert(items[items.Count - 1]);
+
+                if (earlier != null)
                 {
+                    secondPosition = firstPosition;
+                    firstPosition = earlier;
                     items.RemoveAt(items.Count - 1);
-                    // Two-position shorthand: "red 0 50%" — discard the extra position token
-                    if (items.Count != 0 && LengthOrPercentConverter.Convert(items[items.Count - 1]) != null)
-                        items.RemoveAt(items.Count - 1);
                 }
             }
 
@@ -62,7 +75,11 @@ namespace PeachPDF.CSS
                 if (color != null) items.RemoveAt(items.Count - 1);
             }
 
-            return items.Count == 0 ? new StopValue(color, position, value) : null;
+            // The two-position form is only defined for a <color-stop>; a bare <length-percentage> with no
+            // colour is a <linear-color-hint>, which takes exactly one position.
+            if (secondPosition != null && color == null) return null;
+
+            return items.Count == 0 ? new StopValue(color, firstPosition, secondPosition, value) : null;
         }
 
         protected abstract IPropertyValue ConvertFirstArgument(IEnumerable<Token> value);
@@ -70,12 +87,15 @@ namespace PeachPDF.CSS
         private sealed class StopValue : IPropertyValue
         {
             private readonly IPropertyValue _color;
-            private readonly IPropertyValue _position;
+            private readonly IPropertyValue _firstPosition;
+            private readonly IPropertyValue _secondPosition;
 
-            public StopValue(IPropertyValue color, IPropertyValue position, IEnumerable<Token> tokens)
+            public StopValue(IPropertyValue color, IPropertyValue firstPosition, IPropertyValue secondPosition,
+                IEnumerable<Token> tokens)
             {
                 _color = color;
-                _position = position;
+                _firstPosition = firstPosition;
+                _secondPosition = secondPosition;
                 Original = new TokenValue(tokens);
             }
 
@@ -83,11 +103,13 @@ namespace PeachPDF.CSS
             {
                 get
                 {
-                    if (_color == null && _position != null) return _position.CssText;
+                    var parts = new List<string>(3);
 
-                    if (_color != null && _position == null) return _color.CssText;
+                    if (_color != null) parts.Add(_color.CssText);
+                    if (_firstPosition != null) parts.Add(_firstPosition.CssText);
+                    if (_secondPosition != null) parts.Add(_secondPosition.CssText);
 
-                    return string.Concat(_color?.CssText, " ", _position.CssText);
+                    return string.Join(" ", parts);
                 }
             }
 


### PR DESCRIPTION
Found while porting this fork's CSS improvements upstream to [ExCSS](https://github.com/TylerBrinks/ExCSS/pull/199).

### Problem

A gradient color stop may carry **two** positions — [CSS Images 4 §3.5.1](https://drafts.csswg.org/css-images-4/#color-stop-syntax) defines `<color-stop-length> = <length-percentage>{1,2}`, with the note that this *"is equivalent to specifying two color stops with the same color, one for each position"*. It's how a solid color band is authored:

```css
linear-gradient(red 0 50%, blue 50% 100%)   /* red band 0→50%, blue band 50%→100% */
```

`GradientConverter.ToGradientStop` parsed the second position but **discarded** it (`// discard the extra position token`), and `StopValue` held only one. The property's serialized value — which is what the render layer consumes via `CssUtils.SetPropertyValue` → `ParseImages` — therefore collapsed:

| authored | stored `Value` |
| --- | --- |
| `linear-gradient(red 0 50%, blue 50% 100%)` | `linear-gradient(red 50%, blue 100%)` |
| `linear-gradient(90deg, red 0 8px, blue)` | `linear-gradient(90deg, red 8px, blue)` |

`CssValueParser.ParseLinearGradient` already expands two positions into two stops (its "check second-to-last for two-position shorthand" branch), so the render machinery was ready — it just never received the first position. The intended hard edge at 50% rendered as a single smooth interpolation across the whole box.

### Fix

Keep both positions, in source order, so the value round-trips as authored and the render layer draws the band. Guards from the grammar: the two-position form requires a color (a bare `<length-percentage>` is a one-position `<linear-color-hint>`), and three positions stay invalid.

### Why the existing test didn't catch it

`LinearGradientIntegrationTests.HardStopShorthand_ExpandsToTwoStops` asserted only that a `/FunctionType` is present. That stayed true with a dropped position — a two-stop gradient still emits a stitching function — so per [`CLAUDE.md`'s substring-assertion caveat](../CLAUDE.md) it never actually verified the band. It now asserts the type-3 stitching function's `/Bounds` place a **coincident pair at `0.5`** (the hard edge), which distinguishes the four-stop hard-stop (`FUNCS=4`, `/Bounds [0.5 0.5]`) from the collapsed single interpolation (`FUNCS=1`, no bounds).

### Tests

- 3 CSS-level round-trip cases (`Gradient.cs`) asserting the exact non-lossy `Value` for linear, linear-with-angle, and radial
- 4 validity cases (single-position, hint, three-position, two-bare-positions)
- the strengthened integration assertion above

All 4 of the value/render tests fail on `main`; validity cases pass both ways. Diff coverage **100%** (22/22); full suite green at 5069 passed. The docs already listed "two-position hard-stop shorthand" as supported — this makes the rendering match the claim.
