### PR TITLE
Fix transform-origin accepting a single keyword followed by a length

### DIFF
--- a/src/PeachPDF.Tests/CSS/PropertyTests/TransformProperty.cs
+++ b/src/PeachPDF.Tests/CSS/PropertyTests/TransformProperty.cs
@@ -297,6 +297,36 @@ namespace PeachPDF.Tests.CSS.PropertyTests
         }
 
         [Fact]
+        public void CssTransformOriginVerticalKeywordThenLengthIllegal()
+        {
+            // "top 2px" is invalid (CSS Transforms 1): the trailing <length> z-offset only exists in the
+            // two-value production, but "top" is a vertical-only keyword that cannot fill the horizontal
+            // position, and there is no second position value - so this is neither a valid single value nor a
+            // valid two-value pair, and the "2px" cannot be reinterpreted as a z-offset.
+            var snippet = "transform-origin:  top 2px ";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("transform-origin", property.Name);
+            Assert.False(property.IsImportant);
+            Assert.IsType<TransformOriginProperty>(property);
+            var concrete = (TransformOriginProperty)property;
+            Assert.False(concrete.HasValue);
+        }
+
+        [Fact]
+        public void CssTransformOriginVerticalKeywordThenLengthWithZIllegal()
+        {
+            // As above, invalid for the same reason; a trailing <length> z-offset cannot rescue an invalid
+            // single-keyword-plus-length position.
+            var snippet = "transform-origin:  top 2px 10px ";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("transform-origin", property.Name);
+            Assert.False(property.IsImportant);
+            Assert.IsType<TransformOriginProperty>(property);
+            var concrete = (TransformOriginProperty)property;
+            Assert.False(concrete.HasValue);
+        }
+
+        [Fact]
         public void CssTransformOriginXKeywordYOffsetLegal()
         {
             var snippet = "transform-origin:  left 2px ";

--- a/src/PeachPDF/CSS/StyleProperties/Transform/TransformOriginProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Transform/TransformOriginProperty.cs
@@ -34,15 +34,30 @@ namespace PeachPDF.CSS
                 .Or(Keywords.Bottom, Length.Full)
                 .Or(Keywords.Center, Length.Half);
 
-        private static readonly IValueConverter StyleConverter = WithOrder(
+        // A one- or two-value <position> with no z-offset (this is exactly the perspective-origin grammar).
+        private static readonly IValueConverter Position =
             LengthOrPercentConverter.Or(Keywords.Center, Point.Center)
                 // Ordered horizontal-then-vertical (rejects a keyword in the wrong axis position).
                 .Or(WithOrder(Horizontal.Option(Length.Half), Vertical.Option(Length.Half)))
                 // Keyword-only form, any order ("center left"): a token accepted by both axes must not be
                 // claimed positionally, so this needs order-independent matching.
-                .Or(WithAnyOrderIndependent(HorizontalKeyword.Option(Length.Half), VerticalKeyword.Option(Length.Half)))
-                .Required(),
-            LengthConverter.Option(Length.Zero)).OrDefault(Point.Center);
+                .Or(WithAnyOrderIndependent(HorizontalKeyword.Option(Length.Half), VerticalKeyword.Option(Length.Half)));
+
+        // A genuine two-value position: BOTH a horizontal and a vertical component must be present. The axis
+        // converters are bare (not .Option), so each must actually consume a token. The <length> z-offset only
+        // exists in this two-value production, so gating the z-offset behind this (rather than the shared outer
+        // WithOrder) is what makes a single-value position + length such as "top 2px" invalid.
+        private static readonly IValueConverter TwoValuePosition =
+            WithOrder(Horizontal, Vertical)
+                .Or(WithAnyOrderIndependent(HorizontalKeyword, VerticalKeyword));
+
+        private static readonly IValueConverter StyleConverter =
+            // Two-value position followed by a (required) <length> z-offset - this branch only matches when a
+            // third length token is actually present...
+            WithOrder(TwoValuePosition, LengthConverter)
+                // ...otherwise a plain one- or two-value <position> with no z-offset.
+                .Or(Position)
+                .OrDefault(Point.Center);
 
         internal TransformOriginProperty()
             : base(PropertyNames.TransformOrigin, PropertyFlags.Animatable)


### PR DESCRIPTION
## Summary

`transform-origin: top 2px` was accepted by the CSS value parser and resolved to `center`/`top` with `2px` taken as the z-offset, but it is invalid per [CSS Transforms 1](https://www.w3.org/TR/css-transforms-1/#transform-origin-property) and must be dropped. The trailing `<length>` z-offset only exists in the **two-value** production (after both a horizontal *and* a vertical position are given); `top` is a vertical-only keyword that cannot fill the horizontal slot, and there is no second value.

## Root cause

`TransformOriginProperty` built `WithOrder(<position>.Required(), LengthConverter.Option(...))`. Because the optional z-offset sat at the **outer** `WithOrder`, it attached to every `<position>` alternative — including the single-keyword form. `OrderedOptionsConverter.VaryStart` greedily matched `top` alone (horizontal defaulting via `.Option`, vertical = `top`), leaving `2px` to satisfy the outer optional length slot.

For contrast, `perspective-origin: top 2px` was already rejected (it has no z-offset slot), and the mirror cases `transform-origin: 2px left` / `2px left 10px` were already rejected.

## Fix

Restructure the converter so the `<length>` z-offset only follows a genuine two-value position:

- **`Position`** — the one/two-value `<position>` grammar with no z-offset (the same grammar `perspective-origin` uses).
- **`TwoValuePosition`** — the ordered and reorderable keyword forms with **both** axis components required (bare converters, not `.Option`), so each must actually consume a token.
- **`StyleConverter`** = `WithOrder(TwoValuePosition, LengthConverter).Or(Position).OrDefault(Point.Center)` — the two-value+z branch only matches when a third length token is actually present; otherwise it falls back to a plain one/two-value `<position>`.

Serialization of every valid form is unchanged, so the layout/paint consumers (which read the resolved string) are unaffected. The `transform-origin` row in `docs/html-css-support.md` already documents the correct grammar, so no docs change is needed.

## Tests

Added two illegal-case tests to `TransformProperty.cs`, mirroring the existing `perspective-origin` coverage:

- `CssTransformOriginVerticalKeywordThenLengthIllegal` — `top 2px` → `HasValue == false` (the issue's repro).
- `CssTransformOriginVerticalKeywordThenLengthWithZIllegal` — `top 2px 10px` → `HasValue == false`.

Verified locally on net8.0: new tests pass; all existing transform-origin/perspective-origin tests still pass (53/53), broader CSS property suite (796) and transform suite (169) green. Diff coverage of the changed converter lines is 100%.

Fixes #249

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuBg3rFPzNnZdHBp7AnsPq)_