### PR TITLE
Retire a retraction: TryRestartAt re-appends instead of re-placing

### DIFF
--- a/.claude/invariants/fragmentation-a-pass-output-is-not-final-and-five-mechanisms-retract-work.md
+++ b/.claude/invariants/fragmentation-a-pass-output-is-not-final-and-five-mechanisms-retract-work.md
@@ -1,5 +1,0 @@
-# A pass's output is not final, and five mechanisms now retract work
-
-_CSS Fragmentation Level 3. Tracker: [#320](https://github.com/jhaygood86/PeachPDF/issues/320)._
-
-Five mechanisms now retract work: `FragmentEmitter.InvalidateFrom`, `ResetChildrenForRefill`, `DiscardLineBoxesFrom`, #355's pass re-entry and #371's rewind. Undoing an attempt on a *resumed* pass is a three-way question — below the resume point, at it, and above it — and "resumed" is not one state. Retracting lines is not retracting geometry: the words have to go too (`AwaitsTheNextFragmentainer`, which is self-healing). **The invariant that catches both directions of getting any of this wrong is one line over the fragment tree: every word claimed exactly once.**

--- a/.claude/invariants/fragmentation-a-pass-output-is-not-final-and-three-mechanisms-retract-work.md
+++ b/.claude/invariants/fragmentation-a-pass-output-is-not-final-and-three-mechanisms-retract-work.md
@@ -1,0 +1,24 @@
+# A pass's output is not final, and three mechanisms now retract work
+
+_CSS Fragmentation Level 3. Tracker: [#320](https://github.com/jhaygood86/PeachPDF/issues/320)._
+
+Three mechanisms now retract work: `FragmentEmitter.InvalidateFrom`, `DiscardLineBoxesFrom`, and
+`PassRewind.RollBackTo` — the last one shared by #355's pass re-entry, #371's rewind, and the
+multi-column engine's own abandoned-fill retry, which used to wrap it in a fourth name
+(`ResetChildrenForRefill`) that added nothing but a wrapper
+([#516](https://github.com/jhaygood86/PeachPDF/issues/516)). `TryRestartAt`'s own same-pass
+restart needs none of the three: it hands the run's head a target through the same `ResumeAt`
+channel an ordinary fragmentainer resumption uses, then re-enters the parent's child loop from
+there — every box from the head on gets a fresh `PerformLayoutImp` call exactly as an
+unreached child would, and `BeginLayoutPass` resets `_earlyBreakTaken` for each one on that entry
+regardless of who calls it, so there is nothing left to retract by hand first. That is what "the
+parent holding the offset" (`PlaceBlockChild`) buys a same-pass restart over a cross-pass one: the
+head's *position* is resolved the same way whether re-appended into a still-open pass or rewound
+into a completed one, and only the completed case needs a real rollback, since only there has the
+box's own state (a completed prologue, finalized line boxes) actually been settled onto record.
+
+Undoing an attempt on a *resumed* pass is a three-way question — below the resume point, at it, and
+above it — and "resumed" is not one state. Retracting lines is not retracting geometry: the words
+have to go too (`AwaitsTheNextFragmentainer`, which is self-healing). **The invariant that catches
+both directions of getting any of this wrong is one line over the fragment tree: every word claimed
+exactly once.**

--- a/.claude/recent-fixes/2026-07-30-tryrestartat-re-appends-a-run-instead-of-clearing-its-own-latch.md
+++ b/.claude/recent-fixes/2026-07-30-tryrestartat-re-appends-a-run-instead-of-clearing-its-own-latch.md
@@ -1,0 +1,55 @@
+# TryRestartAt re-appends a run instead of clearing its own latch
+
+_Landed 2026-07-30._
+
+**#390's stage 3** ([issue #516](https://github.com/jhaygood86/PeachPDF/issues/516)): "with the
+parent holding the offset, `TryRestartAt` no longer has to re-place a box — it re-appends."
+`TryRestartAt`'s own retraction step — a hand-written loop clearing `_earlyBreakTaken` on every box
+from the run's head up to (but not including) the box that raised the restart — turned out to be
+dead code. `BeginLayoutPass` already resets that same flag, unconditionally, on *every* entry to
+`PerformLayoutImp`, and every box the rewound loop reaches from the head on gets exactly that: a
+fresh `PerformLayout` call, indistinguishable from one an ordinary forward walk would make on a
+child it had not reached yet. That is what "re-appends" means in practice — the loop does not
+retract anything of its own first; it just resumes the same walk it already had, and the walk's own
+per-entry reset does the rest. Traced rather than assumed: the for-loop that rewinds to `resumeFrom`
+walks forward through every index up to and past `raisedAt` again, so even the box that raised the
+decision gets a second `PerformLayoutImp` call and the same unconditional reset — which is also why
+the old comment about that box "keeping its latch" never actually held; nothing read the stale value
+before the reset overwrote it.
+
+**One live worry going in, closed by reading rather than guessing.** The obvious alternative
+reading — that "re-appends" meant giving `TryRestartAt` the *same* rollback the cross-pass rewind
+uses (`PassRewind.RollBackTo`, which also clears `_prologueDone` and re-runs the prologue) — turned
+out to be the wrong direction entirely. `_earlyBreakRetryTop`'s own retry (the sibling mechanism for
+`decision.BeforeBox == this`) explicitly does *not* reset the prologue, and says why in its own
+comment: doing so would register named strings and the named page a second time. The actual
+correctness net for that case is `PerformLayoutEpilogue`'s own tail sync — `NamedStrings` and
+`RegisteredNamedPageElement` are corrected in place against the box's final `Location.Y` on every
+epilogue run, prologue or no — and `PrologueReentryRegistrationTests` already covers it for the
+sibling retry. `TryRestartAt`'s boxes reach the same epilogue tail on their own re-entry, so they get
+the same correction for free; forcing a prologue re-run onto them would have been a regression risk
+for zero benefit, not a fix.
+
+**`ResetChildrenForRefill` retired.** It was already a two-line wrapper around
+`PassRewind.RollBackTo` (`CssLayoutEngineColumns`'s measurement-pass-to-real-fill handoff and its
+own balance-retry loop), so both call sites now call `PassRewind.RollBackTo` directly. Byte-identical
+behaviour — it is the same call with the wrapper's name removed — and it is what the invariants file
+now calls three retraction mechanisms instead of five: `FragmentEmitter.InvalidateFrom`,
+`DiscardLineBoxesFrom`, and `PassRewind.RollBackTo` (already shared by #355's pass re-entry and #371's
+rewind, now also the columns engine's only name for it).
+
+**What #516 leaves open.** `DiscardLineBoxesFrom` is untouched — it is inline layout's own
+retraction, and every #390 stage states inline layout as out of scope. `FragmentEmitter.InvalidateFrom`
+is untouched too: it retracts *emitted fragments*, a later, different layer than anything `TryRestartAt`
+touches (confirmed by `HtmlContainerInt.InvalidateEmittedFragmentsFor`'s own gate, `HoldsFragmentsFor`,
+which is false for a box still inside the pass that is filling it — nothing is frozen yet for
+`TryRestartAt` to invalidate). Both stay as recorded reasons rather than silent gaps.
+
+**Evidence.** Full net8.0 suite green (6982 passed, 0 failed, 9 skipped) — including the
+`EarlyBreakLayoutIntegrationTests.PulledRun_*` family, which exercises exactly this restart path
+end to end (interior-gap spacing, exactly-once word claims, the repeating-table replay case, the
+already-restarted-this-pass guard) — and `dotnet build PeachPDF.slnx -t:Rebuild` at zero warnings.
+Both touched call sites in `CssLayoutEngineColumns` show 285 and 118 hits in the coverage run, so the
+inlined `PassRewind.RollBackTo` calls are exercised, not merely reachable. No new fixture was added:
+every scenario this change could plausibly break already has a named test asserting it, which is the
+existing coverage doing exactly what `EarlyBreakLayoutIntegrationTests`' own comments say it is for.

--- a/src/PeachPDF.Tests/Integration/MulticolLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/MulticolLayoutIntegrationTests.cs
@@ -1259,7 +1259,7 @@ namespace PeachPDF.Tests.Integration
         /// box that is not the container's own child is lost entirely — no page break and no column break —
         /// so there is nothing here for an escaping record to carry. Its cause is one level down from
         /// anything about columns: <c>_forcedBreakTop</c> is a one-shot, and the measurement pass that sizes
-        /// the fill spends it, because <c>ResetChildrenForRefill</c> re-opens the prologue for the
+        /// the fill spends it, because <c>PassRewind.RollBackTo</c> re-opens the prologue for the
         /// container's own children only.
         /// </summary>
         /// <remarks>

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -1359,9 +1359,9 @@ namespace PeachPDF.Html.Core.Dom
         /// The forced-break arm of <c>PlaceBlockChild</c> runs on the pass that <i>declines</i> to place
         /// the box; the pass that places it takes the resumed-target branch instead, which is not the
         /// branch that asserts either of these. And between the two, a nested engine re-opens this box's
-        /// prologue (<c>CssLayoutEngineColumns.ResetChildrenForRefill</c>), which retracts both so a
-        /// re-decided break can re-assert them — right for a break being decided again, wrong for one
-        /// already decided and travelling in a record.
+        /// prologue (<see cref="PassRewind.RollBackTo"/>, called from <c>CssLayoutEngineColumns</c>'s own
+        /// fill retry), which retracts both so a re-decided break can re-assert them — right for a break
+        /// being decided again, wrong for one already decided and travelling in a record.
         /// </para>
         /// <para>
         /// Deliberately <b>not</b> cleared by the prologue, for that reason; cleared per layout in
@@ -2934,10 +2934,16 @@ namespace PeachPDF.Html.Core.Dom
         /// on the same page" test the translation used, which asked the same question of coordinates.
         /// </para>
         /// <para>
-        /// Only the head is told where to go; every other member re-derives its position from the
-        /// sibling above it, which has just been re-placed. Their break latches are cleared so a member
-        /// can still take a decision of its own at its new position — except the box that raised this
-        /// one, which keeps its latch and so follows the run rather than deciding again.
+        /// Only the head is told where to go — via <see cref="ResumeAt"/>'s target, the same channel an
+        /// ordinary fragmentainer resumption hands a continuing child. Every member from the head on is
+        /// simply <b>re-appended</b>: the rewound loop calls <see cref="PerformLayout"/> on each of them
+        /// again, in order, exactly as it would for a child it had never reached yet, and each one
+        /// re-derives its position from the sibling above it — which, for the head, is
+        /// <see cref="PlaceBlockChild"/> reading the resumed target rather than deriving one, and for
+        /// every member after it, the ordinary derivation now reads a sibling already re-placed. Nothing
+        /// here has to clear a break latch of its own first: <see cref="BeginLayoutPass"/> resets
+        /// <c>_earlyBreakTaken</c> for every box on every entry to <see cref="PerformLayoutImp"/>, which a
+        /// re-appended child gets from the same call the ordinary walk already makes.
         /// </para>
         /// </remarks>
         private bool TryRestartAt(EarlyBreak restart, int start, int raisedAt, ref HashSet<int>? restartedHeads, out int resumeFrom)
@@ -2960,11 +2966,6 @@ namespace PeachPDF.Html.Core.Dom
             restartedHeads ??= [];
 
             if (!restartedHeads.Add(resumeFrom)) return false;
-
-            for (var j = resumeFrom; j < raisedAt; j++)
-            {
-                Boxes[j]._earlyBreakTaken = false;
-            }
 
             Boxes[resumeFrom].ResumeAt(null, restart.Top);
             return true;
@@ -3178,12 +3179,12 @@ namespace PeachPDF.Html.Core.Dom
                         // An escaping forced break is placed *here*, one pass after the arm below settled
                         // it, and that arm is not re-entered - so what it settled has to be re-asserted
                         // rather than re-derived. Two things, both retracted in between by a prologue the
-                        // engine re-opened (ResetChildrenForRefill): that this box is placed by a forced
-                        // break, which its *next* sibling reads through §5.2 and the margin walk-back, and
-                        // the blank slot a directional break reserved to land on the side it names. Losing
-                        // the first put the following sibling ahead of the break; losing the second landed
-                        // the content on a page of the wrong side, which is precisely what the value asked
-                        // about.
+                        // engine re-opened (PassRewind.RollBackTo, called from CssLayoutEngineColumns's own
+                        // fill retry): that this box is placed by a forced break, which its *next* sibling
+                        // reads through §5.2 and the margin walk-back, and the blank slot a directional
+                        // break reserved to land on the side it names. Losing the first put the following
+                        // sibling ahead of the break; losing the second landed the content on a page of the
+                        // wrong side, which is precisely what the value asked about.
                         if (child._escapedForcedBreakPending)
                         {
                             child._escapedForcedBreakPending = false;

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineColumns.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineColumns.cs
@@ -195,8 +195,8 @@ namespace PeachPDF.Html.Core.Dom
 
             // The measurement pass ran every child's prologue, which is once-per-box and owns
             // RectanglesReset. The real fill lays the same boxes out again from scratch, so it has to be
-            // let back in - the same thing the keep-with-next retry does before re-entering a box.
-            ResetChildrenForRefill(children, resume);
+            // let back in - the shared rollback the driver's own pass re-entry uses (#355, #371).
+            PassRewind.RollBackTo(resume, children);
 
             BreakToken? carry;
             double contentBottom;
@@ -268,7 +268,7 @@ namespace PeachPDF.Html.Core.Dom
                     break;
                 }
 
-                ResetChildrenForRefill(children, resume);
+                PassRewind.RollBackTo(resume, children);
 
                 // The attempt being discarded recorded columns of its own.
                 htmlContainer.ClearNestedFragmentainers(columnsBox, startSlot);
@@ -446,17 +446,6 @@ namespace PeachPDF.Html.Core.Dom
                 yield return children[i];
             }
         }
-
-        /// <summary>
-        /// Undoes the fill attempt just made, so the same children can be filled again at a new target.
-        /// </summary>
-        /// <remarks>
-        /// Goes through the shared rollback (<see cref="PassRewind.RollBackTo"/>), which the driver's own
-        /// pass re-entry needs in exactly the same terms — including its no-record branch, which is what
-        /// the pass that starts this container takes.
-        /// </remarks>
-        private static void ResetChildrenForRefill(List<CssBox> children, BreakToken? resume) =>
-            PassRewind.RollBackTo(resume, children);
 
         /// <summary>
         /// Narrows the container's own inline extent to one column, so children lay out at that column's


### PR DESCRIPTION
## Summary

`#390` stage 3. With the parent holding a box's offset (stages 1–2), `TryRestartAt`'s own retraction step turns out to be unnecessary:

- `TryRestartAt` used to run an explicit loop clearing `_earlyBreakTaken` on every sibling box from a keep-with-next run's head up to the box that raised the restart, before re-entering the parent's child loop. Tracing the call graph shows this is dead code: `BeginLayoutPass()` already resets that same flag unconditionally on *every* entry to `PerformLayoutImp`, and every box the rewound loop reaches — including the box that raised the restart itself, since the parent's `for` loop walks forward through it again — gets exactly that fresh entry. Deleting the loop is what "re-appends instead of re-places" means in practice: the loop no longer retracts anything of its own; it just resumes the ordinary child walk, and the walk's own per-entry reset does the rest.
- `CssLayoutEngineColumns.ResetChildrenForRefill` was already a two-line wrapper whose entire body was `PassRewind.RollBackTo(resume, children)`. Both call sites now call `PassRewind.RollBackTo` directly, retiring the wrapper name — a byte-for-byte behavior-neutral change. This is the mechanism issue #516 asks to retire.

`DiscardLineBoxesFrom` is left untouched (inline layout is out of scope for every `#390` stage), and `FragmentEmitter.InvalidateFrom` is left untouched too (it retracts already-*emitted* fragments, a later/different layer — confirmed its gate, `HoldsFragmentsFor`, is false for a box still inside the pass filling it, so it was never reachable from `TryRestartAt` in the first place). Both are recorded as reasons, not silent gaps, in the invariants file, which now tracks three retraction mechanisms instead of five.

One live alternative was considered and rejected during investigation: giving `TryRestartAt` the same full rollback the cross-pass rewind uses (`PassRewind.RollBackTo`, which also resets the prologue). That would have been the wrong direction — the sibling mechanism (`_earlyBreakRetryTop`'s own retry) deliberately avoids re-running the prologue to avoid double-registering named strings/named pages, relying instead on `PerformLayoutEpilogue`'s existing tail-sync correction, which `TryRestartAt`'s boxes already reach on their own re-entry.

## Evidence

- Full net8.0 suite: 6982 passed, 0 failed, 9 skipped — including the `EarlyBreakLayoutIntegrationTests.PulledRun_*` family, which exercises this exact restart path (interior-gap spacing, exactly-once word claims, the repeating-table replay case, the already-restarted-this-pass guard).
- `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings, 0 errors.
- Coverage: both inlined `PassRewind.RollBackTo` call sites in `CssLayoutEngineColumns.cs` show 285 and 118 hits in the coverage run.
- An independent review pass traced the dead-code claim against the actual call graph (rather than trusting the stated reasoning) and found no issues.

No new test fixture was added — every scenario this change could plausibly affect already has a named test asserting it in `EarlyBreakLayoutIntegrationTests`.

Fixes #516

## Test plan

- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 6982 passed, 0 failed
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings
- [x] Coverage spot-check on touched lines
- [x] Independent post-change review pass (no findings)


---
_Generated by [Claude Code](https://claude.ai/code/session_013cDz2CnEQwTeop6BZtMbHQ)_