### PR TITLE
Fix flaky RelativeImage_ResolvedAgainstTheWorkingDirectory test

### DIFF
--- a/src/PeachPDF.Tests/Integration/FileUriLoaderIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FileUriLoaderIntegrationTests.cs
@@ -48,7 +48,7 @@ namespace PeachPDF.Tests.Integration
             }
             finally
             {
-                Directory.Delete(dir, recursive: true);
+                TempDirectory.DeleteWithRetry(dir);
             }
         }
 
@@ -85,7 +85,7 @@ namespace PeachPDF.Tests.Integration
             }
             finally
             {
-                Directory.Delete(dir, recursive: true);
+                TempDirectory.DeleteWithRetry(dir);
             }
         }
 
@@ -114,7 +114,7 @@ namespace PeachPDF.Tests.Integration
             }
             finally
             {
-                Directory.Delete(dir, recursive: true);
+                TempDirectory.DeleteWithRetry(dir);
             }
         }
 
@@ -144,7 +144,7 @@ namespace PeachPDF.Tests.Integration
             }
             finally
             {
-                Directory.Delete(absDir, recursive: true);
+                TempDirectory.DeleteWithRetry(absDir);
             }
         }
 

--- a/src/PeachPDF.Tests/Integration/LocalFileAccessTests.cs
+++ b/src/PeachPDF.Tests/Integration/LocalFileAccessTests.cs
@@ -82,7 +82,7 @@ namespace PeachPDF.Tests.Integration
             }
             finally
             {
-                Directory.Delete(dir, recursive: true);
+                TempDirectory.DeleteWithRetry(dir);
             }
         }
 
@@ -109,7 +109,7 @@ namespace PeachPDF.Tests.Integration
             }
             finally
             {
-                Directory.Delete(dir, recursive: true);
+                TempDirectory.DeleteWithRetry(dir);
             }
         }
 
@@ -151,7 +151,7 @@ namespace PeachPDF.Tests.Integration
             }
             finally
             {
-                Directory.Delete(dir, recursive: true);
+                TempDirectory.DeleteWithRetry(dir);
             }
         }
 
@@ -162,25 +162,29 @@ namespace PeachPDF.Tests.Integration
         {
             // With no loader configured a relative reference resolves against the process's working
             // directory - the implicit "load relative paths from disk" behaviour. Denying file access is
-            // what stops that, and it stops it at the base-URI stage rather than at the read.
-            var dir = CreateTempDir();
-            var originalWorkingDirectory = Directory.GetCurrentDirectory();
+            // what stops that, and it stops it at the base-URI stage rather than at the read. The asset
+            // lives in a subdirectory under the real working directory rather than via
+            // Directory.SetCurrentDirectory: that call is process-global, and mutating it here raced any
+            // other test reading the working directory while this one's await points had yielded the
+            // thread - see FileUriLoaderIntegrationTests.RelativeImage_WithNoLoader_LoadsFromCurrentWorkingDirectory,
+            // which established this pattern for the same reason.
+            var relDir = "peachpdf-localfile-" + Guid.NewGuid().ToString("N");
+            var absDir = Path.Combine(Directory.GetCurrentDirectory(), relDir);
+            Directory.CreateDirectory(absDir);
 
             try
             {
-                File.WriteAllBytes(Path.Combine(dir, "pic.png"), Convert.FromBase64String(PngBase64));
-                Directory.SetCurrentDirectory(dir);
+                File.WriteAllBytes(Path.Combine(absDir, "pic.png"), Convert.FromBase64String(PngBase64));
 
                 var doc = await new PdfGenerator().GeneratePdf(
-                    "<!DOCTYPE html><html><body><img src=\"pic.png\"></body></html>",
+                    $"<!DOCTYPE html><html><body><img src=\"{relDir}/pic.png\"></body></html>",
                     new PdfGenerateConfig { PageSize = PageSize.A4, AllowLocalFileAccess = allowLocalFileAccess });
 
                 Assert.Equal(allowLocalFileAccess, GetPdfText(doc).Contains("/Subtype /Image"));
             }
             finally
             {
-                Directory.SetCurrentDirectory(originalWorkingDirectory);
-                Directory.Delete(dir, recursive: true);
+                TempDirectory.DeleteWithRetry(absDir);
             }
         }
 
@@ -214,7 +218,7 @@ namespace PeachPDF.Tests.Integration
             }
             finally
             {
-                Directory.Delete(dir, recursive: true);
+                TempDirectory.DeleteWithRetry(dir);
             }
         }
 
@@ -256,7 +260,7 @@ namespace PeachPDF.Tests.Integration
             }
             finally
             {
-                Directory.Delete(dir, recursive: true);
+                TempDirectory.DeleteWithRetry(dir);
             }
         }
 
@@ -305,7 +309,7 @@ namespace PeachPDF.Tests.Integration
             }
             finally
             {
-                Directory.Delete(dir, recursive: true);
+                TempDirectory.DeleteWithRetry(dir);
             }
         }
 

--- a/src/PeachPDF.Tests/PdfSharpCore/FontResolverTests.cs
+++ b/src/PeachPDF.Tests/PdfSharpCore/FontResolverTests.cs
@@ -206,7 +206,7 @@ namespace PeachPDF.Tests.PdfSharpCoreTests
             finally
             {
                 Environment.SetEnvironmentVariable("HOME", originalHome);
-                Directory.Delete(homeDir, recursive: true);
+                TempDirectory.DeleteWithRetry(homeDir);
             }
         }
 

--- a/src/PeachPDF.Tests/TestSupport/TempDirectory.cs
+++ b/src/PeachPDF.Tests/TestSupport/TempDirectory.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using System.Threading;
+
+namespace PeachPDF.Tests.TestSupport
+{
+    /// <summary>
+    /// Deletes a directory tree, retrying briefly on <see cref="IOException"/>/<see cref="UnauthorizedAccessException"/>.
+    /// A temp directory a test just created under the OS temp path is frequently opened transiently by
+    /// antivirus real-time scanning or the search indexer right after its files are written - the same
+    /// path Windows reports as "being used by another process" even though nothing in the test process
+    /// still holds a handle. That is host-environment noise, not a defect under test, so any test that
+    /// creates a temp directory and deletes it in a <c>finally</c> block should route the delete through
+    /// here instead of calling <see cref="Directory.Delete(string, bool)"/> directly.
+    /// </summary>
+    internal static class TempDirectory
+    {
+        public static void DeleteWithRetry(string path, int maxAttempts = 5, int retryDelayMilliseconds = 100)
+        {
+            for (var attempt = 1; ; attempt++)
+            {
+                try
+                {
+                    Directory.Delete(path, recursive: true);
+                    return;
+                }
+                catch (Exception ex) when (attempt < maxAttempts && ex is IOException or UnauthorizedAccessException)
+                {
+                    Thread.Sleep(retryDelayMilliseconds);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `RelativeImage_ResolvedAgainstTheWorkingDirectory_LoadsOnlyWhenAllowed` mutated the process-wide working directory via `Directory.SetCurrentDirectory`. Being in the `CWD-Dependent` xUnit collection only serializes it against other tests in that collection — it doesn't stop a genuinely-parallel test in a different collection from touching files while the CWD points at this test's temp directory, which showed up as an intermittent `IOException: ... being used by another process` on `Directory.Delete` in the `finally` block.
- Rewrites the test to place its asset under a subdirectory of the real working directory and reference it with a relative path, following the pattern already established by `FileUriLoaderIntegrationTests.RelativeImage_WithNoLoader_LoadsFromCurrentWorkingDirectory`, instead of mutating `Directory.CurrentDirectory` at all.
- Adds a `TempDirectory.DeleteWithRetry` test helper and routes every temp-directory cleanup in `LocalFileAccessTests.cs`, `FileUriLoaderIntegrationTests.cs`, and `FontResolverTests.cs` through it, since a freshly created temp file can also be transiently locked by antivirus/indexing independent of the race above.

## Test plan
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 3 consecutive full runs, 0 failures (previously intermittent)
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net10.0` — clean
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings, 0 errors