### PR TITLE
Add CSS position/inset/z-index parsing coverage adapted from WPT

### DIFF
--- a/src/PeachPDF.Tests/CSS/PropertyTests/WptCssPositionParsingTests.cs
+++ b/src/PeachPDF.Tests/CSS/PropertyTests/WptCssPositionParsingTests.cs
@@ -1,0 +1,125 @@
+namespace PeachPDF.Tests.CSS.PropertyTests
+{
+    using PeachPDF.CSS;
+    using System.Linq;
+    using Xunit;
+
+    /// <summary>
+    /// Grammar coverage for <c>position</c>, the four physical inset longhands (<c>top</c>/<c>right</c>/
+    /// <c>bottom</c>/<c>left</c>), and <c>z-index</c>, adapted from the web-platform-tests
+    /// css/css-position/parsing/ fixtures (position-valid.html, position-invalid.html, top/right/bottom/
+    /// left-valid.html, top/right/bottom/left-invalid.html, z-index-valid.html, z-index-invalid.html).
+    /// WPT's test_valid_value/test_invalid_value assert against a live getComputedStyle(); this engine has
+    /// no CSSOM computed-style API to match that against, so the equivalent here is whether the declaration
+    /// round-trips through <see cref="StyleDeclaration.GetPropertyValue"/> (accepted) or is dropped
+    /// entirely, leaving an empty string (rejected) - see CssConstructionFunctions.ParseStyleSheet.
+    /// </summary>
+    public class WptCssPositionParsingTests : CssConstructionFunctions
+    {
+        private static string DeclaredValue(string property, string value)
+        {
+            var sheet = ParseStyleSheet($".x {{ {property}: {value}; }}");
+            var rule = sheet.Rules.OfType<StyleRule>().Single();
+            return rule.Style.GetPropertyValue(property);
+        }
+
+        // ─── position: 'static | relative | absolute | sticky | fixed' ───────────
+
+        [Theory]
+        [InlineData("static")]
+        [InlineData("relative")]
+        [InlineData("absolute")]
+        [InlineData("sticky")]
+        [InlineData("fixed")]
+        public void Position_AcceptsValidKeyword(string value)
+        {
+            Assert.Equal(value, DeclaredValue("position", value));
+        }
+
+        [Theory]
+        [InlineData("auto")]
+        [InlineData("static relative")]
+        public void Position_RejectsInvalidValue(string value)
+        {
+            Assert.Equal(string.Empty, DeclaredValue("position", value));
+        }
+
+        // ─── top/right/bottom/left: 'auto | <length-percentage>' ─────────────────
+
+        public static readonly TheoryData<string> CoordinateProperties = new()
+        {
+            "top", "right", "bottom", "left",
+        };
+
+        [Theory]
+        [MemberData(nameof(CoordinateProperties))]
+        public void Coordinate_AcceptsAuto(string property)
+        {
+            Assert.Equal("auto", DeclaredValue(property, "auto"));
+        }
+
+        [Theory]
+        [MemberData(nameof(CoordinateProperties))]
+        public void Coordinate_AcceptsNegativeLength(string property)
+        {
+            Assert.Equal("-10px", DeclaredValue(property, "-10px"));
+        }
+
+        [Theory]
+        [MemberData(nameof(CoordinateProperties))]
+        public void Coordinate_AcceptsNegativePercentage(string property)
+        {
+            Assert.Equal("-20%", DeclaredValue(property, "-20%"));
+        }
+
+        [Theory]
+        [MemberData(nameof(CoordinateProperties))]
+        public void Coordinate_AcceptsCalcExpression(string property)
+        {
+            Assert.False(string.IsNullOrEmpty(DeclaredValue(property, "calc(2em + 3ex)")));
+        }
+
+        [Theory]
+        [MemberData(nameof(CoordinateProperties))]
+        public void Coordinate_RejectsNonLengthKeyword(string property)
+        {
+            Assert.Equal(string.Empty, DeclaredValue(property, "min-content"));
+        }
+
+        [Theory]
+        [MemberData(nameof(CoordinateProperties))]
+        public void Coordinate_RejectsUnitlessNumber(string property)
+        {
+            Assert.Equal(string.Empty, DeclaredValue(property, "60"));
+        }
+
+        [Theory]
+        [MemberData(nameof(CoordinateProperties))]
+        public void Coordinate_RejectsMultipleValues(string property)
+        {
+            Assert.Equal(string.Empty, DeclaredValue(property, "10px 20%"));
+        }
+
+        // ─── z-index: 'auto | <integer>' ──────────────────────────────────────────
+
+        [Theory]
+        [InlineData("auto")]
+        [InlineData("-789")]
+        [InlineData("0")]
+        [InlineData("123")]
+        public void ZIndex_AcceptsValidValue(string value)
+        {
+            Assert.Equal(value, DeclaredValue("z-index", value));
+        }
+
+        [Theory]
+        [InlineData("none")]
+        [InlineData("10px")]
+        [InlineData("0.5")]
+        [InlineData("auto 123")]
+        public void ZIndex_RejectsInvalidValue(string value)
+        {
+            Assert.Equal(string.Empty, DeclaredValue("z-index", value));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds native xUnit coverage adapted from the web-platform-tests `css/css-position/parsing/` fixtures: `position`, `top`, `right`, `bottom`, `left`, and `z-index`.
- Each WPT `-valid.html`/`-invalid.html` pair becomes a `[Theory]` asserting the value round-trips through `StyleDeclaration.GetPropertyValue` (accepted) or is dropped entirely (rejected), following the existing `CssConstructionFunctions` convention used elsewhere in the CSS-OM test suite.
- This is the first of a planned series of batches mining `web-platform-tests/wpt`'s `css-position` directory as a source for PeachPDF-native tests (WPT's reftest/testharness.js format isn't directly executable against a non-browser, static-PDF renderer, but its fixtures and expected values are a good source to adapt from).

## Test plan

- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~WptCssPositionParsingTests"` — 43/43 passed
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` (full suite) — 7286 passed, 9 pre-existing skips, 0 failures
- [x] No production code changed, so the diff-coverage gate doesn't apply


---
_Generated by [Claude Code](https://claude.ai/code/session_01GC5Lqx6nyqWK3LvN9x3Adi)_