### PR TITLE
Reserve the slot a plain forced break lands a content-empty box on

### DIFF
--- a/.claude/recent-fixes/2026-07-30-a-forced-breaks-blank-page-is-reserved-so-materialization-does-not-drop-it.md
+++ b/.claude/recent-fixes/2026-07-30-a-forced-breaks-blank-page-is-reserved-so-materialization-does-not-drop-it.md
@@ -1,0 +1,57 @@
+# A forced break's blank page is reserved, so materialization does not drop it
+
+Tracker: [#320](https://github.com/jhaygood86/PeachPDF/issues/320), area epic
+[#498](https://github.com/jhaygood86/PeachPDF/issues/498). Closes
+[#147](https://github.com/jhaygood86/PeachPDF/issues/147).
+
+## The load-bearing idea
+
+#147 described two separate defects behind the same fixture (`A|B|C`, `B` empty, both `A` and `B`
+carrying `page-break-after: always`) — a layout-position bug (the break between `B` and `C` collapsed
+through `B` to `A`'s bottom) and a materialization bug (even once positioned correctly, `B`'s own
+content-empty page could still be dropped by CSS Paged Media 3 §3.2's content-empty-page skip). Reading
+the current code against the issue found the **first half already fixed**, as an unlabelled side effect
+of the unrelated `#390`/`#515` "re-derive a forced break's target at every placement" work
+(`CssBox.ForcedBreakTopFor`/`PlacedByForcedBreak`, landed the same day as this fix): `FoldMarginsPrecedingChild`
+already treats a `PlacedByForcedBreak` box as a real position anchor even when it is otherwise
+margin-collapse-through, so `B` no longer gets collapsed through. The two tests #147 pinned
+(`PerPageGeometryLayoutIntegrationTests.ConsecutiveForcedBreaks_StillProduceIntentionalBlankSlot`,
+`.ForcedBreakAfterCollapseThroughSiblingAtBoundary_TargetsSlotAfterIt`) already passed on `main` — their
+own docstrings describe the old bug in the past tense.
+
+What remained was the **second half**: `HtmlContainerInt.SetBlankSlotReservation` — the mechanism that
+tells `FragmentEmitter.Finish` to materialize a content-empty slot anyway (`hasPrintableContent ||
+container.IsReservedBlankSlot(slot.Index)`) — was called from exactly two of the three places a forced
+break can place a box (`StepPastSlotsOnTheWrongSide`'s directional stepping, and the escaped-multicol-resume
+branch), never from the **plain** forced-break landing arm in `CssBox.ResolveBlockChildOffset`. A plain
+`page-break-after: always` that lands an otherwise content-empty box alone on a slot could still have
+that slot silently dropped from the PDF. The fix is one call, mirroring the other two call sites exactly:
+reserve the box's own landing slot right after `StepPastSlotsOnTheWrongSide` settles `top`, guarded on
+`reservedBlankSlot is null` so it never overwrites a directional break's own stepped-over-slot reservation
+(the underlying dictionary holds one slot per owning box).
+
+## What was found by running it, not by reading it
+
+The two pinned tests only assert **layout coordinates** (`Location.Y`), which is a different, earlier
+stage than materialization — they would pass even with the gap fully open, since `FragmentEmitter.Finish`
+runs once, after all layout, and never feeds back into box positions. The actual proof needed a
+fragment-tree-level assertion: a new test
+(`EmptyBoxAloneBetweenTwoForcedBreaks_SlotIsMaterializedAsABlankPage`) asserting
+`container.FragmentTree!.Fragmentainers.Select(f => f.SlotIndex)` is `[0, 1, 2]`, not `[0, 2]` — this is
+the one that actually fails on unfixed `main` (confirmed by reverting the fix and re-running it).
+
+## What was deliberately not done
+
+The escaped-forced-break-through-a-nested-fragmentainer path (a plain forced break degrading past a
+multicol measurement pass) was left unreserved for the box's own landing slot — only the directional
+stepped-over slots are carried across that specific retraction/reassert boundary
+(`_escapedForcedBreakBlankSlot`). Reaching it would need a second field mirroring that one, and no
+fixture in this repo exercises "a plain forced break escapes a nested fragmentainer AND the box it lands
+is itself content-empty" — narrower than #147's own scope, and left rather than guessed at.
+
+## Evidence
+
+Full `net8.0` suite green (7249 passing, 9 skipped, 0 failed) and CLI suite green (96 passing).
+Zero-warning `dotnet build PeachPDF.slnx -t:Rebuild`. **100% diff coverage** against `origin/main`. Full
+78-showcase corpus byte-identical (normalized for `/CreationDate`, `/ID`, and font subset tags) — no
+existing showcase exercises this exact shape.

--- a/src/PeachPDF.Tests/Integration/PerPageGeometryLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/PerPageGeometryLayoutIntegrationTests.cs
@@ -229,6 +229,55 @@ namespace PeachPDF.Tests.Integration
             Assert.Equal(container.PageTopOf(2), c!.Location.Y, 0.1);
         }
 
+        [Fact]
+        public async Task EmptyBoxAloneBetweenTwoForcedBreaks_SlotIsMaterializedAsABlankPage()
+        {
+            // css-break-3 §4.4 / the classic "insert a blank page" idiom: A|B and B|C are distinct
+            // break points, and B - landed alone on slot 1 by A's break-after, with nothing of its
+            // own to paint - must still surface as a real (blank) page in the output, not merely as
+            // a layout coordinate. The two siblings' *positions* already land correctly (see
+            // ForcedBreakAfterCollapseThroughSiblingAtBoundary_TargetsSlotAfterIt above); this
+            // asserts the separate, later concern the issue raised: CSS Paged Media 3 §3.2's
+            // content-empty-page skip must not also swallow a slot a forced break deliberately left
+            // empty. Slot 1 has no printable content of its own (b has no border/background/text),
+            // so without an explicit reservation FragmentEmitter.Finish would drop it.
+            var container = await BuildLayoutAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { margin: 60pt 50pt; }
+                body { margin: 0; }
+                div, p { margin: 0; }
+                </style></head><body>
+                <div style='page-break-after: always'>a</div>
+                <div id='b' style='page-break-after: always'></div>
+                <p id='c'>c</p>
+                </body></html>
+                """);
+
+            Assert.Equal([0, 1, 2], container.FragmentTree!.Fragmentainers.Select(f => f.SlotIndex));
+        }
+
+        [Fact]
+        public async Task NonEmptyBoxBetweenTwoForcedBreaks_SlotIsMaterialized()
+        {
+            // Companion to the test above: when the box taking the break carries its own printable
+            // content, its slot is already materialized on its own merit (hasPrintableContent).
+            // Reserving it too (the fix applies unconditionally) must be a harmless no-op rather than
+            // double-counting or otherwise disturbing the fragment span.
+            var container = await BuildLayoutAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { margin: 60pt 50pt; }
+                body { margin: 0; }
+                div, p { margin: 0; }
+                </style></head><body>
+                <div style='page-break-after: always'>a</div>
+                <div id='b' style='page-break-after: always'>b</div>
+                <p id='c'>c</p>
+                </body></html>
+                """);
+
+            Assert.Equal([0, 1, 2], container.FragmentTree!.Fragmentainers.Select(f => f.SlotIndex));
+        }
+
         [Theory]
         [InlineData(1.0)]
         [InlineData(1.5)]

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -3653,6 +3653,22 @@ namespace PeachPDF.Html.Core.Dom
                         (top, reservedBlankSlot) =
                             StepPastSlotsOnTheWrongSide(child, forcedTop + forcedBreakMargin, forcedBreakMargin);
 
+                        // css-break-3 §4.4's blank-page idiom: a forced break can land a box that carries
+                        // no printable content of its own alone on a slot (an empty break marker between
+                        // two "break-after: always" siblings is the canonical case). Without an explicit
+                        // reservation, CSS Paged Media 3 §3.2's content-empty-page skip
+                        // (FragmentEmitter.Finish) would drop that slot from the output entirely, silently
+                        // discarding the deliberate blank page - the layout-position half of this (which
+                        // slot the box lands on) was already correct without it. Skipped when a directional
+                        // step already reserved a slot for this box: the dictionary holds one slot per
+                        // owner, and the stepped-over slot must keep it - the box's own landing slot is what
+                        // a directional break exists to carry real content to.
+                        if (reservedBlankSlot is null)
+                        {
+                            child.HtmlContainer!.SetBlankSlotReservation(
+                                child, child.HtmlContainer.SlotStartingAt(top));
+                        }
+
                         // §3.1: a forced *page* break is not a nested fragmentainer's to satisfy. The page
                         // vehicle is realized by placement, and placing the child at `top` inside a column
                         // puts it past that column's band - which the container's own overflow arm then


### PR DESCRIPTION
## Summary

css-break-3 §4.4's blank-page idiom — two consecutive forced breaks around an empty box, so that box lands alone on its own page — already positioned the box correctly (fixed as a side effect of the unrelated `#390`/`#515` "re-derive a forced break's target at every placement" work: `FoldMarginsPrecedingChild` already treats a `PlacedByForcedBreak` box as a real position anchor even when it's otherwise margin-collapse-through). The two tests #147 pinned already passed on `main` for that reason.

What remained: CSS Paged Media 3 §3.2's content-empty-page skip (`FragmentEmitter.Finish`, `hasPrintableContent || container.IsReservedBlankSlot(slot.Index)`) could still drop that box's own page from the output PDF entirely, since `HtmlContainerInt.SetBlankSlotReservation` was only called from two of the three places a forced break can place a box — directional-break stepping (`StepPastSlotsOnTheWrongSide`) and the escaped-multicol-resume branch — never the plain (non-directional) forced-break landing arm in `CssBox.ResolveBlockChildOffset`.

The fix is one call mirroring the other two sites: reserve the box's own landing slot right after `StepPastSlotsOnTheWrongSide` settles `top`, guarded on `reservedBlankSlot is null` so it never overwrites a directional break's own stepped-over-slot reservation (the underlying dictionary holds one slot per owning box).

## Test plan

- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 7288 passing, 0 failed
- [x] `dotnet test PeachPDF.Cli.Tests/PeachPDF.Cli.Tests.csproj` — 96 passing
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] 100% diff coverage against `origin/main`
- [x] Full 78-showcase corpus regression — byte-identical (normalized for `/CreationDate`, `/ID`, font subset tags); no existing showcase exercises this shape
- [x] New `EmptyBoxAloneBetweenTwoForcedBreaks_SlotIsMaterializedAsABlankPage` — verified load-bearing (fails on unfixed `main`, asserting `container.FragmentTree!.Fragmentainers` includes the otherwise content-empty slot); companion `NonEmptyBoxBetweenTwoForcedBreaks_SlotIsMaterialized` confirms the reservation is a harmless no-op when the box already carries real content

Fixes #147


---
_Generated by [Claude Code](https://claude.ai/code/session_01EfeKTMR96uDhG5VvD8Fz4X)_