### PR TITLE
Skip redundant multi-column rollback resets on untouched children

### DIFF
--- a/src/PeachPDF.Tests/Integration/MulticolLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/MulticolLayoutIntegrationTests.cs
@@ -746,6 +746,55 @@ namespace PeachPDF.Tests.Integration
             return Wrap($"<div id='mc' style='columns:{columnCount}; column-gap:0; width:200px'>{items}</div>");
         }
 
+        // ─── A whole remaining tail reset across many pages (#573) ─────────────────
+
+        // PassRewind.RollBackTo resets every one of a container's *remaining* children on every page it
+        // resumes into, not just the handful that page's fill reaches - so a container with far more
+        // children than fit on one page redundantly re-resets the same distant, untouched children again
+        // on every earlier page before the fill finally reaches them (CssBox.ResetForRefill now skips a
+        // child already sitting in that reset-and-untouched state - see its remarks). This is the
+        // large-container shape that makes the redundancy actually add up: many more children than any
+        // single page holds, spanning many resumed pages, so most children get reset - and, before the
+        // fix, re-reset - several times over before the fill ever reaches them.
+        [Fact]
+        public async Task ManyChildrenAcrossManyResumedPages_KeepsEveryWordExactlyOnceAndOverlapsNone()
+        {
+            const int itemCount = 60;
+            var items = string.Concat(Enumerable.Range(1, itemCount)
+                .Select(i => $"<div class='item' id='i{i}'>Entry {i} with a little text of its own.</div>"));
+            var html = Wrap($"<div id='mc' style='columns:2; column-gap:0; width:200px'>{items}</div>");
+
+            var (root, container) = await BuildAndLayout(html, pageHeight: 100);
+
+            // Confirms the fixture actually exercises the shape the fix targets: many more resumed pages
+            // than the earlier 12-item fixtures reach, so most children are reset several times over
+            // before the fill reaches them.
+            Assert.True(container.FragmentainerPasses > 4,
+                $"expected many resumed pages, got {container.FragmentainerPasses}");
+
+            var placed = FindAllByClass(root, "item");
+            Assert.Equal(itemCount, placed.Count);
+            AssertNoOverlaps(placed);
+
+            // The same double-claim/dropped-word guard as BalanceRetryOnAResumedFragment_KeepsEveryWordExactlyOnce,
+            // at a scale where a child can be redundantly reset many times before the fill actually reaches it.
+            var claimed = container.FragmentTree!.Fragmentainers
+                .SelectMany(f => FlattenFragments(f.Root))
+                .SelectMany(f => f.Words)
+                .Select(w => w.Word)
+                .ToList();
+
+            Assert.Equal(claimed.Count, claimed.Distinct().Count());
+
+            var authored = placed
+                .SelectMany(LayoutHarness.Descendants)
+                .SelectMany(b => b.Words)
+                .Where(w => !w.IsSpaces)
+                .ToList();
+
+            Assert.All(authored, word => Assert.Contains(word, claimed));
+        }
+
         private static IEnumerable<BoxFragment> FlattenFragments(BoxFragment fragment)
         {
             yield return fragment;

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -1240,6 +1240,15 @@ namespace PeachPDF.Html.Core.Dom
         /// </remarks>
         internal void ResetForRefill()
         {
+            // A caller that resets a whole remaining child range on every page/retry (PassRewind.RollBackTo)
+            // re-asks this for children the page in hand will never reach, over and over, across every later
+            // page too - and a box already sitting in exactly the state this method produces, untouched since,
+            // has nothing left to redo. Skipping needs no extra bookkeeping to stay correct: _awaitingRefill
+            // clears the moment this box's own pass genuinely starts again (BeginBlockPass), which is the
+            // only event that could make a repeat of this method do something different (see #573).
+            if (_awaitingRefill) return;
+            _awaitingRefill = true;
+
             // The columns engine calls this before the real fill lays the same boxes out again from scratch,
             // which on a resumed pass includes boxes a frozen fragmentainer already holds.
             NotifyGeometryChanged(OwnGeometryTop(), 0);
@@ -1503,6 +1512,23 @@ namespace PeachPDF.Html.Core.Dom
         private bool _prologueDone;
 
         /// <summary>
+        /// Whether <see cref="ResetForRefill"/> has already brought this box into the state a pass
+        /// re-entry needs, with nothing having touched it since - so a second call before the box is
+        /// genuinely laid out again would repeat exactly the same work for no new effect.
+        /// </summary>
+        /// <remarks>
+        /// Set by <see cref="ResetForRefill"/> itself and cleared the moment this box's own pass
+        /// genuinely starts again (<see cref="BeginBlockPass"/>, guarded the same way
+        /// <see cref="_prologueDone"/> is - both flip together because a box's prologue re-running and a
+        /// box being "used since its last reset" are the same event). A caller that resets a box already
+        /// in this state (e.g. <see cref="Fragmentation.PassRewind.RollBackTo"/> re-resetting a
+        /// container's whole remaining child list on every page/retry, most of which the page in hand
+        /// never reaches) can skip the whole subtree walk rather than repeat it - see
+        /// <see href="https://github.com/jhaygood86/PeachPDF/issues/573">#573</see>.
+        /// </remarks>
+        private protected bool _awaitingRefill;
+
+        /// <summary>
         /// Where <see cref="PerformLayoutImp"/> is to re-place this box, set when an
         /// <see cref="EarlyBreak"/> is taken by re-laying the box out rather than by moving it.
         /// </summary>
@@ -1745,6 +1771,11 @@ namespace PeachPDF.Html.Core.Dom
             if (!_prologueDone)
             {
                 _prologueDone = true;
+
+                // This box's pass is genuinely starting again - the one event that can make a later
+                // ResetForRefill() need to do real work rather than skip as already-reset (see its remarks).
+                _awaitingRefill = false;
+
                 await PerformLayoutPrologue(g);
             }
 
@@ -2007,6 +2038,13 @@ namespace PeachPDF.Html.Core.Dom
                 _escapedForcedBreakBlankSlot = null;
                 _orphansBreakTaken = false;
                 _widowsRewindTaken = false;
+
+                // A box can end one layout generation sitting in "reset, not yet re-entered" state (e.g.
+                // the last child a container's own RollBackTo touched, never revisited before the
+                // generation ended) - carrying that flag into a brand new generation would let the first
+                // ResetForRefill() call of the new one skip as a no-op, when nothing about this generation
+                // has touched this box yet.
+                _awaitingRefill = false;
             }
 
             var resume = _incomingToken;

--- a/src/PeachPDF/Html/Core/Dom/CssBoxHr.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBoxHr.cs
@@ -80,6 +80,12 @@ namespace PeachPDF.Html.Core.Dom
             // progress — which is the driver's own backstop, and how the omission announced itself.
             BeginLayoutPass();
 
+            // This box's own pass never routes through CssBox.BeginBlockPass (there is no prologue/
+            // placement/content split for a rule), so nothing else clears CssBox._awaitingRefill for it -
+            // without this, a container resetting this rule once and then genuinely laying it out again
+            // here would leave a later reset skipped as a stale no-op.
+            _awaitingRefill = false;
+
             RectanglesReset();
 
             //width at 100% (or auto)

--- a/src/PeachPDF/Html/Core/Dom/CssBoxMarker.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBoxMarker.cs
@@ -132,6 +132,12 @@ namespace PeachPDF.Html.Core.Dom
         /// </summary>
         protected override async ValueTask PerformLayoutImp(RGraphics g, CssBox frame, bool framePlacesChild)
         {
+            // This box's own pass never routes through CssBox.BeginBlockPass (there is no prologue/
+            // placement/content split for a marker), so nothing else clears CssBox._awaitingRefill for it -
+            // without this, a container resetting this marker once and then genuinely laying it out again
+            // here would leave a later reset skipped as a stale no-op.
+            _awaitingRefill = false;
+
             await MeasureWordsSize(g);
 
             if (ListStylePosition != CssConstants.Outside) return;

--- a/src/PeachPDF/Html/Core/Dom/CssProxyBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssProxyBox.cs
@@ -86,6 +86,13 @@ namespace PeachPDF.Html.Core.Dom
         /// </summary>
         protected override async ValueTask PerformLayoutImp(RGraphics g, CssBox frame, bool framePlacesChild)
         {
+            // This box's own pass never routes through CssBox.BeginBlockPass (a proxy translates a source
+            // box's already-laid-out geometry rather than running a prologue/placement/content pass of its
+            // own), so nothing else clears CssBox._awaitingRefill for it - without this, a container
+            // resetting this proxy once and then genuinely laying it out again here would leave a later
+            // reset skipped as a stale no-op.
+            _awaitingRefill = false;
+
 #if DEBUG
             System.Console.WriteLine($"CssProxyBox.PerformLayoutImp: START - Location={Location}, Display={Display}");
             System.Console.WriteLine($"  Source already laid out: Location={_sourceBox.Location}, ActualBottom={_sourceBox.ActualBottom}, ActualRight={_sourceBox.ActualRight}");


### PR DESCRIPTION
## Summary

- `PassRewind.RollBackTo` resets every remaining child of a container on every page it resumes into, and again on every `column-fill: balance` retry attempt — not just the handful of children the page in hand actually reaches. For a multi-column container with far more children than fit on one page (e.g. a chapter of a few thousand short paragraphs), this means the same distant, untouched children get redundantly reset over and over across every earlier page before the fill ever reaches them.
- `CssBox.ResetForRefill` now skips a child that's already sitting in exactly the state a reset produces, with nothing having touched it since. The new `_awaitingRefill` guard clears the moment the box's own pass genuinely starts again (`BeginBlockPass`, mirroring the same transition `_prologueDone` already tracks) or crosses a layout-generation boundary (`BeginLayoutPass`, so `ShrinkToFit`'s second full pass can't inherit stale state from the first). The three box kinds that never route through `BeginBlockPass` at all (`<hr>`, an outside `::marker`, a repeated `<thead>`/`<tfoot>` proxy) clear it defensively in their own `PerformLayoutImp` overrides, so the flag can never get permanently stuck skipping for them.

## Evidence this was a real, quadratic bug

Instrumented call counts (not committed — measured locally, then reverted) on an isolated single-chapter multi-column benchmark (short paragraphs, same shape as the real-world stress document this was found investigating) showed `ResetForRefill` call count scaling as a clean quadratic function of paragraph count N, holding essentially constant when divided by N²:

| N | `ResetForRefill` calls | calls / N² |
|---|---|---|
| 500 | 3,285 | 0.01314 |
| 1,000 | 12,617 | 0.01262 |
| 2,000 | 49,425 | 0.01236 |
| 2,252 | 62,521 | 0.01233 |
| 3,000 | 110,425 | 0.01227 |
| 4,000 | 195,681 | 0.01223 |

After the fix, the expensive recursive part of the reset (`AllowDescendantForcedBreaksToBeRetaken`, which walks a child's whole descendant subtree) drops from that quadratic shape to a clean linear one — the same measurement, calls / N, now holds constant (~9.2) across the same N range instead of growing.

**Honest caveat**: this genuinely turns an O(N²) mechanism into O(N), but it does not measurably change overall wall-clock time or allocation on either the isolated benchmark or the real stress document — each redundant call was cheap (a bool set plus a `Boxes` loop, no allocation), so eliminating 90%+ of them doesn't show up against the real per-page layout cost. This is a correct, verified algorithmic fix, not a fix for that document's overall runtime (which remains open).

## Test plan

- [x] `dotnet build PeachPDF.slnx -t:Rebuild -c Release` — builds clean, zero warnings
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 7369 passed, 0 failed, 9 skipped (pre-existing platform-specific skips)
- [x] `diff-cover` against `origin/main` — 100% diff coverage on the changed lines
- [x] Added `ManyChildrenAcrossManyResumedPages_KeepsEveryWordExactlyOnceAndOverlapsNone` — 60 paragraphs across 2 columns and 5+ resumed pages, asserting no two boxes overlap and every word is claimed by the fragment tree exactly once (the same double-claim/dropped-word invariant the existing `BalanceRetryOnAResumedFragment_KeepsEveryWordExactlyOnce` test checks, at the scale where a child gets redundantly reset many times before the fill reaches it)
- [x] Mutation sanity check: temporarily replaced the guard with an unconditional skip (`if (true) return;`) and reran the full suite — it broke 7 existing tests, all in the forced-break/page-break area the guard's placement is meant to protect (`NamedPageElement_RegistersOnceForThePageItLandsIn`, `AForcedPageBreak_LeavesTheColumnsBeforeItBalanced`, `AForcedPageBreak_InsideAColumn_StartsTheNextPage`, `AForcedPageBreak_InsideANestedContainer_EscapesBothOfThem`, and others) — confirming the guard's exact placement is load-bearing rather than redundant caution, and that the suite has real teeth against an over-aggressive version of this same idea. Reverted before finalizing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M3hPZc4ntV2y6PiP7yS3YR)_