### PR TITLE
Trigger Release Binaries workflow after Publish NuGet Package creates the release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,11 @@ jobs:
           --generate-notes \
           $PRERELEASE_FLAG
 
+    - name: Trigger release binaries build
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: gh workflow run release-binaries.yml --ref main -f tag="v${{ steps.version.outputs.value }}"
+
     - name: Trigger docs deploy
       if: steps.version.outputs.prerelease != 'true'
       env:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,8 +1,11 @@
 name: Release Binaries
 
 # Builds the NativeAOT `peachpdf` CLI for each platform and attaches the archives to the GitHub
-# Release. Runs automatically when a release is published (the "Publish NuGet Package" workflow creates
-# it), or manually via workflow_dispatch against an existing tag.
+# Release. The "Publish NuGet Package" workflow triggers this explicitly (via workflow_dispatch) right
+# after it creates the release — a release created with the default GITHUB_TOKEN does not cascade-fire
+# other workflows' `release` triggers, so the `release: published` trigger below only covers a release
+# published by hand through the GitHub UI. It can also be run manually via workflow_dispatch against an
+# existing tag.
 on:
   release:
     types: [published]


### PR DESCRIPTION
## Summary
- `publish.yml`'s "Create GitHub Release" step uses the default `GITHUB_TOKEN`, and a release created that way does not cascade-trigger other workflows' `release` events — the same reason the existing "Trigger docs deploy" step already calls `pages.yml` explicitly rather than relying on its own `release: published` trigger.
- Added the same pattern for `release-binaries.yml`: a "Trigger release binaries build" step runs `gh workflow run release-binaries.yml --ref main -f tag=v<version>` right after the release is created, so the NativeAOT CLI binaries actually get built and attached to every release this workflow creates.
- Fixed `release-binaries.yml`'s header comment, which incorrectly claimed the `release: published` trigger already covered this. That trigger is kept for the case of someone publishing a release by hand through the GitHub UI (a real user token there does cascade-fire other workflows).

## Test plan
- [x] Validated both edited workflow files parse as valid YAML.
- [ ] Not exercised end-to-end (would require actually running `publish.yml`, which cuts a real release) — the change mirrors the already-working `pages.yml` trigger pattern in the same job.