### PR TITLE
Widen the widows pass re-entry to the shared rollback

### DIFF
--- a/.claude/recent-fixes/2026-07-30-the-widows-rewind-now-uses-the-shared-rollback.md
+++ b/.claude/recent-fixes/2026-07-30-the-widows-rewind-now-uses-the-shared-rollback.md
@@ -1,0 +1,54 @@
+# The widows rewind now uses the shared rollback
+
+_Landed 2026-07-30._
+
+**`HtmlContainerInt.TryRewindForWidows` now widens to the shared `PassRewind.RollBackTo`**
+([issue #440](https://github.com/jhaygood86/PeachPDF/issues/440)), closing the one pass re-entry that
+still did its own narrower thing: it used to discard only the widowed box's own line boxes past its
+budget, leaving whatever the pass placed after that box exactly where it was rather than resetting and
+re-laying it out. The other two pass re-entries (the columns engine's abandoned fill attempt, the
+driver's keep-with-next run pull) already used the shared rollback; widows was the holdout, and its own
+doc comment said why: widening it once measured a **16-word loss** from the `paged_media_horizontal_reflow`
+showcase.
+
+**The loss was never widows' own bug.** `git bisect` (fully clean rebuilds at every step — an
+incremental-build artifact produced a false transition on the first attempt, caught by re-verifying both
+endpoints manually before trusting the automated run) landed the fix at
+[3a20fca](https://github.com/jhaygood86/PeachPDF/commit/3a20fca47468f6e6d05ae56780210544a75d668b), the
+commit immediately after the one that introduced `TryRewindForWidows`'s narrow-only behavior — fixing
+[issue #433](https://github.com/jhaygood86/PeachPDF/issues/433), not #440. #433's bug: a word a stopped
+flow never reached kept a stale position (document Y 0, or whatever an earlier discarded attempt left on
+it), which lies inside the *first* page's own band, so an earlier fragment wrongly claimed it. The fix
+makes a block's inline flow say `AwaitPlacement()` of itself at the start of every fresh flow. Once that
+landed, the specific loss `TryRewindForWidows`'s widening depended on stopped reproducing — it was #433's
+stale-position bug surfacing through the shared rollback's later-sibling reset, not a defect in the
+rollback itself.
+
+**Verified on the platform the loss was originally measured on.** The issue's own investigation
+(recorded separately, [2026-07-30](2026-07-30-the-no-progress-recoverys-two-remaining-holes-closed-the-third-stays-open.md))
+already tried three escalating reproductions on Linux and could not reproduce the loss there — Georgia
+isn't installed in that sandbox, so font substitution changes the exact line-wrap shape the defect
+depended on. This fix was verified on Windows with Georgia actually installed: a standalone repro against
+`PdfGenerator.GeneratePdf` confirmed the widows rewind still fires (3 times, budget 2, against the
+showcase's `<p>` boxes) and produces byte-for-byte identical per-page text with the narrow rewind and the
+naive shared rollback both — no loss, on the exact machine/font combination the original report used.
+
+**What running it bought over reading it.** Reading the code alone would only show that `RollBackTo`
+resets later siblings outright (`ResetForRefill`) rather than leaving them be — indistinguishable, by
+inspection, from the version that lost content. Running the full showcase corpus (regenerated and
+text-compared with PyMuPDF, both against the narrow rewind at the same commit and against `origin/main`)
+is what shows the loss doesn't recur anywhere, not just in the one showcase the issue named.
+
+**No new regression test.** Three attempts at a small, deterministic fixture that would fail under the
+narrow rewind and pass under the shared one — a single widowed paragraph with one sibling; 40 paragraphs
+at `orphans:4`/`widows:4` under per-page reflow; 20 four-line paragraphs with mirrored per-page margins on
+a small page — each produced *identical* output under both old and new code. The actual defect needed 70
+real paragraphs, real Georgia metrics, and mirrored per-page margins to manifest; it does not reduce to a
+small fixture, the same shape #438's own dev note already recorded for a sibling defect
+(["What running it bought, and what reading it would not have"](2026-07-27-the-driver-rolls-the-box-tree-back-when-it-re-enters-a-pass.md)).
+Relying instead on the unmodified, still-passing `OrphansWidowsIntegrationTests.cs` suite plus the
+full-corpus text comparison as evidence.
+
+Tests: full net8.0 suite green (7355 passed, 0 failed), 100% diff coverage against `origin/main`,
+zero-warning solution rebuild. All 78 showcases text-identical (PyMuPDF-extracted) against both the
+narrow-rewind build at the same commit and against `origin/main`.

--- a/src/PeachPDF/Html/Core/Fragmentation/PassRewind.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/PassRewind.cs
@@ -10,10 +10,11 @@ namespace PeachPDF.Html.Core.Fragmentation
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Two callers re-run a pass and so need the same rollback: the multi-column engine, which abandons a
-    /// fill attempt when <c>column-fill: balance</c> has to try another target, and the driver, which
-    /// re-enters the pass that placed a keep-with-next run's head. Both hand back a box tree that must
-    /// look the way it did when that pass began, and "the way it looked" is stated entirely by the
+    /// Three callers re-run a pass and so need the same rollback: the multi-column engine, which abandons a
+    /// fill attempt when <c>column-fill: balance</c> has to try another target; the driver, which re-enters
+    /// the pass that placed a keep-with-next run's head; and the driver again, which re-enters the pass
+    /// that has just ended to give <c>widows</c> the lines it asks for. All three hand back a box tree that
+    /// must look the way it did when that pass began, and "the way it looked" is stated entirely by the
     /// resumption record itself — one link per ancestor, down to the box that stopped.
     /// </para>
     /// <para>

--- a/src/PeachPDF/Html/Core/HtmlContainerInt.cs
+++ b/src/PeachPDF/Html/Core/HtmlContainerInt.cs
@@ -1340,19 +1340,22 @@ namespace PeachPDF.Html.Core
         /// the box does move, and that is exactly what re-running this pass onwards lays out again.
         /// </para>
         /// <para>
-        /// Three things have to be undone, which is #374's lesson in a different shape. The box's own line
-        /// boxes past the budget go (<see cref="CssBox.DiscardLineBoxesFrom"/>, which also un-places their
-        /// words, since the retry need not reach every one of them again). The fragment the earlier pass
-        /// froze goes, because it is about to describe fewer lines than it did. And the resumption record
-        /// the pass was entered with is rebuilt to name the budget, since that record is the only thing that
-        /// says where the flow picks up.
+        /// Undone the same way the other two pass re-entries do it (<see cref="PassRewind.RollBackTo"/>):
+        /// the box's own line boxes past the budget go, and everything the pass placed after it — laid out
+        /// from the start, exactly as on a starting pass — is reset outright and laid out again by the
+        /// re-entered pass. The fragment the earlier pass froze goes too, because it is about to describe
+        /// different content. And the resumption record the pass was entered with is rebuilt to name the
+        /// budget, since that record is the only thing that says where the flow picks up.
         /// </para>
         /// <para>
-        /// Deliberately <b>narrower</b> than <see cref="PassRewind.RollBackTo"/>, which the other two pass
-        /// re-entries use: what the pass placed after the box is left exactly where it is, rather than
-        /// being reset and laid out again. Widening it to the shared rollback was tried and <i>lost
-        /// content</i> — 16 words of <c>paged_media_horizontal_reflow</c> — so what it would take is a
-        /// question of its own (issue #440).
+        /// Widening this from a narrower rewind of only the box's own lines was tried once and measurably
+        /// <i>lost content</i> — 16 words of <c>paged_media_horizontal_reflow</c> — and filed as issue #440.
+        /// The actual cause was a pre-existing, unrelated defect: a word a stopped flow never reached still
+        /// carried document Y 0, which lies inside the <i>first</i> page's own band, so an earlier
+        /// fragment wrongly claimed it (issue #433, fixed by the block's own inline flow now saying
+        /// <see cref="CssBox.AwaitPlacement"/> of itself before it starts). Once that was fixed, the shared
+        /// rollback stopped losing anything — confirmed with real Georgia metrics on Windows (the platform
+        /// the loss was originally measured on) via <c>git bisect</c> against the full showcase corpus.
         /// </para>
         /// <para>
         /// Declined where the record does not name the box — the box is only rewindable when it is the one
@@ -1367,7 +1370,7 @@ namespace PeachPDF.Html.Core
                 return false;
 
             InvalidateEmittedFragmentsFor(rewind.Box, rewind.Box.LineBoxes[0].LineTop);
-            rewind.Box.DiscardLineBoxesFrom(rewind.Budget);
+            PassRewind.RollBackTo(rebuilt, Root!.Boxes);
 
             token = rebuilt;
             return true;


### PR DESCRIPTION
## Summary
- `TryRewindForWidows` now calls the shared `PassRewind.RollBackTo` instead of only discarding the widowed box's own line boxes past its budget, matching the other two pass re-entries (the columns engine's fill retry, the driver's keep-with-next run pull).
- Widening this was previously deferred: it once measured a 16-word content loss from `paged_media_horizontal_reflow`, recorded as #440.
- `git bisect` (clean rebuilds verified at every step, on Windows with real Georgia — the platform/font combination the loss was originally measured on) traces that loss to an unrelated, already-fixed defect: #433 (a word a stopped flow never reached kept a stale position that fell inside the first page's own band, wrongly claimed by an earlier fragment), fixed the very next commit after the one that introduced the narrow rewind.
- With #433's fix in place, the shared rollback no longer loses anything anywhere in the full 78-showcase corpus (text-compared with PyMuPDF, both against the narrow rewind at the same commit and against `origin/main`).

## Test plan
- [x] Full net8.0 suite green (7355 passed, 0 failed)
- [x] 100% diff coverage against `origin/main`
- [x] Zero-warning full solution rebuild
- [x] Full 78-showcase corpus regenerated and text-compared (PyMuPDF): zero differences against both the narrow rewind and `origin/main`
- [x] Independent post-change review pass: no changes requested

Fixes #440