### PR TITLE
Refuse a fragmentation question during a detached measurement pass

### DIFF
--- a/.claude/accepted-gaps/flex-item-with-no-direct-text-loses-background-past-its-first-page-fragment.md
+++ b/.claude/accepted-gaps/flex-item-with-no-direct-text-loses-background-past-its-first-page-fragment.md
@@ -1,0 +1,35 @@
+# A flex item with no direct text of its own loses its background past its first page fragment
+
+_Tracked as [#569](https://github.com/jhaygood86/PeachPDF/issues/569). Found while diagnosing why the
+`invoice` showcase rendered as 2 pages — that pagination bug itself is fixed
+(`BlockConstraint.For`/`EndingAt` now refuse a fragmentation question during a detached measurement
+pass); this is a distinct, narrower defect noticed in the process, in code that landed the same day
+(`CssLayoutEngineFlex`'s column/row commit passes, `ItemContentCommit.CommitLayout`)._
+
+A flex item whose own content is entirely block-level children — no direct text on the item itself,
+e.g. a `<footer>` flex item holding only `<div>`/`<p>` children — loses its `background` (and padding)
+on every page after the first, if its content genuinely spans more than one page. A plain, non-flex
+block with the identical shape (no direct text, only block children, content spanning several pages)
+renders its background correctly on every page it spans — confirmed by comparing the two side by side.
+The gap is specific to a box going through the flex engine's per-item content commit pass.
+
+`FragmentEmitter.BuildDraft` sets `usesOwnBounds = true` for any box with zero own line-rectangles
+(`RectanglesOf(box, snapshot).Count == 0`) — true here, since all of `footer`'s content lives on child
+boxes rather than directly on itself. The existing "shell" branch that resolves a rectangle for an
+`usesOwnBounds` box only fires when the box holds **no** children in this fragmentainer either
+(`children.Count == 0`) — the pure "shell continues a fragment" case. A continuation fragment that
+legitimately holds children (some of `footer`'s `<p>`s really do land on the second page) but no line
+content of its own falls into neither path, so it never gets a decoration rectangle at all: traced via
+`FragmentPainter.PaintBackground`, which is invoked exactly once for such a box, covering only the
+first page's own portion.
+
+`FragmentEmitterTests.AMultiPageBlock_KeepsItsDecorationOnEveryPageItSpans` only covers a box with its
+own *direct* text spanning pages (`rectangles.Count > 0` takes an entirely different, already-correct
+path in `BuildDraft`) — it does not cover a box whose content is exclusively via children. No existing
+test covers a flex item with this shape splitting across pages while checking its decoration continues.
+
+Left out of scope here because closing it needs the same kind of deep, first-principles trace into
+`FragmentEmitter.BuildDraft`'s draft-materialization logic that the pagination bug above did, and
+doing that in the same sitting risked rushing a fix to genuinely tricky fragment-tree code. See
+issue #569 for the suggested fix direction (a per-fragment decoration rectangle for a box that has
+children in this fragmentainer but no line content of its own, alongside the existing pure-shell case).

--- a/.claude/migration-notes/2026-07-31-a-flex-column-item-flush-anchored-with-margin-top-auto-no-longer-spuriously-paginates.md
+++ b/.claude/migration-notes/2026-07-31-a-flex-column-item-flush-anchored-with-margin-top-auto-no-longer-spuriously-paginates.md
@@ -1,0 +1,23 @@
+# A flex-column item anchored with `margin-top: auto` no longer spuriously paginates
+
+**Landed:** 2026-07-31 — fix a detached measurement pass taking a real page break
+**Doc section:** none dedicated; the affected pattern (`display:flex; flex-direction:column` with an
+explicit `height` close to the page height, and a `margin-top:auto`-anchored last item) is ordinary
+CSS, not a documented PeachPDF feature.
+**Verified against v0.9.7:** the bug is present at the `v0.9.7` tag — `git show
+v0.9.7:src/PeachPDF/Html/Core/Fragmentation/BlockConstraint.cs` shows `For`/`EndingAt` gated only on
+`HtmlContainerInt.HasRealPageGrid`, with no check of `CurrentFragmentainer`, and `git show
+v0.9.7:src/PeachPDF.TestHarness/Program.cs` confirms the `invoice` showcase (added at that tag,
+commit `eb23595`) already had this exact markup; `BlockConstraint.cs` was untouched between that tag
+and the fix, so the same 2-page rendering this note describes was already present at `v0.9.7`.
+
+A `display:flex; flex-direction:column` container whose declared `height` sits close to (but under)
+a page's own height, with a last item pinned flush to the container's bottom edge via
+`margin-top:auto`, could previously trip a spurious page break: if any of that item's own descendants
+(reached through a nested flex/grid formatting context — a common shape for footer-style layouts, a
+row of columns followed by a closing line) happened, purely as an artifact of an internal measurement
+pass, to sit at a position straddling the true page boundary, PeachPDF would insert a real page break
+there and continue that content onto a mostly-blank next page — even though the document's real
+content fit within one page with room to spare. A document that relied on this now renders one page
+shorter, with the previously-stranded content back on the original page. See the `invoice` showcase
+(`src/PeachPDF.TestHarness/Program.cs`) for the shape this affected.

--- a/.claude/recent-fixes/2026-07-31-a-detached-measurement-pass-can-no-longer-take-a-page-break.md
+++ b/.claude/recent-fixes/2026-07-31-a-detached-measurement-pass-can-no-longer-take-a-page-break.md
@@ -1,0 +1,77 @@
+# A detached measurement pass can no longer take a real page break
+
+The `invoice` showcase (US-Letter, full-bleed, `body { display:flex; flex-direction:column;
+height: calc(11in - 1mm) }` with a `margin-top:auto`-anchored `<footer>`) rendered as 2 pages instead
+of 1, with a nearly-blank second page holding only the footer's last paragraph, missing its own
+background. The showcase's own content is nowhere near a page's worth too tall — a plain
+`display:block` render of the same markup ends at 587pt of a 792pt page — so the pattern that
+actually mattered was: `margin-top:auto` flush-anchoring a `flex-direction:column` item to a
+container height that is close to (but under) the true page height.
+
+## The load-bearing idea
+
+`BlockConstraint.For`/`EndingAt` (`src/PeachPDF/Html/Core/Fragmentation/BlockConstraint.cs`) — read by
+the §4.3 avoid/monolithic mover and the §5.4 widows/orphans mover in
+`CssBox.PerformLayoutEpilogue` — decided whether a fragmentation question could be asked at all using
+only `HtmlContainerInt.HasRealPageGrid`. That is true for the *entire* document, including inside a
+flex/grid item's own measurement pass (`CssLayoutEngineFlex.MeasureItem`'s `PerformLayoutBlockified`),
+which keeps a real page grid but explicitly detaches the ambient fragmentainer
+(`HtmlContainerInt.DetachFragmentainer`, `CurrentFragmentainer = null`) so that content laid out at its
+throwaway, provisional position cannot answer a fragmentation question — the whole reason
+`DetachFragmentainer`'s own doc comment calls it "an absence rather than a suppressed flag." Neither
+factory method consulted `CurrentFragmentainer`, so they silently reconstructed a *fresh*
+`FragmentainerContext` from the real page grid regardless — the detachment did nothing for them.
+
+Traced end to end: the `invoice` footer's nested row-direction `.cols` (three `<div>` columns) is laid
+out via ordinary block flow, not through any engine's own item measurement — so measuring *its* three
+column `<div>`s (`CssLayoutEngineFlex.MeasureItem`, itself properly detached) still ran with a real,
+un-detached ambient ancestor state up the call stack. One column's own paragraph, at its throwaway
+measurement position, happened to straddle the real page boundary. The widows mover's
+`BlockConstraint.For` built a real constraint anyway, `TakeEarlyBreak`'s unconditional
+`TranslateForEarlyBreak` fallback moved that paragraph to the next page's content top *during the
+measurement*, and the column's measured cross-size came back roughly double its true height (the
+gap between the paragraph's throwaway top and its post-break position). That inflated height fed the
+footer's own pinned commit-pass height (`ItemContentCommit.CommitLayout`) at exactly the document's
+real page bottom — landing the *next* sibling's real offset resolution (`CssBox.ResolveBlockChildOffset`,
+which also calls `BlockConstraint.EndingAt`) flush on that same boundary, so it took a real early break
+too.
+
+The fix is two lines: both factories now also return `Measurement` (no fragmentainer) when
+`container.CurrentFragmentainer is null`, mirroring the check `FragmentainerContext`'s own constructor
+already makes for its ambient instances. See [`.claude/invariants/`](../invariants/) for nothing new
+here — this closes the gap the existing detachment mechanism already declared it wanted.
+
+## What was found by running it, not by reading it
+
+Reading the widows/avoid movers in isolation, both looked correct — each already gates on
+`!PositionAssignedByEngine` and `HtmlContainer.IsFragmenting` in the branches that matter for a *live*
+pass. The defect was only visible by instrumenting an actual repro end to end (temporary
+`Console.Error` tracing through `CssBox.LayoutBlockChildren`/`ResolveBlockChildOffset`,
+`CssLayoutEngineFlex.MeasureItem`, and `FragmentPainter.PaintBackground`), which is what turned up
+that `TakeEarlyBreak`'s *fallback* path (`TranslateForEarlyBreak`, taken whenever `CanBeLaidOutAgain`
+correctly refuses because breaking is not live) has no matching `IsFragmenting` guard of its own — it
+translates the box regardless, as an unconditional side effect of a boolean condition whose overall
+truth value is then ignored. `BlockConstraint`'s missing guard is what let that fallback path be
+reached from inside a detached pass at all.
+
+## What was deliberately not done
+
+A second, narrower, real defect turned up in the same trace — a flex item with no direct text of its
+own (all content via children, e.g. the same `<footer>`) loses its own background/decoration once its
+content genuinely (not spuriously) spans more than one page, specific to a box going through the flex
+engine's commit pass. This is unrelated to the fix above (root-caused to
+`FragmentEmitter.BuildDraft`'s decoration-materialization logic, not `BlockConstraint`) and left open —
+filed as [#569](https://github.com/jhaygood86/PeachPDF/issues/569),
+recorded in
+[`.claude/accepted-gaps/flex-item-with-no-direct-text-loses-background-past-its-first-page-fragment.md`](../accepted-gaps/flex-item-with-no-direct-text-loses-background-past-its-first-page-fragment.md).
+
+## Evidence
+
+Full `net8.0` suite: 7361 passing, 9 skipped, 0 failed (unaffected suites: `Flex`/`Fragment`/`Widow`/
+`Orphan`/`Grid`/`Table`/`Column`/`BreakInside`/`PageBreak` filter alone, 1648 tests, all green). Two
+new `BlockConstraintTests` (`For_ReturnsMeasurement_WhenTheFragmentainerIsDetached`,
+`EndingAt_ReturnsMeasurement_WhenTheFragmentainerIsDetached`) confirmed to fail without the fix and
+pass with it. 100% diff coverage on the changed lines. `dotnet build PeachPDF.slnx -t:Rebuild`: zero
+warnings. The full 79-showcase corpus regenerated cleanly through `PeachPDF.TestHarness`;
+`invoice.pdf` is now 1 page, rasterized and visually confirmed complete (footer background, all
+content, "Thank you" line all present and correctly positioned).

--- a/src/PeachPDF.Tests/Html/Core/Fragmentation/BlockConstraintTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Fragmentation/BlockConstraintTests.cs
@@ -18,12 +18,24 @@ namespace PeachPDF.Tests.Html.Core.Fragmentation
         private const double BandHeight = 800;
         private const double MarginTop = 70;
 
-        private static HtmlContainerInt CreateContainer(double bandHeight = BandHeight) =>
-            new(new PdfSharpAdapter())
+        private static HtmlContainerInt CreateContainer(double bandHeight = BandHeight)
+        {
+            var container = new HtmlContainerInt(new PdfSharpAdapter())
             {
                 PageSize = new RSize(500, bandHeight),
                 MarginTop = MarginTop,
             };
+
+            // BlockConstraint.For/EndingAt answer "no fragmentainer" whenever breaking isn't live
+            // (HtmlContainerInt.CurrentFragmentainer is null), the same detached state a flex/grid
+            // item's own measurement pass runs in - not just when there is no real page grid at all.
+            // These tests are about the "real, live pass" arithmetic, so they need a live fragmentainer
+            // in place, exactly as HtmlContainerInt.LayoutDocument's own per-slot loop sets one up.
+            var root = new CssBox(null, null) { HtmlContainer = container };
+            container.EnterNestedFragmentainer(new FragmentainerContext(container, root, 0));
+
+            return container;
+        }
 
         private static CssBox CreateBox(HtmlContainerInt container, double locationY)
         {
@@ -65,6 +77,30 @@ namespace PeachPDF.Tests.Html.Core.Fragmentation
             var box = CreateBox(container, 500);
 
             var constraint = BlockConstraint.For(box);
+
+            Assert.Null(constraint.Fragmentainer);
+            Assert.Equal(BlockConstraint.Measurement, constraint);
+        }
+
+        // A flex/grid item's own measurement pass (CssLayoutEngineFlex.MeasureItem's
+        // PerformLayoutBlockified) keeps a real page grid but detaches the fragmentainer
+        // (HtmlContainerInt.DetachFragmentainer) so content laid out at its provisional position cannot
+        // answer a fragmentation question. Before this guard, a nested box whose throwaway coordinate
+        // happened to straddle a page boundary during that measurement had the §4.3 widows/orphans or
+        // avoid/monolithic mover translate it to the next page anyway — corrupting the very size the
+        // engine was in the middle of computing (a nested flex-in-flex footer's own measured height
+        // could come out roughly double, observed in the "invoice" showcase). HasRealPageGrid alone
+        // does not tell the two states apart, since it stays true throughout a detached pass.
+        [Fact]
+        public void For_ReturnsMeasurement_WhenTheFragmentainerIsDetached()
+        {
+            var container = CreateContainer();
+            var box = CreateBox(container, MarginTop + 30);
+            var live = container.DetachFragmentainer();
+
+            var constraint = BlockConstraint.For(box);
+
+            container.RestoreFragmentainer(live);
 
             Assert.Null(constraint.Fragmentainer);
             Assert.Equal(BlockConstraint.Measurement, constraint);
@@ -189,6 +225,24 @@ namespace PeachPDF.Tests.Html.Core.Fragmentation
             var box = new CssBox(null, null) { HtmlContainer = container };
 
             Assert.Equal(BlockConstraint.Measurement, BlockConstraint.EndingAt(container, box, 500));
+        }
+
+        // Same detached-pass guard as For's own test above - the §5.2 margin-truncation mover
+        // (CssBox.ResolveBlockChildOffset) that calls EndingAt must not truncate a margin, or move a
+        // child to a page boundary, against a position a flex/grid item's own measurement pass will
+        // discard anyway.
+        [Fact]
+        public void EndingAt_ReturnsMeasurement_WhenTheFragmentainerIsDetached()
+        {
+            var container = CreateContainer();
+            var box = new CssBox(null, null) { HtmlContainer = container };
+            var live = container.DetachFragmentainer();
+
+            var constraint = BlockConstraint.EndingAt(container, box, MarginTop + BandHeight + 1);
+
+            container.RestoreFragmentainer(live);
+
+            Assert.Equal(BlockConstraint.Measurement, constraint);
         }
 
         // FallsPast is the same bottom-edge convention asked of an absolute coordinate, tolerance included -

--- a/src/PeachPDF/Html/Core/Fragmentation/BlockConstraint.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/BlockConstraint.cs
@@ -20,9 +20,14 @@ namespace PeachPDF.Html.Core.Fragmentation
     /// "the pass's cursor" is not, in general, a safe substitution).
     /// </para>
     /// <para>
-    /// <see cref="Fragmentainer"/> is null exactly where there is no page grid to ask at all
-    /// (<see cref="HtmlContainerInt.HasRealPageGrid"/> false — a measurement/unpaginated pass): no
-    /// fragmentation question may be asked there, per css-break-3 §400(c)'s own requirement.
+    /// <see cref="Fragmentainer"/> is null wherever no fragmentation question may be asked at all, per
+    /// css-break-3 §400(c)'s own requirement — either there is no page grid to ask
+    /// (<see cref="HtmlContainerInt.HasRealPageGrid"/> false), or breaking is not live right now
+    /// (<see cref="HtmlContainerInt.CurrentFragmentainer"/> null: a flex/grid item's own measurement
+    /// pass, <see cref="HtmlContainerInt.DetachFragmentainer"/>). The second case is content laid out
+    /// at a throwaway, provisional position purely to be measured — asking either question against it
+    /// would translate that content to a real page-break target before the engine measuring it has
+    /// even decided where it will really go.
     /// </para>
     /// </remarks>
     /// <param name="Fragmentainer">the fragmentainer being asked about, or null where there is none</param>
@@ -81,7 +86,17 @@ namespace PeachPDF.Html.Core.Fragmentation
         internal static BlockConstraint For(CssBox box)
         {
             var container = box.HtmlContainer;
-            if (container is null || !container.HasRealPageGrid) return Measurement;
+
+            // HasRealPageGrid alone answers "is there a page grid at all", not "may this pass ask it
+            // a fragmentation question" - a flex/grid item's own measurement pass (MeasureItem's
+            // PerformLayoutBlockified) keeps a real page grid but detaches the fragmentainer
+            // (HtmlContainerInt.DetachFragmentainer) precisely so content laid out at its provisional
+            // position cannot answer one. Without this, a nested box whose throwaway coordinate
+            // happens to straddle a page boundary during that measurement gets translated by the
+            // avoid/monolithic or widows mover below to a position it is about to be measured away
+            // from anyway, corrupting the very size the engine is in the middle of computing.
+            if (container is null || !container.HasRealPageGrid || container.CurrentFragmentainer is null)
+                return Measurement;
 
             var slot = container.PageIndexOf(box.Location.Y);
             var fragmentainer = new FragmentainerContext(container, box, slot);
@@ -109,7 +124,8 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// </remarks>
         internal static BlockConstraint EndingAt(HtmlContainerInt container, CssBox contextRoot, double blockEnd)
         {
-            if (!container.HasRealPageGrid) return Measurement;
+            // Same detached-pass guard as For's own remark above.
+            if (!container.HasRealPageGrid || container.CurrentFragmentainer is null) return Measurement;
 
             var fragmentainer = new FragmentainerContext(container, contextRoot, container.SlotEndingAt(blockEnd));
 


### PR DESCRIPTION
## Summary

- `BlockConstraint.For`/`EndingAt` decided whether a fragmentation question could be asked using only `HasRealPageGrid`, which stays true even inside a flex/grid item's own *detached* measurement pass (`CssLayoutEngineFlex.MeasureItem`'s `PerformLayoutBlockified`). Content laid out at a throwaway, provisional position that happened to straddle a page boundary during that measurement could take a real page-break translation anyway (via the §5.4 widows mover / §4.3 avoid mover in `CssBox.PerformLayoutEpilogue`), corrupting the size the engine was in the middle of computing.
- Traced this end to end to the `invoice` showcase (`src/PeachPDF.TestHarness/Program.cs`) rendering as 2 pages instead of 1: a nested row-flex column inside a `margin-top:auto`-anchored `<footer>`, measured at its provisional position, straddled the real page boundary; the widows mover moved it for real during the measurement, inflating the column's measured height and cascading into a spurious break before the footer's last paragraph.
- Fix: both factories now also refuse (return `Measurement`) when `HtmlContainerInt.CurrentFragmentainer` is null, matching the detachment invariant the container already declares (`DetachFragmentainer`'s own doc comment).
- Along the way, found and filed a second, narrower, unrelated defect (a flex item with no direct text of its own loses its background past its first page fragment when it genuinely spans multiple pages) — tracked as #569, not fixed here; see the accepted-gap note.

## Test plan

- [x] Two new `BlockConstraintTests` (`For_ReturnsMeasurement_WhenTheFragmentainerIsDetached`, `EndingAt_ReturnsMeasurement_WhenTheFragmentainerIsDetached`) — confirmed to fail without the fix, pass with it
- [x] Full `net8.0` suite: 7361 passed, 9 skipped, 0 failed
- [x] `dotnet build PeachPDF.slnx -t:Rebuild`: zero warnings
- [x] 100% diff coverage on the changed lines
- [x] Full 79-showcase corpus regenerated via `PeachPDF.TestHarness`; `invoice.pdf` confirmed 1 page, rasterized and visually checked (background, all content, closing line all present and correctly positioned)