### PR TITLE
Keep a table cell's own line on one page

### DIFF
--- a/.claude/recent-fixes/2026-07-27-a-table-cells-own-line-belongs-to-one-page.md
+++ b/.claude/recent-fixes/2026-07-27-a-table-cells-own-line-belongs-to-one-page.md
@@ -1,0 +1,44 @@
+# A table cell's own line belongs to one page
+
+_Landed 2026-07-27._
+
+[CSS Fragmentation Level 3 §4.1](https://www.w3.org/TR/css-break-3/#possible-breaks) — a line box is a
+monolithic break unit.
+
+A table cell with more text than a page holds painted the line on the boundary **twice**: its top half
+at the foot of one page and its bottom half at the head of the next, the same line drawn under two
+different page clips. Measured on a 300-word cell as 300 words laid out and **312 emitted**, with 12 of
+them (one whole line) claimed by both fragmentainers.
+
+**The load-bearing observation is that the identical text in the identical cell was already correct one
+wrapper away.** `CssLayoutEngine.FlowBox`'s per-word boundary check was guarded
+`box is { IsFixed: false, IsTableCell: false }`, so it skipped a word whose owner box *is* the cell —
+but a word inside `<td><p>…</p></td>` belongs to the `<p>`, which is not a cell, and took the check
+normally. A sweep of 200–320 words over three shapes says it outright: bare `<td>` duplicates at 244
+words, `<p>`-in-`<td>` and a plain `<div>` never do. That asymmetry is what makes the exemption a
+defect rather than a rule — there is no reading of §4.1 under which the same text breaks differently
+because of a wrapper.
+
+With nothing to stop the line straddling, the emitter did what it is supposed to do: `FragmentRegion`
+claims a rectangle that overlaps a band by more than the epsilon, and a straddling line overlaps
+**both**. So the double-paint is downstream of the layout defect, not a second bug.
+
+**`IsFixed` stays**, and for a real reason: a fixed box repeats at the same page-box position on every
+page (CSS 2.1 §13.3.1), so a page boundary means nothing to its words.
+
+**What this does not do** is make a table cell fragment its content through the break-token model. The
+cell's words still relocate one at a time via `CssRect.BreakPage`, because `CssBox.LayoutContents`
+runs the table under `LayoutMonolithicContent` and the engine reads no resumption record — that is
+[#390](https://github.com/jhaygood86/PeachPDF/issues/390) stage 4, and this fix is what the shape of it
+looks like from outside until then. The `else` arm in `FlowBox` that this restores a caller to is
+exactly what [#400](https://github.com/jhaygood86/PeachPDF/issues/400)'s remaining half is blocked on.
+
+**All 67 pre-existing showcases are byte-identical**, which is why this survived: none of them has a
+bare-`<td>` line landing on a page boundary. New showcase `paged_media_table_cell_lines` does, and on
+the unfixed build `word150 word151 word152 word153 word154` is visibly cut through the middle on both
+pages. Verified in both PDFium and MuPDF.
+
+Tests: `TableCellLineFragmentationTests` (5 — the no-duplication sweep over all three shapes, no line
+spanning the boundary, and the cell still paginating every word). Verified load-bearing by restoring
+the exemption: two fail, the `<p>`-in-`<td>` and `<div>` controls pass either way. Full net8.0 suite
+green (6573), CLI green (96), 0 warnings, 100% diff coverage.

--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -653,6 +653,8 @@ Two limits are worth knowing. A flex or grid container **inside a table** is pos
 
 **A table that did not break moves whole.** A table breaks between two of its rows when the next row does not fit, and where no row break was taken at all — most often a single-row table, or one whose cells hold tall block content the row-height estimate could not see — the table did not fragment, and it is carried onto the next page in one piece rather than painting sliced across the boundary. This applies to every table, including one repeating a `<thead>` or a `<tfoot>`: the header follows it onto the page it lands on. A table taller than one page is left where it is, since moving it would only recreate the straddle. A heading chained to the table by `break-after: avoid` — the user-agent print default for `h1`–`h6` — travels with it, as at every other relocation.
 
+**A cell's text breaks between lines, not through one.** Where a cell holds more text than the page has room for, the text continues on the next page and each line lands whole on one page or the other — a line is never cut through the middle and drawn on both. This holds for the cell's own text and for text inside a block within it alike.
+
 Two limits. Keep-with-next (`break-after: avoid`) between two rows is not honored — the chain is read among block-flow siblings, and a table's rows are placed by the table itself. And a break value on a box *inside* a cell is likewise the table's row grid to answer, not the page grid's.
 
 <a id="monolithic-content"></a>

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -1817,6 +1817,37 @@ var tableRowBreaksHtml = """
     </body></html>
     """;
 
+// ── a cell's own text across a page boundary ───────────────────────────────
+// A line box is monolithic (CSS Fragmentation §4.1), so it belongs to exactly one page. A table
+// cell's own text used to be exempt from word flow's boundary check, which left nothing to stop a
+// line straddling the break - the emitter then claimed it on both pages and it painted sliced in
+// half on each.
+var tallCellHtml = """
+    <!DOCTYPE html>
+    <html><head><style>
+    @page { size: a6; margin: 12mm }
+    body { font: 9pt Helvetica, Arial, sans-serif; margin: 0; color: #1f2937 }
+    h1 { font-size: 11pt; margin: 0 0 0.4em }
+    p.intro { color: #6b7280; font-size: 8pt; margin: 0 0 0.8em }
+    table { width: 100%; border-collapse: collapse }
+    td { padding: 5pt 6pt; border: 0.75pt solid #94a3b8; line-height: 1.5; text-align: justify }
+    </style></head><body>
+    <h1>A cell with more text than a page holds</h1>
+    <p class="intro">The cell's own text - no wrapper block - runs past the page boundary. Every line
+    lands whole on one page or the other; none is cut through the middle.</p>
+    <table><tr><td>
+    """
+    + string.Join(" ", Enumerable.Range(1, 240).Select(i => $"word{i}"))
+    + """
+    </td></tr></table>
+    </body></html>
+    """;
+
+await SaveShowcaseAsync("paged_media_table_cell_lines", "Paged Media", "Table Cell Text Across Pages",
+    "CSS Fragmentation §4.1: a line box is a monolithic break unit, so a table cell's own text breaks "
+    + "between lines rather than through one.",
+    tallCellHtml, new PdfGenerateConfig { PageSize = PageSize.A6 });
+
 await SaveShowcaseAsync("paged_media_table_row_breaks", "Paged Media", "Table Row Break Values",
     "CSS Fragmentation §3.1's forced break values honored at the break point between two table rows, "
     + "with the table's repeating header carried onto the page the break opens.",

--- a/src/PeachPDF.Tests/Integration/TableCellLineFragmentationTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableCellLineFragmentationTests.cs
@@ -1,0 +1,119 @@
+using PeachPDF.Html.Core.Fragments;
+using PeachPDF.Tests.TestSupport;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// A line box is a monolithic break unit
+    /// (<see href="https://www.w3.org/TR/css-break-3/#possible-breaks">css-break-3 §4.1</see>), so it
+    /// belongs to exactly one fragmentainer — including when it is a table cell's own text.
+    /// </summary>
+    /// <remarks>
+    /// A cell used to be exempt from word flow's page-boundary check, which left its own text with no
+    /// mechanism to stop a line straddling the boundary. The emitter then claimed that line in both
+    /// bands and it painted sliced in half on each page. Wrapping the identical text in a block inside
+    /// the same cell was already correct, because the nested box is not a cell — which is what showed
+    /// the exemption to be a defect rather than a rule.
+    /// </remarks>
+    public class TableCellLineFragmentationTests
+    {
+        private static IEnumerable<BoxFragment> Flatten(BoxFragment fragment)
+        {
+            yield return fragment;
+
+            foreach (var child in fragment.Children)
+            {
+                foreach (var descendant in Flatten(child))
+                {
+                    yield return descendant;
+                }
+            }
+        }
+
+        private static string Words(int count) =>
+            string.Join(" ", Enumerable.Range(1, count).Select(i => $"word{i}"));
+
+        // The word count is swept rather than fixed: which line lands on the boundary depends on the
+        // font the host resolves, so a single count would pin the defect on one machine and miss it on
+        // another. 244 is where it reproduced here.
+        [Theory]
+        [InlineData("<table style='width:100%'><tr><td>{0}</td></tr></table>")]
+        [InlineData("<table style='width:100%'><tr><td><p style='margin:0'>{0}</p></td></tr></table>")]
+        [InlineData("<div>{0}</div>")]
+        public async Task NoWordIsPaintedTwice_AtAPageBoundary(string wrapper)
+        {
+            for (var count = 200; count <= 320; count += 4)
+            {
+                var (root, container) = await LayoutHarness.LayoutAsync(
+                    LayoutHarness.Wrap(string.Format(wrapper, Words(count))),
+                    pageHeight: 300, margin: 20);
+
+                var laidOut = LayoutHarness.Descendants(root)
+                    .SelectMany(b => b.Words)
+                    .Where(w => !w.IsSpaces)
+                    .ToList();
+
+                var emitted = container.FragmentTree!.Fragmentainers
+                    .SelectMany(f => Flatten(f.Root))
+                    .SelectMany(f => f.Words)
+                    .Select(w => w.Word)
+                    .ToList();
+
+                Assert.True(emitted.Count == emitted.Distinct().Count(),
+                    $"{count} words: {emitted.Count - emitted.Distinct().Count()} painted twice — a line "
+                    + "straddling the boundary was claimed by both fragmentainers");
+
+                // The other half of the same invariant: nothing was dropped to achieve it.
+                Assert.All(laidOut, word => Assert.Contains(word, emitted));
+            }
+        }
+
+        // The direct statement of §4.1 for the shape that used to break it: no line's own rectangle may
+        // span a page boundary, so no page clip can cut one in half.
+        [Fact]
+        public async Task ACellsOwnLine_DoesNotSpanAPageBoundary()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(
+                LayoutHarness.Wrap($"<table style='width:100%'><tr><td>{Words(244)}</td></tr></table>"),
+                pageHeight: 300, margin: 20);
+
+            var boundary = container.PageTopOf(1);
+
+            var straddling = LayoutHarness.Descendants(root)
+                .SelectMany(b => b.Words)
+                .Where(w => !w.IsSpaces && w.Top < boundary - 0.5 && w.Bottom > boundary + 0.5)
+                .ToList();
+
+            Assert.True(straddling.Count == 0,
+                $"{straddling.Count} words straddle the boundary at {boundary:F1}, e.g. "
+                + $"'{straddling.FirstOrDefault()?.Text}' at "
+                + $"[{straddling.FirstOrDefault()?.Top:F1}, {straddling.FirstOrDefault()?.Bottom:F1}]");
+        }
+
+        // The cell still paginates: the fix moves the straddling line rather than truncating the cell.
+        [Fact]
+        public async Task ACellTallerThanAPage_StillPaginatesAllOfItsText()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(
+                LayoutHarness.Wrap($"<table style='width:100%'><tr><td>{Words(244)}</td></tr></table>"),
+                pageHeight: 300, margin: 20);
+
+            var laidOut = LayoutHarness.Descendants(root)
+                .SelectMany(b => b.Words)
+                .Where(w => !w.IsSpaces)
+                .ToList();
+
+            var emitted = container.FragmentTree!.Fragmentainers
+                .SelectMany(f => Flatten(f.Root))
+                .SelectMany(f => f.Words)
+                .Select(w => w.Word)
+                .ToHashSet();
+
+            Assert.True(container.FragmentTree.Fragmentainers.Count > 1,
+                "the fixture no longer spans more than one page; it asserts nothing as written");
+            Assert.Equal(laidOut.Count, emitted.Count);
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -1413,7 +1413,14 @@ namespace PeachPDF.Html.Core.Dom
                         word.Left = coordinates.CurrentX;
                         word.Top = coordinates.CurrentY;
 
-                        if (box is { IsFixed: false, IsTableCell: false } && box.HtmlContainer?.SuppressWordPageBreaks != true)
+                        // A fixed box repeats at the same page-box position on every page (CSS 2.1
+                        // §13.3.1), so a boundary means nothing to its words. A *table cell* used to be
+                        // exempt here too, and that was a defect rather than a rule: a cell's own text
+                        // then had no mechanism to stop a line straddling the boundary, so the emitter
+                        // claimed that line in both bands and it painted sliced in half on each. The
+                        // giveaway is that wrapping the identical text in a block inside the same cell
+                        // was already correct - the nested box is not a cell, so it never took this arm.
+                        if (box is { IsFixed: false } && box.HtmlContainer?.SuppressWordPageBreaks != true)
                         {
                             if (coordinates.Fragmentainer is not null)
                             {
@@ -1710,8 +1717,8 @@ namespace PeachPDF.Html.Core.Dom
             // Word flow already ran CssRect.BreakPage per word; the inset shift below can push
             // a line that legitimately fit above a page boundary back across it, so the shifted
             // words re-check - a monolithic line must land fully within one fragmentainer
-            // (css-break §4). Same exemptions as the flow-time call.
-            var breakPages = flowContext is { IsFixed: false, IsTableCell: false };
+            // (css-break §4). Same exemption as the flow-time call.
+            var breakPages = flowContext is { IsFixed: false };
             var maxWordBottom = OffsetFlowedWords(b, topInset, breakPages);
 
             if (maxWordBottom > double.MinValue


### PR DESCRIPTION
A table cell with more text than a page holds painted the line on the boundary **twice**: its top half at the foot of one page and its bottom half at the head of the next, the same line drawn under two different page clips. Measured on a 300-word cell as 300 words laid out and **312 emitted**, with 12 of them — one whole line — claimed by both fragmentainers.

**The load-bearing observation is that the identical text in the identical cell was already correct one wrapper away.** `CssLayoutEngine.FlowBox`'s per-word boundary check was guarded `box is { IsFixed: false, IsTableCell: false }`, so it skipped a word whose owner box *is* the cell — but a word inside `<td><p>…</p></td>` belongs to the `<p>`, which is not a cell, and took the check normally. A sweep of 200–320 words over three shapes says it outright:

| shape | result |
|---|---|
| `<td>text</td>` | **duplicates at 244 words** |
| `<td><p>text</p></td>` | never duplicates |
| `<div>text</div>` | never duplicates |

That asymmetry is what makes the exemption a defect rather than a rule — there is no reading of [§4.1](https://www.w3.org/TR/css-break-3/#possible-breaks) ("a line box is a monolithic break unit") under which the same text breaks differently because of a wrapper.

With nothing to stop the line straddling, the emitter did what it is supposed to do: `FragmentRegion` claims a rectangle that overlaps a band by more than the epsilon, and a straddling line overlaps **both**. So the double-paint is downstream of the layout defect, not a second bug.

**`IsFixed` stays**, and for a real reason: a fixed box repeats at the same page-box position on every page (CSS 2.1 §13.3.1), so a page boundary means nothing to its words.

## What this does not do

It does not make a table cell fragment its content through the break-token model. The cell's words still relocate one at a time via `CssRect.BreakPage`, because `CssBox.LayoutContents` runs the table under `LayoutMonolithicContent` and the engine reads no resumption record — that is #390 stage 4, and this fix is what the shape of it looks like from outside until then. The `else` arm in `FlowBox` that this restores a caller to is exactly what #400's remaining half is blocked on.

## Verification

- **All 67 pre-existing showcases byte-identical**, which is why this survived: none has a bare-`<td>` line landing on a page boundary. New showcase `paged_media_table_cell_lines` does, and **on the unfixed build `word150 word151 word152 word153 word154` is visibly cut through the middle on both pages**. Verified in both PDFium and MuPDF.
- Full net8.0 suite green (6573), CLI green (96), 0 warnings, **100% diff coverage**.
- Tests: `TableCellLineFragmentationTests` (5 — the no-duplication sweep over all three shapes, no line spanning the boundary, and the cell still paginating every word). Verified load-bearing by restoring the exemption: two fail, the `<p>`-in-`<td>` and `<div>` controls pass either way.


---
_Generated by [Claude Code](https://claude.ai/code/session_013hQgw6Vy3ddJ6wPrSph2DK)_