### PR TITLE
Drop @page size declaration when any dimension is invalid

### DIFF
--- a/src/PeachPDF.Tests/Integration/PageSizeUnitIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/PageSizeUnitIntegrationTests.cs
@@ -79,20 +79,42 @@ namespace PeachPDF.Tests.Integration
             Assert.Null(container.CssPageSize);
         }
 
-        [Fact]
-        public async Task Size_UnparseableToken_IsSkipped_ValidDimensionStillResolves()
+        [Theory]
+        // Issue #163: a `size` value with any token that isn't a valid component is invalid *as a
+        // whole* (CSS Syntax §9) and must be dropped, keeping the configured page size — not partially
+        // honored by squaring the one dimension that happened to parse.
+        [InlineData("nonsense 40mm")]  // an unparseable token beside a valid length
+        [InlineData("40em 50%")]       // the issue's example: `%` is not a <length> for `size`
+        [InlineData("40em 0")]         // a degenerate zero dimension
+        [InlineData("-5em 40mm")]      // a negative dimension
+        [InlineData("10em 20em 30em")] // more than two lengths
+        [InlineData("a4 40em")]        // a named size can't combine with a length
+        public async Task Size_InvalidToken_DropsWholeDeclaration(string size)
         {
-            // A token that is neither a named size, an orientation keyword, nor a parseable length is
-            // skipped; a following valid dimension still resolves (single dimension → square page).
+            var container = await BuildAsync($$"""
+                <!DOCTYPE html><html><head><style>
+                @page { size: {{size}}; }
+                </style></head><body><p>content</p></body></html>
+                """);
+
+            Assert.Null(container.CssPageSize);
+        }
+
+        [Fact]
+        public async Task Size_NamedWithOrientation_StillResolves()
+        {
+            // Regression guard: the valid [ <page-size> || orientation ] branch is unaffected.
             var container = await BuildAsync("""
                 <!DOCTYPE html><html><head><style>
-                @page { size: nonsense 40mm; }
+                @page { size: a4 landscape; }
                 </style></head><body><p>content</p></body></html>
                 """);
 
             Assert.NotNull(container.CssPageSize);
-            Assert.Equal(40 * 72.0 / 25.4, container.CssPageSize!.Value.Width, 3);
-            Assert.Equal(40 * 72.0 / 25.4, container.CssPageSize!.Value.Height, 3);
+            // A4 is 595.28 × 841.89pt portrait; `landscape` swaps to width > height.
+            Assert.True(container.CssPageSize!.Value.Width > container.CssPageSize!.Value.Height);
+            Assert.Equal(841.89, container.CssPageSize!.Value.Width, 2);
+            Assert.Equal(595.28, container.CssPageSize!.Value.Height, 2);
         }
 
         private static async Task<HtmlContainerInt> BuildAsync(string html)

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -342,24 +342,54 @@ namespace PeachPDF.Html.Core.Parse
             if (parts.Length == 0)
                 return null;
 
+            // Classify every token in one pass. Per css-page-3 §7.1 the grammar is
+            // <length>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]; a value that does
+            // not match it is invalid as a whole and must be dropped (CSS Syntax §9), not partially
+            // honored - so any token that is present but not a valid component invalidates the whole
+            // declaration (issue #163), rather than being silently skipped.
             XSize? namedSize = null;
             bool? landscape = null;
+            double? firstLength = null, secondLength = null;
+            var invalid = false;
 
             foreach (var part in parts)
             {
                 if (part.Equals("portrait", StringComparison.OrdinalIgnoreCase))
                 {
+                    if (landscape.HasValue) invalid = true;
                     landscape = false;
                 }
                 else if (part.Equals("landscape", StringComparison.OrdinalIgnoreCase))
                 {
+                    if (landscape.HasValue) invalid = true;
                     landscape = true;
                 }
                 else if (NamedPageSizes.TryGetValue(part, out var known))
                 {
+                    if (namedSize.HasValue) invalid = true;
                     namedSize = known;
                 }
+                else
+                {
+                    // "size: 0" parses as a length (the shared grammar accepts unitless zero), but a
+                    // degenerate zero/negative page dimension is rejected as it always was - and now
+                    // rejects the whole declaration rather than squaring the other dimension. A token
+                    // that isn't a <length> at all (%/vw/ch/garbage) returns null here → also invalid.
+                    var pt = ParseSizeDimensionToPdfPoints(part, context);
+                    if (pt is not > 0) invalid = true;
+                    else if (firstLength == null) firstLength = pt;
+                    else if (secondLength == null) secondLength = pt;
+                    else invalid = true; // more than two lengths
+                }
             }
+
+            // A length can't combine with a named size or an orientation keyword (the <length>{1,2}
+            // branch is mutually exclusive with the [ <page-size> || orientation ] branch).
+            if (firstLength.HasValue && (namedSize.HasValue || landscape.HasValue))
+                invalid = true;
+
+            if (invalid)
+                return null;
 
             if (namedSize.HasValue)
             {
@@ -371,27 +401,13 @@ namespace PeachPDF.Html.Core.Parse
                 return size;
             }
 
-            // landscape/portrait keyword alone — caller will handle orientation after we return null
-            if (landscape.HasValue)
-                return null;
+            if (firstLength.HasValue)
+                return new XSize(firstLength.Value, secondLength ?? firstLength.Value);
 
-            // Try parsing explicit length values
-            double? width = null, height = null;
-            foreach (var part in parts)
-            {
-                var pt = ParseSizeDimensionToPdfPoints(part, context);
-                // "size: 0" now parses as a length (the shared grammar accepts unitless zero),
-                // but a degenerate zero page dimension stays rejected as it always was.
-                if (pt is > 0)
-                {
-                    if (width == null) width = pt;
-                    else if (height == null) { height = pt; break; }
-                }
-            }
-
-            if (width.HasValue)
-                return new XSize(width.Value, height ?? width.Value);
-
+            // Reached for an orientation keyword alone — no explicit size, so the configured page size
+            // is kept. (`auto` and any other unrecognized single token fall into the invalid branch
+            // above and also return null here, which is the same "keep the configured size" outcome
+            // `auto` calls for.)
             return null;
         }
 


### PR DESCRIPTION
Fixes #163

## Problem

`@page { size: ... }` resolved each dimension token independently and kept whichever one/two parsed to a positive length, silently skipping the rest. A declaration with one invalid dimension was therefore *partially* applied instead of dropped:

```css
@page { size: 40em 50%; }   /* → square 40em×40em page; the invalid 50% was skipped */
```

Per [CSS Syntax §9](https://www.w3.org/TR/css-syntax-3/#error-handling) and the `size` grammar in [css-page-3 §7.1](https://www.w3.org/TR/css-page-3/#page-size-prop) (`<length>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]`), a value that doesn't match the property grammar is invalid **as a whole** and must be discarded, keeping the configured page size — a UA doesn't keep the parts that happened to parse.

## Fix

Rewrite `DomParser.ParsePageSizeToPdfPoints` to classify every token in one pass and return `null` (drop the declaration) if any token is present-but-invalid:

- a token that isn't a valid **positive** `<length>` (`%`/`vw`/`ch`/garbage → not a length; `0`/negative → degenerate);
- a length combined with a named size or orientation keyword (the two grammar branches are mutually exclusive);
- more than two lengths; a second named size; a second, conflicting orientation.

Valid forms are unchanged: a named size, a named size + orientation, one or two lengths, and orientation-alone (still returns `null` so the configured page size is kept). `ParseSizeDimensionToPdfPoints` and the `NamedPageSizes` table are untouched — the fix only adds the "reject the whole declaration" guard around the existing shared `<length>` resolver.

## Tests

`PageSizeUnitIntegrationTests`: the former `Size_UnparseableToken_IsSkipped_ValidDimensionStillResolves` test asserted the exact partial-honor behavior this fixes (`size: nonsense 40mm` → 40mm square). It's replaced by `Size_InvalidToken_DropsWholeDeclaration`, a theory asserting each malformed value is dropped (`nonsense 40mm`, `40em 50%`, `40em 0`, `-5em 40mm`, `10em 20em 30em`, `a4 40em`), plus a `size: a4 landscape` regression guard that the valid named-size + orientation branch still resolves. The existing `size: 50%` / `size: 40vw 60vh` (already asserting null) and all `@page { size: A4 }` / `letter portrait` fixtures are unaffected.

## Verification

- Full net8.0 suite green (5210 passed); diff coverage 94%.
- Adversarial review pass confirmed the change is spec-correct, no valid `size` value is dropped, all listed malformed values are dropped, and no other test or call site depended on the old partial-honor behavior.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1LacsZTsa5wyjvUuVWAEK)_