### PR TITLE
Say a block has placed none of its words before it flows them

### DIFF
--- a/.claude/invariants/fragmentation-always-and-all-are-level-4-additions-not-level-3-removals.md
+++ b/.claude/invariants/fragmentation-always-and-all-are-level-4-additions-not-level-3-removals.md
@@ -1,0 +1,25 @@
+# `always` and `all` are Level 4 additions, not Level 3 removals
+
+_CSS Fragmentation. Tracker: [#320](https://github.com/jhaygood86/PeachPDF/issues/320)._
+
+`break-before: always` used to force a page break in PeachPDF and no longer does
+([#299](https://github.com/jhaygood86/PeachPDF/issues/299)). The reason is **not** that
+css-break-3 dropped the value: `always` and `all` were never in
+[Level 3](https://www.w3.org/TR/css-break-3/#break-between)'s `<break-between>` production at all —
+they are [Level 4](https://www.w3.org/TR/css-break-4/) *additions*. Rejecting them is PeachPDF
+implementing the Level 3 grammar, not tracking a removal.
+
+#299's own issue text has this backwards, and the first implementation pass propagated the mistake
+into the docs and the tests before review caught it. Anyone re-reading that issue will be misled the
+same way.
+
+Forward-porting the Level 4 values was considered and **declined**
+([#328](https://github.com/jhaygood86/PeachPDF/issues/328), closed not-planned): Level 4 is a
+Working Draft, and this repo does not implement draft-only values ahead of the spec settling. The
+legacy `page-break-*: always` alias is unaffected and still normalizes to `page`.
+
+**The general rule this produced**, and the reason it is worth keeping: a spec-correctness fix that
+changes how a *non-compliant* document renders is not a regression. It is stated for readers in the
+docs' own [Forward compatibility](https://github.com/jhaygood86/PeachPDF/blob/main/docs/html-css-support.md#forward-compatibility)
+section, which is where any future change of this shape should point, alongside a migration note in
+the affected doc section.

--- a/.claude/invariants/fragmentation-an-unpositioned-word-is-not-a-word-at-the-origin.md
+++ b/.claude/invariants/fragmentation-an-unpositioned-word-is-not-a-word-at-the-origin.md
@@ -1,0 +1,31 @@
+# An unpositioned word is not a word at the origin
+
+_CSS Fragmentation Level 3. Tracker: [#320](https://github.com/jhaygood86/PeachPDF/issues/320)._
+
+A `CssRect`'s position is a `double` pair that starts at 0 and is written when the flow reaches the
+word. Nothing in the type distinguishes *placed at document Y 0* from *never placed*, and the two
+have to be told apart, because document Y 0 lies inside the **first** page slot's own band — so the
+first page's fragment claims an unplaced word, paints it, and puts it in that page's text layer
+([#433](https://github.com/jhaygood86/PeachPDF/issues/433): 2,999 of 3,000 words claimed by a page
+showing 1,153).
+
+**`CssRect.AwaitsTheNextFragmentainer` is how the difference is stated**, and it is self-healing:
+`CssRect.Top`'s setter clears it, so being positioned is what makes a word this layout's. The
+corollary is the rule to keep: **any mechanism that can leave a word unreached has to say so before
+the attempt starts**, because afterwards there is nothing to read — the position the word carries is
+indistinguishable from a real one. Three callers say it (`CssBox.ResetForRefill`,
+`CssBox.DiscardLineBoxesFrom`, and the block's own inline flow in
+`CssLayoutEngine.CreateLineBoxes`), and all three say it the same way: mark, then let placement
+clear it.
+
+**The position an unreached word carries is not always 0**, which is what makes "just check for the
+origin" the wrong fix. A box laid out a second time — the reflow loop settling per-page widths, a
+§4.3 mover laying a subtree out again — leaves the previous attempt's coordinates on every word the
+new attempt does not reach, and those are ordinary-looking coordinates in the middle of the
+document. The showcase symptom for #433 was exactly that: a line of the *next* page's text painted
+at the foot of `paged_media_horizontal_reflow`'s pages 2 and 4, at a stale X as well as a stale Y.
+
+**Marking may only be done by the pass that opens the flow.** On a resumed pass the words below the
+resume point belong to a fragmentainer already filled and frozen; marking them takes back content
+another page legitimately holds (measured: 9 test failures when the `resume is null` guard is
+removed from `CreateLineBoxes`).

--- a/.claude/invariants/fragmentation-an-unpositioned-word-is-not-a-word-at-the-origin.md
+++ b/.claude/invariants/fragmentation-an-unpositioned-word-is-not-a-word-at-the-origin.md
@@ -13,10 +13,11 @@ showing 1,153).
 `CssRect.Top`'s setter clears it, so being positioned is what makes a word this layout's. The
 corollary is the rule to keep: **any mechanism that can leave a word unreached has to say so before
 the attempt starts**, because afterwards there is nothing to read — the position the word carries is
-indistinguishable from a real one. Three callers say it (`CssBox.ResetForRefill`,
-`CssBox.DiscardLineBoxesFrom`, and the block's own inline flow in
-`CssLayoutEngine.CreateLineBoxes`), and all three say it the same way: mark, then let placement
-clear it.
+indistinguishable from a real one. Four sites say it — `CssBox.AwaitPlacement` (over a whole
+subtree, for a discarded fill via `ResetForRefill` and for a block's inline flow on the pass that
+opens it), `CssBox.DiscardLineBoxesFrom`, and §4.1's own discarded line in
+`CssLayoutEngine.CreateLineBoxes` — and all of them say it the same way: mark, then let placement
+clear it. One reader: `FragmentEmitter.BuildDraft`.
 
 **The position an unreached word carries is not always 0**, which is what makes "just check for the
 origin" the wrong fix. A box laid out a second time — the reflow loop settling per-page widths, a

--- a/.claude/invariants/fragmentation-the-shape-of-the-fragmentation-model.md
+++ b/.claude/invariants/fragmentation-the-shape-of-the-fragmentation-model.md
@@ -1,0 +1,55 @@
+# The shape of the fragmentation model
+
+_CSS Fragmentation Level 3. Tracker: [#320](https://github.com/jhaygood86/PeachPDF/issues/320)._
+
+What a change in this area has to keep true. Each clause is settled work with an issue behind it;
+the point of the file is that the model is easy to violate one clause at a time.
+
+**Layout is a driver over fragmentainers** ([#321](https://github.com/jhaygood86/PeachPDF/issues/321)).
+It targets one, and where content does not fit reads back a **break token** — a chain with one link
+per ancestor, from the fragmentation-context root down to the box that stopped — then opens the next
+fragmentainer and re-enters there. A document that fits takes a single pass.
+
+**Layout emits its own fragments as it fills**
+([#331](https://github.com/jhaygood86/PeachPDF/issues/331)): `FragmentTree` →
+`FragmentainerFragment` → `BoxFragment` → `LineFragment`/`TextFragment`, under
+`Html/Core/Fragments/`, with `FragmentEmitter` as the seam. **Paint consumes only that** and never
+reads geometry off `CssBox` ([#298](https://github.com/jhaygood86/PeachPDF/issues/298),
+[#325](https://github.com/jhaygood86/PeachPDF/issues/325)), in its own phase under
+`Html/Core/Paint/` ([#324](https://github.com/jhaygood86/PeachPDF/issues/324)). Each fragment carries
+**geometry of its own** ([#366](https://github.com/jhaygood86/PeachPDF/issues/366)), which is what
+lets two columns of one box exist at all.
+
+**A multi-column column is a real fragmentainer** in §2's sense
+([#322](https://github.com/jhaygood86/PeachPDF/issues/322), #366), so the block-axis break machinery
+works inside one without being told about columns.
+
+**A break value names the context it speaks for**
+([#304](https://github.com/jhaygood86/PeachPDF/issues/304),
+[#312](https://github.com/jhaygood86/PeachPDF/issues/312),
+[#313](https://github.com/jhaygood86/PeachPDF/issues/313)), and each context is realized by a
+different **vehicle**: a page break by *placement*, a column break by a *break decision*.
+`FragmentationContext` has no region member, which is what makes `region`/`avoid-region` inert by
+construction rather than by omission ([#319](https://github.com/jhaygood86/PeachPDF/issues/319)).
+
+**"Did this cross out of its fragmentainer?" is one question with two bands**
+([#400](https://github.com/jhaygood86/PeachPDF/issues/400) (b)), asked with two named boundary
+conventions rather than an epsilon spelt out at every call site (#400 (a)) — and **a measurement
+pass names no fragmentainer at all** (#400 (c)): a box laid out at a provisional position it is
+about to be moved away from cannot ask a fragmentation question, rather than asking one that is
+suppressed.
+
+**§4.3's relaxation ladder reaches its last rung.** Every tier is allowed to refuse — the
+keep-with-next run is trimmed, then dropped, then the container is left behind, then the constraint
+is given up — because the backstop underneath them all cannot: a pass reproducing the record it was
+handed has its remainder laid out monolithically, overflowing one fragmentainer rather than losing
+content ([#404](https://github.com/jhaygood86/PeachPDF/issues/404)).
+
+**Re-entering a pass rolls the box tree back to the state that pass began in**
+([#415](https://github.com/jhaygood86/PeachPDF/issues/415)), through one shared
+`PassRewind.RollBackTo`. A box's prologue is once per *layout*, so a re-entered pass gets none of
+what it settles back unless the rollback lets it.
+
+The rendering-side counterpart lives in
+[docs/architecture.md](https://github.com/jhaygood86/PeachPDF/blob/main/docs/architecture.md) §5–§6,
+which is the reader-facing description of the same pipeline.

--- a/.claude/recent-fixes/2026-07-27-a-word-the-flow-never-reached-is-not-the-first-pages.md
+++ b/.claude/recent-fixes/2026-07-27-a-word-the-flow-never-reached-is-not-the-first-pages.md
@@ -50,6 +50,19 @@ laid out by `CssBox.PerformLayoutEpilogue`, which the pass that breaks never rea
 positioned only on the completing pass — after the slot it belongs to was frozen. Filed as
 [#444](https://github.com/jhaygood86/PeachPDF/issues/444).
 
+**`windows-latest` found a second defect, and it is not this one.** The claimed-exactly-once
+invariant, asked of the whole document, failed there on a plain paragraph with **16 words claimed by
+slots [0,1], living in 0** — one whole line, drawn again in the next page's top margin. That is a
+tolerance mismatch, not an unplaced word: layout keeps a line overhanging the band bottom by up to
+`PageBoundaryEpsilon` (0.5pt) while the emitter counts an overlap of `BandOverlapEpsilon` (1e-6) as
+membership of the next band, and whether a page's last line lands in that window is a function of
+the platform's font metrics. Filed as [#446](https://github.com/jhaygood86/PeachPDF/issues/446); the
+fixtures here now pin their line geometry (a 20pt line against an 830pt band, so every page's last
+line is 10pt clear) and turn `orphans`/`widows` off, so what they measure is which fragment claims a
+word the flow never reached. **Making the diagnostic name the slots, the word and where it lives is
+what turned one red check into a filed issue in a single CI cycle** — the assertion message is part
+of the test.
+
 **One residual the review chased and the numbers closed.** `AwaitPlacement` marks a subtree
 strictly larger than `FlowBox` visits — an outside `::marker` is skipped by the flow — so the
 question is whether anything is now newly *un*painted. Measured over seven shapes at 2,500 words

--- a/.claude/recent-fixes/2026-07-27-a-word-the-flow-never-reached-is-not-the-first-pages.md
+++ b/.claude/recent-fixes/2026-07-27-a-word-the-flow-never-reached-is-not-the-first-pages.md
@@ -15,7 +15,7 @@ slot's own band, and `FragmentEmitter.BuildDraft` asks nothing but `region.Conta
 and `AwaitsTheNextFragmentainer` — a flag §4.1's *discarded line* sets and nothing else did. After
 the pass there is nothing left to read: a word that was never placed and a word placed at the top of
 page 1 carry the same coordinates. So the statement has to be made **before** the attempt, which is
-what `CssBox.AwaitPlacementAgain` already exists to do for a discarded multicol fill. The block's
+what `CssBox.AwaitPlacement` already exists to do for a discarded multicol fill. The block's
 own inline flow now says the same thing about itself on the pass that opens it, and
 `CssRect.Top`'s setter clears it per word — so what survives the flow is exactly what the flow did
 not reach. One call; the mechanism was already there and self-healing, as the issue predicted.
@@ -50,13 +50,24 @@ laid out by `CssBox.PerformLayoutEpilogue`, which the pass that breaks never rea
 positioned only on the completing pass — after the slot it belongs to was frozen. Filed as
 [#444](https://github.com/jhaygood86/PeachPDF/issues/444).
 
-Tests: `UnreachedWordClaimTests` (3 — #374's claimed-exactly-once invariant over the *whole*
-document at two lengths, and the symptom stated directly: the first page's fragment holds exactly
-the words whose own position falls in its band), plus
+**One residual the review chased and the numbers closed.** `AwaitPlacement` marks a subtree
+strictly larger than `FlowBox` visits — an outside `::marker` is skipped by the flow — so the
+question is whether anything is now newly *un*painted. Measured over seven shapes at 2,500 words
+each, with and without the fix: duplicates go 1,330–1,397 → **0** in every shape that had any, and
+the two shapes with an unclaimed word (a list's own marker, an absolutely-positioned inline's words)
+report the **same** count either way. So the marking loses nothing; both residuals are pre-existing,
+and the second one belongs to [#318](https://github.com/jhaygood86/PeachPDF/issues/318). The
+regression guard for the class is `AListWhoseItemsDoNotBreak_StillClaimsEveryMarker`, which passes on
+both builds by design — an item that does not itself break reaches its own epilogue on the same
+pass, so its marker is positioned before the slot freezes.
+
+Tests: `UnreachedWordClaimTests` (7 — #374's claimed-exactly-once invariant over the *whole*
+document for five shapes, since what stops is the fill rather than the paragraph; the symptom stated
+from the page grid rather than from the flag the fix sets; and the marker guard), plus
 `EarlyBreakLayoutIntegrationTests.PulledRun_FromAPassThatResumedIntoAParagraph_ClaimsEachBlockWordExactlyOnce`
-**promoted** from the two blocks the pull moves to the whole document. Removing the one call fails 4
-of those 5. Full net8.0
-suite green (6,636 passed / 6,645 total), CLI green (96); **100% diff coverage**; 0 warnings on
+**promoted** from the two blocks the pull moves to the whole document. Removing the one call fails 6
+of those 9. Full net8.0
+suite green (6,640 passed / 6,649 total), CLI green (96); **100% diff coverage**; 0 warnings on
 `dotnet build PeachPDF.slnx -t:Rebuild`.
 
 The durable half is in

--- a/.claude/recent-fixes/2026-07-27-a-word-the-flow-never-reached-is-not-the-first-pages.md
+++ b/.claude/recent-fixes/2026-07-27-a-word-the-flow-never-reached-is-not-the-first-pages.md
@@ -1,0 +1,63 @@
+# A word the flow never reached is not the first page's
+
+_Landed 2026-07-27._
+
+**A word the flow never reached is not the first page's** ([issue #433](https://github.com/jhaygood86/PeachPDF/issues/433),
+[CSS Fragmentation 3 §4.1](https://www.w3.org/TR/css-break-3/#possible-breaks)). An ordinary
+paragraph that breaks at the **first** page boundary had every word below the break claimed by page
+0's fragment as well as by the page it really lands on. Measured on the issue's own fixture — a
+3,000-word `<p>` on A4 at the production default 10pt margins — page 0's text layer held **2,999**
+words where the page shows **1,153**.
+
+**The load-bearing idea is that an unpositioned word is not a word at the origin, and only the flow
+can tell the difference.** `CssRect`'s position starts at 0, document Y 0 lies inside the first
+slot's own band, and `FragmentEmitter.BuildDraft` asks nothing but `region.Contains(word.Rectangle)`
+and `AwaitsTheNextFragmentainer` — a flag §4.1's *discarded line* sets and nothing else did. After
+the pass there is nothing left to read: a word that was never placed and a word placed at the top of
+page 1 carry the same coordinates. So the statement has to be made **before** the attempt, which is
+what `CssBox.AwaitPlacementAgain` already exists to do for a discarded multicol fill. The block's
+own inline flow now says the same thing about itself on the pass that opens it, and
+`CssRect.Top`'s setter clears it per word — so what survives the flow is exactly what the flow did
+not reach. One call; the mechanism was already there and self-healing, as the issue predicted.
+
+**The guard is the whole of the care needed, and it is load-bearing.** Only a pass with
+`resume is null` may mark: on a resumed pass the words below the resume point belong to a
+fragmentainer already filled and frozen, and marking them takes back content another page
+legitimately holds. Removing the guard fails **9** tests across the widows, keep-with-next and
+multicol suites.
+
+**What running it bought.** The bug does *not* reproduce in `LayoutHarness`'s default fixture, and
+the reason is worth knowing before writing a fixture for anything in this family: the harness
+defaults to a 20pt margin, so slot 0's band begins at document Y 20 and a word's zero rectangle
+(height ≈ 13pt) does not overlap it at all. The defect is real at
+`PdfGenerateConfig`'s **own default of 10pt** and at 0, and invisible above roughly one line height.
+A fixture that picks its margin for tidiness rather than from production silently tests nothing here.
+
+**The showcase found a second form of it that the issue did not describe, and it is the more
+alarming one.** 68 of 69 showcases are byte-identical; `paged_media_horizontal_reflow` is the one
+that differs, and it differs by **losing a whole line of the following page's text painted at the
+foot of pages 2 and 4** — an interior page, not page 0. That document's per-page widths are settled
+by a bounded reflow loop, so its boxes are laid out more than once, and a word the *second* layout
+does not reach keeps the *first* one's coordinates: ordinary-looking coordinates in the middle of
+the document rather than the origin. The fix covers both because it says "this layout has placed
+none of these yet" rather than testing for a magic position. Page count unchanged (7), verified in
+both PDFium and MuPDF.
+
+**Deliberately not chased**, because it is pre-existing and identical on `main` (verified by running
+the same fixture on both): a `<li>` whose own text straddles a page boundary can leave its
+`::marker` in no fragment at all — 39 of 40 markers claimed in a 40-item list. An outside marker is
+laid out by `CssBox.PerformLayoutEpilogue`, which the pass that breaks never reaches, so its word is
+positioned only on the completing pass — after the slot it belongs to was frozen. Filed as
+[#444](https://github.com/jhaygood86/PeachPDF/issues/444).
+
+Tests: `UnreachedWordClaimTests` (3 — #374's claimed-exactly-once invariant over the *whole*
+document at two lengths, and the symptom stated directly: the first page's fragment holds exactly
+the words whose own position falls in its band), plus
+`EarlyBreakLayoutIntegrationTests.PulledRun_FromAPassThatResumedIntoAParagraph_ClaimsEachBlockWordExactlyOnce`
+**promoted** from the two blocks the pull moves to the whole document. Removing the one call fails 4
+of those 5. Full net8.0
+suite green (6,636 passed / 6,645 total), CLI green (96); **100% diff coverage**; 0 warnings on
+`dotnet build PeachPDF.slnx -t:Rebuild`.
+
+The durable half is in
+[.claude/invariants/fragmentation-an-unpositioned-word-is-not-a-word-at-the-origin.md](../invariants/fragmentation-an-unpositioned-word-is-not-a-word-at-the-origin.md).

--- a/src/PeachPDF.Tests/Integration/EarlyBreakLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/EarlyBreakLayoutIntegrationTests.cs
@@ -483,10 +483,10 @@ namespace PeachPDF.Tests.Integration
         /// to a fragmentainer already filled.
         /// </summary>
         /// <remarks>
-        /// Asked of the two blocks rather than of the whole document: a word the pass that froze the first
-        /// slot never reached still carries document Y 0, which lies inside that slot's own band, so the
-        /// first page's fragment claims it — a pre-existing defect this fixture would otherwise trip over
-        /// (issue #433), present identically with and without the pull.
+        /// Asked of the whole document since #433: a word the pass that froze the first slot never reached
+        /// used to carry document Y 0, which lies inside that slot's own band, so the first page's fragment
+        /// claimed it — a pre-existing defect this fixture tripped over, which is why the assertion was
+        /// originally scoped to the two blocks the pull moves.
         /// </remarks>
         [Theory]
         [InlineData(50, 30, 120)]
@@ -497,20 +497,17 @@ namespace PeachPDF.Tests.Integration
             var (root, container) = await LayoutHarness.LayoutAsync(
                 ResumedParagraphDocument(leadWords, cardWords), pageWidth: 300, pageHeight: pageHeight, margin: 10);
 
-            var blockWords = new[] { 1, 2 }
-                .SelectMany(n => WordsIn(LayoutHarness.FindById(root, $"card{n}")!))
-                .ToHashSet(ReferenceEqualityComparer.Instance);
+            var authored = WordsIn(root);
 
-            Assert.NotEmpty(blockWords);
+            Assert.NotEmpty(authored);
 
             var claimed = container.FragmentTree!.Fragmentainers
                 .SelectMany(f => Flatten(f.Root))
                 .SelectMany(f => f.Words)
                 .Select(w => (object)w.Word)
-                .Where(blockWords.Contains)
                 .ToList();
 
-            Assert.Equal(blockWords.Count, claimed.Count);
+            Assert.Equal(authored.Count, claimed.Count);
             Assert.Equal(claimed.Count, claimed.Distinct(ReferenceEqualityComparer.Instance).Count());
         }
 

--- a/src/PeachPDF.Tests/Integration/UnreachedWordClaimTests.cs
+++ b/src/PeachPDF.Tests/Integration/UnreachedWordClaimTests.cs
@@ -49,7 +49,8 @@ namespace PeachPDF.Tests.Integration
             var claimed = ClaimedWords(container);
 
             Assert.NotEmpty(authored);
-            Assert.Equal(claimed.Distinct(ReferenceEqualityComparer.Instance).Count(), claimed.Count);
+            Assert.True(claimed.Count == claimed.Distinct(ReferenceEqualityComparer.Instance).Count(),
+                DescribeDoubleClaims(container));
             Assert.Equal(claimed.Count, authored.Count);
         }
 
@@ -105,6 +106,35 @@ namespace PeachPDF.Tests.Integration
             var claimed = ClaimedWords(container).ToHashSet(ReferenceEqualityComparer.Instance);
 
             Assert.All(markerWords, w => Assert.Contains(w, claimed));
+        }
+
+        /// <summary>
+        /// Names the words more than one fragment claims, with the slots that claim them and the slot the
+        /// word's own position falls in — the three facts needed to tell #433's shape from any other.
+        /// </summary>
+        private static string DescribeDoubleClaims(HtmlContainerInt container)
+        {
+            var claims = new Dictionary<CssRect, List<int>>(ReferenceEqualityComparer.Instance);
+
+            foreach (var fragmentainer in container.FragmentTree!.Fragmentainers)
+            {
+                foreach (var word in Flatten(fragmentainer.Root).SelectMany(f => f.Words))
+                {
+                    if (!claims.TryGetValue(word.Word, out var slots))
+                    {
+                        claims[word.Word] = slots = [];
+                    }
+
+                    slots.Add(fragmentainer.SlotIndex);
+                }
+            }
+
+            var doubled = claims.Where(c => c.Value.Count > 1).ToList();
+
+            return $"{doubled.Count} words claimed more than once: " + string.Join("; ", doubled
+                .Take(8)
+                .Select(c => $"'{c.Key.Text}' by [{string.Join(",", c.Value)}], lives in "
+                             + container.SlotStartingAt(c.Key.Top)));
         }
 
         private static string Document(string template, int wordCount) =>

--- a/src/PeachPDF.Tests/Integration/UnreachedWordClaimTests.cs
+++ b/src/PeachPDF.Tests/Integration/UnreachedWordClaimTests.cs
@@ -1,0 +1,92 @@
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Fragments;
+using PeachPDF.Tests.TestSupport;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// A word the pass never reached carries no position of its own, and document Y 0 lies inside the
+    /// <i>first</i> slot's own band — so the first page's fragment used to claim every word below the
+    /// break as well as the page the word really lands on (issue #433).
+    /// </summary>
+    public class UnreachedWordClaimTests
+    {
+        /// <summary>
+        /// #374's workhorse invariant, over the whole document rather than around the first page: every
+        /// word the document authored is claimed by exactly one fragment. It fails one way if a fragment
+        /// claims a word another one also holds, and the other way if a word is dropped entirely.
+        /// </summary>
+        [Theory]
+        [InlineData(1500)]
+        [InlineData(3000)]
+        public async Task AParagraphSplitAtTheFirstBoundary_ClaimsEveryWordExactlyOnce(int wordCount)
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(Document(wordCount), margin: 10);
+
+            var authored = WordsIn(root);
+            var claimed = ClaimedWords(container);
+
+            Assert.NotEmpty(authored);
+            Assert.Equal(claimed.Count, claimed.Distinct(ReferenceEqualityComparer.Instance).Count());
+            Assert.Equal(authored.Count, claimed.Count);
+        }
+
+        /// <summary>
+        /// The symptom the invariant above states abstractly: the first page's own text layer holds only
+        /// the words that page shows. Every later slot's band starts below 0, so an unpositioned word was
+        /// only ever inside the first one's.
+        /// </summary>
+        [Fact]
+        public async Task TheFirstPage_ClaimsOnlyTheWordsItShows()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(Document(3000), margin: 10);
+
+            var fragmentainers = container.FragmentTree!.Fragmentainers;
+            Assert.True(fragmentainers.Count > 1, "the fixture must span more than one page");
+
+            var onFirstPage = Flatten(fragmentainers[0].Root).SelectMany(f => f.Words).Count();
+
+            var authored = WordsIn(root).Count;
+
+            Assert.True(onFirstPage < authored,
+                $"the first page claimed {onFirstPage} of the document's {authored} words");
+
+            // What the page really shows: the words on the line boxes whose own position falls in the
+            // first slot's band. The fragment's own count has to agree with it.
+            var shown = WordsIn(root)
+                .Count(w => container.SlotStartingAt(w.Top) == 0 && !w.AwaitsTheNextFragmentainer);
+
+            Assert.Equal(shown, onFirstPage);
+        }
+
+        private static string Document(int wordCount) =>
+            LayoutHarness.Wrap($"<p>{string.Join(" ", Enumerable.Range(0, wordCount).Select(i => $"w{i}"))}</p>");
+
+        private static List<CssRect> WordsIn(CssBox box) =>
+            LayoutHarness.Descendants(box).SelectMany(b => b.Words).ToList();
+
+        private static List<CssRect> ClaimedWords(HtmlContainerInt container) =>
+            container.FragmentTree!.Fragmentainers
+                .SelectMany(f => Flatten(f.Root))
+                .SelectMany(f => f.Words)
+                .Select(w => w.Word)
+                .ToList();
+
+        private static IEnumerable<BoxFragment> Flatten(BoxFragment fragment)
+        {
+            yield return fragment;
+
+            foreach (var child in fragment.Children)
+            {
+                foreach (var descendant in Flatten(child))
+                {
+                    yield return descendant;
+                }
+            }
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/UnreachedWordClaimTests.cs
+++ b/src/PeachPDF.Tests/Integration/UnreachedWordClaimTests.cs
@@ -14,9 +14,19 @@ namespace PeachPDF.Tests.Integration
     /// well as the page the word really lands on (issue #433).
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The margin matters and is taken from production. <see cref="LayoutHarness"/>'s own default of 20pt
     /// puts slot 0's band below a word's zero rectangle (height ≈ 13pt) entirely, so the defect is
     /// invisible there; <c>PdfGenerateConfig</c>'s default is 10pt, where it is not.
+    /// </para>
+    /// <para>
+    /// The line geometry is pinned rather than left to the platform's default font, and the two other
+    /// mechanisms that can move a word are turned off (<c>orphans: 1; widows: 1</c>), so that what these
+    /// fixtures measure is which fragment claims a word the flow never reached. A 20pt line against an
+    /// 830pt band leaves every page's last line 10pt clear of the boundary, which keeps them out of the
+    /// 0.5pt window where layout and the emitter disagree about membership (#446) — reached on
+    /// <c>windows-latest</c> only, and a different defect.
+    /// </para>
     /// </remarks>
     public class UnreachedWordClaimTests
     {
@@ -33,14 +43,14 @@ namespace PeachPDF.Tests.Integration
         /// inline drops its words (#318).
         /// </remarks>
         [Theory]
-        [InlineData("<p>{F}</p>")]
-        [InlineData("<p>{F} <b>bold words carried across the break</b> {F}</p>")]
-        [InlineData("<p><span style='color:red'>{F}</span></p>")]
-        [InlineData("<div>{F}<span style='float:left;width:40pt'>fl oa ted</span>{F}</div>")]
-        [InlineData("<div style='column-count:2'><p>{F}</p></div>")]
+        [InlineData("<p style='orphans:1;widows:1;font-size:10pt;line-height:20pt'>{F}</p>")]
+        [InlineData("<p style='orphans:1;widows:1;font-size:10pt;line-height:20pt'>{F} <b>bold words carried across the break</b> {F}</p>")]
+        [InlineData("<p style='orphans:1;widows:1;font-size:10pt;line-height:20pt'><span style='color:red'>{F}</span></p>")]
+        [InlineData("<div style='orphans:1;widows:1;font-size:10pt;line-height:20pt'>{F}<span style='float:left;width:40pt'>fl oa ted</span>{F}</div>")]
+        [InlineData("<div style='column-count:2'><p style='orphans:1;widows:1;font-size:10pt;line-height:20pt'>{F}</p></div>")]
         public async Task AParagraphSplitAtAPageBoundary_ClaimsEveryWordExactlyOnce(string template)
         {
-            var (root, container) = await LayoutHarness.LayoutAsync(Document(template, 2500), margin: 10);
+            var (root, container) = await LayoutHarness.LayoutAsync(Document(template, 2500), pageHeight: 850, margin: 10);
 
             Assert.True(container.FragmentTree!.Fragmentainers.Count > 1,
                 "the fixture must span more than one page");
@@ -62,7 +72,9 @@ namespace PeachPDF.Tests.Integration
         [Fact]
         public async Task TheFirstPage_ClaimsOnlyTheWordsItShows()
         {
-            var (root, container) = await LayoutHarness.LayoutAsync(Document("<p>{F}</p>", 3000), margin: 10);
+            var (root, container) = await LayoutHarness.LayoutAsync(
+                Document("<p style='orphans:1;widows:1;font-size:10pt;line-height:20pt'>{F}</p>", 3000),
+                pageHeight: 850, margin: 10);
 
             var fragmentainers = container.FragmentTree!.Fragmentainers;
             Assert.True(fragmentainers.Count > 1, "the fixture must span more than one page");
@@ -89,9 +101,9 @@ namespace PeachPDF.Tests.Integration
         [Fact]
         public async Task AListWhoseItemsDoNotBreak_StillClaimsEveryMarker()
         {
-            var items = string.Join("", Enumerable.Range(0, 200).Select(i => $"<li>item {i} of the list</li>"));
+            var items = string.Join("", Enumerable.Range(0, 200).Select(i => $"<li style='font-size:10pt;line-height:20pt'>item {i} of the list</li>"));
             var (root, container) = await LayoutHarness.LayoutAsync(
-                LayoutHarness.Wrap($"<ul>{items}</ul>"), margin: 10);
+                LayoutHarness.Wrap($"<ul>{items}</ul>"), pageHeight: 850, margin: 10);
 
             Assert.True(container.FragmentTree!.Fragmentainers.Count > 1,
                 "the fixture must span more than one page");

--- a/src/PeachPDF.Tests/Integration/UnreachedWordClaimTests.cs
+++ b/src/PeachPDF.Tests/Integration/UnreachedWordClaimTests.cs
@@ -9,62 +9,107 @@ using System.Threading.Tasks;
 namespace PeachPDF.Tests.Integration
 {
     /// <summary>
-    /// A word the pass never reached carries no position of its own, and document Y 0 lies inside the
-    /// <i>first</i> slot's own band — so the first page's fragment used to claim every word below the
-    /// break as well as the page the word really lands on (issue #433).
+    /// A word the flow never reached carries no position of its own, and document Y 0 lies inside the
+    /// <i>first</i> slot's own band — so the first page's fragment claimed every word below the break as
+    /// well as the page the word really lands on (issue #433).
     /// </summary>
+    /// <remarks>
+    /// The margin matters and is taken from production. <see cref="LayoutHarness"/>'s own default of 20pt
+    /// puts slot 0's band below a word's zero rectangle (height ≈ 13pt) entirely, so the defect is
+    /// invisible there; <c>PdfGenerateConfig</c>'s default is 10pt, where it is not.
+    /// </remarks>
     public class UnreachedWordClaimTests
     {
         /// <summary>
-        /// #374's workhorse invariant, over the whole document rather than around the first page: every
-        /// word the document authored is claimed by exactly one fragment. It fails one way if a fragment
-        /// claims a word another one also holds, and the other way if a word is dropped entirely.
+        /// #374's workhorse invariant, over the whole document: every word the document authored is claimed
+        /// by exactly one fragment. It fails one way if a fragment claims a word another one also holds, and
+        /// the other way if a word is dropped entirely.
         /// </summary>
+        /// <remarks>
+        /// Asked of several shapes because what stops is the fill rather than the paragraph: an inline box,
+        /// a float and a multi-column container each reach <c>CreateLineBoxes</c> by their own route. Two
+        /// shapes are deliberately absent, each with a pre-existing residual measured identical with and
+        /// without this fix — a list item drops its own <c>::marker</c> (#444), and an absolutely-positioned
+        /// inline drops its words (#318).
+        /// </remarks>
         [Theory]
-        [InlineData(1500)]
-        [InlineData(3000)]
-        public async Task AParagraphSplitAtTheFirstBoundary_ClaimsEveryWordExactlyOnce(int wordCount)
+        [InlineData("<p>{F}</p>")]
+        [InlineData("<p>{F} <b>bold words carried across the break</b> {F}</p>")]
+        [InlineData("<p><span style='color:red'>{F}</span></p>")]
+        [InlineData("<div>{F}<span style='float:left;width:40pt'>fl oa ted</span>{F}</div>")]
+        [InlineData("<div style='column-count:2'><p>{F}</p></div>")]
+        public async Task AParagraphSplitAtAPageBoundary_ClaimsEveryWordExactlyOnce(string template)
         {
-            var (root, container) = await LayoutHarness.LayoutAsync(Document(wordCount), margin: 10);
+            var (root, container) = await LayoutHarness.LayoutAsync(Document(template, 2500), margin: 10);
+
+            Assert.True(container.FragmentTree!.Fragmentainers.Count > 1,
+                "the fixture must span more than one page");
 
             var authored = WordsIn(root);
             var claimed = ClaimedWords(container);
 
             Assert.NotEmpty(authored);
-            Assert.Equal(claimed.Count, claimed.Distinct(ReferenceEqualityComparer.Instance).Count());
-            Assert.Equal(authored.Count, claimed.Count);
+            Assert.Equal(claimed.Distinct(ReferenceEqualityComparer.Instance).Count(), claimed.Count);
+            Assert.Equal(claimed.Count, authored.Count);
         }
 
         /// <summary>
-        /// The symptom the invariant above states abstractly: the first page's own text layer holds only
-        /// the words that page shows. Every later slot's band starts below 0, so an unpositioned word was
-        /// only ever inside the first one's.
+        /// The symptom the invariant above states abstractly: the first page's own text layer holds only the
+        /// words that page shows. Every later slot's band starts below 0, so an unpositioned word was only
+        /// ever inside the first one's.
         /// </summary>
         [Fact]
         public async Task TheFirstPage_ClaimsOnlyTheWordsItShows()
         {
-            var (root, container) = await LayoutHarness.LayoutAsync(Document(3000), margin: 10);
+            var (root, container) = await LayoutHarness.LayoutAsync(Document("<p>{F}</p>", 3000), margin: 10);
 
             var fragmentainers = container.FragmentTree!.Fragmentainers;
             Assert.True(fragmentainers.Count > 1, "the fixture must span more than one page");
 
-            var onFirstPage = Flatten(fragmentainers[0].Root).SelectMany(f => f.Words).Count();
-
+            var onFirstPage = Flatten(fragmentainers[0].Root).SelectMany(f => f.Words).ToList();
             var authored = WordsIn(root).Count;
 
-            Assert.True(onFirstPage < authored,
-                $"the first page claimed {onFirstPage} of the document's {authored} words");
+            Assert.NotEmpty(onFirstPage);
+            Assert.True(onFirstPage.Count < authored,
+                $"the first page claimed {onFirstPage.Count} of the document's {authored} words");
 
-            // What the page really shows: the words on the line boxes whose own position falls in the
-            // first slot's band. The fragment's own count has to agree with it.
-            var shown = WordsIn(root)
-                .Count(w => container.SlotStartingAt(w.Top) == 0 && !w.AwaitsTheNextFragmentainer);
-
-            Assert.Equal(shown, onFirstPage);
+            // Stated from the page grid rather than from the flag the fix sets, so that it is an independent
+            // statement of the symptom: every word this page claims really does sit in this page's band.
+            Assert.All(onFirstPage, w => Assert.Equal(0, container.SlotStartingAt(w.Word.Top)));
         }
 
-        private static string Document(int wordCount) =>
-            LayoutHarness.Wrap($"<p>{string.Join(" ", Enumerable.Range(0, wordCount).Select(i => $"w{i}"))}</p>");
+        /// <summary>
+        /// Saying "this layout has placed none of these words yet" reaches every word in the block's
+        /// subtree, which is a larger set than its inline flow visits — an <i>outside</i> <c>::marker</c> is
+        /// skipped by the flow (<c>CssLayoutEngine.FlowBox</c>) and laid out by the item's own epilogue
+        /// instead. That epilogue runs in the same pass for an item that does not itself break, so the
+        /// marker is positioned before the slot is frozen and the claim stands.
+        /// </summary>
+        [Fact]
+        public async Task AListWhoseItemsDoNotBreak_StillClaimsEveryMarker()
+        {
+            var items = string.Join("", Enumerable.Range(0, 200).Select(i => $"<li>item {i} of the list</li>"));
+            var (root, container) = await LayoutHarness.LayoutAsync(
+                LayoutHarness.Wrap($"<ul>{items}</ul>"), margin: 10);
+
+            Assert.True(container.FragmentTree!.Fragmentainers.Count > 1,
+                "the fixture must span more than one page");
+
+            var markerWords = LayoutHarness.Descendants(root)
+                .Where(b => b.IsMarkerPseudoElement)
+                .SelectMany(b => b.Words)
+                .ToList();
+
+            Assert.NotEmpty(markerWords);
+
+            var claimed = ClaimedWords(container).ToHashSet(ReferenceEqualityComparer.Instance);
+
+            Assert.All(markerWords, w => Assert.Contains(w, claimed));
+        }
+
+        private static string Document(string template, int wordCount) =>
+            LayoutHarness.Wrap(template.Replace(
+                "{F}", string.Join(" ", Enumerable.Range(0, wordCount).Select(i => $"w{i}"))));
 
         private static List<CssRect> WordsIn(CssBox box) =>
             LayoutHarness.Descendants(box).SelectMany(b => b.Words).ToList();

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -1150,12 +1150,20 @@ namespace PeachPDF.Html.Core.Dom
         /// the layout about to run actually places can be claimed by it.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// A discarded attempt leaves its words where it put them, and the attempt that replaces it need not
         /// reach all of them again — a shorter column stops sooner. Cleared per word by being positioned
         /// (<see cref="CssRect.Top"/>'s setter), so what survives is exactly what this layout did not place:
         /// the same rule §4.1's own discarded line already follows, applied to a discarded fill.
+        /// </para>
+        /// <para>
+        /// The other caller is the flow itself: a word a stopped flow never reached carries no position of
+        /// its own either, and the one it carries instead — document Y 0 — lies inside the first slot's own
+        /// band. So the block's inline flow says the same thing about itself before it starts, on the pass
+        /// that opens it (<c>CssLayoutEngine.CreateLineBoxes</c>).
+        /// </para>
         /// </remarks>
-        private void AwaitPlacementAgain()
+        internal void AwaitPlacementAgain()
         {
             foreach (var word in Words)
             {

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -1142,7 +1142,7 @@ namespace PeachPDF.Html.Core.Dom
 
             _prologueDone = false;
 
-            AwaitPlacementAgain();
+            AwaitPlacement();
         }
 
         /// <summary>
@@ -1163,7 +1163,7 @@ namespace PeachPDF.Html.Core.Dom
         /// that opens it (<c>CssLayoutEngine.CreateLineBoxes</c>).
         /// </para>
         /// </remarks>
-        internal void AwaitPlacementAgain()
+        internal void AwaitPlacement()
         {
             foreach (var word in Words)
             {
@@ -1172,7 +1172,7 @@ namespace PeachPDF.Html.Core.Dom
 
             foreach (var childBox in Boxes)
             {
-                childBox.AwaitPlacementAgain();
+                childBox.AwaitPlacement();
             }
         }
 

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -275,7 +275,23 @@ namespace PeachPDF.Html.Core.Dom
             // A resumed flow continues the same block: its earlier lines live in a fragmentainer that
             // has already been filled, so they are neither cleared nor re-finalized.
             var completedLines = resume?.CompletedLineCount ?? 0;
-            if (resume is null) blockBox.LineBoxes.Clear();
+
+            if (resume is null)
+            {
+                blockBox.LineBoxes.Clear();
+
+                // A word carries no position of its own until the flow reaches it, and the position it
+                // carries instead — document Y 0, or whatever an earlier layout of the same box left on
+                // it — describes nothing. Y 0 lies inside the *first* slot's own band, so the first page's
+                // fragment claimed every word a stopped flow never got to (issue #433). Saying up front
+                // that this layout has placed none of them, and letting being positioned clear it
+                // (CssRect.Top's setter), makes what survives the flow exactly what the flow did not
+                // reach — the rule §4.1's own discarded line already follows, asked of the whole block.
+                //
+                // Only on the pass that opens the block: a resumed pass would otherwise take back the
+                // words an earlier fragmentainer has already placed and frozen a fragment around.
+                blockBox.AwaitPlacementAgain();
+            }
 
             var limitRight = blockBox.ClientRight;
 

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -290,7 +290,7 @@ namespace PeachPDF.Html.Core.Dom
                 //
                 // Only on the pass that opens the block: a resumed pass would otherwise take back the
                 // words an earlier fragmentainer has already placed and frozen a fragment around.
-                blockBox.AwaitPlacementAgain();
+                blockBox.AwaitPlacement();
             }
 
             var limitRight = blockBox.ClientRight;


### PR DESCRIPTION
Fixes #433

An ordinary paragraph that breaks at the **first** page boundary had every word below the break claimed by page 0's fragment as well as by the page it really lands on. On the issue's own fixture — a 3,000-word `<p>` on A4 at `PdfGenerateConfig`'s default 10pt margins — page 0's text layer held **2,999** words where the page shows **1,153**: a smear of overlapping glyphs in the top margin, a text layer that finds the continuation on the page it is not on, and a content stream 2.4× the size it needs.

## The load-bearing idea

**An unpositioned word is not a word at the origin, and only the flow can tell the difference.** `CssRect`'s position starts at 0, document Y 0 lies inside the first slot's own band, and `FragmentEmitter.BuildDraft` asks nothing but `region.Contains(word.Rectangle)` and `AwaitsTheNextFragmentainer` — a flag §4.1's *discarded line* sets and nothing else did. After the pass there is nothing left to read: a word that was never placed and a word placed at the top of page 1 carry the same coordinates.

So the statement has to be made **before** the attempt, which is exactly what `CssBox.AwaitPlacementAgain` already does for a discarded multi-column fill. The block's own inline flow now says the same thing about itself on the pass that opens it, and `CssRect.Top`'s setter clears it per word — so what survives the flow is precisely what the flow did not reach. One call; the mechanism was already there and self-healing, as the issue predicted.

**The guard is the whole of the care needed.** Only a pass with `resume is null` may mark: on a resumed pass the words below the resume point belong to a fragmentainer already filled and frozen, and marking them takes back content another page legitimately holds. Removing the guard fails **9** tests across the widows, keep-with-next and multicol suites.

## What running it bought

The bug does **not** reproduce in `LayoutHarness`'s default fixture, and the reason is worth knowing before writing a fixture for anything in this family: the harness defaults to a 20pt margin, so slot 0's band begins at document Y 20 and a word's zero rectangle (height ≈ 13pt) does not overlap it at all. The defect is real at the production default of 10pt and at 0, and invisible above roughly one line height.

## What the showcase found, which the issue did not describe

**68 of 69 showcases are byte-identical.** `paged_media_horizontal_reflow` is the one that differs, and it differs by **losing a whole line of the following page's text painted at the foot of pages 2 and 4** — an interior page, not page 0:

| | |
|---|---|
| before | `…commodo consequat.` / `31: Lorem ipsum dolor sit amet, consectetur adipiscing` |
| after | `…commodo consequat.` |

That document's per-page widths are settled by a bounded reflow loop, so its boxes are laid out more than once, and a word the *second* layout does not reach keeps the *first* one's coordinates — ordinary-looking coordinates in the middle of the document rather than the origin. The fix covers both forms because it says "this layout has placed none of these yet" rather than testing for a magic position. Page count unchanged (7); verified in both PDFium and MuPDF.

## Filed rather than fixed

A `<li>` whose own text straddles a page boundary can leave its `::marker` in no fragment at all — 39 of 40 markers claimed in a 40-item list. Pre-existing and identical on `main` (verified by running the same fixture on both): an outside marker is laid out by `CssBox.PerformLayoutEpilogue`, which the pass that breaks never reaches, so its word is positioned only on the completing pass — after the slot it belongs to was frozen. Filed as #444.

## Verification

- Tests: `UnreachedWordClaimTests` (3 — #374's claimed-exactly-once invariant over the *whole* document at two lengths, and the symptom stated directly: the first page's fragment holds exactly the words whose own position falls in its band), plus `EarlyBreakLayoutIntegrationTests.PulledRun_FromAPassThatResumedIntoAParagraph_ClaimsEachBlockWordExactlyOnce` **promoted** from the two blocks the pull moves to the whole document — it was scoped around #433 rather than asserting past it. Removing the one call fails **4 of those 5**.
- Full net8.0 suite green (6,636 passed / 6,645 total), CLI green (96).
- **100% diff coverage**; 0 warnings on `dotnet build PeachPDF.slnx -t:Rebuild`.
- Notes: one new `.claude/recent-fixes/` entry, and the durable half as `.claude/invariants/fragmentation-an-unpositioned-word-is-not-a-word-at-the-origin.md`. Two further invariants moved out of #320's body to keep it under its 20 KB limit (the model's shape, and why `break-before: always` is a Level 4 value rather than a Level 3 removal).


---
_Generated by [Claude Code](https://claude.ai/code/session_01W4SgpVVeZykEGEbSFqFq23)_