### PR TITLE
Support calc() for z-index/order/widows, add logical inset parsing coverage

### DIFF
--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -1311,7 +1311,7 @@ When a `var()` reference can't be resolved and no fallback is given, the contain
 
 ## CSS Math Functions
 
-PeachPDF supports [`calc()`](https://developer.mozilla.org/en-US/docs/Web/CSS/calc), [`min()`](https://developer.mozilla.org/en-US/docs/Web/CSS/min), [`max()`](https://developer.mozilla.org/en-US/docs/Web/CSS/max), and [`clamp()`](https://developer.mozilla.org/en-US/docs/Web/CSS/clamp) anywhere a `<length>`, `<percentage>`, `<angle>`, or plain `<number>` is accepted — width, height, margin, padding, inset (`top`/`left`/`right`/`bottom`), border-width, border-spacing, border-radius, gap, flex-basis, font-size, line-height, text-indent, the length/number arguments of `transform` functions like `translateX()`/`scale()`, the angle argument of `rotate()`/`skewX()`/`skewY()` and gradient direction angles, and the hue component of `hsl()`/`hsla()`.
+PeachPDF supports [`calc()`](https://developer.mozilla.org/en-US/docs/Web/CSS/calc), [`min()`](https://developer.mozilla.org/en-US/docs/Web/CSS/min), [`max()`](https://developer.mozilla.org/en-US/docs/Web/CSS/max), and [`clamp()`](https://developer.mozilla.org/en-US/docs/Web/CSS/clamp) anywhere a `<length>`, `<percentage>`, `<angle>`, `<integer>`, or plain `<number>` is accepted — width, height, margin, padding, inset (`top`/`left`/`right`/`bottom`), border-width, border-spacing, border-radius, gap, flex-basis, font-size, line-height, text-indent, the length/number arguments of `transform` functions like `translateX()`/`scale()`, the angle argument of `rotate()`/`skewX()`/`skewY()` and gradient direction angles, the hue component of `hsl()`/`hsla()`, and the `<integer>`-typed properties `z-index`, `order`, and `widows` (e.g. `z-index: calc(3 - 2)`).
 
 ```css
 .card {
@@ -1335,6 +1335,7 @@ PeachPDF supports [`calc()`](https://developer.mozilla.org/en-US/docs/Web/CSS/ca
 | Time and resolution units (`s`, `dpi`) inside a math function | Not supported | PeachPDF doesn't support these unit categories at all, with or without a math function |
 | Viewport units (`vw`/`vh`/`vmin`/`vmax`) inside a math function | Not supported | PeachPDF has no viewport-unit support anywhere |
 | A math function inside CSS Grid track sizing | Full | A `calc()`/`min()`/`max()`/`clamp()` length resolves as a grid track size — bare, and inside `minmax()`/`fit-content()`/`repeat()` arguments (a wrong-category math function, e.g. an angle, drops the whole track list at parse time) |
+| A math function for an `<integer>`-typed property (`z-index`, `order`, `widows`) | Full | Must type-check as a plain `<number>` (a length/percentage/angle-category expression is rejected); the result is rounded to the nearest integer, ties away from zero, and folded to a literal at parse time — the same as a `<number>`-typed property, calc() is resolved eagerly rather than kept symbolic, since an integer-category expression has no relative unit to defer to layout |
 
 Note: `background-position` and `background-size` are not listed in the table above because they're not part of the math-function-specific test matrix — both fully support `calc()` in their length/percentage values (e.g. `background-position: calc(50% - 10px) center`), resolved via the same length parser used everywhere else in this table.
 

--- a/src/PeachPDF.Tests/CSS/PropertyTests/WptCssPositionInsetLogicalParsingTests.cs
+++ b/src/PeachPDF.Tests/CSS/PropertyTests/WptCssPositionInsetLogicalParsingTests.cs
@@ -1,0 +1,187 @@
+namespace PeachPDF.Tests.CSS.PropertyTests
+{
+    using PeachPDF.CSS;
+    using System.Linq;
+    using Xunit;
+
+    /// <summary>
+    /// Grammar coverage for the logical inset longhands (<c>inset-block-start</c>/<c>inset-block-end</c>/
+    /// <c>inset-inline-start</c>/<c>inset-inline-end</c>) and their two shorthands (<c>inset-block</c>/
+    /// <c>inset-inline</c>), adapted from the web-platform-tests css/css-position/parsing/inset-valid.html
+    /// and inset-invalid.html fixtures.
+    ///
+    /// One WPT expectation deliberately isn't ported: WPT expects the unitless zero length "0" to compute
+    /// to "0px" (a live getComputedStyle() convention). PeachPDF's declaration parser stores a length as
+    /// declared rather than serializing a canonical computed-style string - see
+    /// MarginProperty.cs's MarginZeroLegal-style tests, which already assert "0" round-trips as "0", not
+    /// "0px" - so the equivalent assertion here is against "0", matching this engine's own convention
+    /// rather than a browser CSSOM behavior it doesn't implement.
+    /// </summary>
+    public class WptCssPositionInsetLogicalParsingTests : CssConstructionFunctions
+    {
+        private static string DeclaredValue(string property, string value)
+        {
+            var sheet = ParseStyleSheet($".x {{ {property}: {value}; }}");
+            var rule = sheet.Rules.OfType<StyleRule>().Single();
+            return rule.Style.GetPropertyValue(property);
+        }
+
+        public static readonly TheoryData<string> InsetLonghands = new()
+        {
+            "inset-block-start", "inset-block-end", "inset-inline-start", "inset-inline-end",
+        };
+
+        public static readonly TheoryData<string> InsetShorthands = new()
+        {
+            "inset-block", "inset-inline",
+        };
+
+        // ─── Longhands: 'auto | <length-percentage>' ──────────────────────────────
+
+        [Theory]
+        [MemberData(nameof(InsetLonghands))]
+        public void Longhand_AcceptsZero(string property)
+        {
+            Assert.Equal("0", DeclaredValue(property, "0"));
+        }
+
+        [Theory]
+        [MemberData(nameof(InsetLonghands))]
+        public void Longhand_AcceptsAuto(string property)
+        {
+            Assert.Equal("auto", DeclaredValue(property, "auto"));
+        }
+
+        [Theory]
+        [MemberData(nameof(InsetLonghands))]
+        public void Longhand_AcceptsPercentage(string property)
+        {
+            Assert.Equal("10%", DeclaredValue(property, "10%"));
+        }
+
+        [Theory]
+        [MemberData(nameof(InsetLonghands))]
+        public void Longhand_AcceptsRemLength(string property)
+        {
+            Assert.Equal("1rem", DeclaredValue(property, "1rem"));
+        }
+
+        [Theory]
+        [MemberData(nameof(InsetLonghands))]
+        public void Longhand_AcceptsNegativeLength(string property)
+        {
+            Assert.Equal("-10px", DeclaredValue(property, "-10px"));
+        }
+
+        [Theory]
+        [MemberData(nameof(InsetLonghands))]
+        public void Longhand_AcceptsNegativePercentage(string property)
+        {
+            Assert.Equal("-20%", DeclaredValue(property, "-20%"));
+        }
+
+        [Theory]
+        [MemberData(nameof(InsetLonghands))]
+        public void Longhand_AcceptsCalcExpression(string property)
+        {
+            Assert.False(string.IsNullOrEmpty(DeclaredValue(property, "calc(2em + 3ex)")));
+        }
+
+        [Theory]
+        [MemberData(nameof(InsetLonghands))]
+        public void Longhand_RejectsAngle(string property)
+        {
+            Assert.Equal(string.Empty, DeclaredValue(property, "0deg"));
+        }
+
+        [Theory]
+        [MemberData(nameof(InsetLonghands))]
+        public void Longhand_RejectsCalcAngle(string property)
+        {
+            Assert.Equal(string.Empty, DeclaredValue(property, "calc(20deg)"));
+        }
+
+        [Theory]
+        [MemberData(nameof(InsetLonghands))]
+        public void Longhand_RejectsUnitlessNumber(string property)
+        {
+            Assert.Equal(string.Empty, DeclaredValue(property, "10"));
+        }
+
+        // ─── Shorthands: same single-value grammar, plus a 1-or-2-value periodic form ──
+
+        [Theory]
+        [MemberData(nameof(InsetShorthands))]
+        public void Shorthand_SingleValue_AcceptsAuto(string property)
+        {
+            Assert.Equal("auto", DeclaredValue(property, "auto"));
+        }
+
+        [Theory]
+        [MemberData(nameof(InsetShorthands))]
+        public void Shorthand_SingleValue_AcceptsCalcExpression(string property)
+        {
+            Assert.False(string.IsNullOrEmpty(DeclaredValue(property, "calc(2em + 3ex)")));
+        }
+
+        [Theory]
+        [MemberData(nameof(InsetShorthands))]
+        public void Shorthand_TwoEqualValues_CollapseToOne(string property)
+        {
+            Assert.Equal("auto", DeclaredValue(property, "auto auto"));
+            Assert.Equal("100px", DeclaredValue(property, "100px 100px"));
+        }
+
+        [Theory]
+        [MemberData(nameof(InsetShorthands))]
+        public void Shorthand_TwoUnequalValues_StayTwoValues(string property)
+        {
+            Assert.Equal("10% -5px", DeclaredValue(property, "10% -5px"));
+        }
+
+        [Theory]
+        [MemberData(nameof(InsetShorthands))]
+        public void Shorthand_RejectsAngle(string property)
+        {
+            Assert.Equal(string.Empty, DeclaredValue(property, "0deg"));
+        }
+
+        [Theory]
+        [MemberData(nameof(InsetShorthands))]
+        public void Shorthand_RejectsUnitlessNumber(string property)
+        {
+            Assert.Equal(string.Empty, DeclaredValue(property, "10"));
+        }
+
+        [Theory]
+        [MemberData(nameof(InsetShorthands))]
+        public void Shorthand_RejectsMixedGlobalAndOrdinaryValue(string property)
+        {
+            // A global keyword (inherit/initial/unset/revert) can only appear alone - CSS Cascade 4 §3.1 -
+            // never combined with an ordinary value in the same multi-value shorthand.
+            Assert.Equal(string.Empty, DeclaredValue(property, "inherit auto"));
+            Assert.Equal(string.Empty, DeclaredValue(property, "inherit inherit"));
+        }
+
+        // ─── z-index: calc() folds to a plain rounded integer (css-position/parsing/z-index-positioned-computed.html) ──
+
+        [Theory]
+        [InlineData("calc(3 - 2)", "1")]
+        [InlineData("calc(1.5 + 1.5)", "3")]
+        [InlineData("calc(2 * -3)", "-6")]
+        [InlineData("calc(0.5)", "1")]
+        [InlineData("calc(0.4)", "0")]
+        public void ZIndex_CalcExpression_FoldsToNearestInteger(string value, string expected)
+        {
+            Assert.Equal(expected, DeclaredValue("z-index", value));
+        }
+
+        [Fact]
+        public void ZIndex_RejectsLengthCalcExpression()
+        {
+            // z-index's grammar is 'auto | <integer>' - a calc() is only valid when it type-checks as a
+            // plain <number> (CSS Values 4 §10.9); a length-category calc() must still be rejected.
+            Assert.Equal(string.Empty, DeclaredValue("z-index", "calc(1px + 1px)"));
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/ZIndexCalcIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/ZIndexCalcIntegrationTests.cs
@@ -1,0 +1,42 @@
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Tests.TestSupport;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// End-to-end coverage for <c>z-index: calc(...)</c> folding to a plain integer (CSS Values and Units
+    /// Level 4 §10.9), through the full cascade pipeline - not just the CSS-OM parser level covered by
+    /// <c>WptCssPositionInsetLogicalParsingTests</c>. <c>CssUtils.cs</c>'s DOM-application step gates
+    /// z-index on <c>int.TryParse</c> before assigning <see cref="CssBox.ZIndex"/>, and
+    /// <c>StackingOrder</c> later does a bare <c>int.Parse(box.ZIndex)</c> - both would break if a
+    /// z-index calc() only got as far as parsing without also being folded to a literal integer string.
+    /// </summary>
+    public class ZIndexCalcIntegrationTests
+    {
+        [Fact]
+        public async Task PositionedBox_ZIndexCalcExpression_FoldsToLiteralIntegerOnTheBox()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='position:relative; z-index: calc(3 - 2);'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.Equal("1", box!.ZIndex);
+        }
+
+        [Fact]
+        public async Task PositionedBox_ZIndexNegativeCalcExpression_FoldsToLiteralIntegerOnTheBox()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='position:relative; z-index: calc(2 * -3);'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.Equal("-6", box!.ZIndex);
+        }
+    }
+}

--- a/src/PeachPDF/CSS/Extensions/ValueExtensions.cs
+++ b/src/PeachPDF/CSS/Extensions/ValueExtensions.cs
@@ -242,6 +242,22 @@ namespace PeachPDF.CSS
                 return ((NumberToken)element).IntegerValue;
             }
 
+            // CSS Values and Units Level 4 §10.9: a math function is accepted anywhere <integer> is
+            // expected, provided it type-checks as a plain <number> (no length/percentage/angle leaf -
+            // those categories are meaningless for e.g. z-index/order), and its result is rounded to the
+            // nearest integer (ties away from zero) rather than kept symbolic. Unlike a length calc(),
+            // a Number-category calc() has no em/rem/percent-relative leaf to defer to layout, so it can
+            // - and must, to satisfy every existing int.Parse(box.ZIndex)-style consumer - be folded to a
+            // concrete integer right here rather than carried as a CalcValue.
+            if (element is FunctionToken function && CalcParser.IsCalcFamily(function.Data))
+            {
+                var node = CalcParser.Parse(function);
+                if (node is null || CalcTypeChecker.Check(node) != CalcCategory.Number) return null;
+
+                var result = CalcEvaluator.Evaluate(node, new CalcContext(1, 0, 0));
+                return result.HasValue ? (int)Math.Round(result.Value, MidpointRounding.AwayFromZero) : null;
+            }
+
             return null;
         }
 


### PR DESCRIPTION
## Summary

- Second batch mining `web-platform-tests/wpt`'s `css/css-position/parsing/` fixtures (see #559 for the first batch): adds coverage for the logical inset longhands/shorthands (`inset-block-start`/`inset-block-end`/`inset-inline-start`/`inset-inline-end`, `inset-block`, `inset-inline`) adapted from `inset-valid.html`/`inset-invalid.html`.
- While porting `z-index-positioned-computed.html` (which expects `z-index: calc(3 - 2)` to compute to `1`), found that `ValueExtensions.ToInteger` — the shared converter backing every `<integer>`-typed property (`z-index`, `order`, `widows`) — only accepted a literal number token, rejecting any `calc()`/`min()`/`max()`/`clamp()` expression outright. Per [CSS Values and Units Level 4 §10.9](https://drafts.csswg.org/css-values-4/#calc-type-checking), a math function is valid anywhere `<integer>` is expected provided it type-checks as a plain `<number>`, with the result rounded to the nearest integer (ties away from zero). Fixed at the shared `ToInteger` extension so it cascades to all three properties, folding the expression to a literal integer at parse time (matching how every existing consumer — `CssUtils`'s `int.TryParse` cascade gate, `StackingOrder`'s `int.Parse` — expects `z-index` to already be a literal string).
- Updates the `docs/html-css-support.md` "CSS Math Functions" section to document the new `<integer>` support.

## Test plan

- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~WptCssPositionInsetLogicalParsingTests|FullyQualifiedName~ZIndexCalcIntegrationTests"` — all passed
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` (full suite) — 7348 passed, 9 pre-existing skips, 0 failures
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings
- [x] `diff-cover` against `main` — `ValueExtensions.cs` at 100% diff coverage


---
_Generated by [Claude Code](https://claude.ai/code/session_01GC5Lqx6nyqWK3LvN9x3Adi)_