### PR TITLE
Move the lines below a relocated flex line or grid row with it

### DIFF
--- a/.claude/recent-fixes/2026-07-27-a-column-s-recorded-band-is-the-one-it-filled-not-the-target-it-was.md
+++ b/.claude/recent-fixes/2026-07-27-a-column-s-recorded-band-is-the-one-it-filled-not-the-target-it-was.md
@@ -31,9 +31,10 @@ target. Nothing in the unit suite noticed either loss.
 **The grid case looked like the same bug and was not**, which is worth remembering before assuming a
 nesting defect: a `display: grid` in the same position was losing content past the column's *inline*
 edge. Filed as [#414](https://github.com/jhaygood86/PeachPDF/issues/414) as an engine-independence
-(#166/#315) problem — and that reading was wrong. See the grid-track entry beside this one: it
-reproduces with no multi-column container in sight, and the column merely exposed it. The thing that
-showed this was measuring the same fixture *without* the container.
+(#166/#315) problem — and that reading was wrong. See
+[2026-07-27-a-grid-track-grows-toward-its-limit-with-the-space-that-is-there.md](2026-07-27-a-grid-track-grows-toward-its-limit-with-the-space-that-is-there.md):
+it reproduces with no multi-column container in sight, and the column merely exposed it. The thing
+that showed this was measuring the same fixture *without* the container.
 
 Tests: `MulticolLayoutIntegrationTests` (+2) and `SuppressedPassFragmentainerTests`' own case
 **promoted from the characterization it was drafted as** (0 → 5 → all 10). Full net8.0 suite green

--- a/.claude/recent-fixes/2026-07-27-the-lines-below-a-relocated-flex-line-or-grid-row-follow-it.md
+++ b/.claude/recent-fixes/2026-07-27-the-lines-below-a-relocated-flex-line-or-grid-row-follow-it.md
@@ -1,0 +1,44 @@
+# The lines below a relocated flex line or grid row follow it
+
+_Landed 2026-07-27._
+
+[CSS Fragmentation Level 3 §3.1](https://www.w3.org/TR/css-break-3/#break-between).
+
+A flex container's break points are between its **lines** and a grid container's between its **rows**,
+and #315 made a line that may not be cut move to the next fragmentainer. It moved *only that line*.
+Everything below it stayed exactly where it was, so the relocated line was drawn **on top of** the one
+after it — measured on a three-line wrapping flex container as line 2 landing at 380–440 while line 3
+stayed at 400–460, a 40pt overlap. Both engines had the defect, in the same shape.
+
+**The load-bearing idea is that the displacement accumulates and the geometry has to accumulate with
+it.** Both engines already tracked a running `shift` and already used it to *ask* the question — a
+later line's straddle test reads `bounds.Top + shift`, i.e. where the line will be once everything
+above it has moved. What neither did is *apply* it: each relocated line was offset by its own `delta`
+rather than by the running total, and a line that needed no relocation of its own was never offset at
+all. So the model was right and only the write-back was wrong, which is why no test caught it: every
+existing fixture relocates exactly one line, where `delta == shift` and there is nothing below it.
+
+`LineRelocation.DeltaFor` now states the decision once for both engines — they were asking the same
+question of the same inputs in two copies, differing only in local variable names — and it deliberately
+*returns* the displacement rather than applying it, because applying it is precisely the part that
+cannot be done per line.
+
+**The second half was found by reading the container's own height after fixing the first.** With the
+lines right, an auto-height container still reported a bottom a whole displacement short of the content
+it held (460 against content reaching 500), because both engines sized the container from their
+**lines/tracks** — `lines.Max(l => l.CrossOffset + l.CrossSize)`, `rows.Sum(t => t.Size)` — in a phase
+that runs *after* the relocation and overwrites the `+= shift` it had just applied. The relocation pass
+now runs after that sizing in both engines. Getting this order wrong is silent: the boxes are in the
+right places and only the container's reported box is short, so nothing overlaps and nothing looks
+wrong until something measures against the container.
+
+**All 67 showcases were byte-identical before a fixture was added for it**, which is the whole reason
+this survived: no showcase had two lines relocating. `paged_media_monolithic_content` gained a
+wrapping flex container whose *first* line straddles the boundary, so all three travel — and **on the
+unfixed build lines 2 and 3 stay put and line 1 is drawn underneath them**, with only the top edge of
+its cards visible above the line that overdrew it.
+
+Tests: `FlexGridFragmentationIntegrationTests` (+2 theories × 2 engines — the line after a relocated
+one not overlapping it, and the container reporting a height that holds its content). Verified
+load-bearing by restoring the per-line `delta`: the overlap test fails. Full net8.0 suite green (6568),
+0 warnings.

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -1659,13 +1659,31 @@ var monolithicHtml = """
       <div class="card"><span class="tag">grid item</span><h2>Four</h2>
         <p>An item spanning several rows travels with the first of them.</p></div>
     </div>
+
+    <h1>The lines below a moved one follow it</h1>
+    <p>A wrapping flex container whose middle line meets the page boundary. That line moves to the next
+    page, and every line below it moves with it &mdash; a line does not stay where it was while the one
+    above it leaves, and the container's own height grows by what its content travelled.</p>
+    """
+    + string.Concat(Enumerable.Range(85, 11).Select(i =>
+        $"<p>Filler paragraph {i}. This run puts the second of the three lines below across the boundary.</p>"))
+    + """
+    <div style="display:flex; flex-wrap:wrap; gap:8pt; border:1px dashed #a3a3a3; padding:6pt">
+    """
+    + string.Concat(Enumerable.Range(1, 6).Select(i =>
+        $"<div class=\"card\" style=\"width:38%; margin:0; break-inside:avoid\">"
+        + $"<span class=\"tag\">line {(i + 1) / 2}</span>"
+        + $"<h2>Item {i}</h2><p>Sized so three lines of two wrap inside the container.</p></div>"))
+    + """
+    </div>
     </body></html>
     """;
 
 await SaveShowcaseAsync("paged_media_monolithic_content", "Paged Media", "Monolithic Content",
     "A box with overflow: hidden is a scroll container, which CSS Fragmentation §2 forbids breaking: it "
     + "moves to the next page whole instead of being cut in half by the page boundary. A flex line and a "
-    + "grid row that ask not to be broken move as a unit for the same reason.",
+    + "grid row that ask not to be broken move as a unit for the same reason, and the lines below a "
+    + "moved one follow it rather than staying put.",
     monolithicHtml, new PdfGenerateConfig { PageSize = PageSize.A5 });
 
 // ── orphans / widows showcase ──────────────────────────────────────────────

--- a/src/PeachPDF.Tests/Integration/FlexGridFragmentationIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FlexGridFragmentationIntegrationTests.cs
@@ -221,5 +221,66 @@ namespace PeachPDF.Tests.Integration
             Assert.True(a!.Location.Y >= cell.Location.Y - 0.5,
                 $"expected the item to stay within its cell (cell at {cell.Location.Y}, item at {a.Location.Y})");
         }
+
+        // ─── The lines after a relocated one follow it ────────────────────────────
+
+        // A line or row is moved by the *accumulated* displacement, not by its own. Everything below a
+        // line that moved to the next fragmentainer has to follow it there: applying only the moving
+        // line's own delta left the lines after it sitting on top of it, and the container reported a
+        // height a whole displacement short of the content it holds.
+        private const string ThreeLines =
+            "<div style='height:260pt'>filler</div>"
+            + "<div id='c' style='{0}; width:300pt'>"
+            + "<div class='it' id='i1' style='width:45%;height:60pt;break-inside:avoid'>1</div>"
+            + "<div class='it' id='i2' style='width:45%;height:60pt;break-inside:avoid'>2</div>"
+            + "<div class='it' id='i3' style='width:45%;height:60pt;break-inside:avoid'>3</div>"
+            + "<div class='it' id='i4' style='width:45%;height:60pt;break-inside:avoid'>4</div>"
+            + "<div class='it' id='i5' style='width:45%;height:60pt;break-inside:avoid'>5</div>"
+            + "<div class='it' id='i6' style='width:45%;height:60pt;break-inside:avoid'>6</div>"
+            + "</div>";
+
+        [Theory]
+        [InlineData("display:flex; flex-wrap:wrap")]
+        [InlineData("display:grid; grid-template-columns:auto auto")]
+        public async Task ALineAfterARelocatedOne_FollowsItRatherThanOverlapping(string containerStyle)
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(
+                LayoutHarness.Wrap(string.Format(ThreeLines, containerStyle)),
+                pageHeight: 400, margin: 20);
+
+            var items = Enumerable.Range(1, 6)
+                .Select(i => LayoutHarness.FindById(root, $"i{i}")!)
+                .ToList();
+
+            // The middle line straddled the boundary and moved; the last one has to end up below it.
+            Assert.True(items[2].Location.Y > items[0].ActualBottom - 0.5,
+                "the relocated line must still be below the one before it");
+            Assert.True(items[4].Location.Y >= items[2].ActualBottom - 0.5,
+                $"the line after the relocated one overlaps it: it starts at {items[4].Location.Y:F1} "
+                + $"while the line above ends at {items[2].ActualBottom:F1}");
+
+            // And it really did relocate - otherwise this asserts nothing.
+            Assert.True(items[2].Location.Y > items[0].ActualBottom + 0.5,
+                "the fixture no longer relocates a line; it asserts nothing as written");
+        }
+
+        [Theory]
+        [InlineData("display:flex; flex-wrap:wrap")]
+        [InlineData("display:grid; grid-template-columns:auto auto")]
+        public async Task ARelocatingContainer_ReportsAHeightThatHoldsItsContent(string containerStyle)
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(
+                LayoutHarness.Wrap(string.Format(ThreeLines, containerStyle)),
+                pageHeight: 400, margin: 20);
+
+            var container = LayoutHarness.FindById(root, "c")!;
+            var lowest = Enumerable.Range(1, 6)
+                .Max(i => LayoutHarness.FindById(root, $"i{i}")!.ActualBottom);
+
+            // Sized from its lines before the relocation ran, the container was a whole displacement
+            // short of the content it holds.
+            Assert.True(container.ActualBottom >= lowest - 0.5,
+                $"container ends at {container.ActualBottom:F1} but its content reaches {lowest:F1}");
+        }
     }
 }

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineFlex.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineFlex.cs
@@ -184,10 +184,6 @@ namespace PeachPDF.Html.Core.Dom
             // Phase 9: assign final locations
             AssignLocations(lines);
 
-            // Phase 9b: the break points between lines are real ones now that the items sit where they
-            // will finally sit - see RelocateLinesAcrossFragmentainers.
-            RelocateLinesAcrossFragmentainers(lines);
-
             // Phase 10: update container size if auto.
             // Use Max across all lines because wrap-reverse can make the last line have the smallest offset.
             double maxCrossEnd = lines.Count > 0
@@ -203,6 +199,14 @@ namespace PeachPDF.Html.Core.Dom
                     _flexBox.ActualRight = _flexBox.ClientLeft + maxCrossEnd
                         + _flexBox.ActualPaddingRight + _flexBox.ActualBorderRightWidth;
             }
+
+            // Phase 9b: the break points between lines are real ones now that the items sit where they
+            // will finally sit - see RelocateLinesAcrossFragmentainers. Run *after* the container has
+            // been sized from its lines, because that sizing reads the line offsets rather than the
+            // boxes and so would overwrite the displacement this adds: an auto-height container whose
+            // lines were pushed onto the next fragmentainer reported a height a whole displacement short
+            // of the content it holds.
+            RelocateLinesAcrossFragmentainers(lines);
 
             // Phase 10b: inline-flex shrinks to content in the main axis (like inline-block).
             // For row direction with auto width, update ActualRight to the actual content extent.
@@ -802,32 +806,19 @@ namespace PeachPDF.Html.Core.Dom
             {
                 if (LineBounds(line) is not { } bounds) continue;
 
-                var (top, bottom) = (bounds.Top + shift, bounds.Bottom + shift);
+                shift += LineRelocation.DeltaFor(
+                    container, bounds.Top + shift, bounds.Bottom + shift,
+                    LineTakesAForcedBreak(line), LineMayNotBeCut(line));
 
-                var slot = container.SlotStartingAt(top);
-                var slotBottom = container.PageBottomOf(slot);
-
-                var forced = LineTakesAForcedBreak(line);
-                var straddles = bottom - HtmlContainerInt.PageBoundaryEpsilon > slotBottom
-                                && LineMayNotBeCut(line);
-
-                if (!forced && !straddles) continue;
-
-                var target = container.PageTopOf(slot + 1);
-
-                // A line taller than a whole band has nowhere better to be, and moving it would ask the
-                // same question again on the next fragmentainer, forever.
-                if (!forced && bottom - top > container.PageBandHeightOf(slot + 1)) continue;
-
-                var delta = target - top;
-
-                if (delta <= 0) continue;
-
-                shift += delta;
+                // Every line from the first relocated one onward moves by the *accumulated* displacement,
+                // not by its own: a line below one that moved to the next fragmentainer follows it there,
+                // and a line needing no relocation of its own still has to keep its place under the one
+                // that did. Moving only the line that asked leaves the ones after it on top of it.
+                if (shift <= 0) continue;
 
                 foreach (var item in line.Items)
                 {
-                    item.Box.OffsetTop(delta);
+                    item.Box.OffsetTop(shift);
                 }
             }
 

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineGrid.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineGrid.cs
@@ -311,10 +311,6 @@ namespace PeachPDF.Html.Core.Dom
             // baseline items in the row share a common first baseline.
             AlignRowBaselines(placements);
 
-            // ── The break points between rows are real ones now that the items sit where they will
-            // finally sit - see RelocateRowsAcrossFragmentainers.
-            RelocateRowsAcrossFragmentainers(placements);
-
             // ── Container size when auto.
             var gridHeight = rows.Sum(t => t.Size) + (rowCount > 1 ? rowGap * (rowCount - 1) : 0);
             if (!hasDefiniteHeight)
@@ -322,6 +318,12 @@ namespace PeachPDF.Html.Core.Dom
                 _gridBox.ActualBottom = _gridBox.ClientTop + gridHeight
                     + _gridBox.ActualPaddingBottom + _gridBox.ActualBorderBottomWidth;
             }
+
+            // ── The break points between rows are real ones now that the items sit where they will
+            // finally sit - see RelocateRowsAcrossFragmentainers. Run *after* the container has been
+            // sized from its tracks, because that sizing reads the track sizes rather than the boxes and
+            // so would overwrite the displacement this adds.
+            RelocateRowsAcrossFragmentainers(placements);
 
             // Inline-grid shrinks to the content extent in the inline axis (like inline-block).
             if (_gridBox.Display == CssConstants.InlineGrid && !CssValueParser.IsValidLength(_gridBox.Width) && columns.Length > 0)
@@ -367,29 +369,21 @@ namespace PeachPDF.Html.Core.Dom
             {
                 var boxes = row.Select(p => p.Box).ToList();
 
-                var top = boxes.Min(b => b.Location.Y) + shift;
-                var bottom = boxes.Max(b => b.ActualBottom) + shift;
+                shift += LineRelocation.DeltaFor(
+                    container,
+                    boxes.Min(b => b.Location.Y) + shift,
+                    boxes.Max(b => b.ActualBottom) + shift,
+                    boxes.Any(b => BreakValues.IsForcedPageBreak(b.BreakBefore)),
+                    boxes.Any(b => BreakValues.AvoidsBreak(b.BreakInside, FragmentationContext.Page)
+                                   || MonolithicContent.IsMonolithic(b)));
 
-                var slot = container.SlotStartingAt(top);
-
-                var forced = boxes.Any(b => BreakValues.IsForcedPageBreak(b.BreakBefore));
-                var straddles = bottom - HtmlContainerInt.PageBoundaryEpsilon > container.PageBottomOf(slot)
-                                && boxes.Any(b => BreakValues.AvoidsBreak(b.BreakInside, FragmentationContext.Page)
-                                                  || MonolithicContent.IsMonolithic(b));
-
-                if (!forced && !straddles) continue;
-
-                if (!forced && bottom - top > container.PageBandHeightOf(slot + 1)) continue;
-
-                var delta = container.PageTopOf(slot + 1) - top;
-
-                if (delta <= 0) continue;
-
-                shift += delta;
+                // Every row from the first relocated one onward moves by the *accumulated* displacement -
+                // see LineRelocation for why the delta is returned rather than applied there.
+                if (shift <= 0) continue;
 
                 foreach (var box in boxes)
                 {
-                    box.OffsetTop(delta);
+                    box.OffsetTop(shift);
                 }
             }
 

--- a/src/PeachPDF/Html/Core/Fragmentation/LineRelocation.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/LineRelocation.cs
@@ -1,0 +1,55 @@
+namespace PeachPDF.Html.Core.Fragmentation
+{
+    /// <summary>
+    /// How far a flex line or grid row has to move to stop being cut by a fragmentainer boundary, per
+    /// <see href="https://www.w3.org/TR/css-break-3/#break-between">CSS Fragmentation Level 3 §3.1</see>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A flex container's break points are between its <b>lines</b> and a grid container's between its
+    /// <b>rows</b>, not between the items sharing one — so the two engines ask exactly the same question
+    /// of exactly the same inputs, and asking it in one place is what stops them drifting apart.
+    /// </para>
+    /// <para>
+    /// The caller accumulates what this returns and moves each line by the <i>running total</i>, not by
+    /// its own answer. That is the whole of why the displacement is returned rather than applied here: a
+    /// line below one that moved to the next fragmentainer follows it there, and a line needing no
+    /// relocation of its own still has to keep its place under the one that did. Applying each line's own
+    /// delta instead leaves the lines after the first relocation sitting on top of it.
+    /// </para>
+    /// </remarks>
+    internal static class LineRelocation
+    {
+        /// <summary>
+        /// How far the line spanning <paramref name="top"/>..<paramref name="bottom"/> must move down,
+        /// or 0 to leave it where it is.
+        /// </summary>
+        /// <param name="container">the layout container, for the page grid</param>
+        /// <param name="top">the line's top, already displaced by everything above it that moved</param>
+        /// <param name="bottom">the line's bottom, displaced the same way</param>
+        /// <param name="takesAForcedBreak">a <c>break-before</c> on any of its items forces a break here</param>
+        /// <param name="mayNotBeCut">
+        /// something in it asks not to be broken, or §2 says no user agent may break it. A line that
+        /// neither asks nor forbids is left where it is and the boundary cuts it — the same answer
+        /// ordinary block content gets when it has no line to break at.
+        /// </param>
+        internal static double DeltaFor(
+            HtmlContainerInt container, double top, double bottom, bool takesAForcedBreak, bool mayNotBeCut)
+        {
+            var slot = container.SlotStartingAt(top);
+
+            var straddles = mayNotBeCut
+                            && bottom - HtmlContainerInt.PageBoundaryEpsilon > container.PageBottomOf(slot);
+
+            if (!takesAForcedBreak && !straddles) return 0;
+
+            // A line taller than a whole band has nowhere better to be, and moving it would ask the same
+            // question again on the next fragmentainer, forever.
+            if (!takesAForcedBreak && bottom - top > container.PageBandHeightOf(slot + 1)) return 0;
+
+            var delta = container.PageTopOf(slot + 1) - top;
+
+            return delta > 0 ? delta : 0;
+        }
+    }
+}


### PR DESCRIPTION
A flex container's break points are between its **lines** and a grid container's between its **rows** ([§3.1](https://www.w3.org/TR/css-break-3/#break-between)), and #315 made a line that may not be cut move to the next fragmentainer. It moved *only that line*. Everything below it stayed exactly where it was, so the relocated line was drawn **on top of** the one after it — measured on a three-line wrapping flex container as line 2 landing at 380–440 while line 3 stayed at 400–460, a 40pt overlap. Both engines had the defect, in the same shape.

**The load-bearing idea is that the displacement accumulates and the geometry has to accumulate with it.** Both engines already tracked a running `shift` and already used it to *ask* the question — a later line's straddle test reads `bounds.Top + shift`, i.e. where the line will be once everything above it has moved. What neither did is *apply* it: each relocated line was offset by its own `delta` rather than by the running total, and a line that needed no relocation of its own was never offset at all. So the model was right and only the write-back was wrong, which is why nothing caught it: **every existing fixture relocates exactly one line**, where `delta == shift` and there is nothing below it.

`LineRelocation.DeltaFor` now states the decision once for both engines — they were asking the same question of the same inputs in two copies, differing only in local variable names — and it deliberately *returns* the displacement rather than applying it, because applying it is precisely the part that cannot be done per line.

**The second half was found by reading the container's own height after fixing the first.** With the lines right, an auto-height container still reported a bottom a whole displacement short of the content it held (460 against content reaching 500), because both engines size the container from their **lines/tracks** — `lines.Max(l => l.CrossOffset + l.CrossSize)`, `rows.Sum(t => t.Size)` — in a phase that runs *after* the relocation and overwrites the `+= shift` it had just applied. The relocation pass now runs after that sizing in both engines. Getting this order wrong is silent: the boxes are in the right places and only the container's reported box is short, so nothing overlaps and nothing looks wrong until something measures against the container.

## Verification

- **All 67 showcases were byte-identical before a fixture was added for it**, which is the whole reason this survived: none had two lines relocating. `paged_media_monolithic_content` gained a wrapping flex container whose *first* line straddles the boundary, so all three travel — and **on the unfixed build lines 2 and 3 stay put and line 1 is drawn underneath them**, with only the top edge of its cards visible above the line that overdrew it. Verified in both PDFium and MuPDF.
- Full net8.0 suite green (6568), solution builds with 0 warnings, **100% diff coverage**.
- Tests: `FlexGridFragmentationIntegrationTests` (+2 theories × 2 engines — the line after a relocated one not overlapping it, and the container reporting a height that holds its content). Verified load-bearing by restoring the per-line `delta`: the overlap test fails.


---
_Generated by [Claude Code](https://claude.ai/code/session_013hQgw6Vy3ddJ6wPrSph2DK)_