### PR TITLE
Name the state a resumed table pass would have to carry

### DIFF
--- a/.claude/accepted-gaps/table-row-cursor-names-a-counted-band.md
+++ b/.claude/accepted-gaps/table-row-cursor-names-a-counted-band.md
@@ -1,0 +1,24 @@
+# The table row loop's band is counted, not reached
+
+`CssLayoutEngineTable.LayoutCells` tracks the band it is filling as a counter (`TableRowCursor.SlotIndex`,
+advanced once per break it takes), so it names the band the loop last *opened* rather than the band the row
+cursor has reached. Where a row turns out taller than `EstimateRowHeight` predicted — see
+[the estimate's own gap](table-pre-checks-decide-from-an-estimate.md) — the two diverge, and
+`CalculatePageBreakOffset` then returns a **negative** offset: the rows after a row taller than a page band
+are placed back inside it and painted over its content (measured at 1141pt of overlap for a 1400pt row on a
+260pt band). Tracked as [issue #432](https://github.com/jhaygood86/PeachPDF/issues/432), pinned by
+`TableRowCursorBandTests`.
+
+**Deriving the band from the cursor is not the correction it looks like, and this is the part worth not
+re-deriving.** The stale counter is what compensates for the estimate's undershoot: once the loop believes
+it is on band `k` it keeps measuring every later row against band `k`'s bottom, so a row that overflowed is
+noticed one row late rather than never. A cursor that re-derives its band per row finds every row
+comfortably inside a *fresh* band and stops breaking at all — measured as a 40-row 1400pt table on 842pt
+pages recording no break anywhere, a repeating `<thead>` appearing on one page instead of five, and four
+existing tests failing.
+
+So the estimate has to go first, or the row loop has to ask the question of the row's *real* height, which
+is only knowable after the row has been laid out. The second is
+[#390](https://github.com/jhaygood86/PeachPDF/issues/390) stage 4's own shape: a row loop that can stop and
+record where it stopped can also place a row, see that it straddled, and take the break there instead of
+predicting it.

--- a/.claude/invariants/fragmentation-a-stale-cursor-can-be-load-bearing-compensation-for-a-bad-estimate.md
+++ b/.claude/invariants/fragmentation-a-stale-cursor-can-be-load-bearing-compensation-for-a-bad-estimate.md
@@ -1,0 +1,17 @@
+# A stale cursor can be load-bearing compensation for a bad estimate
+
+_A trap this repo has paid for at least once. Tracker: [#432](https://github.com/jhaygood86/PeachPDF/issues/432)._
+
+The table row loop's band counter is stale by construction — it names the band the loop last *opened*, not
+the band the row cursor reached — and correcting it to read the cursor looks like a one-line application of
+[a resume target must come from where the break fell](fragmentation-a-resume-target-must-come-from-where-the-break-fell.md).
+It is not. `EstimateRowHeight` under-reports a row's height by roughly 2× (one line of text, blind to block
+content in a cell), and the stale band is the only thing that ever notices: once the loop believes it is on
+band `k` it keeps measuring later rows against band `k`'s bottom, so an overflowing row is caught one row
+late. Re-derive the band per row and every row is comfortably inside a *fresh* band, so no break is ever
+taken — measured as a 40-row 1400pt table on 842pt pages recording zero breaks and a repeating `<thead>`
+appearing on one page instead of five.
+
+The general form: **before replacing a cursor that is wrong, find out what its wrongness is currently
+covering for.** A predicted-fit check and a stale band are two errors in opposite directions; removing one
+leaves the other unopposed.

--- a/.claude/recent-fixes/2026-07-27-a-resumed-table-passs-state-has-a-name-and-a-map-of-what-stage-4-costs.md
+++ b/.claude/recent-fixes/2026-07-27-a-resumed-table-passs-state-has-a-name-and-a-map-of-what-stage-4-costs.md
@@ -1,0 +1,88 @@
+# A resumed table pass's state has a name, and a map of what stage 4 costs
+
+`CssLayoutEngineTable.LayoutCells` carried its row loop's state in five locals plus a dictionary. That state
+is exactly what a `BreakToken` would have to carry for a resumed fragmentainer pass to pick a table up
+mid-flight ([#390](https://github.com/jhaygood86/PeachPDF/issues/390) stage 4), so it is now
+`Html/Core/Fragmentation/TableRowCursor.cs` — the resumption record's contents, still held the way the
+engine holds them. `LayoutBodyRow` takes the cursor rather than four positional parameters and a returned
+tuple, and the header/footer measurement passes get a cursor of their own
+(`ForRowGroupMeasurement`), which is what makes it visible that they share only `MaxRight` with the body's:
+their rows are not body rows, so neither the row numbering nor the rowspan bookkeeping is theirs.
+
+Behaviour-neutral: all 69 showcases byte-identical (creation date, `/ID`, subset tags and annotation `/M`
+normalized), 6,623 tests passing.
+
+## What the mapping found by running the code, not by reading it
+
+**The table engine never receives a resumption record today, and a paginating table takes one pass.** Traced
+at `CssBox.LayoutContents`'s table arm: `resume` is null for every fixture, and `container.FragmentainerPasses`
+is **1** for a two-page table where the identical text in a `<div>` takes **3**. The whole of a table's
+pagination happens inside one fragmentainer pass, which is why none of the driver's machinery applies to it.
+
+**A table cell's text is paginated by the legacy per-word relocation, and the count is small.** A cell
+holding 244 words across two pages makes exactly **one** `CssRect.BreakPage` call — once the first
+straddling word is relocated to the next band's top, the rest follow from the cursor. The `<div>` control
+makes zero (it takes the break-token path). With a repeating `<thead>` the count is 12, because the header
+subtree is re-positioned once per proxy and its words are re-asked each time.
+
+**What breaks first if the table simply stops being monolithic, measured.** Swapping
+`LayoutMonolithicContent` for `LayoutEngineContent` on the table arm — so cell content sees a live
+fragmentainer and `CssLayoutEngine.CreateLineBoxes` takes the token arm — loses half the content, because
+`LayoutBodyRow` calls `cell.PerformLayout(g)` and reads only `cell.ActualBottom`: the cell's
+`PendingBreakToken` has no consumer and is dropped on the floor.
+
+| fixture (244 words, 300pt page) | emitted today | emitted non-monolithic |
+|---|---|---|
+| bare `<td>` | 244 | **121** |
+| `<p>` inside `<td>` | 244 | **121** |
+| two rows, tall first cell | 246 | **123** |
+| repeating `<thead>` | 246 | **135** |
+
+Pages drop from 2 to 1 in every case, and the second row's cursor collapses from Y=280 to Y=23 because the
+cell's `ActualBottom` is now only its first fragment. So stage 4's first real obligation is a consumer for
+that token in the row loop — not the monolithic gate.
+
+**A repeating `<thead>` does not repeat when the break falls inside a cell.** The per-row check is guarded
+`i > 0`, so a single-row table whose cell overflows onto page 2 emits its header once. Falls out of the same
+missing consumer.
+
+## The defect this turned up, and the correction that is not one
+
+`TableRowCursor.SlotIndex` is a *counter* — one increment per break — so it names the band the loop last
+opened, not the band `CurrentY` reached. A row taller than a band leaves them several slots apart, and
+`CalculatePageBreakOffset` then returns a **negative** offset: the rows after a 1400pt row on a 260pt band
+are placed at `PageTopOf(1) = 280`, **1141pt inside** the row they follow, and painted over it. Filed as
+[#432](https://github.com/jhaygood86/PeachPDF/issues/432) and characterized by
+`TableRowCursorBandTests.RowsAfterARowTallerThanABand_AreCurrentlyPlacedInsideIt` rather than fixed here.
+
+It was fixed here first, and then unfixed, which is the part worth recording. Deriving the band from the
+cursor (`Math.Max(tableTopSlot, SlotStartingAt(CurrentY))`) corrects all three heights exactly — row 1 lands
+at 723.0 / 1023.0 / 1423.0, a row that genuinely does not fit the band it reached still starts the next one
+down, and `PageBreakBottoms` keys the slice bottom to the right band. It also **regresses four tests**,
+because the stale counter is what compensates for `EstimateRowHeight`'s undershoot: the estimate is one line
+of text (~17pt for a 35pt row), and only a band the loop has already passed ever notices. Re-derive per row
+and every row sits comfortably inside a fresh band, so no break is taken at all — a 40-row 1400pt table on
+842pt pages records zero breaks and a repeating header appears on one page instead of five. Recorded as
+[an accepted gap](../accepted-gaps/table-row-cursor-names-a-counted-band.md) and
+[an invariant](../invariants/fragmentation-a-stale-cursor-can-be-load-bearing-compensation-for-a-bad-estimate.md).
+
+## What a resumed table pass has to carry, verified against the code
+
+Beyond the cursor's own members (`CurrentY`, `MaxRight`, `MaxBottom`, `SlotIndex`, `RowIndex`,
+`RowSpannedBoxes` keyed by **absolute** end-row index), four things a resumed pass must *not* redo, each of
+which is unconditional today:
+
+- **`RestoreStructureFromAnyPreviousRun`** pulls a detached `<thead>`/`<tfoot>` back out of its proxies and
+  removes them. On a resumed pass that destroys every earlier page's repeated header — the proxies are the
+  only surviving reference to the detached group.
+- **`_tableBox.PageBreakBottoms = null`** at the top of `LayoutCells`. It has to accumulate across passes;
+  it is what clips the table's borders per page.
+- **The two whole-table pre-checks**, which move `_tableBox.Location`. Re-running them on a continuation
+  moves a table whose earlier rows are already emitted.
+- **Steps 2 and 3**, which lay the header/footer rows out once to measure them. `CssProxyBox` moves the one
+  shared source subtree to its own position before snapshotting, so the source carries only the *last*
+  proxy's geometry — re-measuring on a resumed pass re-positions a subtree whose earlier snapshots are
+  already frozen in the emitter.
+
+`InsertEmptyBoxes` is already once-only (`CssBox._tableFixed`), and the column widths are recomputed
+deterministically from style and word metrics, so neither needs carrying.

--- a/src/PeachPDF.Tests/Integration/TableRowCursorBandTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableRowCursorBandTests.cs
@@ -1,0 +1,124 @@
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Utils;
+using PeachPDF.Tests.TestSupport;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// What the table engine's row cursor does with the band it is filling, pinned as it stands.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>TableRowCursor.SlotIndex</c> is a counter — one increment per break the row loop takes — so it
+    /// names the band the loop last <i>opened</i>, not the band <c>CurrentY</c> has reached. A row taller
+    /// than <c>EstimateRowHeight</c> predicted carries the cursor past it, and the offset that moves the
+    /// next row "to the next page" then comes out negative.
+    /// </para>
+    /// <para>
+    /// The overlap that produces is characterized here rather than asserted away, because deriving the
+    /// band from the cursor instead is not the correction it looks like: the stale counter is what
+    /// compensates for the estimate's undershoot, and removing it stops the loop breaking at all. See
+    /// <see href="https://github.com/jhaygood86/PeachPDF/issues/432">issue #432</see>; closing it turns
+    /// <see cref="RowsAfterARowTallerThanABand_AreCurrentlyPlacedInsideIt"/> into the no-overlap assertion
+    /// its remarks describe.
+    /// </para>
+    /// </remarks>
+    public class TableRowCursorBandTests
+    {
+        private const double PageHeight = 300;
+        private const double Margin = 20;
+
+        private static string TallFirstRowTable(double tallPt) => LayoutHarness.Wrap($@"
+            <table style='width:100%'>
+              <tr><td><div style='height:{tallPt}pt'>tall</div></td></tr>
+              <tr><td>second row</td></tr>
+              <tr><td>third row</td></tr>
+            </table>");
+
+        private static List<CssBox> RowsOf(CssBox root) =>
+            LayoutHarness.Descendants(root).Where(b => b.Display == CssConstants.TableRow).ToList();
+
+        private static CssBox TableOf(CssBox root) =>
+            LayoutHarness.Descendants(root).First(b => b.Display == CssConstants.Table);
+
+        /// <summary>
+        /// A row taller than a page band leaves the cursor several slots below the counter, so the break
+        /// offset is negative and the rows after it are placed <i>inside</i> it — painted over its
+        /// content. What this should assert is that no row starts above the bottom of the row before it.
+        /// </summary>
+        [Theory]
+        [InlineData(700)]
+        [InlineData(1000)]
+        [InlineData(1400)]
+        public async Task RowsAfterARowTallerThanABand_AreCurrentlyPlacedInsideIt(double tall)
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(
+                TallFirstRowTable(tall), pageHeight: PageHeight, margin: Margin);
+
+            var rows = RowsOf(root);
+            Assert.Equal(3, rows.Count);
+
+            // The characterization: the second row lands at the top of the band after the one the table
+            // began in, which the first row is still filling.
+            Assert.Equal(container.PageTopOf(1), rows[1].Location.Y, 0.01);
+            Assert.True(rows[1].Location.Y < rows[0].ActualBottom,
+                $"tall={tall}: the fixture no longer overlaps, so it characterizes nothing as written");
+        }
+
+        // Where the cursor never leaves the band the counter named — every ordinary table — the loop is
+        // right, and this is the behaviour the correction above must not disturb.
+        [Fact]
+        public async Task AnOrdinaryTableBreaksBetweenTheBandsItsRowsActuallyFill()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(
+                TallFirstRowTable(240), pageHeight: PageHeight, margin: Margin);
+
+            var rows = RowsOf(root);
+            var table = TableOf(root);
+
+            Assert.True(rows[1].ActualBottom <= container.PageBottomOf(0),
+                "the second row still fits the first band");
+            Assert.Equal(container.PageTopOf(1), rows[2].Location.Y, 0.01);
+            Assert.True(rows[2].Location.Y >= rows[1].ActualBottom,
+                "and the third row is below the second, not inside it");
+            Assert.Equal([0], table.PageBreakBottoms!.Keys.ToList());
+        }
+
+        // A many-rowed table breaks once per band it fills, and the header repeats on each — the
+        // behaviour a cursor that re-derived its band from CurrentY silently lost, because every row then
+        // found itself comfortably inside a fresh band and none of them ever asked for a break.
+        [Fact]
+        public async Task AManyRowedTableRecordsOneBreakPerBandItFills()
+        {
+            var rows = string.Concat(Enumerable.Range(1, 40).Select(i =>
+                $"<tr><td><div style='height:30pt'>row {i}</div></td></tr>"));
+
+            var (root, _) = await LayoutHarness.LayoutAsync(
+                LayoutHarness.Wrap($"<table style='width:100%;border-collapse:collapse'>{rows}</table>"),
+                pageHeight: 842, margin: 0);
+
+            var table = TableOf(root);
+
+            Assert.NotNull(table.PageBreakBottoms);
+            Assert.True(table.PageBreakBottoms!.Count >= 1,
+                "a 1400pt table on 842pt pages has to break inside itself somewhere");
+        }
+
+        // No page grid, so there is one band and the cursor stays in it whatever the rows do.
+        [Fact]
+        public async Task WithARollTallEnoughToHoldItAllNoBreakIsRecorded()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(
+                TallFirstRowTable(400), pageHeight: 4000, margin: Margin);
+
+            var rows = RowsOf(root);
+            var table = TableOf(root);
+
+            Assert.Null(table.PageBreakBottoms);
+            Assert.True(rows[1].Location.Y >= rows[0].ActualBottom - 1.01);
+            Assert.True(rows[2].Location.Y >= rows[1].ActualBottom - 1.01);
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
@@ -752,12 +752,19 @@ namespace PeachPDF.Html.Core.Dom
         {
             var startX = Math.Max(_tableBox.ClientLeft + GetHorizontalSpacing(), 0);
             var startY = Math.Max(_tableBox.ClientTop + GetVerticalSpacing(), 0);
-            var currentY = startY;
-            var maxRight = startX;
-            var maxBottom = 0d;
 
             var container = _tableBox.HtmlContainer;
             var pageHeight = container?.PageSize.Height ?? double.MaxValue;
+
+            // Which fragmentainer the table begins in is a question about the table's own top edge, not
+            // about startY: startY is a row cursor, and GetVerticalSpacing() is -1 for a collapsed-border
+            // table, so it sits one point *above* the box for exactly the tables whose top lands flush on
+            // a page boundary. Reading it there names the page the table just left, and the pre-check
+            // below then nudges the table one point onto the next one - which is what a table relocated
+            // by CssBox's own §4.3 mover, and so placed exactly at a page top, does every time.
+            var cursor = new TableRowCursor(
+                startY, startX,
+                pageHeight < double.MaxValue - 1 ? container!.SlotStartingAt(_tableBox.ClientTop) : 0);
 
             // Reset page-break tracking so re-layout doesn't accumulate stale entries
             _tableBox.PageBreakBottoms = null;
@@ -773,15 +780,19 @@ namespace PeachPDF.Html.Core.Dom
             if (_shouldRepeatHeaders && _headerBox != null)
             {
                 // Layout header rows directly using table layout logic
-                var headerRowsLayoutY = currentY;
+                var headerRowsLayoutY = cursor.CurrentY;
+                var headerCursor = cursor.ForRowGroupMeasurement(headerRowsLayoutY);
+
                 foreach (var row in _headerBox.Boxes)
                 {
                     if (row.Display != CssConstants.TableRow)
                         continue;
 
-                    var (newMaxRight, newMaxBottom) = await LayoutBodyRow(g, row, startX, headerRowsLayoutY, -1, new Dictionary<int, List<CssBox>>(), maxRight, headerRowsLayoutY);
-                    maxRight = newMaxRight;
-                    headerRowsLayoutY = newMaxBottom + GetVerticalSpacing();
+                    headerCursor.CurrentY = headerRowsLayoutY;
+                    headerCursor.MaxBottom = headerRowsLayoutY;
+
+                    await LayoutBodyRow(g, row, startX, headerCursor);
+                    headerRowsLayoutY = headerCursor.MaxBottom + GetVerticalSpacing();
 
                     // Unlike the regular body-row loop below, this never set the row's own
                     // Location/ActualRight/ActualBottom (only each cell's) - left it at a
@@ -790,12 +801,14 @@ namespace PeachPDF.Html.Core.Dom
                     // bug at the row-group level) then silently drops from painting entirely.
                     row.Location = new RPoint(row.Boxes.Min(x => x.Location.X), row.Boxes.Min(x => x.Location.Y));
                     row.ActualRight = row.Boxes.Max(x => x.ActualRight);
-                    row.ActualBottom = newMaxBottom;
+                    row.ActualBottom = headerCursor.MaxBottom;
                 }
 
+                cursor.MaxRight = headerCursor.MaxRight;
+
                 // Set header box dimensions
-                _headerBox.Location = new RPoint(startX, currentY);
-                _headerBox.ActualRight = maxRight;
+                _headerBox.Location = new RPoint(startX, cursor.CurrentY);
+                _headerBox.ActualRight = cursor.MaxRight;
                 _headerBox.ActualBottom = headerRowsLayoutY - GetVerticalSpacing();
                 _headerHeight = _headerBox.ActualBottom - _headerBox.Location.Y;
             }
@@ -805,20 +818,26 @@ namespace PeachPDF.Html.Core.Dom
             {
                 // Layout footer rows directly
                 var footerRowsLayoutY = 0d;
+                var footerCursor = cursor.ForRowGroupMeasurement(footerRowsLayoutY);
+
                 foreach (var row in _footerBox.Boxes)
                 {
                     if (row.Display != CssConstants.TableRow)
                         continue;
 
-                    var (newMaxRight, newMaxBottom) = await LayoutBodyRow(g, row, startX, footerRowsLayoutY, -1, new Dictionary<int, List<CssBox>>(), maxRight, footerRowsLayoutY);
-                    maxRight = newMaxRight;
-                    footerRowsLayoutY = newMaxBottom + GetVerticalSpacing();
+                    footerCursor.CurrentY = footerRowsLayoutY;
+                    footerCursor.MaxBottom = footerRowsLayoutY;
+
+                    await LayoutBodyRow(g, row, startX, footerCursor);
+                    footerRowsLayoutY = footerCursor.MaxBottom + GetVerticalSpacing();
 
                     // See the identical fix in the header-rows loop above for why this is needed.
                     row.Location = new RPoint(row.Boxes.Min(x => x.Location.X), row.Boxes.Min(x => x.Location.Y));
                     row.ActualRight = row.Boxes.Max(x => x.ActualRight);
-                    row.ActualBottom = newMaxBottom;
+                    row.ActualBottom = footerCursor.MaxBottom;
                 }
+
+                cursor.MaxRight = footerCursor.MaxRight;
 
                 // Unlike Location/ActualBottom above, ActualRight is a computed property derived
                 // from Size.Width, which is never otherwise set on the footer row-group box itself
@@ -830,23 +849,13 @@ namespace PeachPDF.Html.Core.Dom
                 // painted on any page. Mirrors the identical `_headerBox.ActualRight = maxRight`
                 // assignment above. See GitHub issue #124.
                 _footerBox.Location = new RPoint(startX, 0);
-                _footerBox.ActualRight = maxRight;
+                _footerBox.ActualRight = cursor.MaxRight;
                 _footerBox.ActualBottom = footerRowsLayoutY - GetVerticalSpacing();
                 _footerHeight = _footerBox.ActualBottom - _footerBox.Location.Y;
             }
 
             // Step 4: Layout body rows with page break detection.
             //
-            // Which fragmentainer the table begins in is a question about the table's own top edge, not
-            // about startY: startY is a row cursor, and GetVerticalSpacing() is -1 for a collapsed-border
-            // table, so it sits one point *above* the box for exactly the tables whose top lands flush on
-            // a page boundary. Reading it there names the page the table just left, and the pre-check
-            // below then nudges the table one point onto the next one - which is what a table relocated
-            // by CssBox's own §4.3 mover, and so placed exactly at a page top, does every time.
-            var currentPageNumber = pageHeight < double.MaxValue - 1
-                ? container!.SlotStartingAt(_tableBox.ClientTop)
-                : 0;
-
             // Pre-check: move the entire table to the next page when the first body row
             // would cross a page boundary AND the full table body fits on one page.
             // The per-row page-break check uses `i > 0` so it never fires for single-row
@@ -859,24 +868,24 @@ namespace PeachPDF.Html.Core.Dom
                 && !_shouldRepeatHeaders
                 && !_shouldRepeatFooters)
             {
+                var slot = cursor.SlotIndex;
                 var firstRowHeight = EstimateRowHeight(_bodyRows[0]);
                 // The band height already excludes both margins (PdfGenerator.SetContent) -
                 // subtracting them again here double-counted a marginTop+marginBottom-sized band
                 // out of every page's real capacity.
-                var availableHeight = container!.PageBandHeightOf(currentPageNumber) - _footerHeight;
+                var availableHeight = container!.PageBandHeightOf(slot) - _footerHeight;
                 var estimatedBodyHeight = _bodyRows.Sum(EstimateRowHeight);
 
-                if (WillCrossPageBoundary(container, currentY + firstRowHeight, availableHeight, currentPageNumber)
+                if (WillCrossPageBoundary(container, cursor.CurrentY + firstRowHeight, availableHeight, slot)
                     && estimatedBodyHeight <= availableHeight)
                 {
-                    var pageBreakOffset = CalculatePageBreakOffset(container, currentY, currentPageNumber);
-                    pageBreakOffset = PullKeepWithNextRun(container, currentY, pageBreakOffset,
-                        currentPageNumber, availableHeight, estimatedBodyHeight);
+                    var pageBreakOffset = CalculatePageBreakOffset(container, cursor.CurrentY, slot);
+                    pageBreakOffset = PullKeepWithNextRun(container, cursor.CurrentY, pageBreakOffset,
+                        slot, availableHeight, estimatedBodyHeight);
 
                     _tableBox.Location = _tableBox.Location with { Y = _tableBox.Location.Y + pageBreakOffset };
                     startY = Math.Max(_tableBox.ClientTop + GetVerticalSpacing(), 0);
-                    currentY = startY;
-                    currentPageNumber = container.PageIndexOf(startY);
+                    cursor.RestartAt(startY, container.PageIndexOf(startY));
                 }
             }
 
@@ -895,22 +904,22 @@ namespace PeachPDF.Html.Core.Dom
                 && container != null
                 && _shouldRepeatHeaders && _headerBox != null)
             {
+                var slot = cursor.SlotIndex;
                 var firstRowHeight = EstimateRowHeight(_bodyRows[0]);
-                var availableHeight = container.PageBandHeightOf(currentPageNumber) - _footerHeight;
+                var availableHeight = container.PageBandHeightOf(slot) - _footerHeight;
                 var afterHeaderY = startY + _headerHeight + GetVerticalSpacing();
 
-                if (WillCrossPageBoundary(container, afterHeaderY + firstRowHeight, availableHeight, currentPageNumber))
+                if (WillCrossPageBoundary(container, afterHeaderY + firstRowHeight, availableHeight, slot))
                 {
-                    var pageBreakOffset = CalculatePageBreakOffset(container, startY, currentPageNumber);
+                    var pageBreakOffset = CalculatePageBreakOffset(container, startY, slot);
                     pageBreakOffset = PullKeepWithNextRun(container, startY, pageBreakOffset,
-                        currentPageNumber, availableHeight, _headerHeight + firstRowHeight);
+                        slot, availableHeight, _headerHeight + firstRowHeight);
 
                     _tableBox.Location = _tableBox.Location with { Y = _tableBox.Location.Y + pageBreakOffset };
                     _headerBox.OffsetTop(pageBreakOffset);
 
                     startY = Math.Max(_tableBox.ClientTop + GetVerticalSpacing(), 0);
-                    currentY = startY;
-                    currentPageNumber = container.PageIndexOf(startY);
+                    cursor.RestartAt(startY, container.PageIndexOf(startY));
                 }
             }
 
@@ -923,38 +932,41 @@ namespace PeachPDF.Html.Core.Dom
             // overlap) but wasted content-stream bytes and duplicate structure-tree entries.
             if (_shouldRepeatHeaders && _headerBox != null)
             {
-                var headerProxy = CreateHeaderProxy(currentY);
+                var headerProxy = CreateHeaderProxy(cursor.CurrentY);
                 if (headerProxy != null)
                 {
                     await headerProxy.PerformLayout(g);
 
-                    currentY += _headerHeight + GetVerticalSpacing();
-                    maxBottom = currentY;
+                    cursor.CurrentY += _headerHeight + GetVerticalSpacing();
+                    cursor.MaxBottom = cursor.CurrentY;
                 }
             }
-
-            Dictionary<int, List<CssBox>> rowSpannedBoxes = new();
 
             for (var i = 0; i < _bodyRows.Count; i++)
             {
                 var row = _bodyRows[i];
+                cursor.RowIndex = i;
+
+                // The band the loop last opened, which is not in general the band the cursor has reached -
+                // see TableRowCursor for why it is nevertheless what every question here is asked of.
+                var slot = cursor.SlotIndex;
                 var estimatedRowHeight = EstimateRowHeight(row);
                 // See the identical fix/comment on the pre-check's availableHeight above.
-                var availableHeight = (container?.PageBandHeightOf(currentPageNumber) ?? pageHeight) - _footerHeight;
+                var availableHeight = (container?.PageBandHeightOf(slot) ?? pageHeight) - _footerHeight;
 
                 // Check for page break: either the row does not fit, or a break value says the break
                 // falls here regardless (css-break-3 §3.1's class-A break point between two rows).
                 if (i > 0 && container != null
                     && (ForcedBreakFallsBeforeRow(i)
-                        || WillCrossPageBoundary(container, currentY + estimatedRowHeight, availableHeight, currentPageNumber)))
+                        || WillCrossPageBoundary(container, cursor.CurrentY + estimatedRowHeight, availableHeight, slot)))
                 {
                     // Start with the last body-row bottom; may be extended by the footer below.
-                    var pageBreakBottomY = maxBottom;
+                    var pageBreakBottomY = cursor.MaxBottom;
 
                     // Create footer proxy for current page
                     if (_shouldRepeatFooters && _footerHeight > 0)
                     {
-                        var footerY = CalculateFooterPositionAtPageBottom(container!, currentY, currentPageNumber);
+                        var footerY = CalculateFooterPositionAtPageBottom(container, cursor.CurrentY, slot);
                         var footerProxy = CreateFooterProxy(footerY);
                         if (footerProxy != null)
                         {
@@ -966,50 +978,47 @@ namespace PeachPDF.Html.Core.Dom
 
                     // Record after footer so the border clip includes the footer area.
                     _tableBox.PageBreakBottoms ??= new Dictionary<int, double>();
-                    _tableBox.PageBreakBottoms[currentPageNumber] = pageBreakBottomY;
+                    _tableBox.PageBreakBottoms[slot] = pageBreakBottomY;
 
                     // Move to next page
-                    var pageBreakOffset = CalculatePageBreakOffset(container!, currentY, currentPageNumber);
-                    currentY += pageBreakOffset;
-                    currentPageNumber++;
+                    cursor.OpenNextSlot(
+                        cursor.CurrentY + CalculatePageBreakOffset(container, cursor.CurrentY, slot));
 
                     // Create new header proxy for new page
                     if (_shouldRepeatHeaders && _headerHeight > 0)
                     {
-                        var headerProxy = CreateHeaderProxy(currentY);
+                        var headerProxy = CreateHeaderProxy(cursor.CurrentY);
                         if (headerProxy != null)
                         {
                             await headerProxy.PerformLayout(g);
-                            currentY += _headerHeight + GetVerticalSpacing();
-                            maxRight = Math.Max(maxRight, headerProxy.ActualRight);
+                            cursor.CurrentY += _headerHeight + GetVerticalSpacing();
+                            cursor.MaxRight = Math.Max(cursor.MaxRight, headerProxy.ActualRight);
                         }
                     }
 
-                    maxBottom = currentY;
+                    cursor.MaxBottom = cursor.CurrentY;
                 }
 
                 // Layout body row
-                var (newMaxRight, newMaxBottom) = await LayoutBodyRow(g, row, startX, currentY, i, rowSpannedBoxes, maxRight, maxBottom);
-                maxRight = newMaxRight;
-                maxBottom = newMaxBottom;
+                await LayoutBodyRow(g, row, startX, cursor);
 
-                currentY = maxBottom + GetVerticalSpacing();
+                cursor.CurrentY = cursor.MaxBottom + GetVerticalSpacing();
 
                 row.Location = new RPoint(row.Boxes.Min(x => x.Location.X), row.Boxes.Min(x => x.Location.Y));
                 row.ActualRight = row.Boxes.Max(x => x.ActualRight);
-                row.ActualBottom = maxBottom;
+                row.ActualBottom = cursor.MaxBottom;
             }
 
             // Step 5: Create final footer proxy
             if (_shouldRepeatFooters && _footerHeight > 0)
             {
-                var finalFooterProxy = CreateFooterProxy(currentY);
+                var finalFooterProxy = CreateFooterProxy(cursor.CurrentY);
                 if (finalFooterProxy != null)
                 {
                     await finalFooterProxy.PerformLayout(g);
-                    currentY += _footerHeight + GetVerticalSpacing();
-                    maxBottom = Math.Max(maxBottom, finalFooterProxy.ActualBottom);
-                    maxRight = Math.Max(maxRight, finalFooterProxy.ActualRight);
+                    cursor.CurrentY += _footerHeight + GetVerticalSpacing();
+                    cursor.MaxBottom = Math.Max(cursor.MaxBottom, finalFooterProxy.ActualBottom);
+                    cursor.MaxRight = Math.Max(cursor.MaxRight, finalFooterProxy.ActualRight);
                 }
             }
 
@@ -1029,9 +1038,9 @@ namespace PeachPDF.Html.Core.Dom
             SetRowGroupBoxDimensions();
 
             // Step 7: Set final table dimensions
-            maxRight = Math.Max(maxRight, _tableBox.Location.X + _tableBox.ActualWidth);
-            _tableBox.ActualRight = maxRight + GetHorizontalSpacing() + _tableBox.ActualBorderRightWidth;
-            _tableBox.ActualBottom = Math.Max(maxBottom, startY) + GetVerticalSpacing() + _tableBox.ActualBorderBottomWidth;
+            var tableRight = Math.Max(cursor.MaxRight, _tableBox.Location.X + _tableBox.ActualWidth);
+            _tableBox.ActualRight = tableRight + GetHorizontalSpacing() + _tableBox.ActualBorderRightWidth;
+            _tableBox.ActualBottom = Math.Max(cursor.MaxBottom, startY) + GetVerticalSpacing() + _tableBox.ActualBorderBottomWidth;
 
             // What the pre-checks above decide from EstimateRowHeight - a one-line-of-text heuristic
             // that can grossly undershoot a row whose cells hold tall block content - only real layout
@@ -1108,15 +1117,23 @@ namespace PeachPDF.Html.Core.Dom
         }
 
         /// <summary>
-        /// Layout a single body row
+        /// Lays one row's cells out at <paramref name="cursor"/>'s current position, advancing the
+        /// cursor's <see cref="TableRowCursor.MaxRight"/>/<see cref="TableRowCursor.MaxBottom"/> over them.
         /// </summary>
-        private async ValueTask<(double maxRight, double maxBottom)> LayoutBodyRow(RGraphics g, CssBox row, double startX, double currentY, int rowIndex,
-    Dictionary<int, List<CssBox>> rowSpannedBoxes, double initialMaxRight, double initialMaxBottom)
+        /// <param name="g">the graphics device to measure with</param>
+        /// <param name="row">the row whose cells are being placed</param>
+        /// <param name="startX">the table's own content left edge, where each row's first cell starts</param>
+        /// <param name="cursor">where the row loop has got to; read and advanced</param>
+        private async ValueTask LayoutBodyRow(RGraphics g, CssBox row, double startX, TableRowCursor cursor)
         {
+            var currentY = cursor.CurrentY;
+            var rowIndex = cursor.RowIndex;
+            var rowSpannedBoxes = cursor.RowSpannedBoxes;
+
             var currentX = startX;
             var currentColumn = 0;
-            var rowMaxBottom = initialMaxBottom;
-            var rowMaxRight = initialMaxRight;
+            var rowMaxBottom = cursor.MaxBottom;
+            var rowMaxRight = cursor.MaxRight;
 
             foreach (var cell in row.Boxes)
             {
@@ -1190,7 +1207,8 @@ namespace PeachPDF.Html.Core.Dom
                 }
             }
 
-            return (rowMaxRight, rowMaxBottom);
+            cursor.MaxRight = rowMaxRight;
+            cursor.MaxBottom = rowMaxBottom;
         }
         /// <summary>
         /// Gets the spanned width of a cell (With of all columns it spans minus one).

--- a/src/PeachPDF/Html/Core/Fragmentation/TableRowCursor.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/TableRowCursor.cs
@@ -1,0 +1,110 @@
+using PeachPDF.Html.Core.Dom;
+using System.Collections.Generic;
+
+namespace PeachPDF.Html.Core.Fragmentation
+{
+    /// <summary>
+    /// Where a table's row loop has got to: the state <c>CssLayoutEngineTable.LayoutCells</c> carries from
+    /// one body row to the next.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A table paginates its own content — it runs with the fragmentainer detached
+    /// (<see cref="HtmlContainerInt.DetachFragmentainer"/>), so no break record escapes it and the whole
+    /// table is laid out inside one fragmentainer pass however many pages it covers. Everything saying how
+    /// far through the table layout has got therefore lives in local variables of a single method call,
+    /// which is exactly what a <see cref="BreakToken"/> would have to carry for a resumed pass to pick the
+    /// table up mid-flight. Naming it is the first half of that: <b>this type is the resumption record's
+    /// contents, still held the way the engine holds them today.</b>
+    /// </para>
+    /// <para>
+    /// <see cref="SlotIndex"/> is the member to be careful with, and the care is not obvious.
+    /// It is a <i>counter</i> — the loop advances it by one every time it takes a break — so it names the
+    /// band the loop last <b>opened</b>, not the band <see cref="CurrentY"/> has actually reached. Those
+    /// differ whenever a row turns out taller than <c>EstimateRowHeight</c> predicted, which is often,
+    /// since that estimate is one line of text and is blind to block content inside a cell.
+    /// </para>
+    /// <para>
+    /// Deriving it from <see cref="CurrentY"/> instead is <b>not</b> a safe correction, and the reason is
+    /// worth keeping: the stale counter is what compensates for the estimate. Once the loop believes it is
+    /// on band <c>k</c> it keeps measuring every later row against band <c>k</c>'s bottom, so a row that
+    /// overflowed is noticed one row late rather than never. A cursor that re-derives its band each row
+    /// finds every row comfortably inside a fresh band and stops breaking at all — measured as a
+    /// 40-row table recording no break anywhere and a repeating <c>&lt;thead&gt;</c> appearing on one page
+    /// instead of five. The counter's own defect — a break offset that comes out negative, so the rows
+    /// after a row taller than a band are placed back on a page it still occupies — is tracked as
+    /// <see href="https://github.com/jhaygood86/PeachPDF/issues/432">issue #432</see>. The estimate has to
+    /// go first, or the loop has to ask the question of the row's real height, which is only knowable once
+    /// the row has been laid out.
+    /// </para>
+    /// </remarks>
+    internal sealed class TableRowCursor
+    {
+        internal TableRowCursor(double top, double maxRight, int slotIndex)
+        {
+            CurrentY = top;
+            MaxRight = maxRight;
+            MaxBottom = 0d;
+            SlotIndex = slotIndex;
+        }
+
+        /// <summary>Where the next row starts.</summary>
+        internal double CurrentY { get; set; }
+
+        /// <summary>The rightmost edge any cell placed so far reached.</summary>
+        internal double MaxRight { get; set; }
+
+        /// <summary>The lowest edge any cell placed so far reached.</summary>
+        internal double MaxBottom { get; set; }
+
+        /// <summary>
+        /// The pagination slot the loop is filling — see this type's own remarks for what it does and does
+        /// not mean.
+        /// </summary>
+        internal int SlotIndex { get; private set; }
+
+        /// <summary>
+        /// The index into the table's body rows of the row being placed, or <c>-1</c> while a
+        /// <c>&lt;thead&gt;</c>/<c>&lt;tfoot&gt;</c> group is being measured — those rows are not part of
+        /// the body's own row numbering, and a rowspan inside one must not reach the body's bookkeeping.
+        /// </summary>
+        internal int RowIndex { get; set; } = -1;
+
+        /// <summary>
+        /// Cells with <c>rowspan &gt; 1</c>, keyed by the <b>absolute</b> body-row index they end on, so a
+        /// row can vertically align the cells that finish on it as well as its own.
+        /// </summary>
+        /// <remarks>
+        /// Absolute, not relative to where a pass began — which is why a resumed pass could not simply
+        /// start this empty: a cell begun on one page and ending on the next is entered in the map by the
+        /// row that started it, several pages earlier.
+        /// </remarks>
+        internal Dictionary<int, List<CssBox>> RowSpannedBoxes { get; } = [];
+
+        /// <summary>Moves the cursor onto the next slot, at <paramref name="top"/>.</summary>
+        internal void OpenNextSlot(double top)
+        {
+            CurrentY = top;
+            SlotIndex++;
+        }
+
+        /// <summary>
+        /// Moves the cursor to <paramref name="top"/> in slot <paramref name="slotIndex"/>, for a
+        /// relocation the engine has already worked out — a whole-table pre-check moving the table onto
+        /// the next page, which restarts the row loop rather than continuing it.
+        /// </summary>
+        internal void RestartAt(double top, int slotIndex)
+        {
+            CurrentY = top;
+            SlotIndex = slotIndex;
+        }
+
+        /// <summary>
+        /// A cursor for measuring one row group's own rows, which are laid out once to learn their height
+        /// and then repeated by proxy. It shares only <see cref="MaxRight"/> with the body's cursor: its
+        /// rows are not body rows, so neither its row numbering nor its rowspan bookkeeping is theirs.
+        /// </summary>
+        internal TableRowCursor ForRowGroupMeasurement(double top) =>
+            new(top, MaxRight, SlotIndex) { MaxBottom = top };
+    }
+}


### PR DESCRIPTION
Groundwork for #390 stage 4 — making a table's cell content fragment through the break-token model — plus the map of what that costs, measured rather than read.

## What lands

`CssLayoutEngineTable.LayoutCells` carried its row loop's state in five locals plus a rowspan dictionary. That state is exactly what a `BreakToken` would have to carry for a resumed fragmentainer pass to pick a table up mid-flight, so it becomes `Html/Core/Fragmentation/TableRowCursor.cs`: **the resumption record's contents, still held the way the engine holds them today.**

`LayoutBodyRow` takes the cursor instead of four positional parameters and a returned tuple, and the header/footer measurement passes get a cursor of their own (`ForRowGroupMeasurement`) — which is what makes it visible that they share only `MaxRight` with the body's, since their rows are not body rows and so neither the row numbering nor the rowspan bookkeeping is theirs.

Behaviour-neutral: **all 69 showcases byte-identical** after normalizing creation date, `/ID`, subset tags and annotation `/M`. 6,623 tests passing, 96 CLI tests passing, `dotnet build PeachPDF.slnx -t:Rebuild` at **0 warnings**, **100% diff coverage** (89 coverable changed lines, 0 missed).

## The map, from running the code

**A table never receives a resumption record today, and a paginating table takes one pass.** Traced at `CssBox.LayoutContents`'s table arm: `resume` is null for every fixture, and `FragmentainerPasses` is **1** for a two-page table where the identical text in a `<div>` takes **3**. All of a table's pagination happens inside a single fragmentainer pass, which is why none of the driver's machinery reaches it.

**A cell's text is paginated by the legacy per-word relocation, and the call count is small.** A cell holding 244 words across two pages makes exactly **one** `CssRect.BreakPage` call — once the first straddling word is moved to the next band's top the rest follow from the cursor. The `<div>` control makes zero. With a repeating `<thead>` it is 12, because the header subtree is re-positioned once per proxy.

**What breaks first if the table simply stops being monolithic.** Swapping `LayoutMonolithicContent` → `LayoutEngineContent` on the table arm, so cell content sees a live fragmentainer and `CreateLineBoxes` takes the token arm:

| fixture (244 words, 300pt page) | emitted today | emitted non-monolithic |
|---|---|---|
| bare `<td>` | 244 | **121** |
| `<p>` inside `<td>` | 244 | **121** |
| two rows, tall first cell | 246 | **123** |
| repeating `<thead>` | 246 | **135** |

Pages drop 2 → 1 in every case and the second row's cursor collapses from Y=280 to Y=23. Cause: `LayoutBodyRow` calls `cell.PerformLayout(g)` and reads only `cell.ActualBottom`, so the cell's `PendingBreakToken` has no consumer and is dropped. **Stage 4's first obligation is a consumer for that token in the row loop, not the monolithic gate.**

**A repeating `<thead>` does not repeat when the break falls inside a cell** — the per-row check is guarded `i > 0`, so a single-row table whose cell overflows onto page 2 emits its header once. Same missing consumer.

**Four things a resumed pass must not redo**, all unconditional today, on top of the cursor's own members: `RestoreStructureFromAnyPreviousRun` (pulls the detached `<thead>` back out of its proxies and deletes them — the proxies are the only surviving reference to it), the `PageBreakBottoms = null` reset, the two whole-table pre-checks (they move `_tableBox.Location`), and Steps 2/3's header/footer measurement (`CssProxyBox` moves the one shared source subtree to its own position before snapshotting, so the source carries only the *last* proxy's geometry). `InsertEmptyBoxes` is already once-only and the column widths are deterministic.

The full map is in `.claude/recent-fixes/2026-07-27-a-resumed-table-passs-state-has-a-name-and-a-map-of-what-stage-4-costs.md`.

## The defect this turned up, and the correction that is not one

`TableRowCursor.SlotIndex` is a **counter** — one increment per break — so it names the band the loop last *opened*, not the band `CurrentY` reached. A row taller than a band leaves them several slots apart and `CalculatePageBreakOffset` returns a **negative** offset: the rows after a 1400pt row on a 260pt band land at `PageTopOf(1) = 280`, **1141pt inside** the row they follow, painted over its content. Filed as #432.

It was fixed here first and then unfixed, which is the part worth keeping. Deriving the band from the cursor corrects all three heights exactly (row 1 at 723.0 / 1023.0 / 1423.0, a row that genuinely does not fit still starts the next band down, `PageBreakBottoms` keyed correctly) — and **regresses four tests**, because the stale counter is what compensates for `EstimateRowHeight`'s undershoot (one line of text, ~17pt for a 35pt row). Re-derive per row and every row sits comfortably inside a *fresh* band, so no break is taken at all:

| | counter (today) | derived band |
|---|---|---|
| 40 rows × 35pt on 842pt pages | breaks recorded | **none** |
| repeating `<thead>`, long table | header on ≥ 3 pages | header on **1** |
| `RepeatedTableHeaderClipIntegrationTests` | one proxy per page | two on one page |

So the estimate has to go first, or the loop has to ask the question of the row's *real* height — which is stage 4's own shape. Recorded as an accepted gap and as an invariant (*before replacing a cursor that is wrong, find out what its wrongness is covering for*), and pinned by `TableRowCursorBandTests`, whose characterization becomes the no-overlap assertion when #432 closes.

## Tests

`PeachPDF.Tests/Integration/TableRowCursorBandTests.cs` — the overlap characterized across three heights, plus the three behaviours a correction must not lose: an ordinary table breaking between the bands its rows actually fill, a many-rowed table recording at least one break per band, and a page tall enough to hold everything recording none.