### PR TITLE
Make the UA stylesheet's dir/bdo rules isolate instead of embed

### DIFF
--- a/.claude/accepted-gaps/synthetic-isolate-chaining-deep-nesting-edge-cases.md
+++ b/.claude/accepted-gaps/synthetic-isolate-chaining-deep-nesting-edge-cases.md
@@ -1,0 +1,32 @@
+# CSS synthetic-isolate BD13 chaining has two narrow, deep-nesting edge cases left unfixed
+
+Tracking issues: [#575](https://github.com/jhaygood86/PeachPDF/issues/575) (override push/pop
+ordering for boxes sharing a text index), [#576](https://github.com/jhaygood86/PeachPDF/issues/576)
+(eos approximation for isolates 3+ levels deep that all close flush together).
+
+Fixing #554 (the UA stylesheet's `[dir]`/`bdo[dir]` rules using `unicode-bidi: isolate`/
+`isolate-override` instead of the legacy `embed`/`bidi-override`) surfaced a real gap in how
+`BidiResolver` (`src/PeachPDF/Text/Bidi/BidiResolver.cs`) implements X10/BD13 isolating-run-sequence
+chaining for a CSS-driven isolate: a synthetic `BidiIsolateOverride` never occupies a real character
+index the way an actual Unicode LRI/RLI/FSI/PDI control character would, so chaining has to be
+located by index-adjacency (an override's own `Start`/`End`) instead. Two failure modes from that —
+duplicate-processing when nested isolates close at the same index, and dropped positions when
+sibling isolates merge into one level run with no boundary between them — were found and fixed as
+part of that change (`ComputeIsolatingRunSequences`'s `runEndIndex`-verified chain entries and
+`!visited[...]` guard; see `PeachPDF.Tests/Text/Bidi/BidiResolverSyntheticIsolateTests.cs`).
+
+Two narrower issues remain, deliberately out of scope for that fix:
+
+- **#575**: `CssBidiParagraphResolver.Flatten` appends a child box's override before its parent's,
+  so two boxes whose overrides share a `Start`/`End` (no character of the outer box precedes/follows
+  the inner one) push/pop in child-before-parent order — for opposite-direction nested `dir`
+  attributes this can compute a numerically wrong level, not just a chaining order issue.
+- **#576**: when isolate scopes nest three or more levels deep and all close at the identical real
+  index, the `!visited[...]` guard correctly stops a duplicate add, but the truncated sequence's
+  `eos` is then computed against the next real character's level rather than the true immediately-
+  enclosing scope's level, which a real, distinctly-indexed PDI character would expose instead.
+
+**Deliberately out of scope for now.** Both require either tracking override nesting depth
+explicitly through `Flatten` (#575) or modeling each synthetic isolate close as its own zero-width
+slot in the isolating-run-sequence graph (#576) — real architectural work, and narrower/rarer than
+the two bugs already fixed alongside #554.

--- a/.claude/migration-notes/2026-07-31-dir-and-bdo-now-isolate-instead-of-embedding.md
+++ b/.claude/migration-notes/2026-07-31-dir-and-bdo-now-isolate-instead-of-embedding.md
@@ -1,0 +1,25 @@
+# `dir`/`bdo` now isolate their bidi resolution instead of embedding it
+
+**Landed:** 2026-07-31 — the UA stylesheet's `[dir]` rule actually isolates instead of embedding
+**Doc section:** none dedicated; the affected rules are the `dir` global attribute and `<bdo>`
+compatibility-matrix entries in [docs/html-css-support.md](../../docs/html-css-support.md).
+**Verified against v0.9.7:** `git show v0.9.7:src/PeachPDF/Html/Core/CssDefaults.cs` shows the UA
+stylesheet's `*[DIR="ltr"]`/`*[DIR="rtl"]` rules using `unicode-bidi: embed` and `BDO[DIR="ltr"]`/
+`BDO[DIR="rtl"]` using `unicode-bidi: bidi-override` at that tag — the same behavior this note
+describes as "before."
+
+An element carrying a plain `dir="ltr"`/`dir="rtl"`/`dir="auto"` attribute (any element other than
+`<bdo>` or `<bdi>`, which already isolated/overrode correctly) previously resolved with
+`unicode-bidi: embed`: its own directional levels could leak into how the surrounding paragraph's
+neutral characters (spaces, punctuation) and European/Arabic numbers around it resolved. `<bdo dir>`
+previously resolved with plain `bidi-override` (directional override, no isolation) rather than
+`isolate-override`. Both now match the current HTML Standard's rendering rules — `isolate` for `dir`,
+`isolate-override` for `bdo[dir]` — the same values `<bdi>` already used.
+
+The observable difference is narrow but real: a `dir`-bearing inline element embedded in an
+opposite-direction paragraph is now opaque to that paragraph's own neutral/number resolution, the
+same way `<bdi>` already was. For example, `<p>1 <span dir="rtl">עברית</span> 2</p>` previously
+rendered the trailing `2` immediately after `1` (the RTL span's levels influencing how the digits
+resolved around it); it now keeps the paragraph's own document order (`1`, the isolated RTL run,
+`2`), matching real browsers. A document relying on the old (non-isolating) digit/neutral placement
+around a `dir`-bearing element will see that placement change.

--- a/.claude/recent-fixes/2026-07-31-the-ua-stylesheets-dir-rule-actually-isolates-instead-of-embedding.md
+++ b/.claude/recent-fixes/2026-07-31-the-ua-stylesheets-dir-rule-actually-isolates-instead-of-embedding.md
@@ -1,0 +1,61 @@
+# The UA stylesheet's `[dir]` rule actually isolates instead of embedding
+
+Closes [#554](https://github.com/jhaygood86/PeachPDF/issues/554). Files
+[#575](https://github.com/jhaygood86/PeachPDF/issues/575)/[#576](https://github.com/jhaygood86/PeachPDF/issues/576)
+for the two narrower gaps this uncovered — see
+[`.claude/accepted-gaps/synthetic-isolate-chaining-deep-nesting-edge-cases.md`](../accepted-gaps/synthetic-isolate-chaining-deep-nesting-edge-cases.md).
+
+## The load-bearing idea
+
+The reported bug was surface-level: `CssDefaults.DefaultStyleSheet`
+(`src/PeachPDF/Html/Core/CssDefaults.cs`) used the legacy CSS2.1 sample stylesheet's
+`unicode-bidi: embed`/`bidi-override` for the `[dir=ltr]`/`[dir=rtl]` and `bdo[dir]` UA rules, instead
+of the current HTML Standard's `isolate`/`isolate-override` (`<bdi>`'s own rule was already correct).
+Changing the three keywords looked like the whole fix.
+
+It wasn't. `BidiResolver` (`src/PeachPDF/Text/Bidi/BidiResolver.cs`) implements every CSS
+`unicode-bidi` value as a synthetic push/pop onto an explicit-level stack
+(`BidiIsolateOverride`/`BidiExplicitPush`) rather than by inserting real Unicode LRI/RLI/FSI/PDI
+control characters into the paragraph text — deliberately, so string indices stay stable. But
+`ComputeMatchingPdi`/`ComputeIsolatingRunSequences` (X10/BD13 "isolating run sequence" formation)
+only ever looked for literal LRI/RLI/FSI/PDI `BidiClass` values *in the text* to decide which level
+runs to chain together — which a synthetic push, by construction, never produces. The practical
+effect: `unicode-bidi: isolate` and `embed` produced byte-for-byte identical level arrays for any
+paragraph where neutral/EN-as-R resolution spans the box (UAX#9's N1 rule treats European numbers as
+R for neutral-sandwiching purposes) — exactly issue #554's own repro,
+`<p>1 <span dir="rtl">עברית</span> 2</p>`. Real Chromium renders that as `1 [hebrew] 2`; PeachPDF
+rendered `1 2 [hebrew]` for **both** `isolate` and `embed`, before and after the keyword swap alone.
+
+The actual fix adds a second chaining path to `ComputeIsolatingRunSequences`: a `syntheticChain` map
+built from the isolate-initiating (`Lri`/`Rli`/`Fsi`) overrides, keyed by each override's own `Start`
+(where the "before" run ends) to its `End` (where the "after" run starts) — mirroring real BD13
+chaining, but located by index-adjacency instead of by an actual PDI character type. Two more bugs
+surfaced once two overrides could interact, both caught by an independent review pass before this
+landed: registering a chain entry whose `Start` never actually coincides with any run's end (two
+adjacent same-direction isolates merge into one run with no boundary at all) would mark a run nothing
+chains into as a "continuation," silently dropping it from every sequence — fixed by only registering
+an entry when `runEndIndex` confirms a real run actually ends there. And two isolate scopes closing at
+the identical index (an inner isolate that is the last content of its own enclosing isolate) would
+both chain to the same "after" run, adding its positions twice and letting the second, wrong-context
+`ResolveSequence` call silently overwrite the first's correct one — fixed with a `!visited[...]` guard
+on every chain jump.
+
+## What was found by running it, not by reading it
+
+The keyword-swap-only version passed every existing test unchanged, because none of them mix a CSS
+isolate with digit-sandwiching or nested/sibling isolates closing at the same index — the existing
+`<bdi>` isolation test uses only strong-L content on both sides, which resolves identically whether
+the box embeds or isolates. Rendering the issue's own repro through a real Chromium instance (browser
+tool, before *and* after each change) was what exposed that the keyword swap alone changed nothing
+observable, and later that the first version of the BD13 chaining fix had its own two bugs — an
+independent review agent found both from reading the diff, and both were confirmed by temporarily
+reverting each guard and watching the corresponding new test fail exactly as predicted.
+
+## Evidence
+
+Full `net8.0` suite: 7368 passing, 9 skipped, 0 failed (includes 2 new tests in
+`PeachPDF.Tests/Text/Bidi/BidiResolverSyntheticIsolateTests.cs`, both confirmed to fail without their
+respective guard and pass with it). Unicode's own ~92k-case `BidiCharacterTest.txt` conformance suite
+(`BidiResolverConformanceTests`) still 100% passing — the fix only adds a second, purely additive
+chaining path; it never touches the real-character matching path that suite exercises.
+`dotnet build PeachPDF.slnx -t:Rebuild`: zero warnings. `diff-cover` against `origin/main`: 100%.

--- a/src/PeachPDF.Tests/Html/Core/CssLayoutEngineBidiTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/CssLayoutEngineBidiTests.cs
@@ -49,7 +49,7 @@ namespace PeachPDF.Tests.Html.Core
         [Fact]
         public async Task Bdo_DirRtl_ReversesPlainLatinTextInLayout()
         {
-            // unicode-bidi: bidi-override (the UA stylesheet rule for <bdo>) forces every character's
+            // unicode-bidi: isolate-override (the UA stylesheet rule for <bdo>) forces every character's
             // resolved type to match `direction`, regardless of its own real Bidi_Class - so even plain
             // Latin text (ordinarily strong-L, untouched by a plain direction:rtl) gets reordered and
             // mirrored inside a <bdo dir="rtl">, unlike a plain dir="rtl" element around the same text.
@@ -93,6 +93,33 @@ namespace PeachPDF.Tests.Html.Core
             Assert.Equal(2, bdiWords.Count);
             Assert.True(bdiWords[0].Left > bdiWords[1].Left,
                 $"expected the isolated <bdi>'s own first logical word to end up rightmost; [0].Left={bdiWords[0].Left}, [1].Left={bdiWords[1].Left}");
+        }
+
+        [Fact]
+        public async Task DirRtlSpan_InLtrParagraph_IsolatesFromSurroundingDigitsAndNeutrals()
+        {
+            // The UA stylesheet's [dir=rtl] rule is unicode-bidi: isolate (not the legacy embed) per the
+            // current HTML Standard - the RTL span must be opaque to the surrounding LTR paragraph's own
+            // resolution, so "1" and "2" keep the paragraph's own left-to-right document order around it
+            // instead of the span's internal RTL levels leaking into how the neighboring digits/neutrals
+            // resolve (see CascadeAutoDirectionalityTests.DirRtl_Explicit_SetsIsolateNotOverride for the
+            // cascade-level assertion that the property itself is isolate, not embed).
+            var html = LayoutHarness.Wrap("""<p id="p">1 <span dir="rtl">עברית</span> 2</p>""");
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var p = LayoutHarness.FindById(root, "p");
+
+            Assert.NotNull(p);
+            var words = WordsOf(p!);
+            var one = Assert.Single(words, w => w.Text == "1");
+            var two = Assert.Single(words, w => w.Text == "2");
+            // Same UAX#9 L2/L4 visual mirroring as the <bdo> tests above (see Bdo_DirRtl_ReversesPlainLatinTextInLayout)
+            // reverses the isolated run's own character order within its own scope - "עברית" becomes "תירבע".
+            var hebrew = Assert.Single(words, w => w.Text == "תירבע");
+
+            Assert.True(one.Left < hebrew.Left && hebrew.Left < two.Left,
+                $"expected the paragraph's own document order (1, span, 2) preserved around the isolated " +
+                $"RTL span; one.Left={one.Left}, hebrew.Left={hebrew.Left}, two.Left={two.Left}");
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Html/Core/Dom/CascadeAutoDirectionalityTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/CascadeAutoDirectionalityTests.cs
@@ -105,7 +105,7 @@ namespace PeachPDF.Tests.Html.Core.Dom
         }
 
         [Fact]
-        public async Task Bdo_WithDirRtl_OverridesAndSetsBidiOverride()
+        public async Task Bdo_WithDirRtl_OverridesAndSetsIsolateOverride()
         {
             var html = LayoutHarness.Wrap("""<bdo id="el" dir="rtl">hello</bdo>""");
 
@@ -114,14 +114,14 @@ namespace PeachPDF.Tests.Html.Core.Dom
 
             Assert.NotNull(el);
             Assert.Equal(DirectionMode.Rtl, el!.Direction.Value);
-            Assert.Equal(UnicodeMode.BidirectionalOverride, el!.UnicodeBidi.Value);
+            Assert.Equal(UnicodeMode.IsolateOverride, el!.UnicodeBidi.Value);
         }
 
         [Fact]
-        public async Task DirRtl_Explicit_SetsEmbedNotOverride()
+        public async Task DirRtl_Explicit_SetsIsolateNotOverride()
         {
-            // A plain dir="rtl" (not <bdo>) maps to unicode-bidi: embed per the UA stylesheet, distinct
-            // from <bdo>'s bidi-override.
+            // A plain dir="rtl" (not <bdo>) maps to unicode-bidi: isolate per the current HTML Standard,
+            // distinct from <bdo>'s isolate-override.
             var html = LayoutHarness.Wrap("""<div id="el" dir="rtl">hello</div>""");
 
             var (root, _) = await LayoutHarness.LayoutAsync(html);
@@ -129,7 +129,7 @@ namespace PeachPDF.Tests.Html.Core.Dom
 
             Assert.NotNull(el);
             Assert.Equal(DirectionMode.Rtl, el!.Direction.Value);
-            Assert.Equal(UnicodeMode.Embed, el!.UnicodeBidi.Value);
+            Assert.Equal(UnicodeMode.Isolate, el!.UnicodeBidi.Value);
         }
     }
 }

--- a/src/PeachPDF.Tests/Text/Bidi/BidiResolverSyntheticIsolateTests.cs
+++ b/src/PeachPDF.Tests/Text/Bidi/BidiResolverSyntheticIsolateTests.cs
@@ -1,0 +1,74 @@
+using PeachPDF.Text.Bidi;
+using System.Collections.Generic;
+using Xunit;
+
+namespace PeachPDF.Tests.Text.Bidi
+{
+    /// <summary>
+    /// Regression tests for the X10/BD13 "isolating run sequence" chaining <see cref="BidiResolver"/> does
+    /// for a CSS <c>unicode-bidi: isolate</c>/<c>isolate-override</c> box's synthetic push (see
+    /// <see cref="BidiIsolateOverride"/>), as distinct from a real Unicode LRI/RLI/FSI/PDI control
+    /// character. A synthetic push never occupies an index of its own, so the chain has to be located by
+    /// index-adjacency (an override's own Start/End) rather than by an actual PDI character type - two
+    /// failure modes that surfaced only once two overrides interact are covered here directly, since
+    /// <see cref="CssLayoutEngineBidiTests"/>'s single-span case can't exercise them.
+    /// </summary>
+    public class BidiResolverSyntheticIsolateTests
+    {
+        [Fact]
+        public void NestedIsolate_FlushAgainstEnclosingIsolateClose_DoesNotDoubleResolveTrailingContent()
+        {
+            // "A שלום ש" with an outer isolate over "שלום" and an inner isolate over its own last two
+            // characters ("ום") - the inner isolate's own End coincides exactly with the outer isolate's
+            // End (nothing follows "ום" inside the outer isolate), so both overrides' Start->End chain
+            // entries land on the very same "after" run. Without the !visited guard in
+            // ComputeIsolatingRunSequences, both the outer isolate's own chain (from the "A " run) and the
+            // inner isolate's chain (from the "של" run) would jump to that same trailing run and add its
+            // positions twice - the second (spurious) ResolveSequence call would resolve the trailing
+            // space+Hebrew-letter using the INNER isolate's own (matched R/R neighbor) context instead of
+            // the correct outer/paragraph-level context, silently overwriting the first, correct result.
+            const string text = "A שלום ש"; // "A " + "שלום" + " " + "ש"
+
+            var outer = new BidiIsolateOverride(Start: 2, Length: 4, Push: BidiExplicitPush.Rli); // "שלום"
+            var inner = new BidiIsolateOverride(Start: 4, Length: 2, Push: BidiExplicitPush.Rli); // "ום" (flush against outer's End)
+
+            var result = BidiResolver.Resolve(text, BidiParagraphDirection.Ltr, [outer, inner]);
+
+            // The space right after both isolates close belongs only to the outer isolate's own (correct)
+            // sequence, resolved against "A"(L) before and the trailing "ש"(R) after - a mismatch, so N2's
+            // embedding direction (L, since the paragraph is level 0/even) applies and it stays at level 0.
+            // The inner isolate's spurious duplicate resolution would instead see R/R neighbors (matched,
+            // via N1) and push it to level 1 - so this assertion fails if the duplicate-visit bug regresses.
+            Assert.Equal(0, result.Levels[6]);
+
+            // The trailing Hebrew letter itself is an ordinary strong-R character at the paragraph's base
+            // (even) level - I1/I2 must bump it to level 1 exactly once, regardless of how many isolate
+            // chains reach it.
+            Assert.Equal(1, result.Levels[7]);
+        }
+
+        [Fact]
+        public void AdjacentIsolates_WithNoGapBetweenThem_StillResolveTrailingContent()
+        {
+            // Two sibling dir="rtl" boxes back to back ("שת" then "בג", no text between them) push to the
+            // identical level from the identical starting level, so their content merges into ONE level run
+            // with no boundary at all at the point where the second box's own override starts - that Start
+            // never coincides with any run's End. Registering it in the synthetic chain map regardless
+            // would still mark the run after it (the trailing "ש") as a continuation nothing ever actually
+            // chains into, permanently excluding it from every sequence - so its level would never advance
+            // past whatever ResolveExplicitLevels assigned it pre-resolution, instead of the level I1/I2
+            // implicit resolution actually requires for a strong-R character at the paragraph's base level.
+            const string text = "Aשתבגש"; // "A" + "שת" + "בג" + "ש"
+
+            var span1 = new BidiIsolateOverride(Start: 1, Length: 2, Push: BidiExplicitPush.Rli); // "שת"
+            var span2 = new BidiIsolateOverride(Start: 3, Length: 2, Push: BidiExplicitPush.Rli); // "בג"
+
+            var result = BidiResolver.Resolve(text, BidiParagraphDirection.Ltr, [span1, span2]);
+
+            // The trailing "ש" is a strong-R character sitting at the paragraph's base (even) level once
+            // both isolates close - I1/I2 must still bump it to level 1. A dropped-positions regression
+            // leaves it un-resolved at its raw pre-implicit-level value (0) instead.
+            Assert.Equal(1, result.Levels[5]);
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/CssDefaults.cs
+++ b/src/PeachPDF/Html/Core/CssDefaults.cs
@@ -109,16 +109,16 @@ namespace PeachPDF.Html.Core
             :focus          { outline: thin dotted invert }
             
             /* Begin bidirectionality settings (do not change) */
-            BDO[DIR="ltr"]  { direction: ltr; unicode-bidi: bidi-override }
-            BDO[DIR="rtl"]  { direction: rtl; unicode-bidi: bidi-override }
+            BDO[DIR="ltr"]  { direction: ltr; unicode-bidi: isolate-override }
+            BDO[DIR="rtl"]  { direction: rtl; unicode-bidi: isolate-override }
 
-            *[DIR="ltr"]    { direction: ltr; unicode-bidi: embed }
-            *[DIR="rtl"]    { direction: rtl; unicode-bidi: embed }
+            *[DIR="ltr"]    { direction: ltr; unicode-bidi: isolate }
+            *[DIR="rtl"]    { direction: rtl; unicode-bidi: isolate }
 
-            /* A plain type selector (0,0,1) would lose the unicode-bidi: embed set by the *[DIR=...]
-               rule just above (0,1,0) once the dir="auto"/no-dir-attribute pre-pass has written a
-               literal ltr/rtl dir attribute onto every <bdi> - matching its attribute-selector
-               specificity (0,1,1) is what lets isolate win instead. */
+            /* Redundant with the *[DIR=...] rule above now that both resolve to isolate - kept
+               explicit (and at matching attribute-selector specificity, 0,1,1) so <bdi> keeps
+               isolate on its own terms per the HTML Standard, independent of whatever value a
+               future edit gives the general rule for other dir-bearing elements. */
             bdi[DIR="ltr"], bdi[DIR="rtl"] { unicode-bidi: isolate }
 
             /* Spelt with css-break-3's break-* properties rather than the legacy page-break-*

--- a/src/PeachPDF/Text/Bidi/BidiResolver.cs
+++ b/src/PeachPDF/Text/Bidi/BidiResolver.cs
@@ -67,7 +67,7 @@ namespace PeachPDF.Text.Bidi
             ResolveExplicitLevels(originalTypes, resolvedTypes, levels, overrides, paragraphLevel);
 
             var matchingPdi = ComputeMatchingPdi(resolvedTypes, n);
-            var sequences = ComputeIsolatingRunSequences(resolvedTypes, levels, matchingPdi, n);
+            var sequences = ComputeIsolatingRunSequences(resolvedTypes, levels, matchingPdi, n, overrides);
 
             foreach (var sequence in sequences)
             {
@@ -486,7 +486,8 @@ namespace PeachPDF.Text.Bidi
         }
 
         private static List<int[]> ComputeIsolatingRunSequences(
-            BidiClass[] resolvedTypes, byte[] levels, Dictionary<int, int> matchingPdi, int n)
+            BidiClass[] resolvedTypes, byte[] levels, Dictionary<int, int> matchingPdi, int n,
+            IReadOnlyList<BidiIsolateOverride> overrides)
         {
             var sequences = new List<int[]>();
             if (n == 0) return sequences;
@@ -502,13 +503,51 @@ namespace PeachPDF.Text.Bidi
             }
 
             var runStartIndex = new Dictionary<int, int>();
-            for (var r = 0; r < runs.Count; r++) runStartIndex[runs[r].Start] = r;
+            var runEndIndex = new Dictionary<int, int>();
+            for (var r = 0; r < runs.Count; r++)
+            {
+                runStartIndex[runs[r].Start] = r;
+                runEndIndex[runs[r].End] = r;
+            }
+
+            // A CSS unicode-bidi: isolate/isolate-override box contributes a synthetic RLI/LRI/FSI-then-PDI
+            // pair (see BidiIsolateOverride) that never occupies an index of its own in the text - unlike a
+            // real isolate initiator/PDI, there is no character for resolvedTypes to carry an LRI/RLI/FSI
+            // type on, so the lastType-based chaining just below can never see it. Without this, the level
+            // run ending right before the box and the one starting right after it are never rejoined into
+            // one isolating run sequence, degrading isolate to the same (non-chained) behavior as embed for
+            // any neutral/EN-as-R resolution that spans the box - exactly the case the UA stylesheet's own
+            // [dir] rule (CssDefaults.DefaultStyleSheet) depends on isolate for. Map each isolate-initiating
+            // override's own Start (where the "before" run ends) to its End (where the "after" run starts)
+            // so the loop below can jump the same way real BD13 chaining does - but only when a run
+            // genuinely ends at Start: two adjacent same-direction isolate boxes with nothing between them
+            // (e.g. two sibling dir="rtl" spans) push to the identical level, so their content merges into
+            // one run with no boundary at the shared index, and the second box's own Start never sits at
+            // any run's End at all. Registering it anyway would still mark its End's run as a continuation
+            // that nothing ever actually chains into, silently dropping that run from every sequence.
+            Dictionary<int, int>? syntheticChain = null;
+            foreach (var o in overrides)
+            {
+                if (o.Push is not (BidiExplicitPush.Lri or BidiExplicitPush.Rli or BidiExplicitPush.Fsi)) continue;
+                if (!runEndIndex.ContainsKey(o.Start)) continue;
+                syntheticChain ??= new Dictionary<int, int>();
+                syntheticChain[o.Start] = o.End;
+            }
 
             var isContinuation = new bool[runs.Count];
             foreach (var kv in matchingPdi)
             {
                 if (runStartIndex.TryGetValue(kv.Value, out var runIdx))
                     isContinuation[runIdx] = true;
+            }
+
+            if (syntheticChain != null)
+            {
+                foreach (var kv in syntheticChain)
+                {
+                    if (runStartIndex.TryGetValue(kv.Value, out var runIdx))
+                        isContinuation[runIdx] = true;
+                }
             }
 
             var visited = new bool[runs.Count];
@@ -528,11 +567,29 @@ namespace PeachPDF.Text.Bidi
                     var lastType = resolvedTypes[lastPos];
                     if (lastType is BidiClass.LRI or BidiClass.RLI or BidiClass.FSI
                         && matchingPdi.TryGetValue(lastPos, out var pdiPos)
-                        && runStartIndex.TryGetValue(pdiPos, out var nextRun))
+                        && runStartIndex.TryGetValue(pdiPos, out var nextRun)
+                        && !visited[nextRun])
                     {
                         cur = nextRun;
                         continue;
                     }
+
+                    // Two isolate-initiating overrides can close at the very same real index (a nested
+                    // isolate box that is the last content of its own enclosing isolate box - their Ends
+                    // coincide because nothing occupies the gap a real, separately-indexed PDI pair would).
+                    // Without the !visited guard, both the outer box's own chain and this inner box's chain
+                    // would land on the same "after" run and add its positions twice - once each - so the
+                    // second ResolveSequence call would silently overwrite the first's level assignment for
+                    // those positions instead of resolving them once.
+                    if (syntheticChain != null
+                        && syntheticChain.TryGetValue(e, out var afterIndex)
+                        && runStartIndex.TryGetValue(afterIndex, out var nextSyntheticRun)
+                        && !visited[nextSyntheticRun])
+                    {
+                        cur = nextSyntheticRun;
+                        continue;
+                    }
+
                     break;
                 }
                 sequences.Add(positions.ToArray());


### PR DESCRIPTION
## Summary

- `CssDefaults.DefaultStyleSheet`'s `[dir=ltr]`/`[dir=rtl]`/`[dir=auto]` and `bdo[dir]` UA rules used the legacy CSS2.1 sample stylesheet's `unicode-bidi: embed`/`bidi-override`; they now use the current HTML Standard's `isolate`/`isolate-override`, matching `<bdi>`'s already-correct rule.
- Fixing just the keywords wasn't sufficient: `BidiResolver` implements CSS `unicode-bidi` values as synthetic stack pushes rather than real Unicode LRI/RLI/FSI/PDI control characters, so its BD13 isolating-run-sequence chaining never actually detected a CSS-driven isolate boundary — `isolate` behaved identically to `embed` for any paragraph where UAX#9's EN-as-R neutral resolution spans the isolated box (exactly the issue's own repro, digits sandwiching an RTL span). Added a second, index-based chaining path for synthetic isolate boundaries, with two edge-case guards an independent review pass caught before this landed (dropped-run guard for adjacent same-direction isolates with no gap; duplicate-visit guard for nested isolates closing at the same index).
- Verified against a real Chromium render before/after: `<p>1 <span dir="rtl">עברית</span> 2</p>` now renders `1 [hebrew] 2` (matching real browsers) instead of `1 2 [hebrew]`.
- Filed two narrower, deliberately out-of-scope follow-ups discovered along the way: #575 (override push/pop ordering for boxes sharing a text index) and #576 (eos approximation for isolates 3+ levels deep closing flush together) — see `.claude/accepted-gaps/synthetic-isolate-chaining-deep-nesting-edge-cases.md`.

## Test plan

- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 7368 passed, 9 skipped, 0 failed
- [x] `BidiResolverConformanceTests` (Unicode's ~92k-case `BidiCharacterTest.txt`) — still 100% passing
- [x] Two new regression tests in `BidiResolverSyntheticIsolateTests.cs`, each confirmed to fail without its corresponding guard and pass with it
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings
- [x] `diff-cover` against `origin/main` — 100% diff coverage

Fixes #554