### PR TITLE
Serialize CWD-dependent tests to prevent races

### DIFF
--- a/src/PeachPDF.Tests/Integration/CwdDependentTestsCollection.cs
+++ b/src/PeachPDF.Tests/Integration/CwdDependentTestsCollection.cs
@@ -1,0 +1,18 @@
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Defines an xUnit collection for tests that depend on the process's current working directory (CWD).
+    /// Tests in this collection are serialized (never run in parallel) to prevent race conditions when
+    /// multiple target frameworks (e.g., net8.0 and net10.0) execute concurrently and both manipulate
+    /// directories under the shared CWD.
+    /// </summary>
+    [CollectionDefinition("CWD-Dependent")]
+    public class CwdDependentTestsCollection
+    {
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+    }
+}

--- a/src/PeachPDF.Tests/Integration/FileUriLoaderIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FileUriLoaderIntegrationTests.cs
@@ -16,6 +16,7 @@ namespace PeachPDF.Tests.Integration
     /// <see cref="FileUriNetworkLoader"/>: a <c>&lt;base href="file:///..."&gt;</c> element under the
     /// default loader, and the current-working-directory base default.
     /// </summary>
+    [Collection("CWD-Dependent")]
     public class FileUriLoaderIntegrationTests
     {
         // A real, loadable 1x1 pixel PNG (same constant used across the image integration tests).

--- a/src/PeachPDF.Tests/Integration/LocalFileAccessTests.cs
+++ b/src/PeachPDF.Tests/Integration/LocalFileAccessTests.cs
@@ -16,6 +16,7 @@ namespace PeachPDF.Tests.Integration
     /// meaningful file system to reach. Each denial test has an allowed-variant twin, so a fixture that
     /// silently stopped exercising the feature would fail rather than pass vacuously.
     /// </summary>
+    [Collection("CWD-Dependent")]
     public class LocalFileAccessTests
     {
         // A real, loadable 1x1 pixel PNG (same constant used across the image integration tests).

--- a/src/PeachPDF.Tests/Network/FileUriNetworkLoaderTests.cs
+++ b/src/PeachPDF.Tests/Network/FileUriNetworkLoaderTests.cs
@@ -1,10 +1,8 @@
-using System;
-using System.IO;
-using System.Threading.Tasks;
 using PeachPDF.Network;
 
 namespace PeachPDF.Tests.Network
 {
+    [Collection("CWD-Dependent")]
     public class FileUriNetworkLoaderTests
     {
         [Fact]


### PR DESCRIPTION
This pull request improves the reliability of integration tests that depend on the process's current working directory (CWD) by ensuring they are not run in parallel. It introduces a new xUnit test collection and applies it to relevant test classes to prevent race conditions when tests manipulate shared directories.

**Test serialization for CWD-dependent tests:**

* Added a new `CwdDependentTestsCollection` class in `CwdDependentTestsCollection.cs` to define the `"CWD-Dependent"` xUnit collection, ensuring tests in this group are never run in parallel.
* Applied the `[Collection("CWD-Dependent")]` attribute to the following test classes to serialize their execution:
  * `FileUriLoaderIntegrationTests` (`FileUriLoaderIntegrationTests.cs`)
  * `LocalFileAccessTests` (`LocalFileAccessTests.cs`)
  * `FileUriNetworkLoaderTests` (`FileUriNetworkLoaderTests.cs`)

Fixes #442
Fixes #427 