### PR TITLE
Flip the straddle predicate to ask the fragmentainer being filled

### DIFF
--- a/.claude/recent-fixes/2026-07-30-the-straddle-predicate-asks-the-band-a-pass-is-actually-filling.md
+++ b/.claude/recent-fixes/2026-07-30-the-straddle-predicate-asks-the-band-a-pass-is-actually-filling.md
@@ -1,0 +1,97 @@
+# The straddle predicate asks the band a pass is actually filling
+
+Tracker: [#320](https://github.com/jhaygood86/PeachPDF/issues/320). Closes [#400](https://github.com/jhaygood86/PeachPDF/issues/400),
+[#435](https://github.com/jhaygood86/PeachPDF/issues/435). Stage 2+3 of `#435`, following stage 1
+([2026-07-30-a-pass-tells-its-cursor-when-it-places-content-past-the-band-it-opened-with.md](2026-07-30-a-pass-tells-its-cursor-when-it-places-content-past-the-band-it-opened-with.md)).
+
+## The load-bearing idea
+
+`HtmlContainerInt.BandBeingFilled` — stage 1's instrumentation-only shim — is flipped to actually
+return `filling.Band` (the pass's own cursor, `FragmentainerContext.SlotIndex`) instead of the page
+grid's answer, whenever a real fragmenting pass is filling a fragmentainer with no band of its own.
+`CssRect.WouldStraddleFragmentainer` (the break decision) reads through it; `CssRect.BreakPage`'s
+pure relocation is split into its own `WouldStraddleItsOwnBand`, which deliberately stays grid-based
+— relocating a word into "the band after the one it's in" needs the grid's answer regardless of
+which fragmentainer a pass is nominally filling, or an atomic-inline's vertical inset would relocate
+a word two bands instead of one.
+
+Two follow-on corrections were needed once real content started actually straddling for the first
+time:
+
+- **`CssLayoutEngine`'s `InlineBreakToken` resume slot** used to be `SlotStartingAt(word.Top) + 1` —
+  correct only when the break truly falls at a band boundary, and one slot too many in the "spill"
+  case stage 1 closes (content already past the band it claims to be filling). Replaced with
+  `CssRect.ResumeSlotForBreakBefore()`, which asks whether the word's own bottom (plus its cloned
+  block-decoration-break insets) falls past *the band its own top lands in* — byte-identical to the
+  old expression in the ordinary case, and correctly `k` rather than `k+1` in the spill case.
+- **`CssBox.PlaceBlockChild`'s root placement.** The document root has no predecessor to test §5.2's
+  boundary against, so it never asked `BandBeingFilled` and never stepped the cursor at all — a gap
+  the per-mechanism list in stage 1's own note didn't anticipate, because it only became observable
+  once the predicate itself started reading the cursor. A `StepOverTo` was added for exactly this
+  case.
+- **`CssBox.LayoutBlockChildren`'s block-overflow `StepOverTo`** (added in stage 1, gated on
+  `MonolithicContent.IsMonolithic`) had to be generalized to fire for *any* finished, in-flow block
+  child that overflows past the fragmentainer being filled, monolithic or not. The narrow gate was
+  correct for stage 1 (the predicate wasn't reading the cursor yet, so a stale cursor there cost
+  nothing), but became a source of new failures once the predicate flipped: an ordinary tall filler
+  pushing later content past a boundary needs the same cursor truthfulness a monolithic box does.
+
+## What was found by running it, not by reading it
+
+**Orphans/widows (default 2) were not reliably engaging for ordinary multi-page paragraph overflow
+before this fix.** Without a real break token — which the stale predicate never produced for
+"normal" overflow, only for a genuine forced break or an already-monolithic case — the
+widows-correction mechanism had nothing to act on. This fix makes it correctly functional for
+ordinary paragraphs for the first time, which is a genuine spec-compliance improvement, not merely a
+side effect to neutralize; one existing test
+(`InlineSpanningAPageBreak_KeepsCountingEdgesAcrossPages`) needed `widows:1;orphans:1` added to its
+fixture to keep testing the edge-continuity behavior it was written for, now that the default
+widows correction is actually reachable there.
+
+**A sixth cursor-truthfulness site, missed by stage 1's own enumeration, caused a real content-loss
+defect.** The `flexbox` showcase's corpus diff (page 2 of a demo table) lost a row's label and
+description text entirely on repaint, while its middle cell painted fine. Root-caused through: (1)
+`pymupdf` text extraction confirming the words were genuinely absent from every page, not just
+misplaced; (2) fragment-tree inspection proving layout's own word-claiming was correct — every word
+claimed by the right slot; (3) a full-pipeline repro through the public `PdfGenerator.GeneratePdf`
+API isolating the defect to paint, not layout; (4) paint-side diagnostics tracing the word's
+`fragment.OverflowClip` (from the cell's own `overflow: hidden`) to a rectangle built from the
+cell's *live* `Bounds`, which sat visibly below the cell's own child word's position — geometrically
+impossible for settled layout; (5) instrumenting `HtmlContainerInt.BandBeingFilled` directly and
+comparing `FragmentainerContext` instance identity at each layout attempt, which showed the row's
+own content asking its fragmentation questions against a *different, stale* context instance than
+the one the table's whole-table relocation had actually advanced.
+
+The cause: `LayoutBodyRows`' two whole-table relocation pre-checks ("move the entire table to the
+next page when the first body row would cross a page boundary and the full body fits one page")
+move the table via `TableRowCursor.RestartAt`, which — unlike its sibling `MoveToSlot` — never
+called `StepOverTo` on the document-level fragmentainer cursor. Before this fix, that omission cost
+nothing (`BandBeingFilled` still answered from the grid regardless). Once the predicate started
+reading the cursor, a row laid out at the relocated table's own top asked its fragmentation
+questions of the band the table had just left, read a spurious straddle against a band already
+behind it, and deferred every word of its first row to a same-slot "resume" that then landed with no
+vertical alignment applied and an ~3pt reported height instead of the row's real ~21pt. Fixed by
+giving `RestartAt` the same optional `HtmlContainerInt? container` parameter `MoveToSlot` already
+has, stepping the cursor the same way.
+
+## What was deliberately not done
+
+- **`CssBox.PlaceBlockChild`'s §5.2 test was only taken to its "3a" sub-step** (`Math.Max(prevSlot,
+  filling.SlotIndex)`), not reduced outright to `filling.Band` (the plan's "3b"): the block-overflow
+  generalization above is what "3b" was gated on, and it landed as part of this same change, so 3b
+  applies here too — `band = filling.Band` outright, dropping the coordinate read.
+- **The two remaining tiny corpus diffs** (`background_origin_clip`, `gradients`) were not chased
+  further than confirming their shape: both are a uniform sub-point cascade on one page, starting
+  partway down it and continuing to the page's end, matching mechanism 1 (a tolerance-boundary line)
+  becoming a real break exactly where the design intends. Both renderers agree on the (sub-pixel)
+  result.
+
+## Evidence
+
+Full `net8.0` suite green (7,027 passing, 9 skipped, 0 failed). Zero-warning solution rebuild. 100%
+diff coverage against `origin/main`. 73 of 76 showcases byte-identical; the 3 that differ were each
+rasterized with both PDFium and MuPDF at 150dpi and read: `flexbox` itself is now byte-identical
+(the content-loss defect above is what the corpus diff was catching); `paged_media_monolithic_content`
+page 3 shows a genuine improvement — a monolithically-relocated card that previously reported extra,
+unused blank space inside its own border now reports its content's real height; the other two are
+the sub-point cascades described above.

--- a/src/PeachPDF.Tests/Html/Core/Fragments/FragmentEmitterTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Fragments/FragmentEmitterTests.cs
@@ -74,8 +74,16 @@ namespace PeachPDF.Tests.Html.Core.Fragments
         [InlineData("<div style='height:1000pt'>x</div>", 200, "0", "0")]
         // Forced breaks materialize consecutive pages; each origin is the previous plus one band.
         [InlineData("<p>a</p><p style='page-break-before:always'>b</p><p style='page-break-before:always'>c</p>", 300, "0,1,2", "0,260,520")]
-        // A margin large enough to cross a page is truncated, so it never paginates as blank space.
-        [InlineData("<div style='margin-top:900pt'>far below</div>", 200, "0", "0")]
+        // The div's own margin-top collapses all the way up through html/body to the document root
+        // (§8.3.1) - which §5.2's truncation never sees, since "only the root is excluded: it has
+        // nothing before it for a break to fall between." So the margin is genuinely, entirely applied,
+        // landing the content wherever that lands it on the page grid - slot 5 here, not truncated to
+        // slot 0. Before #435's stage 1 gave the root's own placement a cursor step of its own
+        // (`CssBox.PlaceBlockChild`'s `child.ParentBox is null` arm), this fixture materialized as slot
+        // 0 with local Y 920 - off the bottom of a ~200pt sheet and never actually drawn on any visible
+        // page. Caught only by walking the fragment tree's own word rectangles, not by this slot/origin
+        // pin alone (see ContentAfterARootLevelMarginCollapse_LandsWithinItsFragmentsVisibleArea below).
+        [InlineData("<div style='margin-top:900pt'>far below</div>", 200, "5", "800")]
         // Real content either side of a tall empty gap: the gap's own slots are never materialized.
         [InlineData("<p>top</p><div style='height:900pt'></div><p>far below</p>", 200, "0,6", "0,960")]
         public async Task MaterializedPages_MatchThePrePagedFragmentTreeBehaviour(
@@ -87,6 +95,28 @@ namespace PeachPDF.Tests.Html.Core.Fragments
 
             Assert.Equal(expectedSlots, string.Join(",", fragmentainers.Select(f => f.SlotIndex)));
             Assert.Equal(expectedOrigins, string.Join(",", fragmentainers.Select(f => f.LocalOriginY)));
+        }
+
+        /// <summary>
+        /// The word-level counterpart to the theory above's margin-collapse-through row: not just which
+        /// slot the content materializes on, but that the words actually land within that fragment's own
+        /// visible area (a non-negative local Y no taller than the page). A slot/origin pin alone is
+        /// satisfied by content rendered off the bottom of the page just as well as by content rendered
+        /// on it - this is the check that would have caught #435's root-placement gap, which the theory
+        /// above's old "0"/"0" expectation did not.
+        /// </summary>
+        [Fact]
+        public async Task ContentAfterARootLevelMarginCollapse_LandsWithinItsFragmentsVisibleArea()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(
+                LayoutHarness.Wrap("<div style='margin-top:900pt'>far below</div>"), pageHeight: 200);
+
+            var word = LayoutHarness.Descendants(root).SelectMany(b => b.Words).First(w => w.Text == "far");
+            var fragmentainer = container.FragmentTree!.Fragmentainers.Single();
+            var localY = word.Top - fragmentainer.LocalOriginY;
+
+            Assert.True(localY >= 0 && localY <= container.PageSize.Height,
+                $"word landed at local Y {localY}, outside the fragment's own [0, {container.PageSize.Height}] visible band");
         }
 
         [Fact]
@@ -389,8 +419,15 @@ namespace PeachPDF.Tests.Html.Core.Fragments
         [Fact]
         public async Task InlineSpanningAPageBreak_KeepsCountingEdgesAcrossPages()
         {
+            // widows/orphans pinned to 1: the default of 2 now correctly pulls Gamma onto page 1 along
+            // with Delta (only Delta alone there violates the default widows minimum) since #435 made an
+            // ordinary paragraph overflowing a page a real break the widows mover can act on - which it
+            // could not before, having nothing to act on. That is a real, separate behaviour change (see
+            // BandMembershipToleranceTests/OrphansWidowsIntegrationTests for its own coverage); this
+            // fixture is about edge continuity across a break, not about where the break falls, so it
+            // pins the split it was written around.
             var (_, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
-                "<div style='width:200pt;font:10pt Arial;line-height:30pt'>" +
+                "<div style='width:200pt;font:10pt Arial;line-height:30pt;widows:1;orphans:1'>" +
                 "<span id='s'>Alpha<br>Beta<br>Gamma<br>Delta</span></div>"),
                 pageHeight: 80, margin: 0);
 

--- a/src/PeachPDF.Tests/Integration/TableRowCursorBandTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableRowCursorBandTests.cs
@@ -340,5 +340,37 @@ namespace PeachPDF.Tests.Integration
 
             Assert.Equal(0, container.CursorSpills);
         }
+
+        /// <summary>
+        /// The whole-table relocation pre-check (<c>LayoutBodyRows</c>' "move the entire table to the next
+        /// page when the first body row would cross a page boundary and the full body fits one page")
+        /// moves the table via <c>TableRowCursor.RestartAt</c> rather than <c>MoveToSlot</c>/<c>BandReached</c>
+        /// — the only one of the three that used to leave the document-level cursor stale. A row laid out
+        /// at the relocated table's own top then asked its own fragmentation questions of the band the
+        /// table was relocated *from*, which is exactly what <see cref="HtmlContainerInt.CursorSpills"/>
+        /// counts - see the flexbox showcase corpus regression this pinned down, where the resulting
+        /// spurious straddle deferred a row's words to a same-slot "resume" that landed with no vertical
+        /// alignment applied and effectively zero height.
+        /// </summary>
+        [Fact]
+        public async Task ContentAfterAWholeTableRelocation_SeesATruthfulCursor()
+        {
+            var html = LayoutHarness.Wrap(
+                "<div style='height:250pt'>filler</div>"
+                + "<table style='width:100%'>"
+                + "<tr><td>first row label</td></tr>"
+                + "<tr><td>second row</td></tr>"
+                + "</table>"
+                + "<p>content after the table</p>");
+
+            var (root, container) = await LayoutHarness.LayoutAsync(html, pageHeight: PageHeight, margin: Margin);
+
+            var table = TableOf(root);
+
+            // The whole-table pre-check had to actually fire for this to assert anything.
+            Assert.Equal(container.PageTopOf(1), table.Location.Y, 0.01);
+
+            Assert.Equal(0, container.CursorSpills);
+        }
     }
 }

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -2632,18 +2632,27 @@ namespace PeachPDF.Html.Core.Dom
                         return true;
                     }
 
-                    // On the page grid, unlike a column (above), css-break-3 §2 monolithic content (a
-                    // replaced element, a scroll container) that overflows the fragmentainer it started
-                    // in simply overflows - it has no fragmentable inner structure to ask a break of, and
-                    // there is nowhere better for it to be. But the siblings the loop places after it now
-                    // flow into whatever band follows, with no break ever recording that crossing - #435's
-                    // shape one level up from a word's own unbreakable overflow. Scoped to §2's own set,
-                    // not every block child that happens to overflow: an ordinary container (a plain div,
-                    // html/body themselves) can land deep in the document through no decision of its own -
-                    // a margin collapsed through it from a descendant, say - and stepping the cursor there
-                    // regressed a margin-truncation fixture from one fragmentainer to six.
-                    if (MonolithicContent.IsMonolithic(childBox)
-                        && !childBox.IsOutOfFlow
+                    // On the page grid, unlike a column (above), a child that has genuinely finished -
+                    // no break requested at any level above - but whose own bottom still lands past the
+                    // fragmentainer the pass opened with (css-break-3 §2 monolithic content with nowhere
+                    // better to be; an explicit height; or simply enough accumulated content, table rows,
+                    // or line boxes that it was never asked a single crossing question anywhere on the
+                    // way) is left exactly where it is. But the siblings the loop places after it now flow
+                    // into whatever band follows, with no break ever recording that crossing - #435's
+                    // shape one level up from a word's own unbreakable overflow.
+                    //
+                    // Safe once (not before) the straddle predicate itself asks the fragmentainer being
+                    // filled rather than the page grid (#435 stage 2): before that landed, stepping here
+                    // for every child - rather than only genuinely monolithic ones - corrupted which slot
+                    // the emitter attributed the whole pass to for a child whose position was merely
+                    // *inherited* from an already-exempt ancestor (the document root's own margin, which
+                    // collapses through html/body/div with no crossing ever decided for any of them) -
+                    // regressing a margin-truncation fixture from one fragmentainer to six. Once the
+                    // predicate agrees with the cursor, that inherited position is exactly as real as any
+                    // other, and the narrower monolithic-only gate instead left an ordinary tall filler
+                    // (no break of its own to take, but a bottom past the page it started on) leaving the
+                    // cursor stale for whatever follows it.
+                    if (!childBox.IsOutOfFlow
                         && childBox.Display != CssConstants.None
                         && HtmlContainer?.CurrentFragmentainer is { HasOwnBand: false })
                     {
@@ -3428,6 +3437,18 @@ namespace PeachPDF.Html.Core.Dom
 
                     child.Location = new RPoint(left + child.ActualMarginLeft, top);
                     child.ActualBottom = top;
+
+                    // The root places itself (PlaceAsBlockChild's (ParentBox ?? this) receiver), and §5.2's
+                    // whole crossing question above is never asked of it - "only the root is excluded - it
+                    // has nothing before it for a break to fall between." A descendant's margin can still
+                    // collapse all the way up to the root (margin-collapse-through), landing it far down
+                    // the document with no crossing ever decided anywhere - the one placement every other
+                    // site's StepOverTo call is scoped to skip, and so the one that needs its own - #435.
+                    if (child.ParentBox is null)
+                    {
+                        child.HtmlContainer?.CurrentFragmentainer?.StepOverTo(
+                            child.HtmlContainer!.SlotStartingAt(top));
+                    }
 
                     CssLayoutEngine.FloatBox(child);
                 }

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -1492,9 +1492,10 @@ namespace PeachPDF.Html.Core.Dom
                                     // many lines this fragmentainer actually kept.
                                     coordinates.Break = new InlineBreakToken(
                                         blockBox,
-                                        // The fragmentainer after the one this line was trying to sit
-                                        // in, which is not in general the one after the pass's own.
-                                        box.HtmlContainer!.SlotStartingAt(word.Top) + 1,
+                                        // Derived from where the break actually fell (the band this line
+                                        // was trying to sit in), never assumed to be "the pass after this
+                                        // one" - see ResumeSlotForBreakBefore's own remarks.
+                                        word.ResumeSlotForBreakBefore(),
                                         [], coordinates.LineStartOrdinal, CompletedLineCount: 0);
                                     return;
                                 }

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
@@ -1282,7 +1282,7 @@ namespace PeachPDF.Html.Core.Dom
 
                     _tableBox.Location = _tableBox.Location with { Y = _tableBox.Location.Y + pageBreakOffset };
                     startY = Math.Max(_tableBox.ClientTop + GetVerticalSpacing(), 0);
-                    cursor.RestartAt(startY, container.PageIndexOf(startY));
+                    cursor.RestartAt(startY, container.PageIndexOf(startY), container);
                 }
             }
 
@@ -1320,7 +1320,7 @@ namespace PeachPDF.Html.Core.Dom
                     _headerBox.OffsetTop(pageBreakOffset);
 
                     startY = Math.Max(_tableBox.ClientTop + GetVerticalSpacing(), 0);
-                    cursor.RestartAt(startY, container.PageIndexOf(startY));
+                    cursor.RestartAt(startY, container.PageIndexOf(startY), container);
                 }
             }
 

--- a/src/PeachPDF/Html/Core/Dom/CssRect.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssRect.cs
@@ -280,8 +280,10 @@ namespace PeachPDF.Html.Core.Dom
         }
 
         /// <summary>
-        /// Whether this word, at its current <see cref="Top"/>, crosses a fragmentainer boundary — the
-        /// one predicate both the resumable inline flow and the legacy relocation below decide on.
+        /// Whether this word, at its current <see cref="Top"/>, crosses the fragmentainer the pass
+        /// <i>is filling</i> — the break decision the resumable inline flow makes: a straddle here ends
+        /// the pass with an <see cref="Fragmentation.InlineBreakToken"/> rather than moving the word and
+        /// carrying on.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -298,8 +300,34 @@ namespace PeachPDF.Html.Core.Dom
         /// repeating a <c>&lt;tfoot&gt;</c> claims the foot of the band the same way
         /// (<see cref="Fragmentation.FragmentainerContext.BandEndInsetOf"/>), and the two compose.
         /// </para>
+        /// <para>
+        /// Asks <see cref="HtmlContainerInt.BandBeingFilled"/> — the fragmentainer the pass is actually
+        /// filling, not merely the band this word's own top happens to fall in. Safe now that
+        /// <see href="https://github.com/jhaygood86/PeachPDF/issues/435">#435</see>'s stage 1 makes every
+        /// mechanism that can spill flow past that fragmentainer step the pass cursor to match; before
+        /// that landed, this could only ask the page grid (see <see cref="WouldStraddleItsOwnBand"/>,
+        /// which still does, for the relocation this predicate must never be confused with).
+        /// </para>
         /// </remarks>
-        public bool WouldStraddleFragmentainer()
+        public bool WouldStraddleFragmentainer() => WouldStraddle(BandSource.Filling);
+
+        /// <summary>
+        /// Whether this word, at its current <see cref="Top"/>, has left the band its own top falls in -
+        /// the legacy relocation's question, asked of the page grid rather than the fragmentainer the
+        /// pass is filling.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="BreakPage"/> moves a word to the content top of the band <i>after</i> the one its
+        /// top is in - a coordinate fact about the grid, not a break decision the pass records - so it
+        /// must keep asking this rather than <see cref="WouldStraddleFragmentainer"/>: a word an atomic
+        /// inline's vertical inset has just shifted into a later band, while the pass cursor still names
+        /// an earlier one, is relocated one band on either way, never two.
+        /// </remarks>
+        internal bool WouldStraddleItsOwnBand() => WouldStraddle(BandSource.Grid);
+
+        private enum BandSource { Filling, Grid }
+
+        private bool WouldStraddle(BandSource source)
         {
             var container = OwnerBox.HtmlContainer!;
 
@@ -325,18 +353,10 @@ namespace PeachPDF.Html.Core.Dom
             // as "does the bottom edge fall past that band" rather than as "are the top and bottom in
             // different slots" is what makes the two arms one question with two bands, instead of two
             // questions - a slot index is a fact about the page grid, and a column has no slot of its own.
-            //
-            // Still the *grid's* band rather than the one the pass is filling
-            // (CurrentFragmentainer.Band), even though the cursor now tracks a forced break's step-overs.
-            // Block and inline flow may still put content in a later fragmentainer without recording a
-            // break: a line whose bottom lands within PageBoundaryEpsilon of the band bottom is tolerated,
-            // the next line starts in the following band, and from there everything after it resolves
-            // against that band instead. Naming the pass's own band would call every one of those a
-            // straddle, which is a different layout and a worse one - measured at 63 of 69 showcases changed,
-            // with visibly overlapping content. Tracked as #435 - BandBeingFilled both names this arm's
-            // band (still the grid's, for now) and counts every place the two disagree, so #435's own
-            // remaining work is provable rather than argued.
-            return HtmlContainerInt.FallsPast(Bottom + reservedEnd, container.BandBeingFilled(Top, container.BandStartingAt(Top)));
+            var gridBand = container.BandStartingAt(Top);
+            var band = source is BandSource.Filling ? container.BandBeingFilled(Top, gridBand) : gridBand;
+
+            return HtmlContainerInt.FallsPast(Bottom + reservedEnd, band);
         }
 
         /// <summary>
@@ -384,11 +404,14 @@ namespace PeachPDF.Html.Core.Dom
 
         public bool BreakPage()
         {
-            // Non-null for the same reason WouldStraddleFragmentainer's own read of it is: a word is only
+            // Non-null for the same reason WouldStraddleItsOwnBand's own read of it is: a word is only
             // ever asked this during layout, which a box without a container never reaches.
             var container = OwnerBox.HtmlContainer!;
 
-            if (!WouldStraddleFragmentainer())
+            // A relocation, not a break decision: this word moves to the content top of the next band
+            // whatever the pass cursor is doing, so it must ask the page grid rather than
+            // WouldStraddleFragmentainer's "is the pass filling this" question.
+            if (!WouldStraddleItsOwnBand())
                 return false;
 
             // The fragmentainer's own content edge, per css-break-3 §2. This used to land one unit

--- a/src/PeachPDF/Html/Core/Dom/CssRect.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssRect.cs
@@ -381,6 +381,36 @@ namespace PeachPDF.Html.Core.Dom
         }
 
         /// <summary>
+        /// The fragmentainer a break taken before this word resumes in: the band its own top begins, and
+        /// the one after that only where it cannot fit there either.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Not <c>cursor.SlotIndex + 1</c>: a resume target must come from where the break actually fell,
+        /// never assumed to be "the pass after this one" (see the invariant of that name) - a box can be
+        /// placed far down the document, and after <see href="https://github.com/jhaygood86/PeachPDF/issues/435">#435</see>'s
+        /// stage 1 the two happen to coincide (proven, not assumed, by <c>CursorSpills == 0</c> in the
+        /// fixtures that exercise this), but the moment a future mechanism moves flow without stepping the
+        /// cursor, "the pass after this one" is silently wrong again while this expression is not.
+        /// </para>
+        /// <para>
+        /// In the ordinary straddle - this word's own band is the one the pass is filling - this is
+        /// byte-identical to the retired <c>SlotStartingAt(word.Top) + 1</c> expression. It only differs
+        /// in the spill case the conversion above exists to close: a word whose top already begins a
+        /// later band than the one the pass opened with resumes in <i>that</i> band, not the one after
+        /// it - the band the line was trying to sit in, per #435's own words, not a further one.
+        /// </para>
+        /// </remarks>
+        internal int ResumeSlotForBreakBefore()
+        {
+            var container = OwnerBox.HtmlContainer!;
+            var slot = container.SlotStartingAt(Top);
+            var (_, reservedEnd) = ClonedInsets(container);
+
+            return HtmlContainerInt.FallsPast(Bottom + reservedEnd, container.BandOfSlot(slot)) ? slot + 1 : slot;
+        }
+
+        /// <summary>
         /// Whether this word is too tall to fit in any fragmentainer at all - the <c>css-break-3 §2</c>
         /// monolithic-overflow case <see cref="WouldStraddleFragmentainer"/> exempts from being called a
         /// straddle, since moving it would only repeat the question on the next fragmentainer forever.

--- a/src/PeachPDF/Html/Core/Fragmentation/TableRowCursor.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/TableRowCursor.cs
@@ -414,10 +414,21 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// relocation the engine has already worked out — a whole-table pre-check moving the table onto
         /// the next page, which restarts the row loop rather than continuing it.
         /// </summary>
-        internal void RestartAt(double top, int slotIndex)
+        /// <param name="top">the row loop's new starting position</param>
+        /// <param name="slotIndex">the band the table was moved to</param>
+        /// <param name="container">
+        /// the container whose document-level pass cursor must follow - see the identical reasoning on
+        /// <see cref="MoveToSlot"/>. Missing here left a whole-table relocation invisible to
+        /// <see cref="HtmlContainerInt.BandBeingFilled"/>: row 0's own content asked its fragmentation
+        /// questions of the band the table was relocated *from*, read a spurious straddle against a band
+        /// it had already left, and deferred every word to a same-slot "resume" that then landed with no
+        /// vertical alignment applied - #435.
+        /// </param>
+        internal void RestartAt(double top, int slotIndex, HtmlContainerInt? container = null)
         {
             CurrentY = top;
             SlotIndex = slotIndex;
+            container?.CurrentFragmentainer?.StepOverTo(slotIndex);
         }
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/HtmlContainerInt.cs
+++ b/src/PeachPDF/Html/Core/HtmlContainerInt.cs
@@ -1684,29 +1684,40 @@ namespace PeachPDF.Html.Core
 
         /// <summary>
         /// The band a bottom-edge straddle question about content beginning at <paramref name="top"/>
-        /// is answered against — <paramref name="gridBand"/> where no fragmentainer is named (a
-        /// measurement pass, per <see cref="DetachFragmentainer"/>), inside a column (which has a band
-        /// of its own), or for the driver's suppressed last-resort pass (which may place content
-        /// anywhere and must not break again).
+        /// is answered against: the fragmentainer <see cref="CurrentFragmentainer"/> is actually filling,
+        /// per its own cursor (<c>FragmentainerContext.SlotIndex</c>) — <paramref name="gridBand"/> only
+        /// where no fragmentainer is named (a measurement pass, per <see cref="DetachFragmentainer"/>),
+        /// inside a column (which has a band of its own), or for the driver's suppressed last-resort pass
+        /// (which may place content anywhere and must not break again).
         /// </summary>
         /// <remarks>
-        /// Also the sole instrumentation point for <see cref="CursorSpills"/>: whenever a fragmenting
-        /// page pass is asked this question about content whose own slot disagrees with
-        /// <see cref="CurrentFragmentainer"/>'s, that is a pass placing content past the band it says
-        /// it is filling without a break recorded for the crossing — see
-        /// <see href="https://github.com/jhaygood86/PeachPDF/issues/435">#435</see>. Returns
-        /// <paramref name="gridBand"/> unconditionally today; once every such crossing is closed (so
-        /// <see cref="CursorSpills"/> is provably always zero), this returns <c>filling.Band</c>
-        /// instead, which is what makes <c>CssRect.WouldStraddleFragmentainer</c>'s two arms one
-        /// expression.
+        /// <para>
+        /// Safe since <see href="https://github.com/jhaygood86/PeachPDF/issues/435">#435</see>'s stage 1
+        /// closed every production mechanism that could leave the two disagreeing — an unforced §5.2
+        /// flush placement, unbreakable word/block overflow, a table row-loop band jump, a flex/grid line
+        /// relocation — each now steps <c>FragmentainerContext.StepOverTo</c> to match. Before that, this
+        /// answered <paramref name="gridBand"/> unconditionally; converting it directly, without stage 1
+        /// closing those mechanisms first, is recorded (in the issue and in
+        /// <c>.claude/recent-fixes/</c>) as changing 63 of 69 showcases, with visibly overlapping content.
+        /// </para>
+        /// <para>
+        /// <see cref="CursorSpills"/> remains wired here as the permanent regression guard: any future
+        /// mechanism that reopens the gap this closes shows up as a non-zero count rather than a silent
+        /// re-divergence between the two bands this method used to be able to return.
+        /// </para>
         /// </remarks>
         internal PageBand BandBeingFilled(double top, PageBand gridBand)
         {
             if (CurrentFragmentainer is not { IsFragmenting: true, HasOwnBand: false } filling) return gridBand;
 
+            // Diagnostic only - never a behavioural fallback. A mismatch here means either a mechanism
+            // stage 1 did not close (there should be none left in production), or this word is exactly
+            // the tolerance case stage 1 deliberately left for this conversion to turn into a break: its
+            // own top has drifted into a later grid band while nothing advanced the cursor, and asking
+            // FallsPast against filling.Band (not gridBand) is what makes that word straddle now.
             if (filling.SlotIndex != SlotStartingAt(top)) CursorSpills++;
 
-            return gridBand;
+            return filling.Band;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

`#435` stage 2+3, following stage 1 (`#535`): `HtmlContainerInt.BandBeingFilled` now returns
`filling.Band` — the fragmentainer the pass is actually filling, per its own cursor — instead of the
page grid's answer, unifying `CssRect.WouldStraddleFragmentainer`'s page and column arms into one
expression. Safe now that stage 1 closed every mechanism that could leave the two disagreeing.

Two follow-on corrections the flip required:

- `CssLayoutEngine`'s `InlineBreakToken` resume slot now comes from a new
  `CssRect.ResumeSlotForBreakBefore()` (derived from where the break actually fell) instead of
  `SlotStartingAt(word.Top) + 1`, which assumed "the pass after this one" — wrong in the spill case
  the flip makes real.
- `CssBox.LayoutBlockChildren`'s block-overflow cursor step is generalized from monolithic-only
  content to any finished, in-flow block child that overflows past the fragmentainer being filled.
- `CssBox.PlaceBlockChild` steps the cursor for the document root's own placement, which §5.2's
  crossing test never asks about and so never had a step of its own before.

A genuine, previously-silent consequence: CSS `orphans`/`widows` (default 2) now reliably engage for
ordinary multi-page paragraph overflow, since a real break token exists for the correction to act on
where none did before.

A sixth cursor-truthfulness site, missed by stage 1's own enumeration, surfaced once the predicate
started reading the cursor: `TableRowCursor.RestartAt` (the whole-table relocation pre-check that
moves an entire table onto the next page) updated the row cursor's own position but never stepped
the document-level fragmentainer cursor, unlike its sibling `MoveToSlot`. This is what the `flexbox`
showcase's corpus regression was catching — a table row's label and description text painting as
fully absent. Root-caused through pymupdf text extraction, fragment-tree claim inspection, a
full-pipeline repro through the public API, and finally `FragmentainerContext` instance-identity
comparison across the row's layout attempts. Fixed by giving `RestartAt` the same optional
`HtmlContainerInt? container` parameter `MoveToSlot` already has.

Fixes #400
Fixes #435

## Test plan

- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 7027 passing, 0 failed
- [x] `dotnet test PeachPDF.Cli.Tests/PeachPDF.Cli.Tests.csproj` — 96 passing, 0 failed
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] 100% diff coverage against `origin/main` (`diff-cover` on `coverlet.runsettings` output)
- [x] Full 76-showcase corpus regression (PDFium + MuPDF rasterization for every showcase that
      differs from `main`):
  - `flexbox` is now byte-identical (the content-loss defect this PR fixes is exactly what the prior
    corpus diff was catching)
  - `paged_media_monolithic_content` page 3 shows a genuine improvement: a monolithically-relocated
    card that previously reported extra, unused blank space inside its own border now reports its
    content's real height
  - `background_origin_clip` and `gradients` each show a uniform sub-point cascade starting partway
    down one page, matching the tolerance-boundary case (a line within `PageBoundaryEpsilon` of a
    band bottom) becoming a real break exactly where this change intends — both renderers agree on
    the (sub-pixel) result
  - all other 72 showcases byte-identical
- [x] New regression tests: `ResumableInlineLayoutIntegrationTests`/`FragmentEmitterTests` updates for
      the predicate flip and root-placement fix; `TableRowCursorBandTests.ContentAfterAWholeTableRelocation_SeesATruthfulCursor`
      for the whole-table relocation cursor fix (verified to fail without the `RestartAt` change)
