### PR TITLE
Break at a column boundary below the container's own child

### DIFF
--- a/.claude/invariants/fragmentation-what-a-nested-fragmentainer-states-about-the-next-one-must-be-stated-for-every-link.md
+++ b/.claude/invariants/fragmentation-what-a-nested-fragmentainer-states-about-the-next-one-must-be-stated-for-every-link.md
@@ -1,0 +1,23 @@
+# What a nested fragmentainer states about "the next one" must be stated for every link of the record
+
+_CSS Fragmentation Level 3. Tracker: [#320](https://github.com/jhaygood86/PeachPDF/issues/320)._
+
+A break raised below a container's own child produces a **chain**, and every link of it was decided
+against the page grid — its slot names a page, its target names a coordinate down the document.
+An engine driving fragmentainers of its own restates that record in its own terms; restating only the
+outermost link leaves the deeper ones saying what the page grid said, and the next fragmentainer is
+then filled at a coordinate several bands away. Measured: the second column of a resumed page began
+400pt past the page it was on, and the tail of the flow took a third page it did not need.
+
+The same applies to every question asked *of* the record. "Which boxes did this fragmentainer hold"
+is a prefix at **every** level of the chain, not only at the container's own children: the box the
+break falls before is not here, the box it falls inside is here up to where it stopped, and every
+sibling after the boundary is not here and still carries the measurement pass's geometry. Asking only
+the outermost link claimed one box in two columns at once and left ghost fragments a whole virtual
+column down the document — both of which the one-line invariant over the fragment tree, **every word
+claimed exactly once**, is what catches.
+
+And the one thing that must *not* be restated on a deeper link is the target itself. That box begins
+its own containing block's content rather than the fragmentainer, and where that containing block
+lands in the next fragmentainer is not known when the record is written — it has not been re-placed
+there yet. Drop it, and re-derive it where the placement happens.

--- a/.claude/invariants/testing-a-pdf-carries-two-timestamps-not-one-when-showcases-are-compared.md
+++ b/.claude/invariants/testing-a-pdf-carries-two-timestamps-not-one-when-showcases-are-compared.md
@@ -1,0 +1,14 @@
+# A showcase PDF carries two timestamps, not one — normalize `/M` as well as `/CreationDate`
+
+_Testing convention._
+
+The showcase rasterization diff is worthless unless the non-deterministic bytes are normalized first,
+and the list that gets repeated — `/CreationDate`, the `/ID` array, the random font subset tag, the
+annotation `/NM` GUID — is one short. A **link annotation also carries `/M`**, its modification
+timestamp, written as `D:YYYYMMDDHHMMSS+00'00'`. Any showcase with a link in it therefore differs
+between two runs of *identical* code.
+
+Measured: five showcases (`acid2`, `charts_css`, `document_tree_selectors`, `svg`, `tagged_pdf`)
+reported as differing at **identical byte lengths** on a `main`-versus-`main` comparison. With `/M`
+normalized the same comparison is 69 of 69 identical, which is the baseline a real diff has to be
+read against.

--- a/.claude/recent-fixes/2026-07-27-a-column-break-can-fall-below-the-containers-own-child.md
+++ b/.claude/recent-fixes/2026-07-27-a-column-break-can-fall-below-the-containers-own-child.md
@@ -1,0 +1,76 @@
+# A column break can fall below the container's own child
+
+_Landed 2026-07-27._
+
+[Issue #387](https://github.com/jhaygood86/PeachPDF/issues/387),
+[CSS Fragmentation 3 §2](https://www.w3.org/TR/css-break-3/#fragmentainer).
+
+#366 made a **top-level child** of a multi-column container split at a column boundary. A block one
+level further down did not: on the issue's fixture the wrapper neither moved nor broke, and the
+container reported a height past its own page. Measured on `main` before the change, on a 400pt page
+with `columns: 2; column-fill: auto` and a wrapper of 24 × 20pt rows: `r18` was claimed by **two**
+fragments at once (once in each column, both at y=386, straddling the 400 band), rows 19–23 left
+ghost fragments in column 1 at y=406…486, and the flow spilled onto a second page it did not need.
+
+**The load-bearing idea is that everything the columns engine states about "the next column" is
+stated on the record's *outermost* link, and a break below the container's own child has a chain.**
+Three sites read that record, and each of them was reading one link where it needed the whole chain.
+
+**(a) The target for the box that begins the next column.** The arms that raise a column break
+deliberately record no target — every column of a container begins at the same block-axis
+coordinate, so `CssLayoutEngineColumns.ResumeInTheNextColumn` supplies it. It can only supply it for
+a *top-level* child, though, and a deeper link's box begins its own containing block's content
+rather than the column, at a coordinate not knowable when the record is written because that block
+has not been re-placed in the next column yet. So the target is now re-derived at placement time:
+`CssBox.ColumnTopForTheChildThisFillBeginsAt` gives the child a resume top of
+`max(column.ResumeContentTop, ContainingBlock.ClientTop)`, the same maximum
+`ResumeInTheNextFragmentainer` takes and for the same reason. Without it `PlaceBlockChild` fell back
+to the previous sibling's bottom — a sibling still sitting in the column just vacated.
+
+**(b) The whole chain is restated, not only the outermost link.** Every link was decided against the
+page grid, so a deeper one carries a slot several pages on and a target somewhere down the document.
+`RestatedInTheNextColumn` now walks the chain: every link's slot becomes the container's own, the
+outermost break-before keeps the band top, and every deeper target is **dropped** so (a) re-derives
+it. Found only by running the 60-row case: the second column of the *resumed* page was being filled
+at `ResumeTopOverride = 1200` — a §5.2 page-grid target from the previous column's fill — so the tail
+of the flow landed on a third page while the flat control needed only two.
+
+**(c) Which boxes a column holds is a prefix at every level, not only at the container's.**
+`PlacedBelow` answers it for the container's own children and is the whole answer while a child is
+atomic per column. New `BeyondThisColumn` reads the same three-way distinction off each link of the
+chain — break-*before* means the box itself is beyond, break-*inside* means it is here up to where it
+stopped and the walk descends into it, and everything after the boundary is beyond either way — and
+both `DeepestBottomOf` and `BoxGeometrySnapshot.Capture` now skip those subtrees. That is what fixes
+the double claim and the ghosts: the rejected row was captured into the column it was rejected from,
+and the rows the fill never reached still carried the *measurement* pass's geometry, one tall virtual
+column down the document. It is also what stopped the container reporting a height past its page,
+since `DeepestBottomOf` was measuring the whole flow.
+
+**Verified load-bearing by neutralizing each part separately**: (a) fails 5 of the new/existing
+multicol tests, (b) fails 3, (c) fails 4. None of the three is redundant with the others.
+
+**What was deliberately not done.** `column-fill: balance` treats a wrapper as one atomic child in
+its packing estimate, so a nested fixture balances a little less evenly than the same rows as direct
+children (14/10 against 12/12 on the 24-row fixture). That is the estimate's own approximation — it
+is an estimate by construction, and the fill is correct either way — not a fragmentation defect.
+A forced **page** break declared below the container's own child is still lost entirely; that is
+[#395](https://github.com/jhaygood86/PeachPDF/issues/395), it has a different cause (the measurement
+pass consumes the one-shot `_forcedBreakTop`), and its characterization test is unchanged by this.
+
+**This closes what bounded #335's multicol half.** A `box-decoration-break: clone` box whose content
+is blocks now has a column break inside it, and the room the word path already reserves is what the
+fill obeys — measured on a 194pt band with a 12pt cloned bottom border, the first column stops one
+20pt row earlier than `slice` does. The doc limitation naming that case is removed.
+
+Tests: `MulticolLayoutIntegrationTests` (+8 — the break's placement on every affected box, the
+every-word-claimed-exactly-once invariant across four fill/page-height combinations, the resumed
+container's second column, a two-level chain landing inside its own containing block's padding, and
+the `clone`/`slice` reservation difference). Full net8.0 suite green (6738), CLI suite green (96);
+**100% diff coverage**; zero warnings on `dotnet build PeachPDF.slnx -t:Rebuild`. **68 of 69
+showcases byte-identical** to `main` once `/CreationDate`, `/ID`, the font subset tag and the
+annotation `/NM` **and `/M`** values are normalized — note `/M`, an annotation's modification
+timestamp, which is not one of the four the earlier entries list and which makes five showcases
+differ on every run if it is left alone. `multicol` differs, by its new section 12 alone: pages 1–6
+rasterize identically and page 7 shows the wrapper filling one column and leaving the second empty
+on the unfixed build against a proper two-column split with a fragment's decoration in each on the
+fixed one. Verified in both PDFium and MuPDF.

--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -506,6 +506,7 @@ CSS Multi-column Layout (`column-count`/`column-width`/`columns`) is supported, 
 - `orphans` and [margin truncation](#page-breaks) apply at a column boundary the same way they apply at a page boundary (`widows`, which is enforced after the fact by re-running the pass that filled a fragmentainer, is a page-context rule only).
 - A container whose content outlasts its columns continues on the next page, resuming where its last column stopped rather than starting over, and balances the fragment that holds the end of the flow.
 - A child continues **into** the next column rather than moving to it whole: a paragraph's first lines stay in one column and the rest flow into the next, each fragment carrying its own background, border and padding.
+- The break need not fall between two of the container's own children. A block nested any distance below one is split at the column boundary too, and the content after the break starts the next column at that column's top — inside its own containing block's border and padding, and inside the wrapper's own fragment there.
 
 `column-fill: balance` (the default) aims for equal-height columns, and `column-fill: auto` fills each column before starting the next.
 
@@ -725,7 +726,7 @@ Margin is cloned at a line break, alongside the border and padding, so each line
 
 Limitations:
 
-- Room is reserved for `clone`'s border and padding in normal block and inline flow, and at a column break for a box whose own content is text. Inside a flex, grid or table, whose own engine positions its children, a cloned decoration at a break is painted but no room is made for it, so it can overlap content. The same is true of a box in a multi-column container whose content is blocks rather than text, since such a box is not split at a column boundary at all.
+- Room is reserved for `clone`'s border and padding in normal block and inline flow, and at a column break — including for a box whose own content is blocks rather than text, which is split at a column boundary like any other. Inside a flex, grid or table, whose own engine positions its children, a cloned decoration at a break is painted but no room is made for it, so it can overlap content.
 - A page break is decided against the text itself, so a large `line-height`'s own leading below the last line on a page is not counted. A cloned bottom border can therefore sit within that leading — at most `line-height` minus the text's own height. Ordinary line heights leave this invisible.
 - An inline box that wraps *and* is split at a column boundary has its unbroken width measured within each column rather than across both, so a gradient on such a box restarts in the second column. A block-level box is unaffected, and so is an inline box that only crosses page breaks.
 - `border-image` is parsed but never painted, so §6.2's treatment of it has no visible effect either way. A replaced element (an image, an inline `<svg>`, an `<iframe>`) is never split at all, so it always paints its whole box regardless of the value.

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -3677,6 +3677,20 @@ var multicolHtml = "<!DOCTYPE html><html><head>" + MulticolCss + "</head><body>"
         McEntries(4, "moved") +
         "</div></div>") +
 
+    // A break that falls one level below the container's own child loop. The entries here are wrapped in
+    // a <section> of their own, so the boundary is between two of *its* children rather than between two
+    // of the container's - and the record has to travel up through the wrapper before the columns engine
+    // can read it. Left alone, the wrapper neither moved nor broke: it kept flowing past the column band
+    // and past the page. The wrapper carries a background and a border so both of its fragments are
+    // visible, one per column.
+    McSection("12 &mdash; a break below the container's own child",
+        "<div class=\"frame\"><div class=\"label\">columns: 2; the entries sit inside a &lt;section&gt; of their own, so the break falls between two of its children rather than between two of the container's</div>" +
+        "<div class=\"mc\" style=\"columns:2;column-gap:20px;column-rule:0.5pt solid #000\">" +
+        McEntries(1, "lead") +
+        "<section style=\"background:#eef9f0;border:0.5pt solid #27ae60;padding:3pt;margin:0\">" +
+        McEntries(10, "nested") +
+        "</section></div></div>") +
+
     "</body></html>";
 
 await SaveShowcaseAsync("multicol", "Layout", "Multi-column Layout",

--- a/src/PeachPDF.Tests/Integration/MulticolLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/MulticolLayoutIntegrationTests.cs
@@ -1654,6 +1654,215 @@ namespace PeachPDF.Tests.Integration
             Assert.Equal(claimed.Count, claimed.Distinct().Count());
         }
 
+        // ─── A break raised below the container's own child (css-break-3 §2) ───────
+
+        /// <summary>
+        /// A wrapper holding <paramref name="rowCount"/> 20pt rows, with a 20pt lead sibling above it, in a
+        /// two-column container. Nothing about the rows is special: the point is only that the break falls
+        /// between two of them, which puts it one level below the container's own child loop — the loop
+        /// whose record the columns engine reads.
+        /// </summary>
+        private static string NestedRowsFixture(int rowCount, string fill)
+        {
+            var rows = string.Concat(Enumerable.Range(0, rowCount)
+                .Select(i => $"<div id='r{i}' class='row' style='height:20pt; margin:0'>r{i}</div>"));
+
+            return Wrap($@"
+                <div id='mc' style='columns:2; column-gap:0; width:300pt; {fill}'>
+                    <div id='lead' style='height:20pt; margin:0'>lead</div>
+                    <div id='wrap' style='margin:0'>{rows}</div>
+                </div>");
+        }
+
+        /// <summary>
+        /// The break falls between two rows of a wrapper rather than between two children of the
+        /// container, and the content after it starts the next column at that column's own top. It used to
+        /// neither move nor break: the record travelled up correctly, but the child it named was then
+        /// placed after the previous sibling it had just left behind in the column being vacated, so it
+        /// straddled the boundary and everything after it ran past the page.
+        /// </summary>
+        [Fact]
+        public async Task ABreakBelowTheContainersOwnChild_StartsTheNextColumnAtItsTop()
+        {
+            // A 394pt band holds the 20pt lead plus eighteen 20pt rows exactly; the nineteenth cannot stay.
+            var (root, container) = await BuildAndLayout(NestedRowsFixture(24, "column-fill:auto"), pageHeight: 400);
+
+            var mc = FindById(root, "mc")!;
+            var rows = FindAllByClass(root, "row");
+            var secondColumnLeft = FindById(root, "r18")!.Location.X;
+
+            // Everything up to the break stays where the first column put it.
+            Assert.Equal(mc.ClientLeft, FindById(root, "lead")!.Location.X, 1);
+            for (var i = 0; i <= 17; i++)
+            {
+                Assert.Equal(mc.ClientLeft, rows[i].Location.X, 1);
+                Assert.Equal(mc.ClientTop + 20 * (i + 1), rows[i].Location.Y, 1);
+            }
+
+            // Everything after it is in the next column, which begins at the band top rather than at the
+            // bottom of the row it followed.
+            Assert.True(secondColumnLeft > mc.ClientLeft + 100,
+                $"the continuation is at x={secondColumnLeft}, still in the column it should have left");
+
+            for (var i = 18; i <= 23; i++)
+            {
+                Assert.Equal(secondColumnLeft, rows[i].Location.X, 1);
+                Assert.Equal(mc.ClientTop + 20 * (i - 18), rows[i].Location.Y, 1);
+                Assert.Equal(rows[i].Location.Y + 20, rows[i].ActualBottom, 1);
+            }
+
+            // The wrapper itself is a fragment in each column, and the box carries the second one.
+            var wrap = FindById(root, "wrap")!;
+            Assert.Equal(secondColumnLeft, wrap.Location.X, 1);
+            Assert.Equal(mc.ClientTop, wrap.Location.Y, 1);
+
+            // And the container no longer reports a height past the page it is on: it ends where its
+            // deepest column's content ends, and one page holds the lot.
+            Assert.Equal(rows[17].ActualBottom, mc.ActualBottom, 1);
+            Assert.Single(container.FragmentTree!.Fragmentainers);
+        }
+
+        /// <summary>
+        /// The invariant over the fragment tree, which catches both directions at once: the rows after the
+        /// break claimed by the column they left as well as by the one they moved to (they were captured
+        /// into both), and rows the fill never reached claimed at the measurement pass's position, a whole
+        /// virtual column down the document.
+        /// </summary>
+        [Theory]
+        [InlineData("column-fill:auto", 24, 400)]
+        [InlineData("column-fill:balance", 24, 400)]
+        [InlineData("column-fill:auto", 60, 400)]
+        [InlineData("column-fill:auto", 24, 200)]
+        public async Task ABreakBelowTheContainersOwnChild_ClaimsEveryWordExactlyOnce(
+            string fill, int rowCount, double pageHeight)
+        {
+            var (root, container) = await BuildAndLayout(NestedRowsFixture(rowCount, fill), pageHeight);
+
+            var authored = FindAllByClass(root, "row")
+                .SelectMany(LayoutHarness.Descendants)
+                .SelectMany(b => b.Words)
+                .Where(w => !w.IsSpaces)
+                .ToList();
+
+            var claimed = container.FragmentTree!.Fragmentainers
+                .SelectMany(f => FlattenFragments(f.Root))
+                .SelectMany(f => f.Words)
+                .Select(w => w.Word)
+                .ToList();
+
+            Assert.Equal(rowCount, authored.Count);
+            Assert.All(authored, word => Assert.Contains(word, claimed));
+            Assert.Equal(claimed.Count, claimed.Distinct().Count());
+        }
+
+        /// <summary>
+        /// A <i>resumed</i> container fills its second column too. Each link of the record was worked out
+        /// against the page grid, and only the outermost was being restated in the next column's terms — so
+        /// a deeper link carried a slot several pages on and a target down the document, and the second
+        /// column of the resumed page was filled at that target instead of at its own top.
+        /// </summary>
+        [Fact]
+        public async Task AResumedContainer_FillsItsSecondColumnWhenTheBreakIsNested()
+        {
+            // 60 rows against a 400pt page: two columns of the first page, two of the second, and nothing
+            // left over.
+            var (root, container) = await BuildAndLayout(NestedRowsFixture(60, "column-fill:auto"), pageHeight: 400);
+
+            var rows = FindAllByClass(root, "row");
+            var mc = FindById(root, "mc")!;
+            var secondPageTop = container.PageTopOf(1);
+
+            // The tail of the flow is in the second column of the second page, not on a third page.
+            for (var i = 57; i <= 59; i++)
+            {
+                Assert.True(rows[i].Location.X > mc.ClientLeft + 100,
+                    $"r{i} is at x={rows[i].Location.X}, in the first column of the resumed page");
+                Assert.Equal(secondPageTop + 20 * (i - 57), rows[i].Location.Y, 1);
+            }
+
+            Assert.Equal(2, container.FragmentTree!.Fragmentainers.Count);
+        }
+
+        /// <summary>
+        /// Two levels below the container, so the record's chain has an intermediate link that is itself
+        /// <i>continuing</i>. The target for the box that begins the next column is its own containing
+        /// block's content top, which is inside that block's padding — not the column's band top, and not
+        /// knowable when the record was written, since the block had not been re-placed there yet.
+        /// </summary>
+        [Fact]
+        public async Task ABreakTwoLevelsBelowTheContainer_StartsInsideItsOwnContainingBlock()
+        {
+            var rows = string.Concat(Enumerable.Range(0, 24)
+                .Select(i => $"<div id='r{i}' class='row' style='height:20pt; margin:0'>r{i}</div>"));
+
+            var (root, container) = await BuildAndLayout(Wrap($@"
+                <div id='mc' style='columns:2; column-gap:0; width:300pt; column-fill:auto'>
+                    <div id='lead' style='height:20pt; margin:0'>lead</div>
+                    <div id='wrap' style='margin:0; padding-left:5pt'>
+                        <div id='inner' style='margin:0; padding-top:4pt'>{rows}</div>
+                    </div>
+                </div>"), pageHeight: 400);
+
+            var mc = FindById(root, "mc")!;
+            var inner = FindById(root, "inner")!;
+            var rowBoxes = FindAllByClass(root, "row");
+
+            // The continuation begins at its own containing block's content top - the inner block's
+            // padding is inside the column, not swallowed by it - and at that block's own left edge.
+            Assert.Equal(inner.ClientTop, rowBoxes[18].Location.Y, 1);
+            Assert.Equal(inner.ClientLeft, rowBoxes[18].Location.X, 1);
+            Assert.Equal(mc.ClientTop + 4, rowBoxes[18].Location.Y, 1);
+            Assert.True(rowBoxes[18].Location.X > mc.ClientLeft + 100);
+
+            for (var i = 19; i <= 23; i++)
+            {
+                Assert.Equal(rowBoxes[18].Location.X, rowBoxes[i].Location.X, 1);
+                Assert.Equal(rowBoxes[18].Location.Y + 20 * (i - 18), rowBoxes[i].Location.Y, 1);
+            }
+
+            Assert.Single(container.FragmentTree!.Fragmentainers);
+        }
+
+        /// <summary>
+        /// <see href="https://www.w3.org/TR/css-break-3/#break-decoration">§6.2</see>'s <c>clone</c> at a
+        /// column boundary, for a box whose content is <i>blocks</i>. There was no break inside such a box
+        /// to reserve room at, which is what bounded the multi-column half of the clone reservation; now
+        /// that the break happens, the reservation the word path already makes is what the fill obeys —
+        /// the first column stops a whole row short of where <c>slice</c> stops, leaving the cloned bottom
+        /// border its room.
+        /// </summary>
+        [Fact]
+        public async Task CloneDecorationsAtAColumnBreak_ReserveTheirRoomInABoxOfBlocks()
+        {
+            async Task<IReadOnlyList<CssBox>> RowsWith(string decorationBreak)
+            {
+                var rows = string.Concat(Enumerable.Range(0, 16)
+                    .Select(i => $"<div id='r{i}' class='row' style='height:20pt; margin:0'>r{i}</div>"));
+
+                var (root, _) = await BuildAndLayout(Wrap($@"
+                    <div id='mc' style='columns:2; column-gap:0; width:300pt; column-fill:auto'>
+                        <div id='wrap' style='margin:0; padding:0; border-top:12pt solid red;
+                             border-bottom:12pt solid red; box-decoration-break:{decorationBreak}'>{rows}</div>
+                    </div>"), pageHeight: 200);
+
+                return FindAllByClass(root, "row");
+            }
+
+            var sliced = await RowsWith("slice");
+            var cloned = await RowsWith("clone");
+
+            // Both split at the boundary at all, which is the part that did not happen.
+            Assert.True(sliced[15].Location.X > sliced[0].Location.X + 100);
+            Assert.True(cloned[15].Location.X > cloned[0].Location.X + 100);
+
+            // `slice` fills the band; `clone` stops one row earlier, by the 12pt border it has to close
+            // with. Read off which row is the last one still in the first column.
+            var lastSliced = sliced.Count(r => r.Location.X <= sliced[0].Location.X + 0.5);
+            var lastCloned = cloned.Count(r => r.Location.X <= cloned[0].Location.X + 0.5);
+
+            Assert.Equal(lastSliced - 1, lastCloned);
+        }
+
         /// <summary>
         /// Asserts no two boxes' bounding rectangles overlap — the structural invariant a
         /// two-axis (page, column) fragmentation engine must never violate, since an overlap

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -2215,7 +2215,9 @@ namespace PeachPDF.Html.Core.Dom
                     if (i == start && resumeAt is not null && !resumeConsumed)
                     {
                         resumeConsumed = true;
-                        childBox.ResumeAt(resumeAt.ChildToken, resumeAt.ResumeTopOverride);
+                        childBox.ResumeAt(
+                            resumeAt.ChildToken,
+                            resumeAt.ResumeTopOverride ?? ColumnTopForTheChildThisFillBeginsAt(resumeAt, childBox));
                     }
 
                     await childBox.PerformLayout(g);
@@ -2397,6 +2399,44 @@ namespace PeachPDF.Html.Core.Dom
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Where <paramref name="childBox"/> goes when it is the child a <i>column's</i> fill begins at and
+        /// the record that named it carries no target of its own — the content top of the column being
+        /// filled, per <see href="https://www.w3.org/TR/css-break-3/#fragmentainer">§2</see>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The arms that raise a column break deliberately record no target: every column of a container
+        /// begins at the same block-axis coordinate, so the columns engine states that coordinate on the
+        /// record it hands to the next column
+        /// (<c>CssLayoutEngineColumns.ResumeInTheNextColumn</c>). It can only state it on the record's
+        /// <b>outermost</b> link, though, because that is the only one it holds — so a break raised inside a
+        /// block nested below the container's own child arrives at that block's loop with nothing, and
+        /// <see cref="PlaceBlockChild"/> falls back to deriving the child's top from its previous sibling.
+        /// That sibling is still in the column just left, so the continuation was laid out at the foot of a
+        /// column it is not in, straddling the boundary it was moved to avoid.
+        /// </para>
+        /// <para>
+        /// Only for a child laid out here <i>afresh</i>. One that carries a record of its own is
+        /// <i>continuing</i>, and moves itself in both axes
+        /// (<see cref="ResumeInTheNextFragmentainer"/>) — writing a target for it would place it twice.
+        /// </para>
+        /// <para>
+        /// The destination is the lower of the column's own content edge and this box's, for the same reason
+        /// <see cref="ResumeInTheNextFragmentainer"/> takes that maximum: the containing block has just been
+        /// re-placed in this column and its content edge sits inside its own border and padding, while a
+        /// container that began on an earlier page names a coordinate this column does not reach.
+        /// </para>
+        /// </remarks>
+        private double? ColumnTopForTheChildThisFillBeginsAt(BlockBreakToken resumeAt, CssBox childBox)
+        {
+            if (resumeAt.ChildToken is not null) return null;
+
+            if (HtmlContainer?.CurrentFragmentainer is not { HasOwnBand: true } column) return null;
+
+            return Math.Max(column.ResumeContentTop, childBox.ContainingBlock.ClientTop);
         }
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineColumns.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineColumns.cs
@@ -337,7 +337,12 @@ namespace PeachPDF.Html.Core.Dom
                     // laid out again in the next column, so its geometry is not this column's.
                     var placedBelow = PlacedBelow(columnsBox.PendingBreakToken, children);
 
-                    columnBottom = MaxBottomOf(children, placedBelow);
+                    // And the same is true one level further down, which the index above cannot say:
+                    // a break raised inside a nested block leaves that block in this column while
+                    // everything from the break onward belongs to the next one.
+                    var beyond = BeyondThisColumn(columnsBox.PendingBreakToken);
+
+                    columnBottom = MaxBottomOf(children, placedBelow, beyond);
 
                     // This column's geometry, handed over while the boxes still hold it. A child
                     // continuing into the next column is laid out again there, at that column's own
@@ -357,7 +362,7 @@ namespace PeachPDF.Html.Core.Dom
                         startSlot,
                         (boxTop, Math.Max(boxTop + target, columnBottom)),
                         (columnInlineLeft, columnInlineLeft + columnWidth),
-                        BoxGeometrySnapshot.Capture(ChildrenIn(children, columnStart, placedBelow)),
+                        BoxGeometrySnapshot.Capture(ChildrenIn(children, columnStart, placedBelow), beyond),
                         ContinuingPast(columnsBox.PendingBreakToken));
                 }
                 finally
@@ -458,13 +463,55 @@ namespace PeachPDF.Html.Core.Dom
             columnsBox.ActualRight = columnsBox.Location.X + width + columnsBox.ActualBoxSizeIncludedWidth;
         }
 
-        private static double MaxBottomOf(List<CssBox> children, int limit)
+        /// <summary>
+        /// The boxes this column does <b>not</b> hold, read off the record it stopped at — at every level
+        /// of the chain rather than only the container's own.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <see cref="PlacedBelow"/> answers this for the container's own children, which is the whole
+        /// answer while a child is atomic per column. It is not the whole answer once a break can be raised
+        /// <i>inside</i> a child: the child stays, and what belongs to the next column is the part of it
+        /// from the break onward — the siblings at and after the boundary at each nested level.
+        /// </para>
+        /// <para>
+        /// A break <i>before</i> a box means the box itself is beyond this column; a break <i>inside</i>
+        /// one means it is here, up to where it stopped, and the chain descends into it. Everything after
+        /// the boundary is beyond either way, and the fill never reached it — so it still carries the
+        /// <i>measurement</i> pass's geometry, one tall virtual column down the document. Measuring it
+        /// sized this column to the whole flow; capturing it described content in a column it is not in,
+        /// and left the same word claimed by two fragments at once.
+        /// </para>
+        /// <para>
+        /// The walk stops at an inline record. A box whose own flow stopped mid-line is in this column, and
+        /// which of its words are not is already said per word
+        /// (<see cref="CssRect.AwaitsTheNextFragmentainer"/>).
+        /// </para>
+        /// </remarks>
+        private static IReadOnlySet<CssBox> BeyondThisColumn(BreakToken? token)
+        {
+            var beyond = new HashSet<CssBox>();
+
+            for (var link = token as BlockBreakToken; link is not null; link = link.ChildToken as BlockBreakToken)
+            {
+                var from = link.IsBreakBefore ? link.ResumeChildIndex : link.ResumeChildIndex + 1;
+
+                for (var i = from; i < link.Box.Boxes.Count; i++)
+                {
+                    beyond.Add(link.Box.Boxes[i]);
+                }
+            }
+
+            return beyond;
+        }
+
+        private static double MaxBottomOf(List<CssBox> children, int limit, IReadOnlySet<CssBox> beyond)
         {
             var bottom = double.MinValue;
 
             for (var i = 0; i < children.Count && i < limit; i++)
             {
-                bottom = Math.Max(bottom, DeepestBottomOf(children[i]));
+                bottom = Math.Max(bottom, DeepestBottomOf(children[i], beyond));
             }
 
             return bottom is double.MinValue ? 0 : bottom;
@@ -494,7 +541,7 @@ namespace PeachPDF.Html.Core.Dom
         /// finished with, so asking one how far down it reaches names the wrong box.
         /// </para>
         /// </remarks>
-        private static double DeepestBottomOf(CssBox box)
+        private static double DeepestBottomOf(CssBox box, IReadOnlySet<CssBox> beyond)
         {
             var bottom = box.PlacesItselfAsBlockBox ? box.ActualBottom : double.MinValue;
 
@@ -505,7 +552,9 @@ namespace PeachPDF.Html.Core.Dom
 
             foreach (var childBox in box.Boxes)
             {
-                bottom = Math.Max(bottom, DeepestBottomOf(childBox));
+                if (beyond.Contains(childBox)) continue;
+
+                bottom = Math.Max(bottom, DeepestBottomOf(childBox, beyond));
             }
 
             return bottom;
@@ -579,15 +628,45 @@ namespace PeachPDF.Html.Core.Dom
         /// The slot is restated as this container's own. A break decided inside a column was worked out
         /// against the page grid, whose next slot is the next <i>page</i> — the next column is on this one.
         /// </para>
+        /// <para>
+        /// <b>Every link of the chain is restated, not only the outermost.</b> A break raised below a
+        /// top-level child produces a chain, and each link of it was decided against the page grid just as
+        /// the outermost one was — so a deeper link left alone carries a slot several pages on and a target
+        /// somewhere down the document, which the next column then places its content at. Measured as a
+        /// resumed page whose second column began 400pt past the page it is on.
+        /// </para>
         /// </remarks>
         private static BreakToken? ResumeInTheNextColumn(CssBox columnsBox, double bandTop, int startSlot)
         {
-            if (columnsBox.TakePendingBreakToken() is not BlockBreakToken token) return null;
+            if (columnsBox.TakePendingBreakToken() is not { } token) return null;
 
-            if (token.IsBreakBefore)
-                return token with { ResumeSlotIndex = startSlot, ResumeTopOverride = bandTop };
+            return RestatedInTheNextColumn(token, bandTop, startSlot, outermost: true);
+        }
 
-            return token with { ResumeSlotIndex = startSlot };
+        /// <summary>
+        /// One link of a resumption record, restated in the next column's terms.
+        /// </summary>
+        /// <remarks>
+        /// Only the <b>outermost</b> link's target is this container's to state: its box is a top-level
+        /// child, so it begins the next column and the band top is where it goes. A deeper link's box
+        /// begins its own containing block's content instead, and where <i>that</i> lands in the next
+        /// column is not known until it has been re-placed there — so the target is dropped rather than
+        /// carried, and re-derived at placement time
+        /// (<c>CssBox.ColumnTopForTheChildThisFillBeginsAt</c>).
+        /// </remarks>
+        private static BreakToken RestatedInTheNextColumn(
+            BreakToken token, double bandTop, int startSlot, bool outermost)
+        {
+            if (token is not BlockBreakToken block) return token with { ResumeSlotIndex = startSlot };
+
+            return block with
+            {
+                ResumeSlotIndex = startSlot,
+                ResumeTopOverride = block.IsBreakBefore && outermost ? bandTop : null,
+                ChildToken = block.ChildToken is null
+                    ? null
+                    : RestatedInTheNextColumn(block.ChildToken, bandTop, startSlot, outermost: false)
+            };
         }
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Fragments/BoxGeometrySnapshot.cs
+++ b/src/PeachPDF/Html/Core/Fragments/BoxGeometrySnapshot.cs
@@ -63,14 +63,23 @@ namespace PeachPDF.Html.Core.Fragments
         }
 
         /// <summary>
-        /// Captures the current geometry of each of <paramref name="roots"/> and their descendants.
+        /// Captures the current geometry of each of <paramref name="roots"/> and their descendants, minus
+        /// the subtrees rooted at <paramref name="excluded"/>.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The subtree-set form exists for a nested fragmentainer, which holds <i>some</i> of a container's
         /// children rather than all of them: the ones a column's fill never reached still carry the
         /// measurement pass's geometry, and capturing that would describe content in a column it is not in.
+        /// </para>
+        /// <para>
+        /// <paramref name="excluded"/> says the same thing about content <i>inside</i> a root. A break can
+        /// be raised below a container's own child, which leaves that child in this fragmentainer while
+        /// everything from the break onward belongs to the next one — so the root is captured and the walk
+        /// stops at each excluded box.
+        /// </para>
         /// </remarks>
-        internal static BoxGeometrySnapshot Capture(IEnumerable<CssBox> roots)
+        internal static BoxGeometrySnapshot Capture(IEnumerable<CssBox> roots, IReadOnlySet<CssBox>? excluded = null)
         {
             ArgumentNullException.ThrowIfNull(roots);
 
@@ -78,13 +87,13 @@ namespace PeachPDF.Html.Core.Fragments
 
             foreach (var root in roots)
             {
-                snapshot.CaptureBox(root);
+                snapshot.CaptureBox(root, excluded);
             }
 
             return snapshot;
         }
 
-        private void CaptureBox(CssBox box)
+        private void CaptureBox(CssBox box, IReadOnlySet<CssBox>? excluded = null)
         {
             var geometry = new BoxGeometry
             {
@@ -108,7 +117,9 @@ namespace PeachPDF.Html.Core.Fragments
 
             foreach (var childBox in box.Boxes)
             {
-                CaptureBox(childBox);
+                if (excluded is not null && excluded.Contains(childBox)) continue;
+
+                CaptureBox(childBox, excluded);
             }
         }
 


### PR DESCRIPTION
Fixes #387

## What was wrong

#366 made a **top-level child** of a multi-column container split at a column boundary. A block one level further down did not. Measured on `main`, on a 400pt page with `columns: 2; column-fill: auto` and a wrapper of 24 × 20pt rows:

- `r18` was claimed by **two** fragments at once — once in each column, both at y=386, straddling the 400pt band;
- rows 19–23 left ghost fragments in column 1 at y=406…486, at the *measurement* pass's positions;
- the flow spilled onto a second page it did not need, and the container reported a height past its own page.

## The idea

Everything the columns engine states about "the next column" is stated on the resumption record's **outermost** link, and a break raised below the container's own child produces a **chain**. Three sites read one link where they needed the whole chain.

**(a) The target for the box that begins the next column.** The arms that raise a column break deliberately record no target — every column of a container begins at the same block-axis coordinate, so `ResumeInTheNextColumn` supplies it. It can only supply it for a *top-level* child; a deeper link's box begins its own containing block's content rather than the column, at a coordinate not knowable when the record is written because that block has not been re-placed in the next column yet. So it is re-derived at placement time: `CssBox.ColumnTopForTheChildThisFillBeginsAt` gives the child `max(column.ResumeContentTop, ContainingBlock.ClientTop)`, the same maximum `ResumeInTheNextFragmentainer` takes. Without it, `PlaceBlockChild` fell back to the previous sibling's bottom — a sibling still in the column just vacated.

**(b) The whole chain is restated, not only the outermost link.** Every link was decided against the page grid, so a deeper one carries a slot several pages on and a target down the document. `RestatedInTheNextColumn` now walks the chain: every slot becomes the container's own, the outermost break-before keeps the band top, and every deeper target is dropped so (a) re-derives it. Found only by running the 60-row case — the second column of the *resumed* page was being filled at `ResumeTopOverride = 1200`, a §5.2 page-grid target from the previous column's fill, so the tail took a third page the flat control did not need.

**(c) Which boxes a column holds is a prefix at every level.** `PlacedBelow` answers it for the container's own children, which is the whole answer while a child is atomic per column. New `BeyondThisColumn` reads the same distinction off each link — break-*before* means the box itself is beyond, break-*inside* means it is here up to where it stopped and the walk descends into it, and everything after the boundary is beyond either way — and both `DeepestBottomOf` and `BoxGeometrySnapshot.Capture` skip those subtrees. That is what fixes the double claim, the ghosts, and the container's height.

## Verification

Each part **verified load-bearing by neutralizing it separately**: (a) fails 5 multicol tests, (b) fails 3, (c) fails 4. None is redundant with the others.

- `MulticolLayoutIntegrationTests` **+8**: the break's placement asserted on every affected box (`lead`, the wrapper's own two fragments, all 24 rows), the every-word-claimed-exactly-once invariant across four fill/page-height combinations, the resumed container's second column, a two-level chain landing inside its own containing block's padding, and the `clone`/`slice` reservation difference.
- Full net8.0 suite green (**6738**), CLI suite green (**96**); **100% diff coverage**; **zero warnings** on `dotnet build PeachPDF.slnx -t:Rebuild`.
- **68 of 69 showcases byte-identical** to `main`. `multicol` differs by its new **section 12** alone: pages 1–6 rasterize identically, and page 7 shows the wrapper filling one column and leaving the second empty on the unfixed build against a proper two-column split with a fragment's decoration in each on the fixed one. Verified in **both PDFium and MuPDF**.

## Effect on #335

This closes what bounded the multi-column half of #335. A `box-decoration-break: clone` box whose content is *blocks* now has a column break inside it, and the room the word path already reserves is what the fill obeys — measured on a 194pt band with a 12pt cloned bottom border, the first column stops one 20pt row earlier than `slice` does. The doc limitation naming that case is removed.

## Deliberately not done

`column-fill: balance` treats a wrapper as one atomic child in its packing estimate, so a nested fixture balances a little less evenly than the same rows as direct children (14/10 against 12/12 on the 24-row fixture). That is the estimate's own approximation, not a fragmentation defect. A forced **page** break declared below the container's own child is still lost entirely — that is #395, it has a different cause (the measurement pass consumes the one-shot `_forcedBreakTop`), and its characterization test is unchanged here.
