### PR TITLE
Ask the repeating-table question of every box a restart replays

### DIFF
--- a/src/PeachPDF.Tests/Integration/EarlyBreakLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/EarlyBreakLayoutIntegrationTests.cs
@@ -1,5 +1,6 @@
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Utils;
 using PeachPDF.Tests.TestSupport;
 
 namespace PeachPDF.Tests.Integration
@@ -202,6 +203,46 @@ namespace PeachPDF.Tests.Integration
 
             Assert.Equal(1, container.PageIndexOf(card.Location.Y + HtmlContainerInt.PageBoundaryEpsilon));
             Assert.Equal(container.PageTopOf(1), card.Location.Y, 6);
+        }
+
+        /// <summary>
+        /// The repeating-table exclusion has to be asked of every box a restart would replay, not only
+        /// of the one that raised it: the run is found by walking siblings, so the index range re-run is
+        /// wider than the run, and a table in it that repeats a header does not survive a second layout.
+        /// </summary>
+        /// <remarks>
+        /// Asserted as an invariant of the table rather than of the relocation, because whether this
+        /// particular fixture reaches the restart at all depends on where the page grid falls: what must
+        /// hold either way is that the table still repeats exactly one header group, once per page it
+        /// spans, with no stale proxy left behind.
+        /// </remarks>
+        [Theory]
+        [InlineData(60)]
+        [InlineData(80)]
+        [InlineData(100)]
+        public async Task RunHeadContainingARepeatingTable_KeepsItsHeaderIntact(double fillerHeight)
+        {
+            var rows = string.Concat(Enumerable.Range(0, 6).Select(i => $"<tr><td>Row {i}</td></tr>"));
+            var html = LayoutHarness.Wrap(
+                $"<div style='height:{fillerHeight}pt'>filler</div>"
+                + "<div id='head' style='break-after:avoid;font-size:10pt;line-height:20pt'>"
+                + $"<table><thead><tr><th>H</th></tr></thead><tbody>{rows}</tbody></table></div>"
+                + $"<div id='card' style='break-inside:avoid;orphans:1;widows:1;line-height:{LineHeight}pt;font-size:10pt;width:60pt'>"
+                + "Aaa Bbb Ccc Ddd Eee Fff Ggg Hhh</div>");
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html, pageHeight: PageHeight, margin: Margin);
+
+            var table = LayoutHarness.Descendants(LayoutHarness.FindById(root, "head")!)
+                .First(b => b.Display == CssConstants.Table);
+            var proxies = table.Boxes.OfType<CssProxyBox>().ToList();
+
+            Assert.NotEmpty(proxies);
+            Assert.Single(proxies.Select(p => p.SourceBox).Distinct());
+            Assert.All(proxies, p => Assert.Equal(CssConstants.TableHeaderGroup, p.SourceBox.Display));
+
+            // Every proxy must sit on a page of its own — a stale one left by a discarded layout would
+            // duplicate a position.
+            Assert.Equal(proxies.Count, proxies.Select(p => Math.Round(p.Location.Y, 3)).Distinct().Count());
         }
 
         private static async Task<(CssBox Heading, CssBox Card, HtmlContainerInt Container)> PulledRunAsync(double fillerHeight)

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -1740,6 +1740,15 @@ namespace PeachPDF.Html.Core.Dom
             resumeFrom = Boxes.IndexOf(restart.BeforeBox);
             if (resumeFrom < start || resumeFrom > raisedAt) return false;
 
+            // Asked of every index about to be replayed, not just of the box that raised this. The run
+            // is found by walking siblings, which skips display:none, floated and out-of-flow ones, so
+            // the range re-run is wider than the run itself — and a table in it that repeats a header
+            // would not survive being laid out a second time.
+            for (var j = resumeFrom; j <= raisedAt; j++)
+            {
+                if (ContainsARepeatingTable(Boxes[j])) return false;
+            }
+
             restartedHeads ??= [];
 
             if (!restartedHeads.Add(resumeFrom)) return false;
@@ -3352,10 +3361,11 @@ namespace PeachPDF.Html.Core.Dom
             // The break falls before an earlier sibling, so this box cannot carry it out: only the
             // parent's child loop can re-run something placed before the box it is currently laying
             // out. Hand it over, and stop - what follows would measure a position about to change.
+            // Whether the boxes a restart would re-run can survive it is the parent's question, not
+            // this one's: only the child loop knows which indices it is about to replay.
             if (decision.BeforeBox != this
                 && ParentBox is { _canRestartChildLoop: true } parent
-                && HtmlContainer is { IsFragmenting: true }
-                && !ContainsARepeatingTable(this))
+                && HtmlContainer is { IsFragmenting: true })
             {
                 parent._requestedChildRestart = decision;
                 _earlyBreakTaken = true;


### PR DESCRIPTION
Follow-up to #356, found by the post-change review pass on that PR.

#356 excludes a subtree containing a table that repeats a header from being laid out again, because such a table does not survive a second layout (#353). The exclusion was asked of **the box that raised the decision** — but a keep-with-next restart replays an **index range**, from the run head up to that box.

The run is discovered by walking siblings (`DomUtils.GetPrecedingKeepWithNextRun` → `GetPreviousSibling`), which skips `display: none`, floated and out-of-flow siblings. So the range actually re-run is wider than the run itself, and a repeating table anywhere in it — most obviously in the run *head*, e.g. a `break-after: avoid` wrapper around a table — was replayed with the exclusion never consulted.

The check moves into `TryRestartAt`, which is the only place that knows which indices it is about to replay. Where it declines, the decision falls back to moving the group, exactly as it already did for every other reason a restart is refused.

## Verification

- Full net8.0 suite green: **6219 passed**.
- All 63 showcases byte-identical after normalization — this narrows when a restart is allowed, and no showcase reaches the narrowed case.
- New `EarlyBreakLayoutIntegrationTests.RunHeadContainingARepeatingTable_KeepsItsHeaderIntact` (3 fillers). It is written as an invariant of the **table** rather than of the relocation: whether a given fixture reaches the restart at all depends on where the page grid falls, but what must hold either way is that the table still repeats exactly one header group, once per page it spans, with no stale proxy left behind.

Relates to #332, #353.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgzFEQAiAfnCj2K4VjtZVt)_