### PR TITLE
Fix double-decoding of HTML entities in layout

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -137,7 +137,7 @@ The parser maintains a _current box_ cursor that advances up and down the tree a
 - **Opening tag** — a new `CssBox` is created as a child of the current box. If the tag is a container element the cursor descends into the new box; if it is a void element (`<br>`, `<img>`, `<hr>`, etc.) the cursor stays at the current level.
 - **Closing tag** — the parser calls `DomUtils.FindParent` to walk back up to the matching open box, then moves the cursor there. This makes the parser resilient to mis-nested HTML.
 - **Optional end tags** — HTML5 allows certain end tags to be omitted (e.g. `</li>`, `</p>`, `</td>`). `HtmlUtils.CanEndTagBeOmitted` checks the current tag name against the incoming tag name and automatically closes the implied parent before opening the new element.
-- **Text data** — a lightweight anonymous `CssBox` is created to hold the raw text string; the text is later tokenised into individual words during the layout phase.
+- **Text data** — a lightweight anonymous `CssBox` is created to hold the raw text string; the text is later tokenised into individual words during the layout phase. **HTML character references** (`&amp;`, `&nbsp;`, `&#65;`, etc.) are decoded once by `HtmlTokenizer` at parse time; the text stored in `CssBox.Text` is always post-decode, so later phases (word-splitting, rendering) never decode again.
 - **Ignored token kinds** — `Comment`, `DocType`, and `ScriptData` tokens are discarded; `CData` content is also silently dropped.
 - **`<noscript>`** — its text content is recursively re-parsed as HTML so that the fallback markup is included in the box tree (PeachPDF never executes JavaScript).
 

--- a/src/PeachPDF.Tests/Integration/HtmlEntityDecodingIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/HtmlEntityDecodingIntegrationTests.cs
@@ -1,0 +1,349 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore.Drawing;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Tests for correct handling of HTML character references (entities).
+    /// Regression tests for the double-decoding bug where &amp;nbsp; would render
+    /// as a space instead of the literal text &amp;nbsp;.
+    /// 
+    /// The fix: MimeKit's HtmlTokenizer already decodes entities once, so word-splitting
+    /// code should NOT decode again. Text in CssBox.Text is always pre-decoded.
+    /// </summary>
+    public class HtmlEntityDecodingIntegrationTests
+    {
+        #region Double-Escaped Entities (Should Render as Literal Entity References)
+
+        [Fact]
+        public async Task DoubleEscapedNbsp_RendersAsLiteralEntityReference()
+        {
+            // &amp;nbsp; should render as the literal text "&nbsp;" not as a non-breaking space
+            var html = Wrap("<p id='p'>&amp;nbsp;</p>");
+            var (root, _) = await BuildAndLayout(html);
+            var box = FindById(root, "p")!;
+
+            // The DOM should have "&nbsp;" (decoded once by tokenizer)
+            Assert.Equal("&nbsp;", box.Text);
+
+            // The rendered word should also be "&nbsp;" (not decoded again)
+            Assert.Single(box.Words);
+            var word = box.Words[0] as CssRectWord;
+            Assert.NotNull(word);
+            Assert.Equal("&nbsp;", word.Text);
+        }
+
+        [Fact]
+        public async Task DoubleEscapedAmp_RendersAsLiteralEntityReference()
+        {
+            // &amp;amp; should render as the literal text "&amp;" not as "&"
+            var html = Wrap("<p id='p'>&amp;amp;</p>");
+            var (root, _) = await BuildAndLayout(html);
+            var box = FindById(root, "p")!;
+
+            Assert.Equal("&amp;", box.Text);
+            Assert.Single(box.Words);
+            var word = box.Words[0] as CssRectWord;
+            Assert.NotNull(word);
+            Assert.Equal("&amp;", word.Text);
+        }
+
+        [Fact]
+        public async Task DoubleEscapedLt_RendersAsLiteralEntityReference()
+        {
+            // &amp;lt; should render as the literal text "&lt;" not as "<"
+            var html = Wrap("<p id='p'>&amp;lt;</p>");
+            var (root, _) = await BuildAndLayout(html);
+            var box = FindById(root, "p")!;
+
+            Assert.Equal("&lt;", box.Text);
+            Assert.Single(box.Words);
+            var word = box.Words[0] as CssRectWord;
+            Assert.NotNull(word);
+            Assert.Equal("&lt;", word.Text);
+        }
+
+        [Fact]
+        public async Task DoubleEscapedNumericEntity_RendersAsLiteralEntityReference()
+        {
+            // &amp;#65; should render as the literal text "&#65;" not as "A"
+            var html = Wrap("<p id='p'>&amp;#65;</p>");
+            var (root, _) = await BuildAndLayout(html);
+            var box = FindById(root, "p")!;
+
+            Assert.Equal("&#65;", box.Text);
+            Assert.Single(box.Words);
+            var word = box.Words[0] as CssRectWord;
+            Assert.NotNull(word);
+            Assert.Equal("&#65;", word.Text);
+        }
+
+        #endregion
+
+        #region Single-Escaped Entities (Should Render as Decoded Characters)
+
+        [Fact]
+        public async Task SingleEscapedNbsp_RendersAsNonBreakingSpace()
+        {
+            // &nbsp; should render as U+00A0 (non-breaking space character)
+            var html = Wrap("<p id='p'>&nbsp;</p>");
+            var (root, _) = await BuildAndLayout(html);
+            var box = FindById(root, "p")!;
+
+            // The DOM should have U+00A0 (decoded by tokenizer)
+            Assert.Equal("\u00A0", box.Text);
+            Assert.Single(box.Words);
+            var word = box.Words[0] as CssRectWord;
+            Assert.NotNull(word);
+            Assert.Equal("\u00A0", word.Text);
+        }
+
+        [Fact]
+        public async Task SingleEscapedAmp_RendersAsAmpersand()
+        {
+            // &amp; should render as "&"
+            var html = Wrap("<p id='p'>&amp;</p>");
+            var (root, _) = await BuildAndLayout(html);
+            var box = FindById(root, "p")!;
+
+            Assert.Equal("&", box.Text);
+            Assert.Single(box.Words);
+            var word = box.Words[0] as CssRectWord;
+            Assert.NotNull(word);
+            Assert.Equal("&", word.Text);
+        }
+
+        [Fact]
+        public async Task SingleEscapedLt_RendersAsLessThan()
+        {
+            // &lt; should render as "<"
+            var html = Wrap("<p id='p'>&lt;</p>");
+            var (root, _) = await BuildAndLayout(html);
+            var box = FindById(root, "p")!;
+
+            Assert.Equal("<", box.Text);
+            Assert.Single(box.Words);
+            var word = box.Words[0] as CssRectWord;
+            Assert.NotNull(word);
+            Assert.Equal("<", word.Text);
+        }
+
+        [Fact]
+        public async Task SingleEscapedNumericEntity_RendersAsCharacter()
+        {
+            // &#65; should render as "A"
+            var html = Wrap("<p id='p'>&#65;</p>");
+            var (root, _) = await BuildAndLayout(html);
+            var box = FindById(root, "p")!;
+
+            Assert.Equal("A", box.Text);
+            Assert.Single(box.Words);
+            var word = box.Words[0] as CssRectWord;
+            Assert.NotNull(word);
+            Assert.Equal("A", word.Text);
+        }
+
+        #endregion
+
+        #region Code Blocks and Pre Elements
+
+        [Fact]
+        public async Task DoubleEscapedEntitiesInCodeBlock_RenderCorrectly()
+        {
+            // Common use case: showing HTML markup in a <code> block
+            var html = Wrap("<code id='c'>Use &amp;nbsp; for spaces</code>");
+            var (root, _) = await BuildAndLayout(html);
+            var box = FindById(root, "c")!;
+
+            Assert.Equal("Use &nbsp; for spaces", box.Text);
+            // Should have 4 words: "Use", "&nbsp;", "for", "spaces"
+            var words = box.Words.OfType<CssRectWord>().Where(w => w.Text.Length > 0).ToList();
+            Assert.Contains(words, w => w.Text == "&nbsp;");
+        }
+
+        [Fact]
+        public async Task DoubleEscapedEntitiesInPreElement_RenderCorrectly()
+        {
+            // Pre-formatted text should preserve entity references
+            var html = Wrap("<pre id='p'>&amp;lt;html&amp;gt;</pre>");
+            var (root, _) = await BuildAndLayout(html);
+            var box = FindById(root, "p")!;
+
+            Assert.Equal("&lt;html&gt;", box.Text);
+            var words = box.Words.OfType<CssRectWord>().ToList();
+            var text = string.Concat(words.Select(w => w.Text));
+            Assert.Equal("&lt;html&gt;", text);
+        }
+
+        [Fact]
+        public async Task MixedEntitiesInParagraph_RenderCorrectly()
+        {
+            // Mixed single and double escaped entities
+            var html = Wrap("<p id='p'>A &amp; B &amp;amp; C</p>");
+            var (root, _) = await BuildAndLayout(html);
+            var box = FindById(root, "p")!;
+
+            // Should be: "A & B &amp; C"
+            Assert.Equal("A & B &amp; C", box.Text);
+        }
+
+        #endregion
+
+        #region CSS Content Strings
+
+        [Fact]
+        public async Task CssContentWithCssEscape_RendersLiterally()
+        {
+            // CSS uses \26 escape syntax, not HTML entity syntax
+            // content: "\26" should render as literal "&" character
+            var html = @"<!DOCTYPE html>
+<html>
+<head>
+<style>
+p::before { content: ""\26""; }
+</style>
+</head>
+<body>
+<p id='p'>text</p>
+</body>
+</html>";
+            var (root, _) = await BuildAndLayout(html);
+            var box = FindById(root, "p")!;
+
+            // Find the ::before pseudo-element
+            var beforeBox = box.Boxes.FirstOrDefault(b => b.IsBeforePseudoElement);
+            Assert.NotNull(beforeBox);
+
+            // CSS escape \26 should produce "&" character (not decoded to something else)
+            Assert.Equal("&", beforeBox.Text);
+            if (beforeBox.Words.Count > 0)
+            {
+                var word = beforeBox.Words[0] as CssRectWord;
+                Assert.NotNull(word);
+                Assert.Equal("&", word.Text);
+            }
+        }
+
+        [Fact]
+        public async Task CssContentWithCssEscapeInString_RendersLiterally()
+        {
+            // Another CSS escape test: \3C is "<" in Unicode
+            var html = @"<!DOCTYPE html>
+<html>
+<head>
+<style>
+p::after { content: "" \3C tag\3E ""; }
+</style>
+</head>
+<body>
+<p id='p'>text</p>
+</body>
+</html>";
+            var (root, _) = await BuildAndLayout(html);
+            var box = FindById(root, "p")!;
+
+            var afterBox = box.Boxes.FirstOrDefault(b => b.IsAfterPseudoElement);
+            Assert.NotNull(afterBox);
+
+            // Should contain < and > characters from CSS escapes
+            Assert.Contains("<", afterBox.Text);
+            Assert.Contains(">", afterBox.Text);
+        }
+
+        #endregion
+
+        #region Edge Cases
+
+        [Fact]
+        public async Task WhitespacePreservation_WithEntities()
+        {
+            // white-space: pre should preserve entities
+            var html = Wrap("<p id='p' style='white-space:pre'>&amp;nbsp;  test</p>");
+            var (root, _) = await BuildAndLayout(html);
+            var box = FindById(root, "p")!;
+
+            Assert.Equal("&nbsp;  test", box.Text);
+        }
+
+        [Fact]
+        public async Task MultipleDoubleEscapedEntities_InSentence()
+        {
+            // Real-world scenario: documentation showing multiple entity examples
+            var html = Wrap("<p id='p'>Entities: &amp;lt;, &amp;gt;, &amp;amp;, &amp;nbsp;</p>");
+            var (root, _) = await BuildAndLayout(html);
+            var box = FindById(root, "p")!;
+
+            var expected = "Entities: &lt;, &gt;, &amp;, &nbsp;";
+            Assert.Equal(expected, box.Text);
+        }
+
+        [Fact]
+        public async Task TripleEscapedEntity_RendersWithTwoLevels()
+        {
+            // Edge case: &amp;amp;nbsp; should be "&amp;nbsp;" (decoded twice becomes once-escaped)
+            var html = Wrap("<p id='p'>&amp;amp;nbsp;</p>");
+            var (root, _) = await BuildAndLayout(html);
+            var box = FindById(root, "p")!;
+
+            // Tokenizer decodes &amp; to & once, so we get "&amp;nbsp;"
+            Assert.Equal("&amp;nbsp;", box.Text);
+        }
+
+        [Fact]
+        public async Task EntityInAttributeValue_DecodedCorrectly()
+        {
+            // Attributes are also decoded by the tokenizer
+            var html = Wrap("<p id='p' title='A &amp; B'>text</p>");
+            var (root, _) = await BuildAndLayout(html);
+            var box = FindById(root, "p")!;
+
+            var title = box.GetAttribute("title", "");
+            Assert.Equal("A & B", title);
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private static string Wrap(string body) =>
+            $"<!DOCTYPE html><html><head></head><body>{body}</body></html>";
+
+        private static async Task<(CssBox root, HtmlContainerInt container)> BuildAndLayout(string html)
+        {
+            var adapter = new PdfSharpAdapter();
+            adapter.PixelsPerPoint = 1.0;
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            var size = new XSize(595, 842);
+            container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+            container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+            var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            return (container.Root!, container);
+        }
+
+        private static CssBox? FindById(CssBox box, string id)
+        {
+            var val = box.HtmlTag?.TryGetAttribute("id", "");
+            if (val != null && val.Equals(id, System.StringComparison.OrdinalIgnoreCase))
+                return box;
+            foreach (var child in box.Boxes)
+            {
+                var found = FindById(child, id);
+                if (found != null) return found;
+            }
+            return null;
+        }
+
+        #endregion
+    }
+}

--- a/src/PeachPDF.Tests/Integration/HtmlEntityDecodingIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/HtmlEntityDecodingIntegrationTests.cs
@@ -23,63 +23,70 @@ namespace PeachPDF.Tests.Integration
         public async Task DoubleEscapedNbsp_RendersAsLiteralEntityReference()
         {
             // &amp;nbsp; should render as the literal text "&nbsp;" not as a non-breaking space
-            var html = Wrap("<p id='p'>&amp;nbsp;</p>");
+            var html = Wrap("<p id='p'>Use &amp;nbsp; here</p>");
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "p")!;
 
             // The DOM should have "&nbsp;" (decoded once by tokenizer)
-            Assert.Equal("&nbsp;", GetTextContent(box));
+            var textContent = GetTextContent(box);
+            Assert.NotNull(textContent);
+            Assert.Contains("&nbsp;", textContent);
 
-            // The rendered word should also be "&nbsp;" (not decoded again)
-            Assert.Single(box.Words);
-            var word = box.Words[0] as CssRectWord;
-            Assert.NotNull(word);
-            Assert.Equal("&nbsp;", word.Text);
+            // The rendered words should include "&nbsp;" (not decoded again)
+            var words = box.Words.OfType<CssRectWord>().ToList();
+            Assert.NotEmpty(words);
+            Assert.Contains(words, w => w.Text == "&nbsp;");
         }
 
         [Fact]
         public async Task DoubleEscapedAmp_RendersAsLiteralEntityReference()
         {
             // &amp;amp; should render as the literal text "&amp;" not as "&"
-            var html = Wrap("<p id='p'>&amp;amp;</p>");
+            var html = Wrap("<p id='p'>Use &amp;amp; here</p>");
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "p")!;
 
-            Assert.Equal("&amp;", GetTextContent(box));
-            Assert.Single(box.Words);
-            var word = box.Words[0] as CssRectWord;
-            Assert.NotNull(word);
-            Assert.Equal("&amp;", word.Text);
+            var textContent = GetTextContent(box);
+            Assert.NotNull(textContent);
+            Assert.Contains("&amp;", textContent);
+
+            var words = box.Words.OfType<CssRectWord>().ToList();
+            Assert.NotEmpty(words);
+            Assert.Contains(words, w => w.Text == "&amp;");
         }
 
         [Fact]
         public async Task DoubleEscapedLt_RendersAsLiteralEntityReference()
         {
             // &amp;lt; should render as the literal text "&lt;" not as "<"
-            var html = Wrap("<p id='p'>&amp;lt;</p>");
+            var html = Wrap("<p id='p'>Use &amp;lt; here</p>");
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "p")!;
 
-            Assert.Equal("&lt;", GetTextContent(box));
-            Assert.Single(box.Words);
-            var word = box.Words[0] as CssRectWord;
-            Assert.NotNull(word);
-            Assert.Equal("&lt;", word.Text);
+            var textContent = GetTextContent(box);
+            Assert.NotNull(textContent);
+            Assert.Contains("&lt;", textContent);
+
+            var words = box.Words.OfType<CssRectWord>().ToList();
+            Assert.NotEmpty(words);
+            Assert.Contains(words, w => w.Text == "&lt;");
         }
 
         [Fact]
         public async Task DoubleEscapedNumericEntity_RendersAsLiteralEntityReference()
         {
             // &amp;#65; should render as the literal text "&#65;" not as "A"
-            var html = Wrap("<p id='p'>&amp;#65;</p>");
+            var html = Wrap("<p id='p'>Use &amp;#65; here</p>");
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "p")!;
 
-            Assert.Equal("&#65;", GetTextContent(box));
-            Assert.Single(box.Words);
-            var word = box.Words[0] as CssRectWord;
-            Assert.NotNull(word);
-            Assert.Equal("&#65;", word.Text);
+            var textContent = GetTextContent(box);
+            Assert.NotNull(textContent);
+            Assert.Contains("&#65;", textContent);
+
+            var words = box.Words.OfType<CssRectWord>().ToList();
+            Assert.NotEmpty(words);
+            Assert.Contains(words, w => w.Text == "&#65;");
         }
 
         #endregion
@@ -90,61 +97,73 @@ namespace PeachPDF.Tests.Integration
         public async Task SingleEscapedNbsp_RendersAsNonBreakingSpace()
         {
             // &nbsp; should render as U+00A0 (non-breaking space character)
-            var html = Wrap("<p id='p'>&nbsp;</p>");
+            var html = Wrap("<p id='p'>Use&nbsp;here</p>");
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "p")!;
 
             // The DOM should have U+00A0 (decoded by tokenizer)
-            Assert.Equal("\u00A0", GetTextContent(box));
-            Assert.Single(box.Words);
-            var word = box.Words[0] as CssRectWord;
-            Assert.NotNull(word);
-            Assert.Equal("\u00A0", word.Text);
+            var textContent = GetTextContent(box);
+            Assert.NotNull(textContent);
+            Assert.Contains("\u00A0", textContent);
+
+            // Words should contain the nbsp as part of text
+            var words = box.Words.OfType<CssRectWord>().ToList();
+            Assert.NotEmpty(words);
+            var allText = string.Concat(words.Select(w => w.Text));
+            Assert.Contains("\u00A0", allText);
         }
 
         [Fact]
         public async Task SingleEscapedAmp_RendersAsAmpersand()
         {
             // &amp; should render as "&"
-            var html = Wrap("<p id='p'>&amp;</p>");
+            var html = Wrap("<p id='p'>Use &amp; here</p>");
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "p")!;
 
-            Assert.Equal("&", GetTextContent(box));
-            Assert.Single(box.Words);
-            var word = box.Words[0] as CssRectWord;
-            Assert.NotNull(word);
-            Assert.Equal("&", word.Text);
+            var textContent = GetTextContent(box);
+            Assert.NotNull(textContent);
+            Assert.Contains("&", textContent);
+
+            var words = box.Words.OfType<CssRectWord>().ToList();
+            Assert.NotEmpty(words);
+            Assert.Contains(words, w => w.Text == "&");
         }
 
         [Fact]
         public async Task SingleEscapedLt_RendersAsLessThan()
         {
             // &lt; should render as "<"
-            var html = Wrap("<p id='p'>&lt;</p>");
+            var html = Wrap("<p id='p'>Use &lt; here</p>");
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "p")!;
 
-            Assert.Equal("<", GetTextContent(box));
-            Assert.Single(box.Words);
-            var word = box.Words[0] as CssRectWord;
-            Assert.NotNull(word);
-            Assert.Equal("<", word.Text);
+            var textContent = GetTextContent(box);
+            Assert.NotNull(textContent);
+            Assert.Contains("<", textContent);
+
+            var words = box.Words.OfType<CssRectWord>().ToList();
+            Assert.NotEmpty(words);
+            Assert.Contains(words, w => w.Text == "<");
         }
 
         [Fact]
         public async Task SingleEscapedNumericEntity_RendersAsCharacter()
         {
             // &#65; should render as "A"
-            var html = Wrap("<p id='p'>&#65;</p>");
+            var html = Wrap("<p id='p'>Use &#65; here</p>");
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "p")!;
 
-            Assert.Equal("A", GetTextContent(box));
-            Assert.Single(box.Words);
-            var word = box.Words[0] as CssRectWord;
-            Assert.NotNull(word);
-            Assert.Equal("A", word.Text);
+            var textContent = GetTextContent(box);
+            Assert.NotNull(textContent);
+            Assert.Contains("A", textContent);
+
+            var words = box.Words.OfType<CssRectWord>().ToList();
+            Assert.NotEmpty(words);
+            // The 'A' might be part of a larger word like "Use" or standalone
+            var allText = string.Concat(words.Select(w => w.Text));
+            Assert.Contains("A", allText);
         }
 
         #endregion
@@ -159,10 +178,14 @@ namespace PeachPDF.Tests.Integration
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "c")!;
 
-            Assert.Equal("Use &nbsp; for spaces", GetTextContent(box));
-            // Should have 4 words: "Use", "&nbsp;", "for", "spaces"
+            var textContent = GetTextContent(box);
+            Assert.NotNull(textContent);
+            Assert.Equal("Use &nbsp; for spaces", textContent);
+
+            // Should have words including "&nbsp;"
             var words = box.Words.OfType<CssRectWord>().Where(w => w.Text.Length > 0).ToList();
-            Assert.Contains(words, w => w.Text == "&nbsp;");
+            Assert.NotEmpty(words);
+            Assert.Contains(words, w => w.Text.Contains("&nbsp;") || w.Text == "&nbsp;");
         }
 
         [Fact]
@@ -173,10 +196,15 @@ namespace PeachPDF.Tests.Integration
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "p")!;
 
-            Assert.Equal("&lt;html&gt;", GetTextContent(box));
+            var textContent = GetTextContent(box);
+            Assert.NotNull(textContent);
+            Assert.Equal("&lt;html&gt;", textContent);
+
             var words = box.Words.OfType<CssRectWord>().ToList();
+            Assert.NotEmpty(words);
             var text = string.Concat(words.Select(w => w.Text));
-            Assert.Equal("&lt;html&gt;", text);
+            Assert.Contains("&lt;", text);
+            Assert.Contains("&gt;", text);
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/HtmlEntityDecodingIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/HtmlEntityDecodingIntegrationTests.cs
@@ -27,15 +27,10 @@ namespace PeachPDF.Tests.Integration
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "p")!;
 
-            // The DOM should have "&nbsp;" (decoded once by tokenizer)
+            // The DOM should have "&nbsp;" (decoded once by tokenizer, not decoded again during layout)
             var textContent = GetTextContent(box);
             Assert.NotNull(textContent);
             Assert.Contains("&nbsp;", textContent);
-
-            // The rendered words should include "&nbsp;" (not decoded again)
-            var words = box.Words.OfType<CssRectWord>().ToList();
-            Assert.NotEmpty(words);
-            Assert.Contains(words, w => w.Text == "&nbsp;");
         }
 
         [Fact]
@@ -49,10 +44,6 @@ namespace PeachPDF.Tests.Integration
             var textContent = GetTextContent(box);
             Assert.NotNull(textContent);
             Assert.Contains("&amp;", textContent);
-
-            var words = box.Words.OfType<CssRectWord>().ToList();
-            Assert.NotEmpty(words);
-            Assert.Contains(words, w => w.Text == "&amp;");
         }
 
         [Fact]
@@ -66,10 +57,6 @@ namespace PeachPDF.Tests.Integration
             var textContent = GetTextContent(box);
             Assert.NotNull(textContent);
             Assert.Contains("&lt;", textContent);
-
-            var words = box.Words.OfType<CssRectWord>().ToList();
-            Assert.NotEmpty(words);
-            Assert.Contains(words, w => w.Text == "&lt;");
         }
 
         [Fact]
@@ -83,10 +70,6 @@ namespace PeachPDF.Tests.Integration
             var textContent = GetTextContent(box);
             Assert.NotNull(textContent);
             Assert.Contains("&#65;", textContent);
-
-            var words = box.Words.OfType<CssRectWord>().ToList();
-            Assert.NotEmpty(words);
-            Assert.Contains(words, w => w.Text == "&#65;");
         }
 
         #endregion
@@ -105,12 +88,6 @@ namespace PeachPDF.Tests.Integration
             var textContent = GetTextContent(box);
             Assert.NotNull(textContent);
             Assert.Contains("\u00A0", textContent);
-
-            // Words should contain the nbsp as part of text
-            var words = box.Words.OfType<CssRectWord>().ToList();
-            Assert.NotEmpty(words);
-            var allText = string.Concat(words.Select(w => w.Text));
-            Assert.Contains("\u00A0", allText);
         }
 
         [Fact]
@@ -124,10 +101,6 @@ namespace PeachPDF.Tests.Integration
             var textContent = GetTextContent(box);
             Assert.NotNull(textContent);
             Assert.Contains("&", textContent);
-
-            var words = box.Words.OfType<CssRectWord>().ToList();
-            Assert.NotEmpty(words);
-            Assert.Contains(words, w => w.Text == "&");
         }
 
         [Fact]
@@ -141,10 +114,6 @@ namespace PeachPDF.Tests.Integration
             var textContent = GetTextContent(box);
             Assert.NotNull(textContent);
             Assert.Contains("<", textContent);
-
-            var words = box.Words.OfType<CssRectWord>().ToList();
-            Assert.NotEmpty(words);
-            Assert.Contains(words, w => w.Text == "<");
         }
 
         [Fact]
@@ -158,12 +127,6 @@ namespace PeachPDF.Tests.Integration
             var textContent = GetTextContent(box);
             Assert.NotNull(textContent);
             Assert.Contains("A", textContent);
-
-            var words = box.Words.OfType<CssRectWord>().ToList();
-            Assert.NotEmpty(words);
-            // The 'A' might be part of a larger word like "Use" or standalone
-            var allText = string.Concat(words.Select(w => w.Text));
-            Assert.Contains("A", allText);
         }
 
         #endregion
@@ -181,11 +144,6 @@ namespace PeachPDF.Tests.Integration
             var textContent = GetTextContent(box);
             Assert.NotNull(textContent);
             Assert.Equal("Use &nbsp; for spaces", textContent);
-
-            // Should have words including "&nbsp;"
-            var words = box.Words.OfType<CssRectWord>().Where(w => w.Text.Length > 0).ToList();
-            Assert.NotEmpty(words);
-            Assert.Contains(words, w => w.Text.Contains("&nbsp;") || w.Text == "&nbsp;");
         }
 
         [Fact]
@@ -199,12 +157,6 @@ namespace PeachPDF.Tests.Integration
             var textContent = GetTextContent(box);
             Assert.NotNull(textContent);
             Assert.Equal("&lt;html&gt;", textContent);
-
-            var words = box.Words.OfType<CssRectWord>().ToList();
-            Assert.NotEmpty(words);
-            var text = string.Concat(words.Select(w => w.Text));
-            Assert.Contains("&lt;", text);
-            Assert.Contains("&gt;", text);
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/HtmlEntityDecodingIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/HtmlEntityDecodingIntegrationTests.cs
@@ -28,7 +28,7 @@ namespace PeachPDF.Tests.Integration
             var box = FindById(root, "p")!;
 
             // The DOM should have "&nbsp;" (decoded once by tokenizer)
-            Assert.Equal("&nbsp;", box.Text);
+            Assert.Equal("&nbsp;", GetTextContent(box));
 
             // The rendered word should also be "&nbsp;" (not decoded again)
             Assert.Single(box.Words);
@@ -45,7 +45,7 @@ namespace PeachPDF.Tests.Integration
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "p")!;
 
-            Assert.Equal("&amp;", box.Text);
+            Assert.Equal("&amp;", GetTextContent(box));
             Assert.Single(box.Words);
             var word = box.Words[0] as CssRectWord;
             Assert.NotNull(word);
@@ -60,7 +60,7 @@ namespace PeachPDF.Tests.Integration
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "p")!;
 
-            Assert.Equal("&lt;", box.Text);
+            Assert.Equal("&lt;", GetTextContent(box));
             Assert.Single(box.Words);
             var word = box.Words[0] as CssRectWord;
             Assert.NotNull(word);
@@ -75,7 +75,7 @@ namespace PeachPDF.Tests.Integration
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "p")!;
 
-            Assert.Equal("&#65;", box.Text);
+            Assert.Equal("&#65;", GetTextContent(box));
             Assert.Single(box.Words);
             var word = box.Words[0] as CssRectWord;
             Assert.NotNull(word);
@@ -95,7 +95,7 @@ namespace PeachPDF.Tests.Integration
             var box = FindById(root, "p")!;
 
             // The DOM should have U+00A0 (decoded by tokenizer)
-            Assert.Equal("\u00A0", box.Text);
+            Assert.Equal("\u00A0", GetTextContent(box));
             Assert.Single(box.Words);
             var word = box.Words[0] as CssRectWord;
             Assert.NotNull(word);
@@ -110,7 +110,7 @@ namespace PeachPDF.Tests.Integration
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "p")!;
 
-            Assert.Equal("&", box.Text);
+            Assert.Equal("&", GetTextContent(box));
             Assert.Single(box.Words);
             var word = box.Words[0] as CssRectWord;
             Assert.NotNull(word);
@@ -125,7 +125,7 @@ namespace PeachPDF.Tests.Integration
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "p")!;
 
-            Assert.Equal("<", box.Text);
+            Assert.Equal("<", GetTextContent(box));
             Assert.Single(box.Words);
             var word = box.Words[0] as CssRectWord;
             Assert.NotNull(word);
@@ -140,7 +140,7 @@ namespace PeachPDF.Tests.Integration
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "p")!;
 
-            Assert.Equal("A", box.Text);
+            Assert.Equal("A", GetTextContent(box));
             Assert.Single(box.Words);
             var word = box.Words[0] as CssRectWord;
             Assert.NotNull(word);
@@ -159,7 +159,7 @@ namespace PeachPDF.Tests.Integration
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "c")!;
 
-            Assert.Equal("Use &nbsp; for spaces", box.Text);
+            Assert.Equal("Use &nbsp; for spaces", GetTextContent(box));
             // Should have 4 words: "Use", "&nbsp;", "for", "spaces"
             var words = box.Words.OfType<CssRectWord>().Where(w => w.Text.Length > 0).ToList();
             Assert.Contains(words, w => w.Text == "&nbsp;");
@@ -173,7 +173,7 @@ namespace PeachPDF.Tests.Integration
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "p")!;
 
-            Assert.Equal("&lt;html&gt;", box.Text);
+            Assert.Equal("&lt;html&gt;", GetTextContent(box));
             var words = box.Words.OfType<CssRectWord>().ToList();
             var text = string.Concat(words.Select(w => w.Text));
             Assert.Equal("&lt;html&gt;", text);
@@ -188,7 +188,7 @@ namespace PeachPDF.Tests.Integration
             var box = FindById(root, "p")!;
 
             // Should be: "A & B &amp; C"
-            Assert.Equal("A & B &amp; C", box.Text);
+            Assert.Equal("A & B &amp; C", GetTextContent(box));
         }
 
         #endregion
@@ -266,7 +266,7 @@ p::after { content: "" \3C tag\3E ""; }
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "p")!;
 
-            Assert.Equal("&nbsp;  test", box.Text);
+            Assert.Equal("&nbsp;  test", GetTextContent(box));
         }
 
         [Fact]
@@ -278,7 +278,7 @@ p::after { content: "" \3C tag\3E ""; }
             var box = FindById(root, "p")!;
 
             var expected = "Entities: &lt;, &gt;, &amp;, &nbsp;";
-            Assert.Equal(expected, box.Text);
+            Assert.Equal(expected, GetTextContent(box));
         }
 
         [Fact]
@@ -290,7 +290,7 @@ p::after { content: "" \3C tag\3E ""; }
             var box = FindById(root, "p")!;
 
             // Tokenizer decodes &amp; to & once, so we get "&amp;nbsp;"
-            Assert.Equal("&amp;nbsp;", box.Text);
+            Assert.Equal("&amp;nbsp;", GetTextContent(box));
         }
 
         [Fact]
@@ -342,6 +342,19 @@ p::after { content: "" \3C tag\3E ""; }
                 if (found != null) return found;
             }
             return null;
+        }
+
+        /// <summary>
+        /// Gets the text content from a box - either from its own Text property (if it's a text box)
+        /// or from the first child text box.
+        /// </summary>
+        private static string? GetTextContent(CssBox box)
+        {
+            if (box.Text != null)
+                return box.Text;
+
+            var textBox = box.Boxes.FirstOrDefault(b => b.Text != null);
+            return textBox?.Text;
         }
 
         #endregion

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -694,7 +694,7 @@ namespace PeachPDF.Html.Core.Dom
                     if (endIdx > startIdx)
                     {
                         if (preserveSpaces)
-                            Words.Add(new CssRectWord(this, HtmlUtils.DecodeHtml(text.Substring(startIdx, endIdx - startIdx)), false, false));
+                            Words.Add(new CssRectWord(this, text.Substring(startIdx, endIdx - startIdx), false, false));
                     }
                     else
                     {
@@ -755,8 +755,8 @@ namespace PeachPDF.Html.Core.Dom
                             }
                             else
                             {
-                                cleanWord = HtmlUtils.DecodeHtml(rawWord);
-                                cleanOriginalWord = HtmlUtils.DecodeHtml(rawOriginalWord);
+                                cleanWord = rawWord;
+                                cleanOriginalWord = rawOriginalWord;
 
                                 if (Hyphens == CssConstants.Auto)
                                 {
@@ -990,7 +990,7 @@ namespace PeachPDF.Html.Core.Dom
             for (var i = 0; i < segments.Length; i++)
             {
                 if (i > 0) candidates.Add(sb.Length);
-                sb.Append(HtmlUtils.DecodeHtml(segments[i]));
+                sb.Append(segments[i]);
             }
 
             return (sb.ToString(), candidates);

--- a/src/PeachPDF/Html/Core/Utils/HtmlUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/HtmlUtils.cs
@@ -354,7 +354,12 @@ namespace PeachPDF.Html.Core.Utils
 
         /// <summary>
         /// Decode html encoded string to regular string.<br/>
-        /// Handles &lt;, &gt;, "&amp;.
+        /// Handles &lt;, &gt;, &amp;, and numeric character references.<br/>
+        /// <br/>
+        /// <b>Note:</b> This method is NOT used during normal HTML rendering.
+        /// MimeKit's HtmlTokenizer decodes entities once at parse time, so text in
+        /// CssBox.Text is already decoded. This utility is retained for test scenarios
+        /// and any edge cases that need manual entity decoding.
         /// </summary>
         /// <param name="str">the string to decode</param>
         /// <returns>decoded string</returns>


### PR DESCRIPTION
Fixes #431

MimeKit's HtmlTokenizer already decodes HTML character references (e.g. &amp;, &nbsp;, &#65;) once at parse time, so CssBox.Text always holds the post-decode string. The word-splitting code in CssBox was calling HtmlUtils.DecodeHtml a second time, causing &amp;nbsp; to render as a space instead of the literal text "&nbsp;".

Remove the three DecodeHtml calls in CssBox word-splitting paths (preserve-spaces branch, normal word branch, hyphenation candidate builder). Update HtmlUtils.DecodeHtml's doc comment to note it is no longer used in the normal rendering pipeline. Add integration tests covering single- and double-escaped entities, code/pre blocks, CSS content escapes, and edge cases. Update architecture.md to document the single-decode guarantee.