### PR TITLE
Use the boundary-aware slot lookup for a resumed column/table restart top

### DIFF
--- a/src/PeachPDF.Tests/Integration/MulticolLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/MulticolLayoutIntegrationTests.cs
@@ -795,6 +795,67 @@ namespace PeachPDF.Tests.Integration
             Assert.All(authored, word => Assert.Contains(word, claimed));
         }
 
+        // ─── A resumption top landing exactly on a page boundary (#573) ────────────
+
+        // CssLayoutEngineColumns.Layout resolved which page slot a resumed column starts filling with
+        // the raw, boundary-ambiguous HtmlContainerInt.PageIndexOf (a coordinate exactly on a page
+        // boundary is "both the end of one band and the start of the next" per its own remarks) instead
+        // of the boundary-aware SlotStartingAt every other "fresh content-top edge" call site uses. A
+        // resumed column's own top is exactly that edge, and it lands precisely on a page boundary by
+        // construction (a genuinely new page always starts at its own designated top) - so with a page
+        // height whose arithmetic doesn't round back to a clean multiple of itself (e.g. a millimeter
+        // page size converted to points), PageIndexOf(boxTop) can resolve to the page being LEFT rather
+        // than the one being entered. That page's own remaining budget then computes to zero, and every
+        // later pass recomputes the exact same (wrong, un-advanced) boxTop forever: the container never
+        // reaches a fresh page and instead piles every remaining word onto the one it already filled, at
+        // the same frozen Y - visually, hundreds of entries stacked directly on top of each other with
+        // the rest of the page left blank. Reproduced directly against the real dictionary.mhtml-shaped
+        // page format (160mm x 200mm, which floating-point-converts to points messily, unlike Letter's
+        // already-integer 612x792pt) - page count stayed frozen at exactly 4 from 500 through 4000
+        // paragraphs, with per-page text length exploding from ~2000 to over 65000 characters, before the
+        // fix. A non-round pageHeight below reproduces the same boundary mismatch in miniature.
+        [Fact]
+        public async Task ManyChildrenAtANonRoundPageHeight_PageCountGrowsAndNoTwoItemsOverlap()
+        {
+            const int itemCount = 400;
+            var items = string.Concat(Enumerable.Range(1, itemCount)
+                .Select(i => $"<div class='item' id='i{i}'>Entry {i} with a little text of its own.</div>"));
+            var html = Wrap($"<div id='mc' style='columns:2; column-gap:0; width:200px'>{items}</div>");
+
+            // 150mm worth of points (150 / 25.4 * 72) - the same messy-binary-fraction shape as the real
+            // document's @page { size: 160mm 200mm }, deliberately not a round number of layout units.
+            // Verified (against the pre-fix code) to actually land a resumed column's top exactly on this
+            // specific page height's boundary: without the fix this fixture is stuck at 11 pages rather
+            // than scaling with content.
+            var (root, container) = await BuildAndLayout(html, pageHeight: 150.0 / 25.4 * 72);
+
+            var placed = FindAllByClass(root, "item");
+            Assert.Equal(itemCount, placed.Count);
+
+            // The frozen-page bug left the container on a small, fixed number of pages regardless of how
+            // much content remained; 400 items at this page height must span well beyond that.
+            var pageCount = placed.Select(b => container.PageIndexOf(b.Location.Y)).Distinct().Count();
+            Assert.True(pageCount > 20, $"expected the container to span many pages, landed on {pageCount}");
+
+            AssertNoOverlaps(placed);
+
+            var claimed = container.FragmentTree!.Fragmentainers
+                .SelectMany(f => FlattenFragments(f.Root))
+                .SelectMany(f => f.Words)
+                .Select(w => w.Word)
+                .ToList();
+
+            Assert.Equal(claimed.Count, claimed.Distinct().Count());
+
+            var authored = placed
+                .SelectMany(LayoutHarness.Descendants)
+                .SelectMany(b => b.Words)
+                .Where(w => !w.IsSpaces)
+                .ToList();
+
+            Assert.All(authored, word => Assert.Contains(word, claimed));
+        }
+
         private static IEnumerable<BoxFragment> FlattenFragments(BoxFragment fragment)
         {
             yield return fragment;

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineColumns.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineColumns.cs
@@ -164,7 +164,15 @@ namespace PeachPDF.Html.Core.Dom
             var columnLeft = columnsBox.ClientLeft;
             var pitch = columnWidth + gap;
 
-            var startSlot = htmlContainer.HasRealPageGrid ? htmlContainer.PageIndexOf(boxTop) : 0;
+            // boxTop is a fragmentainer's own content-top edge, not an arbitrary interior coordinate - a
+            // top edge flush on (or, from arithmetic noise, a hair below) a page boundary begins the
+            // later slot per HtmlContainerInt.SlotStartingAt's own convention. The raw PageIndexOf makes
+            // no such distinction and can resolve the exact boundary to the page being LEFT instead: this
+            // page's own budget then computes to zero, and every later pass recomputes the same boxTop
+            // from that same (wrong, un-advanced) slot forever, so the container never reaches a fresh
+            // page and instead re-fills the one it already exhausted - visibly, every remaining word lands
+            // at that one frozen Y (see #573's investigation, reproduced with a non-Letter page size).
+            var startSlot = htmlContainer.HasRealPageGrid ? htmlContainer.SlotStartingAt(boxTop) : 0;
 
             // What is left of this container's own page. A column can never be taller than that, so it
             // is the ceiling on every target below.

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
@@ -1282,7 +1282,11 @@ namespace PeachPDF.Html.Core.Dom
 
                     _tableBox.Location = _tableBox.Location with { Y = _tableBox.Location.Y + pageBreakOffset };
                     startY = Math.Max(_tableBox.ClientTop + GetVerticalSpacing(), 0);
-                    cursor.RestartAt(startY, container.PageIndexOf(startY), container);
+                    // startY is a fresh restart point at the table's own content-top edge on the new
+                    // page, not an arbitrary interior coordinate - the same "top edge flush on a
+                    // boundary" case HtmlContainerInt.SlotStartingAt exists for (see the identical fix in
+                    // CssLayoutEngineColumns.Layout, #573's investigation).
+                    cursor.RestartAt(startY, container.SlotStartingAt(startY), container);
                 }
             }
 
@@ -1320,7 +1324,11 @@ namespace PeachPDF.Html.Core.Dom
                     _headerBox.OffsetTop(pageBreakOffset);
 
                     startY = Math.Max(_tableBox.ClientTop + GetVerticalSpacing(), 0);
-                    cursor.RestartAt(startY, container.PageIndexOf(startY), container);
+                    // startY is a fresh restart point at the table's own content-top edge on the new
+                    // page, not an arbitrary interior coordinate - the same "top edge flush on a
+                    // boundary" case HtmlContainerInt.SlotStartingAt exists for (see the identical fix in
+                    // CssLayoutEngineColumns.Layout, #573's investigation).
+                    cursor.RestartAt(startY, container.SlotStartingAt(startY), container);
                 }
             }
 


### PR DESCRIPTION
## Summary

`CssLayoutEngineColumns.Layout` and `CssLayoutEngineTable`'s page-break restart both resolved which page slot a fresh content-top edge lands in with the raw, boundary-ambiguous `HtmlContainerInt.PageIndexOf` instead of `SlotStartingAt`.

A resumed column/table restart's top sits exactly on a page boundary by construction — a new page always starts at its own designated top. `PageIndexOf` is explicitly documented as ambiguous at an exact boundary (it's "both the end of one band and the start of the next"), which is exactly why `SlotStartingAt`/`SlotEndingAt` exist. With a page height whose arithmetic doesn't round back to a clean multiple of itself (e.g. a millimeter page size converted to points — non-Letter, non-integer-point dimensions), `PageIndexOf` can resolve that exact boundary to the page being **left** rather than the one being **entered**. That page's own remaining budget then computes to zero, and every later pass recomputes the same (wrong, un-advanced) top forever: the container never reaches a fresh page and instead piles every remaining word onto the one it already filled, at the same frozen Y.

## Impact

This reproduced as severe content corruption, not just slowness: with a non-Letter page size (e.g. `160mm x 200mm`), a multi-column container's page count froze at a small, fixed number regardless of how much content remained, with the last page's text length exploding to dozens of times its neighbors' — visually, hundreds of entries stacked directly on top of each other at the same position, with the rest of the page left blank. Fixing this also resolves the severe performance cost that came with it (the container kept doing real layout work on an ever-growing tail of content each "stuck" pass).

## Testing

- Full `PeachPDF.Tests` suite (net8.0): 7,370 passed, 0 failed.
- 100% diff coverage on the two changed lines.
- New regression test (`ManyChildrenAtANonRoundPageHeight_PageCountGrowsAndNoTwoItemsOverlap`) reproduces the exact boundary collision with a deliberately non-round page height, and is confirmed sensitive to the fix (fails without it, landing on a frozen page count instead of scaling with content).
- Verified directly against the real bug shape: a 500-paragraph, 2-column document at a `160mm x 200mm` page went from stuck at exactly 4 pages (one holding 65,000+ characters of overlapping text) to a correctly-scaling 34 pages with uniform ~2,000-character content per page.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M3hPZc4ntV2y6PiP7yS3YR)_