### PR TITLE
Memoize CssValueParser.IsValidLength by input string

### DIFF
--- a/src/PeachPDF/Html/Core/Parse/CssValueParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/CssValueParser.cs
@@ -17,6 +17,7 @@ using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Entities;
 using PeachPDF.Html.Core.Utils;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -97,6 +98,22 @@ namespace PeachPDF.Html.Core.Parse
         }
 
         /// <summary>
+        /// Memoizes <see cref="IsValidLength"/> by its input string - a pure function of that string
+        /// alone (<see cref="GetCssTokens(string, bool)"/> always runs with <c>inValueContext: false</c>
+        /// here, and neither it nor <see cref="ValueExtensions.ToDistance"/> reads anything else). A
+        /// document's boxes overwhelmingly repeat the same handful of literal length strings (e.g.
+        /// "0px", "auto"), and every caller in the layout engines (<c>ApplyHeight</c>/<c>GetBoxHeight</c>/
+        /// <c>ApplyParentHeight</c>, the flex/grid/table engines) re-asks this on every layout pass of
+        /// every box - by the time a value reaches here it was already validated once, identically, by
+        /// the cascade-time property setters in <see cref="Utils.CssUtils"/> that gate whether it's
+        /// assigned to the box at all, so re-tokenizing the same string over and over is pure waste.
+        /// Unbounded like <see cref="Text.HyphenationEngine"/>'s language-pattern cache and
+        /// <see cref="Network.MimeTypeResolver"/>'s cache: the key space is a small, effectively-fixed
+        /// set of distinct CSS value strings, not user-controlled arbitrary data.
+        /// </summary>
+        private static readonly ConcurrentDictionary<string, bool> IsValidLengthCache = new();
+
+        /// <summary>
         /// Check if the given string is a valid length value.
         /// </summary>
         /// <param name="value">the string value to check</param>
@@ -105,6 +122,15 @@ namespace PeachPDF.Html.Core.Parse
         {
             if (string.IsNullOrEmpty(value)) return false;
 
+            if (IsValidLengthCache.TryGetValue(value, out var cached)) return cached;
+
+            var result = IsValidLengthCore(value);
+            IsValidLengthCache[value] = result;
+            return result;
+        }
+
+        private static bool IsValidLengthCore(string value)
+        {
             if (IsCalcFunction(value)) return true;
 
             // Defer to the same CSS-OM length/percentage grammar already used at cascade time


### PR DESCRIPTION
## Summary

- `CssValueParser.IsValidLength` re-tokenized and re-ran the full CSS-OM length/percentage grammar (a fresh `Lexer` + `List<Token>` + `ToDistance()` conversion) on every call, even though a document's boxes overwhelmingly repeat the same handful of literal length strings (e.g. `"0px"`, `"auto"`), and the value was already validated once by the cascade-time property setters (`CssUtils.cs`) that gate whether it's assigned to a box at all.
- Callers across the layout engines (`CssLayoutEngine.ApplyHeight`/`GetBoxHeight`/`ApplyParentHeight`, the flex/grid/table engines, `CssBox`) re-ask this on every layout pass of every box, so the cost scaled with box-count × layout-pass-count rather than with the number of distinct length values actually in use.
- This memoizes the result by the input string. `IsValidLength` is a pure function of its string argument (`GetCssTokens` always runs with `inValueContext: false` here, and neither it nor `ValueExtensions.ToDistance` reads anything else), so caching by string content is safe. The cache is unbounded, matching the existing shape of `HyphenationEngine`'s language-pattern cache and `MimeTypeResolver`'s cache — the key space is a small, effectively-fixed set of CSS value strings, not user-controlled arbitrary data.

## Context

Found while investigating why the css4.pub "Icelandic Dictionary" stress document (14,645 short paragraphs across 26 two-column chapters) renders extremely slowly. A CPU profile of an isolated micro-benchmark showed `CssValueParser.IsValidLength`/`PeachPDF.CSS.ValueExtensions.ToDistance` consuming a notable share of layout time in a plain block-flow case with no columns/justify/hyphens at all.

## Measured impact

**Isolated single-chapter micro-benchmark** (same shape as the real document's chapters: short `<p>` entries, `columns: 2`, `justify`, `hyphens: auto`, `widows/orphans: 1`), N = number of paragraphs:

| N | before: MB/paragraph | after: MB/paragraph |
|---|---|---|
| 100 | 7.32 | 2.85 |
| 200 | 7.54 | 2.92 |
| 400 | 7.17 | 2.83 |
| 800 | 7.11 | 2.88 |
| 1600 | 7.40 | 3.15 |

A consistent **~2.5x reduction in allocation per paragraph**, and wall time improved roughly 30% at N=800/1600.

**Real document** (the actual `dictionary.mhtml` file, 14,645 paragraphs, up to 2,252 in a single chapter): a bounded before/after comparison at matching elapsed time showed a smaller, but real and consistent, improvement — allocation at the ~1:30–1:35 mark dropped by roughly 3–4% (e.g. 109,569 MB → 105,777 MB at ~1:35). The real document's dominant cost is evidently elsewhere (very likely the multi-column balance-retry/widows-rewind rollback mechanism tracked separately, since real chapters run up to 2,252 children and this document's `widows: 1; orphans: 1` plus mostly-short entries likely trigger that path often) — this change is one confirmed, safe contributor, not a full fix for that document's overall runtime.

## Test plan

- [x] `dotnet build PeachPDF.slnx -c Release` — builds clean, zero warnings
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 7365 passed, 0 failed, 9 skipped (pre-existing platform-specific skips)
- [x] Isolated micro-benchmark before/after (see above)
- [x] Real-document before/after comparison at matched elapsed time (see above)


---
_Generated by [Claude Code](https://claude.ai/code/session_01M3hPZc4ntV2y6PiP7yS3YR)_