### PR TITLE
Serialize GsubTable's sequential reads on the shared OpenTypeFontface

### DIFF
--- a/.claude/recent-fixes/2026-07-30-gsub-table-serializes-its-shared-fontface-reads.md
+++ b/.claude/recent-fixes/2026-07-30-gsub-table-serializes-its-shared-fontface-reads.md
@@ -1,0 +1,64 @@
+# GsubTable serializes its shared-fontface reads
+
+Fixes [#543](https://github.com/jhaygood86/PeachPDF/issues/543): the CLI test suite crashing on
+`windows-latest` CI, regressed by `#536`'s GSUB ligature support.
+
+## The load-bearing idea
+
+`OpenTypeFontface` (`Fonts/OpenType/OpenTypeFontface.cs`) is cached and shared process-wide by
+`OpenTypeFontfaceCache` (keyed by checksum, then by name) - a `PdfGenerator` never gets its own private
+copy of a font it has already seen. Its `Position` property is a plain mutable `int` field with no
+synchronization at all, and every table reader in `Fonts/OpenType/` uses the same "seek, then read
+several values in sequence" pattern against it. `GsubTable.GetActiveLookupIndices` (added by `#536`)
+re-reads the ScriptList/FeatureList tables through that pattern on **every single** `Shape()` call -
+unlike `GetLigatureLookup`, its result isn't cached - making it by far the widest, most frequently hit
+critical section touching the shared cursor. Two threads shaping text concurrently against the same
+cached font (two overlapping renders, or two xUnit test classes under the default parallel-collection
+runner) interleave their `Position` writes/reads, corrupting what each thread reads back. `GsubTable`'s
+own methods (`GetActiveLookupIndices`, `ReadLigatureLookup` and the two private helpers only ever
+reached through it) now `lock (_face)` around their sequential-read sections, closing that race for the
+newly-added GSUB path.
+
+## What was found by running it, not by reading it
+
+**Confirmed the race is real and the fix closes it, not just plausible.** Temporarily replacing both
+`lock (_face)` blocks with a no-op made the new `ConcurrentAccess_FromManyThreads_ProducesConsistentResults`
+test (in `GsubTableSyntheticTests.cs`, which hammers one shared synthetic `GsubTable` from many threads
+via `Parallel.ForEach`) fail reliably - 5/5 runs, either a wrong-result assertion or a thrown exception,
+matching the shape of the CI crash exactly. Restoring the lock made it pass consistently across repeated
+runs. This is the same class of hazard CLAUDE.md already documents for `FontFactory`/OpenType caching
+generally (parallel-test-class flakiness), but this is the first fix rather than just a written warning
+to avoid triggering it.
+
+**Confirmed via CI archaeology, not guesswork, that the regression window starts at `#536`.** Walking
+`main`'s own commit-by-commit CI history (`fe4ad52` and `afac876` both fail on `windows-latest`;
+`b2ff99c`, the commit immediately before `#536` merged, is green) pinned the introduction precisely
+before any fix was attempted, ruling out font-metrics/monolithic-content/unpaginated-mode hypotheses that
+were considered first.
+
+## What was deliberately not done
+
+- **The same unsynchronized-shared-cursor hazard almost certainly also exists for glyph outline
+  decoding** (`GlyphOutlineDecoder.cs`/`GlyphDataTable.cs`/`IndexToLocationTable.cs`) and other table
+  readers (`ColrTable.cs`, `CpalTable.cs`) that read through the same shared `OpenTypeFontface.Position`
+  - none of them take any lock either. This wasn't touched here: those paths pre-date `#536` and were not
+    the regression `#543` reported (CI was green through them for the entire history checked), and fixing
+    the whole subsystem's concurrency model is a materially larger change than the "small, isolated fix"
+    this was scoped as. The likely reason `#536` is what tipped CI over rather than these older paths:
+    `GetActiveLookupIndices` runs its full multi-table read on every `Shape()` call with no caching, while
+    outline decoding and lookup caching mostly memoize after a first hit - a much longer, more frequently
+    re-entered critical section is a much bigger collision target under concurrent load.
+- **No lock was added to `OpenTypeFontface` itself.** Locking on `_face` from within `GsubTable`'s own
+  methods is sufficient to serialize GSUB-vs-GSUB access to a shared face; it does not protect against a
+  concurrent glyph-outline read on the same face interleaving with a GSUB read, since that reader takes no
+  lock. Closing that fully would mean auditing and locking every `OpenTypeFontface` reader, which is out of
+  scope for this fix - noted here for whoever eventually hardens that subsystem.
+
+## Evidence
+
+Full `net8.0` suite green (7081/7081, was 7080 pre-fix + 1 new concurrency test). Zero-warning solution
+rebuild. 100% diff coverage against `origin/main` (68/68 lines - one branch, an empty `ScriptList`, needed
+a dedicated synthetic-font test to close after the lock wrapping shifted line numbers). Full 77-showcase
+corpus byte-identical before/after (expected - this only adds synchronization around unchanged single-
+threaded logic). New `ConcurrentAccess_FromManyThreads_ProducesConsistentResults` and
+`EmptyScriptList_ReturnsEmpty` tests in `GsubTableSyntheticTests.cs`.

--- a/src/PeachPDF.Tests/PdfSharpCore/Fonts/GsubTableSyntheticTests.cs
+++ b/src/PeachPDF.Tests/PdfSharpCore/Fonts/GsubTableSyntheticTests.cs
@@ -1,5 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using PeachPDF.Fonts.OpenType;
 using PeachPDF.PdfSharpCore.Drawing;
 using PeachPDF.Tests.TestSupport;
@@ -250,6 +253,33 @@ namespace PeachPDF.Tests.PdfSharpCoreTests.Fonts
             return b.ToArray();
         }
 
+        /// <summary>A minimal, otherwise-empty GSUB table whose ScriptList has zero records - the one
+        /// branch of <see cref="GsubTable.FindScript"/> no bundled font or the main synthetic table
+        /// above exercises (both always define at least one script).</summary>
+        private static byte[] BuildEmptyScriptListGsub()
+        {
+            var b = new Builder();
+
+            b.U16(1); b.U16(0); // majorVersion, minorVersion
+            int scriptListOffsetAt = b.PlaceholderU16();
+            int featureListOffsetAt = b.PlaceholderU16();
+            int lookupListOffsetAt = b.PlaceholderU16();
+
+            int scriptListStart = b.Position;
+            b.PatchU16(scriptListOffsetAt, scriptListStart);
+            b.U16(0); // scriptCount = 0
+
+            int featureListStart = b.Position;
+            b.PatchU16(featureListOffsetAt, featureListStart);
+            b.U16(0); // featureCount = 0
+
+            int lookupListStart = b.Position;
+            b.PatchU16(lookupListOffsetAt, lookupListStart);
+            b.U16(0); // lookupCount = 0
+
+            return b.ToArray();
+        }
+
         private static byte[] Concat(byte[] a, byte[] b)
         {
             var combined = new byte[a.Length + b.Length];
@@ -277,6 +307,20 @@ namespace PeachPDF.Tests.PdfSharpCoreTests.Fonts
             var indices = gsub.GetActiveLookupIndices(["bbbb"], new HashSet<string> { "extr" });
 
             Assert.Equal([1], indices);
+        }
+
+        [Fact]
+        public void EmptyScriptList_ReturnsEmpty()
+        {
+            byte[] fontBytes = File.ReadAllBytes(BundledFonts.Ttf);
+            int tableStart = fontBytes.Length;
+            byte[] combined = Concat(fontBytes, BuildEmptyScriptListGsub());
+            var face = XFontSource.GetOrCreateFrom(combined).Fontface;
+            var gsub = new GsubTable(face, tableStart);
+
+            var indices = gsub.GetActiveLookupIndices(["aaaa"], new HashSet<string> { "liga" });
+
+            Assert.Empty(indices);
         }
 
         [Fact]
@@ -364,6 +408,51 @@ namespace PeachPDF.Tests.PdfSharpCoreTests.Fonts
 
             Assert.Null(gsub.GetLigatureLookup(-1));
             Assert.Null(gsub.GetLigatureLookup(999));
+        }
+
+        /// <summary>
+        /// Regression test for issue #543: a single <see cref="GsubTable"/> (and the
+        /// <see cref="OpenTypeFontface"/> it reads from) is cached and shared process-wide across
+        /// concurrently-rendering fonts, so <see cref="GsubTable.GetActiveLookupIndices"/> and
+        /// <see cref="GsubTable.GetLigatureLookup"/> must tolerate being called from many threads at
+        /// once against the same instance. Before the locking added for #543, this reliably produced
+        /// wrong results (corrupted <c>_face.Position</c> reads interleaving across threads) or thrown
+        /// exceptions under concurrent load - which is exactly the shape of the Windows-only CI crash
+        /// the issue reported. This can't guarantee reproducing that exact interleaving on every OS/CLR
+        /// combination, but hammering the same shared table from many threads is the most direct
+        /// verification available without live Windows CI access.
+        /// </summary>
+        [Fact]
+        public void ConcurrentAccess_FromManyThreads_ProducesConsistentResults()
+        {
+            var (face, tableStart) = BuildFaceWithSyntheticGsub();
+            var gsub = new GsubTable(face, tableStart);
+
+            var actions = new Action[]
+            {
+                () => Assert.Equal([1], gsub.GetActiveLookupIndices(["bbbb"], new HashSet<string> { "extr" })),
+                () => Assert.Empty(gsub.GetActiveLookupIndices(["cccc"], new HashSet<string> { "liga" })),
+                () => Assert.Equal([0], gsub.GetActiveLookupIndices(["zzzz", "yyyy"], new HashSet<string> { "liga" })),
+                () => Assert.Equal([1], gsub.GetActiveLookupIndices(["yyyy", "bbbb"], new HashSet<string> { "extr" })),
+                () =>
+                {
+                    var lookup = gsub.GetLigatureLookup(1);
+                    Assert.NotNull(lookup);
+                    var subtable = Assert.Single(lookup.Subtables);
+                    Assert.Equal(0, subtable.Coverage.IndexOfGlyph(20));
+                    Assert.Equal(22, subtable.LigatureSets[0][0].LigatureGlyph);
+                },
+                () => Assert.Null(gsub.GetLigatureLookup(2)),
+                () => Assert.Null(gsub.GetLigatureLookup(3)),
+                () => Assert.Null(gsub.GetLigatureLookup(4)),
+                () => Assert.Null(gsub.GetLigatureLookup(999)),
+            };
+
+            const int repeatsPerAction = 40;
+            var work = Enumerable.Range(0, actions.Length * repeatsPerAction)
+                .Select(i => actions[i % actions.Length]);
+
+            Parallel.ForEach(work, action => action());
         }
     }
 }

--- a/src/PeachPDF/Fonts/OpenType/GsubTable.cs
+++ b/src/PeachPDF/Fonts/OpenType/GsubTable.cs
@@ -49,7 +49,10 @@ namespace PeachPDF.Fonts.OpenType
 
         // A GsubTable instance is cached and shared process-wide across concurrently-rendering
         // PdfGenerator instances (see OpenTypeFontface/FontFactory's caching), so this needs to be
-        // safe for concurrent reads/writes rather than a plain Dictionary.
+        // safe for concurrent reads/writes rather than a plain Dictionary. The dictionary alone isn't
+        // enough, though: computing a not-yet-cached entry still means sequential _face.Position reads
+        // (see GetActiveLookupIndices/ReadLigatureLookup's own locking on _face) against the same
+        // shared, mutable-cursor OpenTypeFontface.
         private readonly ConcurrentDictionary<int, GsubLigatureLookup?> _ligatureLookupCache = new();
 
         public GsubTable(OpenTypeFontface face, int tableStart)
@@ -73,49 +76,59 @@ namespace PeachPDF.Fonts.OpenType
         /// </summary>
         public SortedSet<int> GetActiveLookupIndices(IReadOnlyList<string> scriptTagPreference, IReadOnlySet<string> featureTags)
         {
-            var lookupIndices = new SortedSet<int>();
-
-            int scriptOffset = FindScript(scriptTagPreference);
-            if (scriptOffset < 0)
-                return lookupIndices;
-
-            _face.Position = scriptOffset;
-            int defaultLangSysOffset = _face.ReadUShort();
-            if (defaultLangSysOffset == 0)
-                return lookupIndices;
-
-            _face.Position = scriptOffset + defaultLangSysOffset;
-            _face.ReadUShort(); // lookupOrder - reserved, always 0
-            int requiredFeatureIndex = _face.ReadUShort();
-            int featureIndexCount = _face.ReadUShort();
-            var featureIndices = new int[featureIndexCount];
-            for (int i = 0; i < featureIndexCount; i++)
-                featureIndices[i] = _face.ReadUShort();
-
-            var featureRecords = ReadFeatureRecords();
-
-            void CollectFeature(int featureIndex)
+            // OpenTypeFontface.Position is a plain mutable field on an instance that is cached and
+            // shared process-wide (OpenTypeFontfaceCache), so two threads shaping concurrently on the
+            // same cached font would otherwise interleave their Position writes/reads against each
+            // other. Unlike GetLigatureLookup below, this method's result isn't cached at all - it
+            // re-reads the ScriptList/FeatureList tables on every single Shape() call - so it is by far
+            // the widest, most frequently hit critical section, and locking on the shared face closes
+            // that race. See the CI regression this fixed: issue #543.
+            lock (_face)
             {
-                if (featureIndex < 0 || featureIndex >= featureRecords.Length)
-                    return;
-                var (tag, offset) = featureRecords[featureIndex];
-                if (!featureTags.Contains(tag))
-                    return;
+                var lookupIndices = new SortedSet<int>();
 
-                _face.Position = offset;
-                _face.ReadUShort(); // featureParams offset - ignored
-                int lookupIndexCount = _face.ReadUShort();
-                for (int i = 0; i < lookupIndexCount; i++)
-                    lookupIndices.Add(_face.ReadUShort());
+                int scriptOffset = FindScript(scriptTagPreference);
+                if (scriptOffset < 0)
+                    return lookupIndices;
+
+                _face.Position = scriptOffset;
+                int defaultLangSysOffset = _face.ReadUShort();
+                if (defaultLangSysOffset == 0)
+                    return lookupIndices;
+
+                _face.Position = scriptOffset + defaultLangSysOffset;
+                _face.ReadUShort(); // lookupOrder - reserved, always 0
+                int requiredFeatureIndex = _face.ReadUShort();
+                int featureIndexCount = _face.ReadUShort();
+                var featureIndices = new int[featureIndexCount];
+                for (int i = 0; i < featureIndexCount; i++)
+                    featureIndices[i] = _face.ReadUShort();
+
+                var featureRecords = ReadFeatureRecords();
+
+                void CollectFeature(int featureIndex)
+                {
+                    if (featureIndex < 0 || featureIndex >= featureRecords.Length)
+                        return;
+                    var (tag, offset) = featureRecords[featureIndex];
+                    if (!featureTags.Contains(tag))
+                        return;
+
+                    _face.Position = offset;
+                    _face.ReadUShort(); // featureParams offset - ignored
+                    int lookupIndexCount = _face.ReadUShort();
+                    for (int i = 0; i < lookupIndexCount; i++)
+                        lookupIndices.Add(_face.ReadUShort());
+                }
+
+                const int noRequiredFeature = 0xFFFF;
+                if (requiredFeatureIndex != noRequiredFeature)
+                    CollectFeature(requiredFeatureIndex);
+                foreach (int featureIndex in featureIndices)
+                    CollectFeature(featureIndex);
+
+                return lookupIndices;
             }
-
-            const int noRequiredFeature = 0xFFFF;
-            if (requiredFeatureIndex != noRequiredFeature)
-                CollectFeature(requiredFeatureIndex);
-            foreach (int featureIndex in featureIndices)
-                CollectFeature(featureIndex);
-
-            return lookupIndices;
         }
 
         /// <summary>Parses (and caches) the lookup at <paramref name="lookupListIndex"/> as a
@@ -163,49 +176,58 @@ namespace PeachPDF.Fonts.OpenType
 
         private GsubLigatureLookup? ReadLigatureLookup(int lookupListIndex)
         {
-            _face.Position = _lookupListOffset;
-            int lookupCount = _face.ReadUShort();
-            if (lookupListIndex < 0 || lookupListIndex >= lookupCount)
-                return null;
-
-            _face.Position = _lookupListOffset + 2 + lookupListIndex * 2;
-            int lookupTableStart = _lookupListOffset + _face.ReadUShort();
-
-            _face.Position = lookupTableStart;
-            int lookupType = _face.ReadUShort();
-            _face.ReadUShort(); // lookupFlag - GDEF mark filtering not implemented, see file header.
-            int subtableCount = _face.ReadUShort();
-            var subtableOffsets = new int[subtableCount];
-            for (int i = 0; i < subtableCount; i++)
-                subtableOffsets[i] = lookupTableStart + _face.ReadUShort();
-
-            // Only plain Ligature Substitution (4) and Extension Substitution (9) wrapping it are
-            // understood; every other lookup type (single/multiple/alternate/contextual/reverse
-            // chaining substitution) is skipped rather than mis-applied.
-            if (lookupType != 4 && lookupType != 9)
-                return null;
-
-            var subtables = new List<GsubLigatureSubtable>(subtableCount);
-            foreach (int subtableOffset in subtableOffsets)
+            // Reached via _ligatureLookupCache.GetOrAdd, so a result is only ever computed once per
+            // index and then cached - but the sequential _face.Position reads below (and in the
+            // ReadLigatureSubtable/ReadLigatureSet helpers this calls, only ever reached from here)
+            // still need to be serialized against GetActiveLookupIndices and any concurrent first
+            // resolution of a different index, since _face is a single mutable cursor shared
+            // process-wide across concurrently-rendering fonts. See issue #543.
+            lock (_face)
             {
-                int resolvedOffset = subtableOffset;
-                if (lookupType == 9)
+                _face.Position = _lookupListOffset;
+                int lookupCount = _face.ReadUShort();
+                if (lookupListIndex < 0 || lookupListIndex >= lookupCount)
+                    return null;
+
+                _face.Position = _lookupListOffset + 2 + lookupListIndex * 2;
+                int lookupTableStart = _lookupListOffset + _face.ReadUShort();
+
+                _face.Position = lookupTableStart;
+                int lookupType = _face.ReadUShort();
+                _face.ReadUShort(); // lookupFlag - GDEF mark filtering not implemented, see file header.
+                int subtableCount = _face.ReadUShort();
+                var subtableOffsets = new int[subtableCount];
+                for (int i = 0; i < subtableCount; i++)
+                    subtableOffsets[i] = lookupTableStart + _face.ReadUShort();
+
+                // Only plain Ligature Substitution (4) and Extension Substitution (9) wrapping it are
+                // understood; every other lookup type (single/multiple/alternate/contextual/reverse
+                // chaining substitution) is skipped rather than mis-applied.
+                if (lookupType != 4 && lookupType != 9)
+                    return null;
+
+                var subtables = new List<GsubLigatureSubtable>(subtableCount);
+                foreach (int subtableOffset in subtableOffsets)
                 {
-                    _face.Position = subtableOffset;
-                    _face.ReadUShort(); // substFormat (always 1)
-                    int extensionLookupType = _face.ReadUShort();
-                    uint extensionOffset = _face.ReadULong();
-                    if (extensionLookupType != 4)
-                        continue;
-                    resolvedOffset = subtableOffset + (int)extensionOffset;
+                    int resolvedOffset = subtableOffset;
+                    if (lookupType == 9)
+                    {
+                        _face.Position = subtableOffset;
+                        _face.ReadUShort(); // substFormat (always 1)
+                        int extensionLookupType = _face.ReadUShort();
+                        uint extensionOffset = _face.ReadULong();
+                        if (extensionLookupType != 4)
+                            continue;
+                        resolvedOffset = subtableOffset + (int)extensionOffset;
+                    }
+
+                    GsubLigatureSubtable? subtable = ReadLigatureSubtable(resolvedOffset);
+                    if (subtable is not null)
+                        subtables.Add(subtable);
                 }
 
-                GsubLigatureSubtable? subtable = ReadLigatureSubtable(resolvedOffset);
-                if (subtable is not null)
-                    subtables.Add(subtable);
+                return subtables.Count > 0 ? new GsubLigatureLookup { Subtables = subtables } : null;
             }
-
-            return subtables.Count > 0 ? new GsubLigatureLookup { Subtables = subtables } : null;
         }
 
         private GsubLigatureSubtable? ReadLigatureSubtable(int offset)


### PR DESCRIPTION
## Summary

`OpenTypeFontface` instances are cached and shared process-wide (`OpenTypeFontfaceCache`, keyed by
checksum then name), and their `Position` cursor is a plain, unsynchronized `int` field. Every OpenType
table reader uses a "seek, then read several values in sequence" pattern against that shared cursor.

`GsubTable.GetActiveLookupIndices` (added by #536) re-reads the ScriptList/FeatureList tables through
that pattern on **every single** `Shape()` call, with no caching - unlike `GetLigatureLookup`, whose
results are cached after first resolution. That makes it by far the widest, most frequently re-entered
critical section touching the shared cursor. Two threads shaping text concurrently against the same
cached font (overlapping renders, or parallel xUnit test classes under the default parallel-collection
runner) interleave their `Position` reads/writes, corrupting what each thread reads back.

Walking `main`'s own CI history confirmed this precisely: `b2ff99c` (immediately before #536 merged) is
green on `windows-latest`; `afac876` (#536's merge commit) and `fe4ad52` (the next commit) both fail. No
other change in that window touches font/text-shaping code.

## Fix

`GsubTable`'s own `GetActiveLookupIndices` and `ReadLigatureLookup` (plus the private helpers only ever
reached through them) now `lock (_face)` around their sequential-read sections, serializing access to the
shared cursor for the GSUB path.

## Verification

- Confirmed the race is real and the fix actually closes it: temporarily removing both locks made a new
  concurrency-stress test (`ConcurrentAccess_FromManyThreads_ProducesConsistentResults`) fail reliably,
  5/5 runs, with either a wrong-result assertion or a thrown exception - the same shape as the CI crash.
  Restoring the locks made it pass consistently across repeated runs.
- Full `net8.0` test suite green (7081/7081).
- Zero-warning solution rebuild (`dotnet build PeachPDF.slnx -t:Rebuild`).
- 100% diff coverage against `main`.
- Full 77-showcase corpus byte-identical before/after (expected - this only adds synchronization around
  otherwise-unchanged single-threaded logic).

## Scope note

The same unsynchronized-shared-cursor pattern likely also exists in other OpenType table readers (glyph
outline decoding, COLR/CPAL) that pre-date #536 and were not part of this regression. Fixing the whole
subsystem's concurrency model is a larger change than this isolated fix is scoped for; noted in the
accompanying recent-fix note for future hardening.

Fixes #543
