### PR TITLE
Resolve a block box's inline size against the page it lands on

### DIFF
--- a/.claude/recent-fixes/2026-07-30-a-boxs-inline-size-comes-from-the-page-it-lands-on.md
+++ b/.claude/recent-fixes/2026-07-30-a-boxs-inline-size-comes-from-the-page-it-lands-on.md
@@ -1,0 +1,118 @@
+# A box's inline size comes from the page it lands on, not from its previous Location.Y
+
+Tracker: [#320](https://github.com/jhaygood86/PeachPDF/issues/320). Part of [#515](https://github.com/jhaygood86/PeachPDF/issues/515)
+(`#390`'s stage 2). Closes [#540](https://github.com/jhaygood86/PeachPDF/issues/540) (`#515.3`). **The one
+sub-stage in this sequence that changes rendered output by design.**
+
+## The load-bearing idea
+
+[css-page-3 §5.1](https://www.w3.org/TR/css-page-3/#page-model) makes each page's own page area the
+containing block for the layout that occurs between page breaks, so a box's measure comes from the page it
+**lands on**. `CssBox.PlaceBlockBox` resolved the size *first* and asked the frame above for the position
+second, which left `CssLayoutEngine.GetBoxWidth` nothing to read but `box.Location.Y` — a coordinate an
+earlier layout generation wrote, i.e. page 0's measure on the first one. Only
+`HtmlContainerInt.PerformLayout`'s reflow loop could iterate that back to the truth, by feeding each
+generation's positions into the next, and it is capped at three iterations.
+
+The order is simply reversed, because the dependency only ever ran one way: **nothing in the frame's
+block-flow arithmetic reads the child's inline size.** Checked line by line before touching anything —
+`CollapsedMarginBefore`, `prevSibling.StaticBottom`, `ForcedBreakTopFor`, §5.2's `BlockConstraint.EndingAt`
+crossing test, the keep-with-next pull, `StepPastSlotsOnTheWrongSide` — none of them do. The three lines
+that *do* read a size all live past the point the position is written (`child.ActualMarginLeft`, which
+`margin: auto` centres against the used width; a percentage relative offset; `CssLayoutEngine.FloatBox`'s
+displacement scan), which is what makes the split fall at one clean seam.
+
+So `PlaceBlockChild` becomes `ResolveBlockChildOffset` (decide, side effects and all — break requests,
+blank-slot reservations, `StepOverTo`, the keep-with-next run pull) plus `CommitBlockChildOffset` (write
+`Location`, float, relative/absolute/fixed, register the used page name), with a `BlockChildOffset` record
+carrying `Left`/`Top`/`PositionedInBlockFlow` between them. `PlaceBlockBox` runs resolve → size → commit;
+`PlaceBlockChild` stays as the two-in-a-row composition for `PlaceAsBlockChild`'s callers (`CssBoxHr`,
+which has already sized itself), so every doc comment in the repo naming `PlaceBlockChild` still names
+something real. `ResolveOwnInlineSize`/`GetBoxWidth` take the block-start coordinate as a parameter.
+
+**`BlockConstraint` was deliberately not the vehicle**, despite `#540`'s own wording. A constraint names a
+*fragmentainer*, which inside a multi-column container is a column; the per-page measure is a question about
+the **page grid** (`PageContentRightOf` → `PageIndexOf`). Passing the raw document-space coordinate is also
+what makes the read bit-identical to the one it replaces — the value handed over is exactly the value
+`Location.Y` is about to be set to, so no boundary convention changes hands (the trap `#539` documented at
+length).
+
+## What was found by running it, not by reading it
+
+**The whole existing suite passes unchanged (7115), and that is the correct result, not a warning sign.**
+Every existing per-page fixture asserts *converged* geometry, and the reflow loop already converged for
+them; what this changes is how many generations that takes and what happens to a document that needs more
+than the cap. Measured directly with `HtmlContainerInt.LayoutGeneration` (3 is the floor for a per-page-width
+document: one layout, one loop iteration that finds the assignment unchanged, one settled final layout):
+
+| fixture | generations before → after | blocks wrapped for the wrong page, before → after |
+|---|---|---|
+| 90 blocks, `@page :first { margin: 0 }` over 200pt margins | 4 → 3 | 0 → 0 |
+| 120 blocks, alternating `:left` 260pt / `:right` 20pt over a full-bleed `:first` | 5 → 3 | **23 of 120** → 0 |
+| 120 blocks, 240pt base margins over a full-bleed `:first` | 5 → 3 | **39 of 120** → 0 |
+
+The third fixture also came out at **nine pages instead of six** before: blocks measured too wide were laid
+out too short, and nothing re-wrapped them. Those last two are the new tests, and they fail on `origin/main`
+with exactly that message.
+
+**The corpus diff is one showcase, and it is a flex container that no longer overflows its own content.**
+`print_catalog` (`@page :first { margin: 0 }`, 10 pages) is the only one of 77 that differs; every
+`paged_media_*` showcase is byte-identical, because their fixtures are small enough that the loop already
+converged. On pages 1-8 the `.price-row` moved 12pt down. Traced to the box tree rather than guessed at:
+`.item-body` (a flex container) had `ActualBottom = 1174.94` while its own descendant `ul.features` ended at
+`1186.94` — the container was 12pt **shorter than its content**, so `.price-row`'s `margin-top: 9mm` was
+measured from a bottom edge 12pt above the real one and the row sat 12pt into the overflow. After the change
+`.item-body` ends at `1186.94`, exactly where its content does, and the 9mm gap is a real 9mm. Confirmed
+visually at 150dpi with **both** PDFium and MuPDF, which agree.
+
+**The bounded re-resolution round fires, but nothing observable depends on it — worth writing down before
+someone deletes it.** Commit can still move the box (`FloatBox`'s displacement scan, and `clear`), so a
+round re-measures at where it landed and re-commits from the same resolved offset; instrumented across the
+full suite it is entered **zero** times, and a purpose-built fixture (a `clear: both` block pushed past a
+float onto a narrower page) enters it exactly once per layout generation and converges — `guard` never
+exceeds 0. But disabling the loop entirely leaves that fixture's final geometry *identical*: a displacement
+big enough to change the measure has by definition crossed a page boundary, and in a fragmenting layout that
+is also a break decision, so the box is placed again at the resumed target and measured correctly there.
+What the round buys is that the *first* placement is self-consistent on its own terms — the descendants laid
+out inside the box immediately afterwards read its width — rather than by way of a mechanism that runs
+later. Kept, with that measurement recorded at the loop itself and a test pinning the invariant.
+
+**Re-committing is safe only because resolve is not re-entered.** `CollapsedMarginBefore` is not pure (it
+consumes `_groupTopMarginOverride` — see `#539`'s note) and the resumed-target arm consumes
+`_resumeTopOverride`; both live in `ResolveBlockChildOffset`, which the round never calls again. The round
+re-runs commit only, and commit resets `Location` to the resolved offset before re-floating, so each round is
+a fresh attempt rather than a cumulative slide.
+
+## What was deliberately not done
+
+- **The reflow loop stays.** It also settles the width→height→page-assignment feedback of the boxes *after*
+  this one, and `#199`-`#201`'s constrained-block nesting, neither of which this reorder touches. Its
+  convergence pressure is what dropped.
+- **`BlockConstraint` was not threaded into `GetBoxWidth`.** See above: wrong grain (fragmentainer vs page
+  grid), and it would have swapped a boundary convention silently.
+- **The engines' own `GetBoxWidth` calls were left alone** (multicol/flex/grid measuring their own
+  container). Those run after the frame above has already written the container's `Location`, so the box's
+  own coordinate is the truthful answer there; the new parameter is optional precisely so they keep it.
+- **No `docs/**` change.** Nothing documented becomes false: the scope limits in
+  `.claude/accepted-gaps/per-page-horizontal-reflow-scope.md` (`#196`-`#202`) are about *which* boxes reflow,
+  not about how many generations it takes them, and `docs/html-css-support.md`'s "resolved iteratively"
+  wording still holds.
+- **`#545` was not touched**, as `#540` scopes it out — it is about an escaping directional break's blank
+  slot, not about width.
+
+## Evidence
+
+Full `net8.0` suite green (**7119 passing**, 9 skipped, 0 failed — 7115 baseline plus 4 new) and CLI suite
+green (96 passing). Zero-warning `dotnet build PeachPDF.slnx -t:Rebuild`. **100% diff coverage** against
+`origin/main` (38 lines, 0 missing). Corpus: **1 of 77 showcases differs** (`print_catalog`), normalized for
+`/CreationDate`, `/ID`, font subset tags, annotation `/NM`/`/M` and PDFsharp's plaintext creation-date/time
+header lines, and verified more correct as above. New `WidthFromTheSpaceNotTheLocationTests` (4): the
+mechanism in isolation (`GetBoxWidth` answering about the offered block-start, twice, for one box that never
+moves), the two convergence fixtures above (both fail on `origin/main`), and the displaced-`clear` invariant.
+
+**Linux is not the verdict for this one.** Per
+`.claude/invariants/testing-the-reflow-fixtures-are-platform-sensitive-by-design.md`, this fixture class has
+caught regressions twice on `windows-latest` only, because its font metrics put the content at different page
+boundaries. The new fixtures assert an invariant ("every block carries the measure of the page it is on")
+rather than a coordinate, specifically so they stay meaningful there — but `windows-latest` CI must be green
+before this merges.

--- a/src/PeachPDF.Tests/Integration/WidthFromTheSpaceNotTheLocationTests.cs
+++ b/src/PeachPDF.Tests/Integration/WidthFromTheSpaceNotTheLocationTests.cs
@@ -1,0 +1,280 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Adapters;
+using PeachPDF.Html.Adapters.Entities;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore.Drawing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// A block-level box's inline size comes from the space it lands in, not from the coordinate its
+    /// <see cref="CssBox.Location"/> happened to be holding when the size was resolved
+    /// (<see href="https://www.w3.org/TR/css-page-3/#page-model">css-page-3 §5.1</see>: each page's own page
+    /// area is the containing block for the layout that occurs between page breaks).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>CssBox.PlaceBlockBox</c> used to resolve the size <i>before</i> asking the frame above where the
+    /// box goes, which left <c>CssLayoutEngine.GetBoxWidth</c> nothing to read but a <c>Location.Y</c> that
+    /// belonged to an earlier layout generation — page 0's measure on the first one. Only
+    /// <c>HtmlContainerInt.PerformLayout</c>'s reflow loop could iterate that back to the truth, and it is
+    /// capped at three iterations: past the cap, boxes were simply left wrapped for a page they are not on.
+    /// The offset is now decided first and the size resolved against it.
+    /// </para>
+    /// <para>
+    /// <b>These fixtures are font-metric sensitive by design</b> (see
+    /// <c>.claude/invariants/testing-the-reflow-fixtures-are-platform-sensitive-by-design.md</c>): they
+    /// assert an invariant that must hold at <i>whatever</i> page boundaries the platform's metrics produce,
+    /// rather than a coordinate, which is what keeps them meaningful on a platform whose text is a different
+    /// width.
+    /// </para>
+    /// </remarks>
+    public class WidthFromTheSpaceNotTheLocationTests
+    {
+        private const double SheetW = 612;
+        private const double SheetH = 792;
+
+        /// <summary>
+        /// The mechanism, in isolation: the measure follows the block-start offset the caller names, and the
+        /// box's own <see cref="CssBox.Location"/> has no say in it. This is the read that used to be
+        /// <c>box.Location.Y</c> outright.
+        /// </summary>
+        [Fact]
+        public async Task TheMeasureFollowsTheOfferedBlockTop_NotTheBoxsOwnLocation()
+        {
+            var (container, g) = await BuildLayoutAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { margin: 60pt 50pt; }
+                @page :first { margin-left: 0; }
+                body { margin: 0; }
+                p { margin: 0; }
+                </style></head><body>
+                <p id='p0'>page zero paragraph</p>
+                </body></html>
+                """);
+
+            using (g)
+            {
+                var p0 = FindById(container.Root!, "p0")!;
+                Assert.Equal(0, container.PageIndexOf(p0.Location.Y));
+
+                // Page 0 is the wide one (margin-left: 0 -> a 562pt content box, right edge 612); every later
+                // page keeps the base 512pt content box, right edge 562.
+                var pageZeroTop = container.PageTopOf(0);
+                var pageOneTop = container.PageTopOf(1);
+                Assert.NotEqual(container.PageContentRightOf(pageZeroTop), container.PageContentRightOf(pageOneTop));
+
+                // Same box, same Location — two answers, each the measure of the page named by the offset.
+                var atItsOwnPage = await CssLayoutEngine.GetBoxWidth(g, p0, pageZeroTop);
+                var atTheNextPage = await CssLayoutEngine.GetBoxWidth(g, p0, pageOneTop);
+
+                Assert.Equal(container.PageContentRightOf(pageZeroTop) - container.MarginLeft, atItsOwnPage, 0.5);
+                Assert.Equal(container.PageContentRightOf(pageOneTop) - container.MarginLeft, atTheNextPage, 0.5);
+                Assert.True(atItsOwnPage > atTheNextPage);
+
+                // Omitting the offset falls back to the box's own coordinate, which is what the engines
+                // (whose container has already been placed by the frame above) rely on.
+                Assert.Equal(await CssLayoutEngine.GetBoxWidth(g, p0, p0.Location.Y),
+                             await CssLayoutEngine.GetBoxWidth(g, p0), 0.5);
+            }
+        }
+
+        /// <summary>
+        /// Alternating left/right measures over a full-bleed first page, five times more content than the
+        /// reflow loop's three iterations can settle by feeding each generation's positions into the next.
+        /// Measured on <c>origin/main</c>: 23 of the 120 blocks came out wrapped for a page they are not on,
+        /// and the loop burned all three iterations getting that far.
+        /// </summary>
+        [Fact]
+        public async Task AlternatingPageMeasures_EveryBlockCarriesTheMeasureOfThePageItIsOn()
+        {
+            var (container, g) = await BuildLayoutAsync(Blocks(120, """
+                @page { margin: 40pt 20pt; }
+                @page :left { margin: 40pt 260pt; }
+                @page :right { margin: 40pt 20pt; }
+                @page :first { margin: 0; }
+                """));
+
+            using (g)
+            {
+                Assert.True(container.UseVariablePageWidth, "fixture must exercise per-page reflow");
+
+                var blocks = BlocksOf(container);
+                Assert.True(container.PageIndexOf(blocks[^1].Location.Y) >= 4,
+                    "fixture must span more pages than the reflow loop has iterations");
+
+                AssertEveryBlockIsWrappedForItsOwnPage(container, blocks);
+
+                // And the loop itself now has nothing left to settle: PerformLayout runs one layout, one
+                // reflow iteration that finds the page assignment unchanged, and the final settled layout.
+                // Three is the floor for a per-page-width document; this fixture took five before.
+                Assert.Equal(3, container.LayoutGeneration);
+            }
+        }
+
+        /// <summary>
+        /// The same claim with a wide first page and a single narrow measure everywhere after it — the
+        /// shape a cover page in front of a body gives a real document. Measured on <c>origin/main</c>: 39
+        /// of 120 blocks wrapped for the wrong page, and the document ran to nine pages instead of six
+        /// because the over-wide blocks were laid out too short and then never re-wrapped.
+        /// </summary>
+        [Fact]
+        public async Task AFullBleedFirstPageThenNarrowOnes_EveryBlockCarriesTheMeasureOfThePageItIsOn()
+        {
+            var (container, g) = await BuildLayoutAsync(Blocks(120, """
+                @page { margin: 20pt 240pt; }
+                @page :first { margin: 0; }
+                @page :left { margin: 20pt 40pt; }
+                """));
+
+            using (g)
+            {
+                Assert.True(container.UseVariablePageWidth, "fixture must exercise per-page reflow");
+                AssertEveryBlockIsWrappedForItsOwnPage(container, BlocksOf(container));
+            }
+        }
+
+        /// <summary>
+        /// The one thing committing an offset can still move: <c>clear</c> (and the same scan's float
+        /// displacement) pushes the box below a float it may not sit beside, which can carry it onto the
+        /// next page. Its measure follows it there — the bounded re-resolution round in
+        /// <c>PlaceBlockBox</c>, which is what keeps the first placement self-consistent rather than
+        /// leaving it to be corrected by the break that displacement also amounts to.
+        /// </summary>
+        /// <remarks>
+        /// Unlike the two above, this one also holds without that round — a displacement big enough to
+        /// change the measure has crossed a page boundary, and the fragmentation machinery places the box
+        /// again at the resumed target. It is here to pin the invariant at the seam where the box's measure
+        /// and its final position are decided by two different steps, and because a round that fires (it
+        /// does, once per layout generation on this fixture) with nothing asserting its result is a round
+        /// the next change will delete without noticing what it was for.
+        /// </remarks>
+        [Fact]
+        public async Task ABlockClearedPastAFloatOntoTheNextPage_TakesThatPagesMeasure()
+        {
+            var (container, g) = await BuildLayoutAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { margin: 40pt 200pt; }
+                @page :first { margin: 40pt 0; }
+                body { margin: 0; }
+                div, p { margin: 0; }
+                </style></head><body>
+                <div style='height:600pt'></div>
+                <div style='float:left;width:100pt;height:200pt'></div>
+                <p id='cleared' style='clear:both'>cleared paragraph</p>
+                </body></html>
+                """);
+
+            using (g)
+            {
+                var cleared = FindById(container.Root!, "cleared")!;
+
+                // It really was pushed off the page its static position put it on.
+                Assert.True(container.PageIndexOf(cleared.Location.Y) >= 1,
+                    "the fixture must clear the paragraph onto a later page");
+                Assert.False(container.MeasureIsSharedBetween(0, container.PageIndexOf(cleared.Location.Y)),
+                    "the two pages must have different measures for the claim to mean anything");
+
+                Assert.Equal(container.PageContentRightOf(cleared.Location.Y), cleared.ActualRight, 0.5);
+            }
+        }
+
+        private static void AssertEveryBlockIsWrappedForItsOwnPage(HtmlContainerInt container, List<CssBox> blocks)
+        {
+            Assert.True(blocks.Count > 3, "fixture should span several pages worth of blocks");
+
+            var strays = blocks
+                .Where(b => Math.Abs(container.PageContentRightOf(b.Location.Y) - b.ActualRight) > 0.5)
+                .Select(b => $"y={b.Location.Y:F1} page={container.PageIndexOf(b.Location.Y)} " +
+                             $"right={b.ActualRight:F1} expected={container.PageContentRightOf(b.Location.Y):F1}")
+                .ToList();
+
+            Assert.True(strays.Count == 0,
+                $"{strays.Count} of {blocks.Count} blocks are wrapped for a page they are not on: " +
+                string.Join("; ", strays.Take(5)));
+
+            // The fixture is only evidence if the pages genuinely differ, so at least two distinct measures
+            // must actually be in play.
+            Assert.True(blocks.Select(b => Math.Round(container.PageContentRightOf(b.Location.Y), 1)).Distinct().Count() > 1,
+                "the fixture must put blocks on pages of more than one measure");
+        }
+
+        private static string Blocks(int count, string pageCss)
+        {
+            var paragraphs = string.Concat(Enumerable.Range(1, count).Select(i =>
+                $"<p class='b'>Block {i}: lorem ipsum dolor sit amet consectetur adipiscing elit sed " +
+                "do eiusmod tempor incididunt ut labore et dolore magna aliqua ut enim ad minim veniam.</p>"));
+
+            return $$"""
+                <!DOCTYPE html><html><head><style>
+                {{pageCss}}
+                body { margin: 0; }
+                p { margin: 0; }
+                </style></head><body>{{paragraphs}}</body></html>
+                """;
+        }
+
+        private static List<CssBox> BlocksOf(HtmlContainerInt container)
+        {
+            List<CssBox> blocks = [];
+            CollectByClass(container.Root!, "b", blocks);
+            return blocks;
+        }
+
+        // --- Harness (mirrors PdfGenerator.SetContent's geometry derivation; see
+        //     PerPageHorizontalReflowLayoutIntegrationTests) ---
+
+        private static async Task<(HtmlContainerInt Container, RGraphics Graphics)> BuildLayoutAsync(string html)
+        {
+            var adapter = new PdfSharpAdapter { PixelsPerPoint = 1.0 };
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            container.PageSize = new RSize(
+                SheetW - container.MarginLeft - container.MarginRight,
+                SheetH - container.MarginTop - container.MarginBottom);
+            container.Location = new RPoint(container.MarginLeft, container.MarginTop);
+            container.MaxSize = new RSize(container.PageSize.Width, 0);
+
+            var measure = XGraphics.CreateMeasureContext(
+                new XSize(container.PageSize.Width, container.PageSize.Height), XGraphicsUnit.Point, XPageDirection.Downwards);
+            var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            return (container, graphics);
+        }
+
+        private static void CollectByClass(CssBox box, string className, List<CssBox> result)
+        {
+            var classAttr = box.HtmlTag?.TryGetAttribute("class", "");
+            if (!string.IsNullOrEmpty(classAttr) &&
+                classAttr.Split(' ', StringSplitOptions.RemoveEmptyEntries).Contains(className))
+            {
+                result.Add(box);
+            }
+
+            foreach (var child in box.Boxes)
+                CollectByClass(child, className, result);
+        }
+
+        private static CssBox? FindById(CssBox box, string id)
+        {
+            if (string.Equals(box.HtmlTag?.TryGetAttribute("id", ""), id, StringComparison.OrdinalIgnoreCase))
+                return box;
+
+            foreach (var child in box.Boxes)
+            {
+                var found = FindById(child, id);
+                if (found != null) return found;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
@@ -1979,6 +1979,14 @@ namespace PeachPDF.Html.Core.Dom
         /// </summary>
         internal double StaticBottom => ActualBottom - RelativeOffsetY;
 
+        /// <summary>
+        /// The border-box top edge of the box at its static (un-offset) position — the mirror of
+        /// <see cref="StaticBottom"/>, and the coordinate that decides which page's measure the box takes
+        /// (<c>CssLayoutEngine.GetBoxWidth</c>), since a relative offset is visual only and must not move a
+        /// box to another page's containing block any more than it moves its neighbours.
+        /// </summary>
+        internal double StaticTop => Location.Y - RelativeOffsetY;
+
         /// <summary>Gets the left of the client rectangle (Where content starts rendering).</summary>
         public double ClientLeft => Location.X + ActualBorderLeftWidth + ActualPaddingLeft;
 

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -3023,7 +3023,8 @@ namespace PeachPDF.Html.Core.Dom
         }
 
         /// <summary>
-        /// Resolves this box's own inline size, then has the frame above it assign its position.
+        /// Has the frame above this box decide where it goes, resolves this box's own inline size against
+        /// the page that offset lands on, and then has the frame commit the offset.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -3033,6 +3034,19 @@ namespace PeachPDF.Html.Core.Dom
         /// it and whatever this frame placed before it — which only the frame above knows, because the
         /// answer is margin collapsing against a previous sibling, the fragmentainer that sibling ended in,
         /// and the run chained to it by break avoidance.
+        /// </para>
+        /// <para>
+        /// <b>The offset is decided first, because the size depends on it and not the other way round.</b>
+        /// <see href="https://www.w3.org/TR/css-page-3/#page-model">css-page-3 §5.1</see> makes each page's
+        /// own page area the containing block for the layout that occurs between page breaks, so a box's
+        /// measure comes from the page it <i>lands on</i>. Resolving the size first meant
+        /// <c>CssLayoutEngine.GetBoxWidth</c> had nothing to read but <see cref="CssBox.Location"/>, which at
+        /// that moment still held the position some earlier layout generation gave the box — page 0's
+        /// measure on the first one — and only <see cref="HtmlContainerInt.PerformLayout"/>'s reflow loop
+        /// could iterate that back to the truth. Nothing in this frame's block-flow arithmetic reads the
+        /// child's inline size, so the dependency only runs one way and the order can simply be the right
+        /// one. (The reflow loop stays: it also settles the width→height→page-assignment feedback of the
+        /// boxes <i>after</i> this one, and the constrained-block nesting of issues #199-#201.)
         /// </para>
         /// <para>
         /// The root has no frame above it, so it stands in for its own. Nothing is lost by that:
@@ -3048,10 +3062,61 @@ namespace PeachPDF.Html.Core.Dom
         /// </remarks>
         private async ValueTask PlaceBlockBox(RGraphics g)
         {
-            await ResolveOwnInlineSize(g);
+            var frame = ParentBox ?? this;
 
-            PlaceAsBlockChild();
+            // The frame declined to place this box here at all (§5.2 concluded the break falls before it),
+            // so there is no landing page to measure against and nothing to commit.
+            if (frame.ResolveBlockChildOffset(this) is not { } offset) return;
+
+            var measuredAt = offset.Top;
+
+            await ResolveOwnInlineSize(g, measuredAt);
+            frame.CommitBlockChildOffset(this, offset);
+
+            // Committing the offset can still move the box in the block axis: CssLayoutEngine.FloatBox
+            // displaces a float past the ones it intersects, and `clear` pushes it below them. A box carried
+            // into a band of a different measure that way has been measured for a page it is not on, so it
+            // is measured again where it landed and re-committed from the same resolved offset — the float
+            // scan restarts from the offset rather than from wherever the previous round left the box, so
+            // each round is a fresh attempt rather than a cumulative slide. Bounded rather than a plain
+            // `if`, and for the same reason StepPastSlotsOnTheWrongSide is: one round settles every case a
+            // single displacement can produce, and the small cap keeps two measures that displace the box
+            // into each other from spinning. Never entered by a document with one measure, which is every
+            // document without per-page left/right margins.
+            //
+            // Measured, and worth knowing before deleting it: it does fire (a `clear: both` block displaced
+            // past a float onto a narrower page enters it once, on every layout generation), but no fixture
+            // found makes it change the *final* geometry - a displacement big enough to change the measure
+            // has by definition crossed a page boundary, and in a fragmenting layout that is also a break
+            // decision, so the box is placed again at the resumed target and measured correctly there
+            // anyway. What it buys is that the first placement is self-consistent on its own terms rather
+            // than by way of a later mechanism: the descendants laid out inside this box immediately
+            // afterwards read its width, and a width belonging to a page the box is not on is the exact
+            // defect this whole reorder removes.
+            for (var guard = 0; guard < 4 && offset.PositionedInBlockFlow
+                                          && InlineSizeCameFromAnotherPagesMeasure(measuredAt); guard++)
+            {
+                measuredAt = StaticTop;
+
+                await ResolveOwnInlineSize(g, measuredAt);
+                frame.CommitBlockChildOffset(this, offset);
+            }
         }
+
+        /// <summary>
+        /// Whether this box's border-box top now sits on a page whose measure differs from the one at
+        /// <paramref name="measuredAt"/>, which its inline size was resolved against.
+        /// </summary>
+        /// <remarks>
+        /// Asked about the <i>measure</i> rather than about the slot index, and with
+        /// <see cref="HtmlContainerInt.MeasureIsSharedBetween"/>'s own tolerance: two pages that differ only
+        /// in where their content begins (mirrored inner/outer margins) wrap identically, so a box moving
+        /// between them has nothing to re-resolve.
+        /// </remarks>
+        private bool InlineSizeCameFromAnotherPagesMeasure(double measuredAt) =>
+            HtmlContainer is { UseVariablePageWidth: true } container
+            && Math.Abs(container.PageContentRightOf(StaticTop)
+                        - container.PageContentRightOf(measuredAt)) >= 0.01;
 
         /// <summary>
         /// Has the frame above this box assign its position.
@@ -3065,19 +3130,25 @@ namespace PeachPDF.Html.Core.Dom
 
         /// <summary>
         /// Resolves this box's own inline size — the half of placing a block-level box that is the box's
-        /// own to answer.
+        /// own to answer — against the page <paramref name="blockTop"/> falls on.
         /// </summary>
+        /// <param name="g">the device context</param>
+        /// <param name="blockTop">
+        /// the border-box top the frame above has decided this box will occupy. Passed rather than read off
+        /// <see cref="CssBox.Location"/>, which has not been written yet on the pass that places the box —
+        /// see <see cref="PlaceBlockBox"/> for why that read was the whole defect.
+        /// </param>
         /// <remarks>
         /// Written as an extent rather than a width: <see cref="CssBox.ActualRight"/>'s setter
         /// stores it as a size against the current <see cref="CssBox.Location"/>, so the frame
         /// above is free to move the box afterwards and take the size with it.
         /// </remarks>
-        private async ValueTask ResolveOwnInlineSize(RGraphics g)
+        private async ValueTask ResolveOwnInlineSize(RGraphics g, double blockTop)
         {
             // Because their width and height are set by CssTable, CssLayoutEngineFlex or CssLayoutEngineGrid
             if (Display != CssConstants.TableCell && Display != CssConstants.Table && Display != CssConstants.Flex && Display != CssConstants.InlineFlex && Display != CssConstants.Grid && Display != CssConstants.InlineGrid)
             {
-                var width = await CssLayoutEngine.GetBoxWidth(g, this);
+                var width = await CssLayoutEngine.GetBoxWidth(g, this, blockTop);
                 ActualRight = Location.X + width + ActualBoxSizeIncludedWidth;
             }
 
@@ -3228,6 +3299,50 @@ namespace PeachPDF.Html.Core.Dom
         /// lands on.
         /// </summary>
         /// <remarks>
+        /// The two halves together, for a caller that has nothing to do between them —
+        /// <see cref="PlaceAsBlockChild"/>'s own callers, which have already resolved their size. A box
+        /// whose size is still to be resolved goes through <see cref="PlaceBlockBox"/> instead, which is
+        /// exactly the caller that needs the offset before the size.
+        /// </remarks>
+        private void PlaceBlockChild(CssBox child)
+        {
+            if (ResolveBlockChildOffset(child) is { } offset)
+            {
+                CommitBlockChildOffset(child, offset);
+            }
+        }
+
+        /// <summary>
+        /// Where a frame has decided to put a block-level child, decided <i>before</i> that child's inline
+        /// size is resolved so the size can be resolved against the page the offset lands on.
+        /// </summary>
+        /// <param name="Left">
+        /// the containing block's content left edge. The child's own left margin is added to it at commit
+        /// rather than here, because <c>margin: auto</c> resolves against the very inline size this offset
+        /// is settled ahead of (CSS 2.1 §10.3.3).
+        /// </param>
+        /// <param name="Top">
+        /// the child's border-box top — the coordinate whose page decides the child's measure, per
+        /// <see href="https://www.w3.org/TR/css-page-3/#page-model">css-page-3 §5.1</see>.
+        /// </param>
+        /// <param name="PositionedInBlockFlow">
+        /// whether this frame's block-flow arithmetic produced <see cref="Top"/> at all. False for a table
+        /// cell (its engine positions it) and for an absolutely or fixed positioned box (positioned from
+        /// its containing block by <see cref="CommitBlockChildOffset"/>, and out of flow, so no page break
+        /// falls before it): for those, <see cref="Top"/> only reports where the box already sits.
+        /// </param>
+        private readonly record struct BlockChildOffset(double Left, double Top, bool PositionedInBlockFlow);
+
+        /// <summary>
+        /// Decides where <paramref name="child"/> goes in this frame, without writing it.
+        /// </summary>
+        /// <returns>
+        /// the offset to commit, or null when the child declines to be placed here at all: <c>§5.2</c>'s
+        /// margin truncation can conclude that the break falls <i>before</i> it, in which case this records
+        /// the request and returns without writing a position or a registration, and the child contributes
+        /// no fragment to the fragmentainer being filled.
+        /// </returns>
+        /// <remarks>
         /// <para>
         /// Everything here is resolved against boxes only this frame can see — the previous in-flow sibling
         /// this frame placed, the keep-with-next run chained to it, and the fragmentainer that run started
@@ -3235,18 +3350,12 @@ namespace PeachPDF.Html.Core.Dom
         /// to the child: a break point is between two children, so no child can answer it alone.
         /// </para>
         /// <para>
-        /// Synchronous, deliberately. Assigning an offset consults nothing that has to be fetched or
-        /// measured — the child's own size is already resolved by <see cref="ResolveOwnInlineSize"/> before
-        /// this runs — so a position is decided from what is already known.
-        /// </para>
-        /// <para>
-        /// The child may decline to be placed here at all: <c>§5.2</c>'s margin truncation can conclude that
-        /// the break falls <i>before</i> it, in which case this records the request and returns without
-        /// writing a position or a registration, and the child contributes no fragment to the fragmentainer
-        /// being filled.
+        /// Synchronous, deliberately. Deciding an offset consults nothing that has to be fetched or
+        /// measured — and, in particular, nothing about the child's own inline size, which is what lets the
+        /// size be resolved against the answer instead of the other way round.
         /// </para>
         /// </remarks>
-        private void PlaceBlockChild(CssBox child)
+        private BlockChildOffset? ResolveBlockChildOffset(CssBox child)
         {
             if (child.Display != CssConstants.TableCell)
             {
@@ -3364,7 +3473,7 @@ namespace PeachPDF.Html.Core.Dom
                             child._escapedForcedBreakPending = true;
                             child._escapedForcedBreakBlankSlot = reservedBlankSlot;
                             child.RequestBreakBefore(top, escapesNestedFragmentainer: true);
-                            return;
+                            return null;
                         }
 
                         // The pass has just stepped over one or more slots without ending, so the
@@ -3467,7 +3576,7 @@ namespace PeachPDF.Html.Core.Dom
                             if (child.HtmlContainer!.IsFragmenting)
                             {
                                 child.RequestBreakBefore(newTop);
-                                return;
+                                return null;
                             }
 
                             // Breaking is not live here (a measurement pass, or monolithic content), so
@@ -3482,7 +3591,36 @@ namespace PeachPDF.Html.Core.Dom
                         }
                     }
 
-                    child.Location = new RPoint(left + child.ActualMarginLeft, top);
+                    return new BlockChildOffset(left, top, PositionedInBlockFlow: true);
+                }
+            }
+
+            // Nothing in this frame's block flow to decide: a table cell is positioned by the table engine,
+            // and an out-of-flow box by its containing block at commit. Reporting where the box already
+            // sits keeps its measure resolved against the same coordinate it always was.
+            return new BlockChildOffset(0, child.Location.Y, PositionedInBlockFlow: false);
+        }
+
+        /// <summary>
+        /// Writes the offset <see cref="ResolveBlockChildOffset"/> decided on, positions
+        /// <paramref name="child"/> under whichever positioning scheme it uses, and registers the used page
+        /// name it lands on.
+        /// </summary>
+        /// <remarks>
+        /// Split from the decision so the child's inline size can be resolved in between: every line here
+        /// that reads a size — the left margin (which <c>margin: auto</c> centres against the used width),
+        /// a percentage relative offset, and <c>CssLayoutEngine.FloatBox</c>'s displacement scan — needs the
+        /// size the box actually has, and the decision above needs none of it.
+        /// </remarks>
+        private void CommitBlockChildOffset(CssBox child, BlockChildOffset offset)
+        {
+            if (child.Display != CssConstants.TableCell)
+            {
+                if (offset.PositionedInBlockFlow)
+                {
+                    var top = offset.Top;
+
+                    child.Location = new RPoint(offset.Left + child.ActualMarginLeft, top);
                     child.ActualBottom = top;
 
                     // The root places itself (PlaceAsBlockChild's (ParentBox ?? this) receiver), and §5.2's

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -696,7 +696,18 @@ namespace PeachPDF.Html.Core.Dom
             return inset;
         }
 
-        public static async ValueTask<double> GetBoxWidth(RGraphics g, CssBox box)
+        /// <summary>
+        /// The used inline size of <paramref name="box"/>.
+        /// </summary>
+        /// <param name="g">the device context</param>
+        /// <param name="box">the box to measure</param>
+        /// <param name="blockTop">
+        /// the border-box top to resolve the per-page measure against — the position the box is <i>about</i>
+        /// to be placed at, which only the frame placing it knows (<c>CssBox.PlaceBlockBox</c>). Omitted by
+        /// the engines, which call this for a container whose <see cref="CssBox.Location"/> the frame above
+        /// has already written, so the box's own coordinate is the truthful answer there.
+        /// </param>
+        public static async ValueTask<double> GetBoxWidth(RGraphics g, CssBox box, double? blockTop = null)
         {
             // Per-page horizontal reflow (issue #143). When a per-page @page rule overrides left/right
             // margins, content laid out on a page whose margins differ from the base uses THAT page's own
@@ -709,14 +720,17 @@ namespace PeachPDF.Html.Core.Dom
             // column (containing block chain is auto-width root/html/body): a box nested inside some other
             // (or constrained) block resolves against that block instead - deferred as an accepted gap
             // (#199-#201), since only the auto-width main column is guaranteed to span the page area.
-            // Keyed off the box's own Location.Y (the previous layout pass's final position - see
-            // HtmlContainerInt.PerformLayout's reflow loop), since a box's width is resolved before its
-            // Location is assigned in this pass.
+            // Keyed off `blockTop` - the border-box top the frame placing this box has just decided on, not
+            // the box's own Location.Y, which on the pass that places it still holds whatever position an
+            // earlier layout generation left there (page 0's measure, on the first). The frame's offset is
+            // settled before this runs precisely so the measure can come from the page the box lands on;
+            // where no frame is placing the box (an engine measuring its own container), the box's
+            // Location.Y has already been written and is the same answer.
             var availableRight = box.ContainingBlock.ClientRight;
             if (box.HtmlContainer is { } htmlContainer && htmlContainer.UseVariablePageWidth
                 && IsUnconstrainedMainColumn(box.ContainingBlock))
             {
-                availableRight = htmlContainer.PageContentRightOf(box.Location.Y)
+                availableRight = htmlContainer.PageContentRightOf(blockTop ?? box.Location.Y)
                                  - MainColumnRightInset(box.ContainingBlock);
             }
 


### PR DESCRIPTION
## Summary

`#515.3` (`#515`'s / `#390`'s stage 2, following `#515.2`/forced-break-target in `#548`). **The one sub-stage in this 6-PR sequence that changes rendered output by design.**

[css-page-3 §5.1](https://www.w3.org/TR/css-page-3/#page-model) makes each page's own page area the containing block for the layout that occurs between page breaks, so a box's inline size should come from the page it *lands on*. `CssBox.PlaceBlockBox` resolved the size *first* and asked the frame above for the position second, leaving `CssLayoutEngine.GetBoxWidth` nothing to read but `box.Location.Y` — a coordinate an earlier layout generation wrote (page 0's measure, on the first pass). Only `HtmlContainerInt.PerformLayout`'s 3-iteration reflow loop could iterate that back toward the truth, and a document needing more than 3 iterations converged on the wrong answer.

The order is simply reversed, because the dependency only ever ran one way — checked line by line before touching anything: nothing in the frame's block-flow arithmetic (`CollapsedMarginBefore`, `ForcedBreakTopFor`, §5.2's crossing test, the keep-with-next pull, `StepPastSlotsOnTheWrongSide`) reads the child's inline size. The three lines that *do* read a size (`margin: auto`'s centering, a percentage relative offset, `CssLayoutEngine.FloatBox`'s displacement scan) all live past where the position is written, which is where the split falls: `PlaceBlockChild` becomes `ResolveBlockChildOffset` (decide) + `CommitBlockChildOffset` (write), with a `BlockChildOffset` record carrying `Left`/`Top`/`PositionedInBlockFlow` between them. `PlaceBlockBox` now runs resolve → size → commit, plus a small bounded (≤4) re-resolution round for the rare case where committing (a float's displacement scan, `clear`) moves the box onto a band with a different measure.

**`BlockConstraint` was deliberately not the vehicle**, despite the issue's own wording — a constraint names a *fragmentainer* (a column inside multicol), while the per-page measure is a page-grid question. Passing the raw document-space coordinate also keeps the read bit-identical to the one it replaces, so no boundary convention silently changes hands (the exact trap #539/PR4 documented at length).

## What running this found

- **The existing suite passes unchanged (7115 → 7119, 4 new)** — every existing per-page fixture asserts *converged* geometry, which the reflow loop already reached; what changes is how many generations that takes, and what happens when a document needs more than the 3-iteration cap. Measured directly (`HtmlContainerInt.LayoutGeneration`, 3 is the floor): a 120-block fixture over alternating `:left`/`:right` margins went from 5 generations (23/120 blocks wrapped for the wrong page) to 3 (0 wrong); another went from 5 generations, 39/120 wrong, and **9 pages instead of 6**, to 3 generations and 6 pages. Both new fixtures fail on `origin/main` with exactly that message.
- **The corpus diff is exactly one showcase**: `print_catalog` (the only one using `@page :first { margin: 0 }` over enough content that the reflow loop hadn't already converged). Traced in the box tree, not guessed: `.item-body` (a flex container) had `ActualBottom = 1174.94` while its own descendant `ul.features` ended at `1186.94` — the container was 12pt *shorter than its own content*, so `.price-row`'s `margin-top: 9mm` was measured from a bottom edge 12pt too high, sitting the row 12pt into the overflow. After the fix `.item-body` ends exactly where its content does, and the 9mm gap is a real 9mm. Confirmed visually at 150dpi with both PDFium and MuPDF, which agree.
- **The bounded re-resolution round fires but nothing currently observable depends on it** — recorded at the loop itself: a displacement large enough to change the page measure has by definition crossed a page boundary, which in a fragmenting layout is also a break decision, so the box gets re-placed (and re-measured correctly) at the resumed target regardless. Kept anyway, since it makes the *first* placement self-consistent for descendants that immediately read the box's width.

## What was deliberately not done

- The reflow loop stays — it also settles feedback for boxes *after* this one and `#199`-`#201`'s constrained-block nesting.
- The flex/grid/multicol engines' own `GetBoxWidth` calls (measuring their own already-positioned container) were left alone — the new parameter is optional precisely so they keep reading `Location.Y`, which is already truthful there.
- No `docs/**` change — nothing documented becomes false.
- `#545` (the escaping-directional-break blank-slot gap PR4 found) was **not** touched, as scoped — unrelated mechanism.

## ⚠️ Windows CI required before merge

Per `.claude/invariants/testing-the-reflow-fixtures-are-platform-sensitive-by-design.md`, this exact fixture class has caught regressions **twice, `windows-latest`-only**, because font metrics land content at different page boundaries on that platform. The new tests assert an invariant ("every block carries the measure of the page it is on") rather than a coordinate, specifically to survive that — except one assertion (`Assert.Equal(3, container.LayoutGeneration)`), which is the most plausible thing to move on different font metrics. If `windows-latest` CI fails specifically on that line, it can be relaxed without weakening the actual fix.

## Test plan

- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 7119 passing (7115 baseline + 4 new), 0 failed
- [x] `dotnet test PeachPDF.Cli.Tests/PeachPDF.Cli.Tests.csproj` — 96 passing
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] 100% diff coverage against `origin/main` (38/38 lines)
- [x] Full 77-showcase corpus regression — 1 of 77 differs (`print_catalog`), visually confirmed more correct with both PDFium and MuPDF
- [ ] `windows-latest` CI — **required before merge**, not yet confirmed

Fixes #540
