### PR TITLE
Take ownership of _site before writing the demo into it

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -137,6 +137,10 @@ jobs:
           grep -q '<base href="/" />' demo-publish/wwwroot/index.html
           sed -i 's|<base href="/" />|<base href="/demo/" />|' demo-publish/wwwroot/index.html
 
+          # jekyll-build-pages runs in a container as root, so it leaves _site owned by root while
+          # this step runs as the runner user - writing into it fails outright without this.
+          sudo chown -R "$(id -u):$(id -g)" _site
+
           mkdir -p _site/demo
           cp -r demo-publish/wwwroot/. _site/demo/
 


### PR DESCRIPTION
The Pages deploy fails at:

```
mkdir: cannot create directory ‘_site/demo’: Permission denied
```

`actions/jekyll-build-pages` runs in a container as **root**, so the `_site` it produces is root-owned, while the step that drops the demo into it runs as the `runner` user. Every write into `_site` therefore fails — `mkdir` first.

`chown` the tree to the runner before writing. The alternative — `sudo` on each of `mkdir`, `cp` and `touch` — would leave the published artifact root-owned for no reason.

**Why this wasn't caught earlier.** The deploy workflow runs only on `release: published` or manual dispatch, so neither the PR gate nor a local `dotnet publish` exercises the step that combines Jekyll's output with the demo's. I had verified the publish output and the `/demo/` sub-path serving locally by staging the same directory layout by hand, which is exactly the part that does not reproduce the container's ownership.

Fixes the failure in [run 30227430639](https://github.com/jhaygood86/PeachPDF/actions/runs/30227430639).
