### PR TITLE
Relocate a subtree holding a repeating-header table like any other

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,14 @@ Report findings the same way `/code-review` does; fix what's actually wrong, and
 
 ## Recent fixes
 
+- **A subtree holding a repeating-header table is relocated like any other** ([issue #354](https://github.com/jhaygood86/PeachPDF/issues/354)'s first half, the payoff of [#353](https://github.com/jhaygood86/PeachPDF/issues/353)). #332 relocates a box by laying it out again at its destination rather than translating it, which is what stops the fragmentainer gap being carried along inside it — and `CanBeLaidOutAgain` excluded any subtree containing a table that repeats a header, because such a table did not survive a second layout. It does now, so the exclusion and `ContainsARepeatingTable` are gone, from both the epilogue's mover and `TryRestartAt`'s replay range.
+
+  **The improvement is real and was invisible to the showcases.** A `break-inside: avoid` card holding a small table with a `<thead>`, straddling a page boundary at three alignments, measured **70.5 / 80.5 / 74pt** against the same card's settled **55.5pt** — 15 to 25pt of fragmentainer gap kept as height it does not use. Laid out again it is 55.5 at every alignment. All 65 showcases are byte-identical, because none of them relocates such a subtree.
+
+  Full net8.0 suite green (6459); tests: `RepeatingTableRelayoutTests` (4), each verified load-bearing by restoring the exclusion — the three height cases fail and the header-count guard passes either way.
+
+  **Still to do in #354:** the three sites inside the engine that translate rather than raising a decision — the headerless whole-table pre-check, the repeating-`<thead>` pre-check, and the retroactive post-check — along with `PullKeepWithNextRun`, the last open-coded copy of the keep-with-next guards `EarlyBreak.Discover` owns.
+
 - **A table with a repeating header survives being laid out again** ([issue #353](https://github.com/jhaygood86/PeachPDF/issues/353)). `CssLayoutEngineTable` assumes it runs once per table box: `RemoveHeaderFooterFromTree` detaches the repeating `<thead>`/`<tfoot>` and puts one `CssProxyBox` per page in its place, and nothing removed the proxies.
 
   **The symptom is worse than the issue recorded.** A proxy inherits the source group's style, so its `Display` *is* `table-header-group`; a second run's `AssignBoxKinds` therefore took the first stale proxy as `_headerBox` and classified the rest as body rows — and a proxy has no cells, so positioning such a "row" threw `Sequence contains no elements` out of `row.Boxes.Min(...)`. Not a 73.5pt drift: a **crash**, which is what `CssBox.ContainsARepeatingTable` has actually been guarding against.

--- a/src/PeachPDF.Tests/Integration/RepeatingTableRelayoutTests.cs
+++ b/src/PeachPDF.Tests/Integration/RepeatingTableRelayoutTests.cs
@@ -1,0 +1,63 @@
+using PeachPDF.Tests.TestSupport;
+using System.Linq;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// A subtree containing a table that repeats a header takes the same §4.3 relocation every other
+    /// subtree does — laid out again at its destination rather than translated to it.
+    /// </summary>
+    /// <remarks>
+    /// It was excluded because laying such a table out a second time did not reproduce the first result:
+    /// the repeating group was detached and replaced by per-page proxies that nothing removed, so a
+    /// second run threw. With that fixed the exclusion is gone, and a translated box's signature — the
+    /// fragmentainer gap carried along inside it as height it does not use — has to be gone with it.
+    /// </remarks>
+    public class RepeatingTableRelayoutTests
+    {
+        private const double PageHeight = 200;
+        private const double Margin = 20;
+
+        private static string CardWithTable(double fillerHeight) =>
+            LayoutHarness.Wrap(
+                $"<div style='height:{fillerHeight}pt'>filler</div>"
+                + "<div id='card' style='break-inside:avoid;orphans:1;widows:1;font-size:10pt'>"
+                + "<table style='width:100pt'><thead><tr><th>H</th></tr></thead>"
+                + "<tbody><tr><td>One</td></tr><tr><td>Two</td></tr><tr><td>Three</td></tr></tbody>"
+                + "</table></div>");
+
+        [Theory]
+        [InlineData(120)]
+        [InlineData(130)]
+        [InlineData(140)]
+        public async Task ACardHoldingARepeatingHeaderTable_IsRelocatedWithoutCarryingAGap(double fillerHeight)
+        {
+            var (undisturbed, _) = await LayoutHarness.LayoutAsync(
+                CardWithTable(0), pageHeight: PageHeight, margin: Margin);
+            var settledCard = LayoutHarness.FindById(undisturbed, "card")!;
+            var settled = settledCard.ActualBottom - settledCard.Location.Y;
+
+            var (root, _) = await LayoutHarness.LayoutAsync(
+                CardWithTable(fillerHeight), pageHeight: PageHeight, margin: Margin);
+            var card = LayoutHarness.FindById(root, "card")!;
+
+            // A translated box keeps the gap as height it does not use, so its height would depend on
+            // where it happened to straddle. Laid out again, it is the height of its own content
+            // wherever it lands.
+            Assert.Equal(settled, card.ActualBottom - card.Location.Y, 3);
+        }
+
+        [Fact]
+        public async Task TheTableInsideARelocatedCard_StillRepeatsItsHeaderExactlyOnce()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(
+                CardWithTable(130), pageHeight: PageHeight, margin: Margin);
+
+            var headerGroups = LayoutHarness.Descendants(root)
+                .Count(b => b.Display == "table-header-group");
+
+            // One per page the table spans, and no stale copy left by the run that was abandoned.
+            Assert.InRange(headerGroups, 1, 2);
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -2522,16 +2522,6 @@ namespace PeachPDF.Html.Core.Dom
             resumeFrom = Boxes.IndexOf(restart.BeforeBox);
             if (resumeFrom < 0 || resumeFrom > raisedAt) return false;
 
-            // Asked of every index about to be replayed, not just of the box that raised this. The run
-            // is found by walking siblings, which skips display:none, floated and out-of-flow ones, so
-            // the range re-run is wider than the run itself — and a table in it that repeats a header
-            // would not survive being laid out a second time. Asked before the range test below so that
-            // such a table declines the driver's replay too, not only this loop's.
-            for (var j = resumeFrom; j <= raisedAt; j++)
-            {
-                if (ContainsARepeatingTable(Boxes[j])) return false;
-            }
-
             // Below the index this pass began at, the head belongs to a fragmentainer the driver has
             // already filled — nothing this loop can re-run, but something the driver can, by re-entering
             // the pass that filled it. Asked here rather than at the call site so that "this head cannot
@@ -4505,42 +4495,11 @@ namespace PeachPDF.Html.Core.Dom
         /// question. Verified to walk a box down 100,000 pages before the driver's own cap stopped it.
         /// Relaxation therefore keeps the translation, which is exactly what it did before.
         /// </para>
-        /// <para>
-        /// The last exclusion is narrower and is a defect rather than a boundary: laying a table out a
-        /// second time does not reproduce the first result. Its repeating <c>&lt;thead&gt;</c> is
-        /// detached from the tree and replaced by one proxy per page, and a second run neither finds
-        /// the header nor removes the proxies — so the header stops repeating and stale copies are left
-        /// behind, or, once the structure is restored, the header's height is counted twice. Until that
-        /// is fixed a subtree containing one keeps the translation.
-        /// </para>
         /// </remarks>
         private bool CanBeLaidOutAgain(EarlyBreak decision) =>
             PlacesItselfAsBlockBox
             && HtmlContainer is { IsFragmenting: true }
-            && FitsInFragmentainer(decision.Slot)
-            && !ContainsARepeatingTable(this);
-
-        /// <summary>
-        /// Whether <paramref name="box"/>'s subtree contains a table that repeats a header or footer
-        /// group — the structure a second layout of the same table does not reproduce.
-        /// </summary>
-        /// <remarks>
-        /// Both spellings have to be looked for, because the first layout consumes the first one: before
-        /// it, the repeating group is an ordinary child of the table; after it, the group has been
-        /// detached and only the per-page <see cref="CssProxyBox"/> proxies remain.
-        /// </remarks>
-        private static bool ContainsARepeatingTable(CssBox box)
-        {
-            if (box.Display is CssConstants.Table or CssConstants.InlineTable
-                && box.Boxes.Exists(child =>
-                    child is CssProxyBox
-                    || child.Display is CssConstants.TableHeaderGroup or CssConstants.TableFooterGroup))
-            {
-                return true;
-            }
-
-            return box.Boxes.Exists(ContainsARepeatingTable);
-        }
+            && FitsInFragmentainer(decision.Slot);
 
         /// <summary>
         /// Moves this box to the next page (like a plain <see cref="OffsetTop"/> by <paramref name="offset"/>),


### PR DESCRIPTION
The first half of #354, and the payoff of #353 (merged as #409/#410).

## The exclusion is gone

#332 relocates a box by laying it out again at its destination rather than translating it — which is what stops the fragmentainer gap being carried along *inside* it. `CanBeLaidOutAgain` excluded any subtree containing a table that repeats a header, because such a table did not survive a second layout. It does now, so the exclusion and `ContainsARepeatingTable` go, from both the epilogue's mover and `TryRestartAt`'s replay range.

## The improvement is real, and invisible to the showcases

A `break-inside: avoid` card holding a small table with a `<thead>`, straddling a page boundary at three alignments:

| filler | translated (before) | laid out again (after) |
|---|---|---|
| 120pt | 70.5pt | **55.5pt** |
| 130pt | 80.5pt | **55.5pt** |
| 140pt | 74.0pt | **55.5pt** |

55.5pt is the card's settled height when nothing disturbs it. So 15–25pt of fragmentainer gap was being kept as height the box does not use, and where it landed depended on where it happened to straddle.

**All 65 showcases are byte-identical**, because none of them relocates such a subtree — which is exactly why this needed its own fixture. Each of the three height cases was verified load-bearing by restoring the exclusion; all three fail with it, and the header-count guard passes either way.

## Verification

- Full net8.0 suite green (6459), CLI green (96), 0 warnings, **100% diff coverage**.
- Tests: `RepeatingTableRelayoutTests` (4).

## What is left in #354

The three sites inside `CssLayoutEngineTable` that translate rather than raising a decision — the headerless whole-table pre-check, the repeating-`<thead>` pre-check, and the retroactive post-check — along with `PullKeepWithNextRun`, the last open-coded copy of the keep-with-next guards `EarlyBreak.Discover` owns. #314 (row-level break values) and #406 (a table in a multicol losing cell content) follow from the same work.

---
_Generated by [Claude Code](https://claude.ai/code/session_013hQgw6Vy3ddJ6wPrSph2DK)_