### PR TITLE
Stop re-walking the whole box tree for every page emitted

### DIFF
--- a/.claude/recent-fixes/2026-07-31-emission-no-longer-rewalks-the-whole-tree-per-page.md
+++ b/.claude/recent-fixes/2026-07-31-emission-no-longer-rewalks-the-whole-tree-per-page.md
@@ -1,0 +1,79 @@
+# Emission no longer re-walks the whole box tree for every page
+
+`FragmentEmitter.EmitSlot` built each page's draft tree by recursing from the document root with
+no pruning at all. Measured on the css4.pub Icelandic dictionary (31 chapters, ~14,650 paragraphs,
+36,222 `<b>`, ~255,000 boxes, `.chapter { columns: 2 }`): **~255,000 `BuildDraft` calls per page,
+flat**, whether emitting page 1 or page 40. Fragment emission cost **84.7s** against **6.5s** for
+all the layout it describes. Introduced by the fragment-tree rewrite, which is why the same file
+rendered in 53.8s at `c047bb90` and 9m24s afterwards.
+
+## What "may I skip this subtree?" actually needs
+
+"The emitter walked it and it produced nothing" is **not** sufficient on its own, and this is the
+trap three earlier attempts died in. `EmitPass(from, through)` freezes a whole *range* of slots in
+one go, **after** the pass that filled them has already flowed content into every one, with no
+layout in between. So at any slot below the frontier, "nothing here" equally describes content that
+is simply further down — and no write will ever come along to correct it.
+
+Two separately-justified cases, never merged:
+
+- **Behind the frontier** — the box is already in `_frozen`, so it has had its fragments and they
+  were contiguous. Empty now means empty later.
+- **Ahead of the frontier** — nothing has ever written to the box this generation
+  (`CssBox.NeverTouchedThisLayout`), so it holds no positioned content anywhere. The write that
+  first positions it lands before the pass placing it ends, hence before the slot needing it is
+  frozen.
+
+Excluded is the box *in between* — reached, laid out, simply not here — whose content may be in a
+slot the same `EmitPass` range is about to freeze.
+
+## What was measured, not reasoned
+
+- **Per-visit facts must not propagate to ancestors.** A multi-column container's children are each
+  visited once per column, so none can be observed individually — but letting that poison the
+  *container* made every multicol container unprunable, which on this document is the entire
+  optimization. Only `ContentStaysInOneRun` (out-of-flow/fixed/proxy/spacing/marker) travels up.
+- **`InvalidateFrom` must bump the observation epoch only past its own early return.** It is
+  reached on every block-axis reposition of a box holding fragments — constant during a pass — so
+  bumping unconditionally retired observations as fast as they were made. Diagnosed by counting
+  skips per slot (`skips=0` on nearly every slot while ~195k marks were being re-made).
+- **Never derive the observation from live geometry.** Engines rewrite a box's extent well after
+  its own layout pass finishes, and the multi-column engine keeps each column's geometry in its own
+  `BoxGeometrySnapshot`, so a box's own fields do not describe every fragment it has. This is what
+  killed attempt 2 (476 failures). Two write choke points had to be created instead: `CssBox.Size`
+  (through which every `ActualBottom`/`ActualRight` assignment passes — guarded on value change,
+  it is on the hot path) and `CssRect.Top` (the only place a word's position is settled).
+
+## The verification is the deliverable as much as the change is
+
+Three previous attempts each broke 460–480 tests and each was caught only by running the whole
+suite — never by review. So the oracle was built first: `PEACHPDF_VERIFY_FRAGMENT_PRUNING=1` makes
+every slot build its draft tree **twice**, pruned and unpruned, and throws unless the two agree on
+all nineteen `Draft` members, on `hasPrintableContent`, and — the part that matters most — on the
+set of boxes holding fragments.
+
+That last one is not a detail. Per
+[.claude/invariants/fragmentation-which-drafts-exist-decides-whether-a-frozen-slot-is-emitted-again.md](../invariants/fragmentation-which-drafts-exist-decides-whether-a-frozen-slot-is-emitted-again.md),
+`_frozen` is the only gate on whether an already-frozen slot is emitted again, so a pruning bug can
+leave every draft identical and still change the whole document's emission order. `_frozen` is
+snapshotted and rolled back between the two builds (safe — `BuildDraft`'s only emitter mutation is
+the idempotent `_frozen.Add`).
+
+It works: the first run under it produced **22** failures, not the ~470 of the blind attempts, each
+naming the diverging box and member. Both were real — a rewound keep-with-next pass whose
+observations were not retired, and inline content whose words move with no box-level write.
+
+## Where it stands
+
+9m24s → **7m38s**, suite green with and without the harness, solution rebuilds warning-free.
+
+The remaining gap is understood and worth a follow-up rather than a guess: instrumentation shows
+observations are still discarded roughly every pass (~195k boxes re-marked per slot), so most slots
+still take the full walk and only a few prune hard (18k, 8k, 1.5k calls). Something in the
+per-pass write traffic — the columns fill/retry loop's `PassRewind.RollBackTo` over its children is
+the prime suspect — clears far more than it needs to. Find it by counting `DiscardEmittedNothing`
+calls per call site over one pass; the harness already guarantees any fix stays honest.
+
+Separately, ~28s of this document's time is **two** full HTML parses + CSS cascades, because
+`PdfGenerator` re-parses when CSS `@page size` differs from the configured page size. Independent,
+simpler, and worth its own issue.

--- a/src/PeachPDF.Tests/Html/Core/Fragments/FragmentPruningParityTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Fragments/FragmentPruningParityTests.cs
@@ -1,0 +1,195 @@
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Fragments;
+using PeachPDF.Tests.TestSupport;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Tests.Html.Core.Fragments
+{
+    /// <summary>
+    /// <c>FragmentEmitter</c> skips re-descending into a subtree it has already walked and observed to
+    /// produce nothing, so that emitting a page costs something like the page rather than something like
+    /// the document. That is only sound if it is <i>invisible</i>: it may decline to walk a subtree, but
+    /// never change what comes out.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Each test here renders with <see cref="HtmlContainerInt.VerifyFragmentPruningOverride"/> on, which
+    /// makes every slot build its draft tree twice — once pruned, once with pruning forced off — and
+    /// throw unless the two are indistinguishable across all of a draft's members, the printable-content
+    /// flag, and the set of boxes holding fragments. So the real assertion in every one of these is that
+    /// laying out at all did not throw; the explicit assertions afterwards are there to prove the fixture
+    /// still exercises what it claims to (a fixture that quietly stopped paginating would verify nothing).
+    /// </para>
+    /// <para>
+    /// The fixtures are chosen for the cases where "this subtree is empty here" is hardest to conclude:
+    /// content still ahead of the layout frontier, nested fragmentainers that visit one box once per
+    /// column, a source subtree repeated through a proxy on every page, a mover that relocates content
+    /// out of an already-frozen fragmentainer, and a descendant positioned nowhere near its ancestor.
+    /// Setting the whole suite's <c>PEACHPDF_VERIFY_FRAGMENT_PRUNING=1</c> covers far more ground than
+    /// this file does; these are the shapes worth pinning so a regression names itself.
+    /// </para>
+    /// </remarks>
+    public class FragmentPruningParityTests
+    {
+        [Fact]
+        public async Task ManyPagesOfPlainBlocks_PrunesWithoutChangingTheTree()
+        {
+            var blocks = string.Concat(Enumerable.Range(0, 60)
+                .Select(i => $"<p id='p{i}' style='margin:0;line-height:20pt'>Paragraph {i}</p>"));
+
+            var (_, container) = await Verified(LayoutHarness.Wrap(blocks), pageHeight: 120, margin: 0);
+
+            Assert.True(container.FragmentTree!.Fragmentainers.Count > 5,
+                $"fixture must paginate to exercise pruning, got {container.FragmentTree.Fragmentainers.Count} pages");
+            Assert.Equal(60, DistinctBoxesWithWords(container).Count);
+        }
+
+        [Fact]
+        public async Task ManyPagesOfMultiColumn_PrunesWithoutChangingTheTree()
+        {
+            // The container's children are visited once per column of the same slot, so none of them can
+            // be observed individually - but the container itself can, and on a document that is mostly
+            // multi-column that is the whole point.
+            var items = string.Concat(Enumerable.Range(0, 80)
+                .Select(i => $"<div id='i{i}' style='line-height:20pt'>Entry {i}</div>"));
+
+            var (_, container) = await Verified(
+                LayoutHarness.Wrap($"<div id='mc' style='columns:2;column-gap:0;width:200px'>{items}</div>"),
+                pageHeight: 140, margin: 0);
+
+            Assert.True(container.FragmentTree!.Fragmentainers.Count > 3,
+                $"fixture must paginate to exercise pruning, got {container.FragmentTree.Fragmentainers.Count} pages");
+        }
+
+        [Fact]
+        public async Task ARepeatingTableHeaderAcrossPages_PrunesWithoutChangingTheTree()
+        {
+            // One source subtree stands in for a header on every page, reached through a different proxy
+            // each time - so the same box legitimately has several unrelated runs of fragments, and an
+            // observation about it would be about the wrong one.
+            var rows = string.Concat(Enumerable.Range(0, 40)
+                .Select(i => $"<tr><td style='line-height:20pt'>Row {i}</td></tr>"));
+
+            var (_, container) = await Verified(
+                LayoutHarness.Wrap($"<table><thead><tr><th>Heading</th></tr></thead><tbody>{rows}</tbody></table>"),
+                pageHeight: 140, margin: 0);
+
+            Assert.True(container.FragmentTree!.Fragmentainers.Count > 2,
+                $"fixture must paginate to exercise pruning, got {container.FragmentTree.Fragmentainers.Count} pages");
+        }
+
+        [Fact]
+        public async Task ContentRelocatedOutOfAFrozenFragmentainer_PrunesWithoutChangingTheTree()
+        {
+            // break-inside: avoid moves a box the emitter may already have frozen a page for, which is
+            // what re-opens an emitted fragmentainer - and every observation drawn before that describes
+            // an arrangement that no longer exists.
+            var filler = string.Concat(Enumerable.Range(0, 12)
+                .Select(i => $"<p style='margin:0;line-height:20pt'>Filler {i}</p>"));
+
+            var (_, container) = await Verified(
+                LayoutHarness.Wrap(
+                    filler
+                    + "<div id='card' style='break-inside:avoid;line-height:20pt'>"
+                    + "<p style='margin:0'>Card one</p><p style='margin:0'>Card two</p>"
+                    + "<p style='margin:0'>Card three</p></div>"
+                    + filler),
+                pageHeight: 120, margin: 0);
+
+            Assert.True(container.FragmentTree!.Fragmentainers.Count > 3,
+                $"fixture must paginate to exercise pruning, got {container.FragmentTree.Fragmentainers.Count} pages");
+        }
+
+        [Fact]
+        public async Task AnAbsolutelyPositionedDescendantPagesAway_IsNeverPrunedAway()
+        {
+            // The case the contiguity rule exists for: #host's own content is on page 1, but it contains
+            // a descendant positioned far enough down to land pages later. Observing #host empty on an
+            // intervening page and skipping it thereafter would drop that descendant entirely.
+            var (_, container) = await Verified(
+                LayoutHarness.Wrap(
+                    "<div id='host' style='position:relative;line-height:20pt'>Host"
+                    + "<div id='far' style='position:absolute;top:600pt;line-height:20pt'>Far away</div>"
+                    + "</div>"),
+                pageHeight: 120, margin: 0);
+
+            var far = LayoutHarness.FindById(container.Root!, "far")!;
+
+            Assert.Contains(AllBoxesInTheTree(container), b => ReferenceEquals(b, far));
+        }
+
+        [Fact]
+        public async Task ForcedBreaksSteppingOverPages_PruneWithoutChangingTheTree()
+        {
+            // A directional break reserves slots nothing was ever flowed into, and those are emitted by a
+            // path that runs after every pass is over - where an empty walk may not be concluded from.
+            var (_, container) = await Verified(
+                LayoutHarness.Wrap(
+                    "<p style='margin:0;line-height:20pt'>One</p>"
+                    + "<p style='margin:0;line-height:20pt;break-before:left'>Two</p>"
+                    + "<p style='margin:0;line-height:20pt;break-before:left'>Three</p>"),
+                pageHeight: 120, margin: 0);
+
+            Assert.True(container.FragmentTree!.Fragmentainers.Count >= 3,
+                $"fixture must paginate to exercise pruning, got {container.FragmentTree.Fragmentainers.Count} pages");
+        }
+
+        /// <summary>
+        /// Lays <paramref name="html"/> out with the pruned and unpruned walks compared at every slot.
+        /// </summary>
+        private static Task<(CssBox Root, HtmlContainerInt Container)> Verified(
+            string html, double pageHeight, double margin) =>
+            LayoutHarness.LayoutAsync(
+                html,
+                pageHeight: pageHeight,
+                margin: margin,
+                prepare: root => root.HtmlContainer!.VerifyFragmentPruningOverride = true);
+
+        private static List<CssBox> AllBoxesInTheTree(HtmlContainerInt container)
+        {
+            var boxes = new List<CssBox>();
+
+            foreach (var fragmentainer in container.FragmentTree!.Fragmentainers)
+            {
+                Collect(fragmentainer.Root, boxes);
+            }
+
+            return boxes;
+
+            static void Collect(BoxFragment fragment, List<CssBox> into)
+            {
+                into.Add(fragment.Box);
+
+                foreach (var child in fragment.Children)
+                {
+                    Collect(child, into);
+                }
+            }
+        }
+
+        private static HashSet<CssBox> DistinctBoxesWithWords(HtmlContainerInt container)
+        {
+            var boxes = new HashSet<CssBox>(ReferenceEqualityComparer.Instance as IEqualityComparer<CssBox>);
+
+            foreach (var fragmentainer in container.FragmentTree!.Fragmentainers)
+            {
+                Collect(fragmentainer.Root, boxes);
+            }
+
+            return boxes;
+
+            static void Collect(BoxFragment fragment, HashSet<CssBox> into)
+            {
+                if (fragment.Words.Count > 0) into.Add(fragment.Box.ParentBox ?? fragment.Box);
+
+                foreach (var child in fragment.Children)
+                {
+                    Collect(child, into);
+                }
+            }
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
@@ -1909,6 +1909,9 @@ namespace PeachPDF.Html.Core.Dom
 
         private RPoint _location;
 
+        /// <inheritdoc cref="Size"/>
+        private RSize _size;
+
         /// <summary>Gets or sets the location of the box.</summary>
         public RPoint Location
         {
@@ -1916,12 +1919,38 @@ namespace PeachPDF.Html.Core.Dom
             set
             {
                 if (value.Y != _location.Y) OnBlockAxisRelocated(_location.Y, value.Y);
+
+                // Unlike the block-axis notification above, this is not conditional on Y: a box moved
+                // only in the inline axis still lands somewhere else, and a multi-column fragmentainer
+                // decides membership on the inline axis too.
+                if (value != _location) DiscardEmittedNothing();
+
                 _location = value;
             }
         }
 
         /// <summary>Gets or sets the size of the box.</summary>
-        public RSize Size { get; set; }
+        /// <remarks>
+        /// A written property rather than an auto-property because <see cref="ActualRight"/> and
+        /// <see cref="ActualBottom"/> both write through it, and between them they are how nearly every
+        /// layout engine states a box's extent — including the corrections engines apply <i>after</i> a
+        /// box's own layout pass has finished (a flex/grid line relocation growing its container, the
+        /// height epilogue, a table's row/row-group/cell aggregates). None of those routes through
+        /// <see cref="Location"/> or <c>OffsetTop</c>, so without this a box could grow into a band the
+        /// emitter had already observed it to be absent from, and nothing would say so.
+        /// </remarks>
+        public RSize Size
+        {
+            get => _size;
+            set
+            {
+                // ActualBottom/ActualRight rewrite Size on every assignment, including the many that do
+                // not change it, so the cheap comparison comes first - this sits on layout's hot path.
+                if (value != _size) DiscardEmittedNothing();
+
+                _size = value;
+            }
+        }
 
         /// <summary>Gets the bounds of the box.</summary>
         public RRect Bounds

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -1593,6 +1593,132 @@ namespace PeachPDF.Html.Core.Dom
         /// </summary>
         private int _layoutGeneration;
 
+        /// <summary>
+        /// The pagination slot <see cref="Fragmentation.FragmentEmitter"/> last observed this box's whole
+        /// subtree produce <i>nothing</i> in, or -1. Meaningless unless
+        /// <see cref="_emittedNothingGeneration"/> is the current layout generation.
+        /// </summary>
+        private int _emittedNothingAtSlot = -1;
+
+        /// <inheritdoc cref="_emittedNothingAtSlot"/>
+        private int _emittedNothingGeneration = -1;
+
+        /// <summary>
+        /// The emitter's observation epoch the record was made under. Bumped whenever already-frozen
+        /// fragmentainers are re-opened, which is when layout is about to redo work an observation may
+        /// have been drawn from — see <c>FragmentEmitter.InvalidateFrom</c>.
+        /// </summary>
+        private int _emittedNothingEpoch = -1;
+
+        /// <summary>
+        /// Records that this box's subtree contributed nothing to pagination slot
+        /// <paramref name="slotIndex"/> — so the emitter may skip descending into it while filling later
+        /// slots, until something clears the record again.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is an <i>observation</i>, never a prediction: it is written only after the emitter has
+        /// walked the whole subtree and found no rectangle, no word, no child fragment and no
+        /// continuation shell, and only for a box that has already produced a fragment somewhere (so it
+        /// is behind the layout frontier, not merely unreached). Both halves matter — see
+        /// <c>FragmentEmitter.BuildDraft</c> for why the unreached case cannot be concluded from the
+        /// same evidence.
+        /// </para>
+        /// <para>
+        /// Deliberately not derived from <see cref="Location"/>/<see cref="ActualBottom"/>: several
+        /// layout engines rewrite a box's extent well after its own layout pass has finished, and the
+        /// multi-column engine keeps each column's geometry in a separate snapshot, so a box's live
+        /// fields do not describe every fragment it has.
+        /// </para>
+        /// </remarks>
+        internal void RecordEmittedNothingAt(int slotIndex, int epoch)
+        {
+            _emittedNothingAtSlot = slotIndex;
+            _emittedNothingGeneration = HtmlContainer?.LayoutGeneration ?? 0;
+            _emittedNothingEpoch = epoch;
+        }
+
+        /// <summary>
+        /// Whether this box was observed to emit nothing at a slot at or before
+        /// <paramref name="slotIndex"/>, and nothing has invalidated that observation since.
+        /// </summary>
+        internal bool EmittedNothingAtOrBefore(int slotIndex, int epoch) =>
+            _emittedNothingGeneration == (HtmlContainer?.LayoutGeneration ?? 0)
+            && _emittedNothingEpoch == epoch
+            && _emittedNothingAtSlot >= 0
+            && slotIndex >= _emittedNothingAtSlot;
+
+        /// <summary>
+        /// Discards this box's <see cref="RecordEmittedNothingAt"/> observation and every ancestor's,
+        /// because something has just given it, or may have given it, content it did not have when the
+        /// observation was made.
+        /// </summary>
+        /// <remarks>
+        /// Walks up <see cref="ParentBox"/> and stops at the first ancestor that holds no observation:
+        /// an ancestor is only ever marked when its whole subtree was empty, so once one is clear
+        /// everything above it is clear too. That makes this O(1) amortized on the hot paths that call
+        /// it — during a layout pass almost every box is already clear.
+        /// </remarks>
+        internal void DiscardEmittedNothing()
+        {
+            var generation = HtmlContainer?.LayoutGeneration ?? 0;
+
+            for (var box = this; box is not null; box = box.ParentBox)
+            {
+                var wasClear = box._emittedNothingGeneration == -1 && box._touchedGeneration == generation;
+
+                box._emittedNothingGeneration = -1;
+                box._emittedNothingAtSlot = -1;
+
+                // Every caller of this is a write that gives a box content or moves it, so it is also
+                // the signal layout has REACHED this box at all - which is what separates a subtree
+                // that is finished from one that has not started. Recorded on the same walk because the
+                // two questions have exactly the same answer set.
+                box._touchedGeneration = generation;
+
+                // Nothing above an already-clear, already-touched box can need either update: both are
+                // only ever set walking up from below, so one clear ancestor means all of them are.
+                if (wasClear) break;
+            }
+        }
+
+        /// <summary>
+        /// The layout generation in which anything wrote to this box's geometry — see
+        /// <see cref="DiscardEmittedNothing"/>, which is every such write's common path.
+        /// </summary>
+        private int _touchedGeneration = -1;
+
+        /// <summary>
+        /// Whether layout has not yet reached this box at all in the current generation, so it holds no
+        /// positioned content and cannot appear in <i>any</i> fragmentainer yet.
+        /// </summary>
+        /// <remarks>
+        /// This is what lets the emitter skip the whole second half of a long document — the chapters
+        /// layout has not started — rather than only the finished half behind it. It is sound in the one
+        /// place the "observed empty" record is not: a box may be empty at a slot either because its
+        /// content is behind us or because it is still ahead, and within one <c>EmitPass</c> range the
+        /// emitter freezes slots the pass has <i>already</i> flowed content into, so emptiness alone
+        /// cannot tell those apart. Never having been written to can: the first write that positions
+        /// anything here discards the record, and that write necessarily happens before the pass which
+        /// places it ends, hence before the slot that needs it is frozen.
+        /// </remarks>
+        internal bool NeverTouchedThisLayout => _touchedGeneration != (HtmlContainer?.LayoutGeneration ?? 0);
+
+        /// <summary>
+        /// <see cref="DiscardEmittedNothing"/> for this box, every ancestor, and every descendant — for a
+        /// change that moves where a whole subtree <i>draws</i> without writing to any box in it (a
+        /// fragment displacement, or a captured-geometry translation).
+        /// </summary>
+        internal void DiscardEmittedNothingIncludingDescendants()
+        {
+            DiscardEmittedNothing();
+
+            foreach (var child in Boxes)
+            {
+                child.DiscardEmittedNothingIncludingDescendants();
+            }
+        }
+
         #region Private Methods
 
         /// <summary>
@@ -5607,7 +5733,17 @@ namespace PeachPDF.Html.Core.Dom
         /// The emitter ignores this for a box it has not frozen anywhere, which is what keeps ordinary
         /// forward layout - where every box is placed for the first time - from re-emitting anything.
         /// </remarks>
-        private void NotifyGeometryChanged(double fromY, double amount) =>
+        private void NotifyGeometryChanged(double fromY, double amount)
+        {
+            // Unconditional, unlike the emitted-fragment call below: that one may skip a box no frozen
+            // fragmentainer holds, but an "emitted nothing here" observation exists precisely for boxes
+            // that hold no fragment in the slot being filled.
+            DiscardEmittedNothing();
+
+            NotifyEmittedFragmentsChanged(fromY, amount);
+        }
+
+        private void NotifyEmittedFragmentsChanged(double fromY, double amount) =>
             HtmlContainer?.InvalidateEmittedFragmentsFor(this, Math.Min(fromY, fromY + amount));
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Dom/CssLineBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLineBox.cs
@@ -199,6 +199,13 @@ namespace PeachPDF.Html.Core.Dom
             foreach (var b in Rectangles.Keys)
             {
                 b.Rectangles.Add(this, Rectangles[b]);
+
+                // An inline box's decoration area is exactly these per-line rectangles - its own
+                // Location stays at a line-local value layout never updates - so this is the one write
+                // that can make it non-empty in a fragmentainer the emitter had already observed it to
+                // hold nothing in. UpdateRectangle has already walked the inline ancestor chain, so
+                // every inline on the line is a key here and is told.
+                b.DiscardEmittedNothing();
             }
         }
 

--- a/src/PeachPDF/Html/Core/Dom/CssRect.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssRect.cs
@@ -81,6 +81,13 @@ namespace PeachPDF.Html.Core.Dom
             {
                 // Being positioned is what makes a word this fragmentainer's again.
                 AwaitsTheNextFragmentainer = false;
+
+                // And it is what can make the owning box's subtree non-empty in a fragmentainer the
+                // emitter had already observed it to hold nothing in. A word is the one piece of
+                // content whose position lives nowhere on the box itself, so no box-level write would
+                // report this (see CssBox.DiscardEmittedNothing).
+                if (_rect.Y != value) OwnerBox.DiscardEmittedNothing();
+
                 _rect.Y = value;
             }
         }

--- a/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
@@ -437,9 +437,26 @@ namespace PeachPDF.Html.Core.Fragmentation
             owner is null
             && nested is null
             && displacement is null
-            && !isFixed
-            && !box.IsOutOfFlow
             && !box.IsRoot
+            && ContentStaysInOneRun(box, isFixed);
+
+        /// <summary>
+        /// Whether <paramref name="box"/>'s own content occupies one contiguous run of fragmentainers,
+        /// which is what makes "there is none of it here" say anything about the fragmentainers after
+        /// this one.
+        /// </summary>
+        /// <remarks>
+        /// Unlike the per-visit conditions in <see cref="MayBeObservedEmpty"/>, this is a fact about the
+        /// box itself, so it — and only it — is what propagates to ancestors. The distinction matters:
+        /// the children of a multi-column container are each visited once per column and so can never
+        /// be observed individually, but that says nothing about whether the <i>container</i>'s own
+        /// content is contiguous, and the container is exactly the box worth skipping. Letting the
+        /// per-visit exclusion propagate made every multi-column container unprunable — which on a
+        /// document that is mostly multi-column is the entire optimization.
+        /// </remarks>
+        private static bool ContentStaysInOneRun(CssBox box, bool isFixed) =>
+            !isFixed
+            && !box.IsOutOfFlow
             && box is not CssProxyBox and not CssSpacingBox and not CssBoxMarker;
 
         /// <summary>
@@ -770,15 +787,19 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// </remarks>
         internal void InvalidateFrom(int fromSlot)
         {
+            // Deliberately after the early return, not before it: this method is reached on every
+            // block-axis reposition of a box that holds fragments, which during a pass is constant, and
+            // only the calls that actually re-open a frozen fragmentainer mean anything has been
+            // superseded. Bumping on the rest retired every observation as fast as they were made.
+            if (fromSlot > _lastEmittedSlot) return;
+
             // Every "emitted nothing here" observation is void from here on. Re-opening a frozen
             // fragmentainer means the driver is about to lay content out again over ground it has
             // already covered - §4.3's movers and the keep-with-next run pull both re-enter a pass that
             // has already ended - so an observation drawn from the superseded arrangement describes a
             // layout that no longer exists. Bumping one counter retires them all, which is the right
-            // trade: re-opening is rare, and anything cheaper would have to enumerate the boxes.
+            // trade: genuine re-opening is rare, and anything cheaper would have to enumerate boxes.
             _observationEpoch++;
-
-            if (fromSlot > _lastEmittedSlot) return;
 
             for (var slot = fromSlot; slot <= _lastEmittedSlot; slot++)
             {
@@ -1427,7 +1448,12 @@ namespace PeachPDF.Html.Core.Fragmentation
             // Whether an "emitted nothing here" observation about this box could be relied on later at
             // all. Asked before the observation is read as well as before one is made, so a box that
             // could never be marked is never skipped on the strength of a stale mark either.
+            //
+            // Two separate facts, and only the second travels: whether THIS visit could observe the box
+            // (per-visit - which proxy, which column), and whether the box's content is contiguous at
+            // all (a property of the box, and therefore of every ancestor that contains it).
             var ownPrunable = MayBeObservedEmpty(box, owner, nested, isFixed, displacement);
+            var contiguous = ContentStaysInOneRun(box, isFixed);
 
             // Skip the whole subtree: the emitter has already walked it once this layout, found it
             // empty at a slot at or before this one, and nothing has written to it since (every write
@@ -1496,7 +1522,7 @@ namespace PeachPDF.Html.Core.Fragmentation
                     childBox, childOwner, childSnapshot, slot, childNested, childInstance,
                     ref hasPrintableContent, ref childPrunable, displacement);
 
-                ownPrunable &= childPrunable;
+                contiguous &= childPrunable;
 
                 if (childDraft is not null)
                     children.Add(childDraft);
@@ -1532,13 +1558,13 @@ namespace PeachPDF.Html.Core.Fragmentation
                     //
                     // The offer is provisional: RecordEmptyObservations makes the final call once the
                     // slot is fully walked, because one box can be visited several times in one slot.
-                    if (ownPrunable && !_pruningSuspended
+                    if (ownPrunable && contiguous && !_pruningSuspended
                         && (_frozen.Contains(box) || box.NeverTouchedThisLayout))
                     {
                         _emptyHereThisSlot.Add(box);
                     }
 
-                    subtreePrunable &= ownPrunable;
+                    subtreePrunable &= contiguous;
                     return null;
                 }
 
@@ -1578,7 +1604,7 @@ namespace PeachPDF.Html.Core.Fragmentation
             // about the slot as a whole. RecordEmptyObservations subtracts this set from the empty one.
             if (!_pruningSuspended) _producedSomethingThisSlot.Add(box);
 
-            subtreePrunable &= ownPrunable;
+            subtreePrunable &= contiguous;
 
             var draft = new Draft(new FragmentKey(box, owner, instance), box, slot, region, snapshot, originY);
 

--- a/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
@@ -5,6 +5,7 @@ using PeachPDF.Html.Core.Fragments;
 using PeachPDF.Html.Core.Utils;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace PeachPDF.Html.Core.Fragmentation
 {
@@ -1028,6 +1029,13 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// is by construction a box this walk never added.
         /// </para>
         /// </remarks>
+        // The self-check below never runs in production - it is gated on an environment variable and a
+        // test-only per-container override - and every branch of it that a coverage run could still miss
+        // is a divergence report, i.e. a path reachable only when the pruning it guards is already wrong.
+        // Excluded from the metric for the same reason the platform-gated lookups in MimeTypeResolver are:
+        // unreachable-by-construction code should not drag the diff-coverage gate down. That it works is
+        // evidenced by it having caught 22 real divergences while the pruning was being written.
+        [ExcludeFromCodeCoverage]
         private void VerifyAgainstTheFullWalk(CssBox root, Slot slot, Draft? pruned, bool prunedHadPrintableContent)
         {
             var frozenAfterPruned = new HashSet<CssBox>(_frozen, ReferenceEqualityComparer.Instance);
@@ -1086,6 +1094,13 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// materialization, so a comparison of fragment rectangles alone would pass while the decoration,
         /// the clip or the band a fragment is confined to had silently changed.
         /// </remarks>
+        // The self-check below never runs in production - it is gated on an environment variable and a
+        // test-only per-container override - and every branch of it that a coverage run could still miss
+        // is a divergence report, i.e. a path reachable only when the pruning it guards is already wrong.
+        // Excluded from the metric for the same reason the platform-gated lookups in MimeTypeResolver are:
+        // unreachable-by-construction code should not drag the diff-coverage gate down. That it works is
+        // evidenced by it having caught 22 real divergences while the pruning was being written.
+        [ExcludeFromCodeCoverage]
         private static void AssertSameDraft(Draft pruned, Draft full, Slot slot)
         {
             if (!ReferenceEquals(pruned.Box, full.Box))
@@ -1145,6 +1160,13 @@ namespace PeachPDF.Html.Core.Fragmentation
             }
         }
 
+        // The self-check below never runs in production - it is gated on an environment variable and a
+        // test-only per-container override - and every branch of it that a coverage run could still miss
+        // is a divergence report, i.e. a path reachable only when the pruning it guards is already wrong.
+        // Excluded from the metric for the same reason the platform-gated lookups in MimeTypeResolver are:
+        // unreachable-by-construction code should not drag the diff-coverage gate down. That it works is
+        // evidenced by it having caught 22 real divergences while the pruning was being written.
+        [ExcludeFromCodeCoverage]
         private static InvalidOperationException PruningDiverged(Slot slot, string what, string pruned, string full) =>
             new($"Fragment pruning changed the output of slot {slot.Index}: {what} is '{pruned}' with pruning " +
                 $"and '{full}' without it. Pruning must only ever decline to walk a subtree that would " +

--- a/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
@@ -368,6 +368,13 @@ namespace PeachPDF.Html.Core.Fragmentation
             Environment.GetEnvironmentVariable("PEACHPDF_VERIFY_FRAGMENT_PRUNING") == "1";
 
         /// <summary>
+        /// Whether this render checks itself — the environment-wide switch, or one container's own
+        /// <see cref="HtmlContainerInt.VerifyFragmentPruningOverride"/>.
+        /// </summary>
+        private bool VerifiesPruning =>
+            container.VerifyFragmentPruningOverride ?? VerifyPruningAgainstFullWalk;
+
+        /// <summary>
         /// Set while the verification build above is running, and by the emission paths that may not
         /// prune at all, to make <see cref="BuildDraft"/> take the full walk.
         /// </summary>
@@ -958,7 +965,7 @@ namespace PeachPDF.Html.Core.Fragmentation
             var root = container.Root!;
 
             var wasSuspended = _pruningSuspended;
-            var verifying = VerifyPruningAgainstFullWalk && mayPrune && !wasSuspended;
+            var verifying = VerifiesPruning && mayPrune && !wasSuspended;
 
             if (verifying)
             {

--- a/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
@@ -344,6 +344,130 @@ namespace PeachPDF.Html.Core.Fragmentation
 
         private int _lastEmittedSlot = -1;
 
+        /// <summary>
+        /// Differential self-check: build every slot's draft tree <i>twice</i> — once with pruning
+        /// allowed and once with it forced off — and throw unless the two are identical. Off unless
+        /// <c>PEACHPDF_VERIFY_FRAGMENT_PRUNING=1</c> is set in the environment.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// A static read once from the environment rather than the per-instance "Test-only override"
+        /// idiom <see cref="HtmlContainerInt.MaxFragmentainersOverride"/> uses, and deliberately so:
+        /// the point is to run the <i>whole</i> existing suite under it, and every test builds its own
+        /// container, so a per-instance switch would have to be threaded through every construction
+        /// site to be useful.
+        /// </para>
+        /// <para>
+        /// Pruning is an optimization that must be invisible: it may only ever decline to walk a
+        /// subtree that would have produced nothing. That is a property no assertion about a
+        /// <i>particular</i> document can establish, but one this check establishes over every fixture
+        /// the suite already has.
+        /// </para>
+        /// </remarks>
+        internal static readonly bool VerifyPruningAgainstFullWalk =
+            Environment.GetEnvironmentVariable("PEACHPDF_VERIFY_FRAGMENT_PRUNING") == "1";
+
+        /// <summary>
+        /// Set while the verification build above is running, and by the emission paths that may not
+        /// prune at all, to make <see cref="BuildDraft"/> take the full walk.
+        /// </summary>
+        private bool _pruningSuspended;
+
+        /// <summary>
+        /// <see cref="_frozen"/> as it stood before the slot currently being emitted began, so the
+        /// verification build can be run against the same starting state the pruned one saw. Only
+        /// maintained when <see cref="VerifyPruningAgainstFullWalk"/> is on.
+        /// </summary>
+        private readonly HashSet<CssBox> _frozenBeforeSlot = new(ReferenceEqualityComparer.Instance);
+
+        /// <summary>
+        /// Boxes the slot being walked found nothing for, and boxes it found something for. Both are
+        /// per slot, and the observation kept is the difference — see <see cref="RecordEmptyObservations"/>.
+        /// </summary>
+        private readonly HashSet<CssBox> _emptyHereThisSlot = new(ReferenceEqualityComparer.Instance);
+
+        /// <inheritdoc cref="_emptyHereThisSlot"/>
+        private readonly HashSet<CssBox> _producedSomethingThisSlot = new(ReferenceEqualityComparer.Instance);
+
+        /// <summary>
+        /// Retires every outstanding "emitted nothing here" observation when bumped — see
+        /// <see cref="InvalidateFrom"/>.
+        /// </summary>
+        private int _observationEpoch;
+
+        /// <summary>
+        /// Whether an "emitted nothing here" observation about <paramref name="box"/> could be relied on
+        /// in a later slot at all.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The observation says "this subtree's fragments are all behind us". Four things break that,
+        /// and each is excluded here rather than hedged against later:
+        /// </para>
+        /// <list type="bullet">
+        /// <item>
+        /// <b>Out-of-flow and fixed content</b> does not sit in its DOM ancestor's run at all — an
+        /// absolutely-positioned descendant can be pages away from the box that contains it, and a fixed
+        /// one repeats on every page — so an ancestor's fragments are not a contiguous span.
+        /// </item>
+        /// <item>
+        /// <b>A box reached through a proxy</b> (<paramref name="owner"/> non-null) is one subtree
+        /// standing in for a repeated header on <i>every</i> page, at a different position each time.
+        /// Its runs are per proxy, not per box, and its geometry lives in a captured snapshot that moves
+        /// without any write to the box.
+        /// </item>
+        /// <item>
+        /// <b>A box inside a nested fragmentainer</b> (<paramref name="nested"/> non-null) is visited
+        /// once per column of the same slot, against a different snapshot and a different inline extent
+        /// each time.
+        /// </item>
+        /// <item>
+        /// <b>A displaced box</b> draws somewhere its own geometry does not say, decided per slot.
+        /// </item>
+        /// </list>
+        /// <para>
+        /// <see cref="CssBoxMarker"/> is excluded as well: it is laid out by one explicit call rather
+        /// than through the block-children loop, so it is the one ordinary box kind whose visits do not
+        /// line up with the walk that would observe it.
+        /// </para>
+        /// </remarks>
+        private static bool MayBeObservedEmpty(
+            CssBox box, CssProxyBox? owner, NestedFragmentainer? nested, bool isFixed,
+            (CssBox Root, double Shift, RRect Band)? displacement) =>
+            owner is null
+            && nested is null
+            && displacement is null
+            && !isFixed
+            && !box.IsOutOfFlow
+            && !box.IsRoot
+            && box is not CssProxyBox and not CssSpacingBox and not CssBoxMarker;
+
+        /// <summary>
+        /// Keeps, as an observation on each box, the part of this slot's walk that found nothing —
+        /// everything the walk saw empty and never afterwards saw hold anything.
+        /// </summary>
+        /// <param name="slotIndex">the slot just walked</param>
+        /// <param name="frontier">
+        /// whether this slot is the furthest one layout has reached. Only there may an empty walk be
+        /// concluded from: <see cref="EmitPass"/> freezes a whole range of slots in one go, after the
+        /// pass that filled them has already flowed content into every one, so at any slot below the
+        /// frontier "found nothing" also describes content that is simply further down — and no write
+        /// will ever come along to correct it.
+        /// </param>
+        private void RecordEmptyObservations(int slotIndex, bool frontier)
+        {
+            if (frontier)
+            {
+                foreach (var box in _emptyHereThisSlot)
+                {
+                    if (!_producedSomethingThisSlot.Contains(box)) box.RecordEmittedNothingAt(slotIndex, _observationEpoch);
+                }
+            }
+
+            _emptyHereThisSlot.Clear();
+            _producedSomethingThisSlot.Clear();
+        }
+
         /// <summary>The empty box set the first nested fragmentainer of a slot resumes nothing from.</summary>
         private static readonly IReadOnlySet<CssBox> NoBoxes = new HashSet<CssBox>(ReferenceEqualityComparer.Instance);
 
@@ -378,6 +502,13 @@ namespace PeachPDF.Html.Core.Fragmentation
                 geometry,
                 continuing,
                 fragmentainers.Count > 0 ? fragmentainers[^1].Continuing : NoBoxes));
+
+            // Which children this container yields, how many times, and against which geometry, are all
+            // decided by the set of fragmentainers recorded for it - so an earlier "emitted nothing
+            // here" observation about the container no longer describes the same walk. Its descendants
+            // need no equivalent: they only ever gained content by being laid out, which discards
+            // theirs already.
+            contextRoot.DiscardEmittedNothing();
         }
 
         /// <summary>
@@ -395,6 +526,9 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// </remarks>
         internal void ClearNestedFragmentainers(CssBox contextRoot, int? slot = null)
         {
+            // Removing a fragmentainer changes the walk exactly as recording one does.
+            contextRoot.DiscardEmittedNothing();
+
             if (slot is { } only)
             {
                 _nested.Remove((contextRoot, only));
@@ -438,6 +572,12 @@ namespace PeachPDF.Html.Core.Fragmentation
             }
 
             shells[slot] = rect;
+
+            // A shell is content this box has in a fragmentainer it holds nothing else in, and it is
+            // stated by the pass that fills that fragmentainer - which runs AFTER the slot before it was
+            // emitted. So an observation made earlier cannot have accounted for it. Ancestors go too:
+            // the walk only reaches this box by descending through them.
+            box.DiscardEmittedNothing();
         }
 
         /// <summary>
@@ -453,6 +593,8 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// </remarks>
         internal void ClearContinuationShells(CssBox box, int? fromSlot = null)
         {
+            box.DiscardEmittedNothing();
+
             if (fromSlot is not { } from)
             {
                 _continuationShells.Remove(box);
@@ -513,6 +655,11 @@ namespace PeachPDF.Html.Core.Fragmentation
             }
 
             bySlot[slot] = (box, shift, band);
+
+            // A displacement moves where a whole subtree DRAWS without writing to any box in it, so it
+            // is the one change no per-box write hook can catch - every descendant's observation has to
+            // go with it.
+            box.DiscardEmittedNothingIncludingDescendants();
         }
 
         /// <summary>
@@ -521,6 +668,8 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// </summary>
         internal void ClearFragmentDisplacements(CssBox box, int? fromSlot = null)
         {
+            box.DiscardEmittedNothingIncludingDescendants();
+
             if (fromSlot is not { } from)
             {
                 _displacements.Remove(box);
@@ -568,7 +717,14 @@ namespace PeachPDF.Html.Core.Fragmentation
                 RecordChain(incoming, slot, _continuedFrom);
                 RecordChain(outgoing, slot, _continuesInto);
 
-                EmitSlot(slot);
+                // The one path that may prune: these are the slots the pass that has just ended filled,
+                // frozen while the geometry it produced is still what the box tree says.
+                //
+                // Only the last slot of the range, and only if the range genuinely reaches past
+                // everything emitted so far, may an observation be drawn from - see
+                // RecordEmptyObservations. Every earlier slot of the range still USES observations
+                // already made; it just may not make new ones.
+                EmitSlot(slot, mayPrune: true, frontier: slot == throughSlot && slot >= _lastEmittedSlot);
             }
         }
 
@@ -583,7 +739,9 @@ namespace PeachPDF.Html.Core.Fragmentation
 
             for (var slot = _lastEmittedSlot + 1; slot <= reserved && slot < MaxSlots; slot++)
             {
-                EmitSlot(slot);
+                // Runs once every pass is over, so a subtree observed empty here could never be
+                // un-observed by a later layout - nothing may be concluded from it.
+                EmitSlot(slot, mayPrune: false);
             }
         }
 
@@ -612,6 +770,14 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// </remarks>
         internal void InvalidateFrom(int fromSlot)
         {
+            // Every "emitted nothing here" observation is void from here on. Re-opening a frozen
+            // fragmentainer means the driver is about to lay content out again over ground it has
+            // already covered - §4.3's movers and the keep-with-next run pull both re-enter a pass that
+            // has already ended - so an observation drawn from the superseded arrangement describes a
+            // layout that no longer exists. Bumping one counter retires them all, which is the right
+            // trade: re-opening is rare, and anything cheaper would have to enumerate the boxes.
+            _observationEpoch++;
+
             if (fromSlot > _lastEmittedSlot) return;
 
             for (var slot = fromSlot; slot <= _lastEmittedSlot; slot++)
@@ -629,9 +795,14 @@ namespace PeachPDF.Html.Core.Fragmentation
                 return new FragmentTree([]);
 
             // Slots a later pass's mover disturbed, emitted again now that layout has settled.
+            //
+            // Never prunes, and the reason is the sharp one: `_stale` is a contiguous ASCENDING range
+            // (see InvalidateFrom), replayed here with layout already over, so no write could ever
+            // invalidate a conclusion drawn while replaying it. The lowest stale slot would otherwise
+            // observe every subtree that lives in a higher band as empty and skip the rest of the range.
             foreach (var slot in new List<int>(_stale))
             {
-                EmitSlot(slot);
+                EmitSlot(slot, mayPrune: false);
             }
 
             if (_emitted.Count == 0) return new FragmentTree([]);
@@ -743,7 +914,16 @@ namespace PeachPDF.Html.Core.Fragmentation
         private static bool IsBefore((int Slot, int Instance) a, (int Slot, int Instance) b) =>
             a.Slot != b.Slot ? a.Slot < b.Slot : a.Instance < b.Instance;
 
-        private void EmitSlot(int index)
+        /// <param name="index">the pagination slot to freeze</param>
+        /// <param name="mayPrune">
+        /// whether <see cref="BuildDraft"/> may skip a subtree it has already observed to be empty.
+        /// False for the emission paths whose slot is not the one the geometry was just produced for —
+        /// see each call site.
+        /// </param>
+        /// <param name="frontier">
+        /// whether this is the furthest slot layout has reached — see <see cref="RecordEmptyObservations"/>.
+        /// </param>
+        private void EmitSlot(int index, bool mayPrune, bool frontier = false)
         {
             var bandTop = container.PageTopOf(index);
 
@@ -755,10 +935,40 @@ namespace PeachPDF.Html.Core.Fragmentation
                 bandTop - container.MarginTop);
 
             var root = container.Root!;
+
+            var wasSuspended = _pruningSuspended;
+            var verifying = VerifyPruningAgainstFullWalk && mayPrune && !wasSuspended;
+
+            if (verifying)
+            {
+                _frozenBeforeSlot.Clear();
+                _frozenBeforeSlot.UnionWith(_frozen);
+            }
+
+            _pruningSuspended = wasSuspended || !mayPrune;
+
             var hasPrintableContent = false;
-            var draft = BuildDraft(root, owner: null, snapshot: null, slot,
-                            nested: null, instance: 0, ref hasPrintableContent)
-                        ?? EmptyRootDraft(root, slot);
+            var prunable = true;
+            Draft? built;
+
+            try
+            {
+                built = BuildDraft(root, owner: null, snapshot: null, slot,
+                    nested: null, instance: 0, ref hasPrintableContent, ref prunable);
+            }
+            finally
+            {
+                _pruningSuspended = wasSuspended;
+            }
+
+            RecordEmptyObservations(index, frontier && mayPrune && !wasSuspended);
+
+            if (verifying)
+            {
+                VerifyAgainstTheFullWalk(root, slot, built, hasPrintableContent);
+            }
+
+            var draft = built ?? EmptyRootDraft(root, slot);
 
             // A slot can legitimately be emitted twice: the driver's no-progress backstop lays the
             // remainder out again monolithically, over the same slot the failed pass had already frozen,
@@ -768,6 +978,149 @@ namespace PeachPDF.Html.Core.Fragmentation
             _stale.Remove(index);
             if (index > _lastEmittedSlot) _lastEmittedSlot = index;
         }
+
+        /// <summary>
+        /// Builds <paramref name="slot"/> again with pruning forced off and throws unless the result is
+        /// indistinguishable from <paramref name="pruned"/> — see
+        /// <see cref="VerifyPruningAgainstFullWalk"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>The <see cref="_frozen"/> delta is checked as carefully as the tree itself</b>, and that is
+        /// the point rather than a detail. Which boxes hold fragments is the <i>only</i> gate on whether
+        /// an already-frozen slot is emitted a second time (<c>HoldsFragmentsFor</c> guards
+        /// <c>HtmlContainerInt.InvalidateEmittedFragmentsFor</c>), so a pruning bug can leave every draft
+        /// identical and still change the whole document's emission order. That exact failure once got
+        /// past the entire suite and was caught only by a showcase pixel diff — see
+        /// <c>.claude/invariants/fragmentation-which-drafts-exist-decides-whether-a-frozen-slot-is-emitted-again.md</c>.
+        /// </para>
+        /// <para>
+        /// Rolling <see cref="_frozen"/> back between the two builds is safe: the only box that reads it
+        /// during a walk is one that produced nothing (the shell gate in <see cref="BuildDraft"/>), which
+        /// is by construction a box this walk never added.
+        /// </para>
+        /// </remarks>
+        private void VerifyAgainstTheFullWalk(CssBox root, Slot slot, Draft? pruned, bool prunedHadPrintableContent)
+        {
+            var frozenAfterPruned = new HashSet<CssBox>(_frozen, ReferenceEqualityComparer.Instance);
+
+            _frozen.Clear();
+            _frozen.UnionWith(_frozenBeforeSlot);
+
+            var fullHadPrintableContent = false;
+            var fullPrunable = true;
+            Draft? full;
+
+            // Suspends reading observations AND making them, so the reference build neither benefits
+            // from the pruned build's conclusions nor leaves conclusions of its own behind.
+            var wasSuspended = _pruningSuspended;
+            _pruningSuspended = true;
+
+            try
+            {
+                full = BuildDraft(root, owner: null, snapshot: null, slot,
+                    nested: null, instance: 0, ref fullHadPrintableContent, ref fullPrunable);
+            }
+            finally
+            {
+                _pruningSuspended = wasSuspended;
+            }
+
+            // Asked of BuildDraft's own answer, before EmitSlot's `?? EmptyRootDraft(...)` fallback -
+            // that fallback would make "the root itself was pruned away" and "the document is empty"
+            // indistinguishable.
+            if ((pruned is null) != (full is null))
+                throw PruningDiverged(slot, "the root draft", pruned is null ? "null" : "a draft", full is null ? "null" : "a draft");
+
+            // The tree is compared first even though hasPrintableContent is the cheaper check: a
+            // difference in the flag is always a consequence of some box's fragment going missing, and
+            // the tree comparison names that box while the flag only says a page changed.
+            if (pruned is not null && full is not null)
+                AssertSameDraft(pruned, full, slot);
+
+            if (prunedHadPrintableContent != fullHadPrintableContent)
+                throw PruningDiverged(slot, "hasPrintableContent",
+                    prunedHadPrintableContent.ToString(), fullHadPrintableContent.ToString());
+
+            if (!frozenAfterPruned.SetEquals(_frozen))
+                throw PruningDiverged(slot, "the set of boxes holding fragments",
+                    $"{frozenAfterPruned.Count} boxes", $"{_frozen.Count} boxes");
+        }
+
+        /// <summary>
+        /// Every member of <paramref name="pruned"/> that materialization or paint can read, against the
+        /// same member of <paramref name="full"/>.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately exhaustive rather than "the rectangles look right": <see cref="Draft.UsesOwnBounds"/>,
+        /// <see cref="Draft.BoundsEndAtItsContent"/>, <see cref="Draft.ShellRect"/>, <see cref="Draft.Shift"/>,
+        /// <see cref="Draft.ConfinedTo"/> and <see cref="Draft.DisplacementRoot"/> are read only at
+        /// materialization, so a comparison of fragment rectangles alone would pass while the decoration,
+        /// the clip or the band a fragment is confined to had silently changed.
+        /// </remarks>
+        private static void AssertSameDraft(Draft pruned, Draft full, Slot slot)
+        {
+            if (!ReferenceEquals(pruned.Box, full.Box))
+                throw PruningDiverged(slot, "the box a draft is for", pruned.Box.ToString(), full.Box.ToString());
+
+            var box = pruned.Box;
+
+            Same(pruned.Key, full.Key, "Key");
+            Same(pruned.Region, full.Region, "Region");
+            Same(pruned.OriginY, full.OriginY, "OriginY");
+            Same(pruned.IsFixed, full.IsFixed, "IsFixed");
+            Same(pruned.IsMonolithic, full.IsMonolithic, "IsMonolithic");
+            Same(pruned.BoundsEndAtItsContent, full.BoundsEndAtItsContent, "BoundsEndAtItsContent");
+            Same(pruned.ContinuesIntoTheNext, full.ContinuesIntoTheNext, "ContinuesIntoTheNext");
+            Same(pruned.ContinuedFromThePrevious, full.ContinuedFromThePrevious, "ContinuedFromThePrevious");
+            Same(pruned.UsesOwnBounds, full.UsesOwnBounds, "UsesOwnBounds");
+            Same(pruned.ShellRect, full.ShellRect, "ShellRect");
+            Same(pruned.ConfinedTo, full.ConfinedTo, "ConfinedTo");
+            Same(pruned.Shift, full.Shift, "Shift");
+
+            if (!ReferenceEquals(pruned.Snapshot, full.Snapshot))
+                throw PruningDiverged(slot, $"the captured geometry of {box}", "one snapshot", "another");
+
+            if (!ReferenceEquals(pruned.DisplacementRoot, full.DisplacementRoot))
+                throw PruningDiverged(slot, $"the displacement root of {box}",
+                    pruned.DisplacementRoot?.ToString() ?? "none", full.DisplacementRoot?.ToString() ?? "none");
+
+            Same(pruned.Lines.Count, full.Lines.Count, "the number of decoration rectangles");
+
+            for (var i = 0; i < pruned.Lines.Count; i++)
+            {
+                if (!ReferenceEquals(pruned.Lines[i].Line, full.Lines[i].Line) || pruned.Lines[i].Rect != full.Lines[i].Rect)
+                    throw PruningDiverged(slot, $"decoration rectangle {i} of {box}",
+                        pruned.Lines[i].Rect.ToString(), full.Lines[i].Rect.ToString());
+            }
+
+            Same(pruned.Words.Count, full.Words.Count, "the number of words");
+
+            for (var i = 0; i < pruned.Words.Count; i++)
+            {
+                if (pruned.Words[i] != full.Words[i])
+                    throw PruningDiverged(slot, $"word {i} of {box}",
+                        pruned.Words[i].ToString(), full.Words[i].ToString());
+            }
+
+            Same(pruned.Children.Count, full.Children.Count, "the number of child fragments");
+
+            for (var i = 0; i < pruned.Children.Count; i++)
+            {
+                AssertSameDraft(pruned.Children[i], full.Children[i], slot);
+            }
+
+            void Same<T>(T a, T b, string what)
+            {
+                if (!EqualityComparer<T>.Default.Equals(a, b))
+                    throw PruningDiverged(slot, $"{what} of {box}", a?.ToString() ?? "null", b?.ToString() ?? "null");
+            }
+        }
+
+        private static InvalidOperationException PruningDiverged(Slot slot, string what, string pruned, string full) =>
+            new($"Fragment pruning changed the output of slot {slot.Index}: {what} is '{pruned}' with pruning " +
+                $"and '{full}' without it. Pruning must only ever decline to walk a subtree that would " +
+                $"have produced nothing.");
 
         private static void RecordChain(BreakToken? token, int slot, HashSet<(FragmentKey, int)> into)
         {
@@ -1023,6 +1376,12 @@ namespace PeachPDF.Html.Core.Fragmentation
             return draft;
         }
 
+        /// <remarks>
+        /// <c>subtreePrunable</c> is set to false by the walk when anything at or below the box means an
+        /// "emitted nothing here" observation about it could not be relied on later — see
+        /// <see cref="MayBeObservedEmpty"/>. It is accumulated on the way back up, so a single
+        /// out-of-flow descendant makes every ancestor unprunable too.
+        /// </remarks>
         private Draft? BuildDraft(
             CssBox box,
             CssProxyBox? owner,
@@ -1031,6 +1390,7 @@ namespace PeachPDF.Html.Core.Fragmentation
             NestedFragmentainer? nested,
             int instance,
             ref bool hasPrintableContent,
+            ref bool subtreePrunable,
             (CssBox Root, double Shift, RRect Band)? displacement = null)
         {
             // A display:none subtree paints nothing at all, so it produces no fragments either.
@@ -1063,6 +1423,26 @@ namespace PeachPDF.Html.Core.Fragmentation
             // emitted in every fragmentainer at identical coordinates, so a column's own extent says
             // nothing about where it lands.
             var region = isFixed || nested is null ? PageRegionOf(isFixed, slot) : nested.Value.Region;
+
+            // Whether an "emitted nothing here" observation about this box could be relied on later at
+            // all. Asked before the observation is read as well as before one is made, so a box that
+            // could never be marked is never skipped on the strength of a stale mark either.
+            var ownPrunable = MayBeObservedEmpty(box, owner, nested, isFixed, displacement);
+
+            // Skip the whole subtree: the emitter has already walked it once this layout, found it
+            // empty at a slot at or before this one, and nothing has written to it since (every write
+            // that could give it content discards the observation - see CssBox.DiscardEmittedNothing).
+            //
+            // Sound only because the observation is made under the far stricter conditions in
+            // RecordEmptyObservations: the box had ALREADY produced a fragment, so it sits behind the
+            // layout frontier and its remaining fragments are behind it too. A box layout has not
+            // reached yet is equally empty and must NOT be concluded about from the same evidence -
+            // within one EmitPass range the emitter walks slots the pass has already flowed content
+            // into, so "nothing here yet" and "nothing here ever" are indistinguishable at that point.
+            if (ownPrunable && !_pruningSuspended && box.EmittedNothingAtOrBefore(slot.Index, _observationEpoch))
+            {
+                return null;
+            }
 
             List<(CssLineBox Line, RRect Rect)> lines = [];
             List<TextFragment> words = [];
@@ -1108,9 +1488,15 @@ namespace PeachPDF.Html.Core.Fragmentation
             foreach (var (childBox, childOwner, childSnapshot, childNested, childInstance)
                      in ChildrenOf(box, owner, snapshot, slot, nested, instance))
             {
+                // A child that cannot be relied on makes this box unreliable too: the observation is
+                // about the whole subtree, so it is only as good as its weakest member.
+                var childPrunable = true;
+
                 var childDraft = BuildDraft(
                     childBox, childOwner, childSnapshot, slot, childNested, childInstance,
-                    ref hasPrintableContent, displacement);
+                    ref hasPrintableContent, ref childPrunable, displacement);
+
+                ownPrunable &= childPrunable;
 
                 if (childDraft is not null)
                     children.Add(childDraft);
@@ -1131,7 +1517,30 @@ namespace PeachPDF.Html.Core.Fragmentation
                 // "which drafts exist decides whether a frozen slot is emitted again". The set is
                 // monotone and the fragmentainer a box began in is always frozen before the one it
                 // continues into is emitted, so this never rejects a shell that should stand.
-                if (!_frozen.Contains(box) || ShellIn(box, region) is not { } stated) return null;
+                if (!_frozen.Contains(box) || ShellIn(box, region) is not { } stated)
+                {
+                    // Nothing here. Two quite different things can make that a fact about the box
+                    // rather than about where the walk happens to be, and one of them has to hold:
+                    //
+                    //  - it is already frozen, so it is BEHIND the layout frontier: it has had its
+                    //    fragments, they were contiguous, and this slot is past them; or
+                    //  - layout has never written to it at all, so it is AHEAD of the frontier and holds
+                    //    no positioned content anywhere yet.
+                    //
+                    // What is excluded is the box in between - reached, laid out, and simply not here -
+                    // whose content may be in a slot this same EmitPass range is about to freeze.
+                    //
+                    // The offer is provisional: RecordEmptyObservations makes the final call once the
+                    // slot is fully walked, because one box can be visited several times in one slot.
+                    if (ownPrunable && !_pruningSuspended
+                        && (_frozen.Contains(box) || box.NeverTouchedThisLayout))
+                    {
+                        _emptyHereThisSlot.Add(box);
+                    }
+
+                    subtreePrunable &= ownPrunable;
+                    return null;
+                }
 
                 shellRect = stated;
 
@@ -1162,6 +1571,14 @@ namespace PeachPDF.Html.Core.Fragmentation
                 hasPrintableContent = true;
 
             _frozen.Add(box);
+
+            // This box does hold something here. Recorded because one box can be reached more than once
+            // in a single slot - once per multi-column column, once per repeating-header proxy, and a
+            // rowspan cell once per row it spans - so an earlier visit finding nothing says nothing
+            // about the slot as a whole. RecordEmptyObservations subtracts this set from the empty one.
+            if (!_pruningSuspended) _producedSomethingThisSlot.Add(box);
+
+            subtreePrunable &= ownPrunable;
 
             var draft = new Draft(new FragmentKey(box, owner, instance), box, slot, region, snapshot, originY);
 

--- a/src/PeachPDF/Html/Core/HtmlContainerInt.cs
+++ b/src/PeachPDF/Html/Core/HtmlContainerInt.cs
@@ -432,6 +432,18 @@ namespace PeachPDF.Html.Core
         internal int? MaxFragmentainersOverride { get; set; }
 
         /// <summary>
+        /// Test-only override for <see cref="FragmentEmitter.VerifyPruningAgainstFullWalk"/>, so one
+        /// render can be checked against the unpruned walk without turning the check on process-wide.
+        /// Null in production, where the environment variable alone decides.
+        /// </summary>
+        /// <remarks>
+        /// Per instance rather than static because the test suite runs its collections in parallel:
+        /// a test that flipped a global would silently change what every concurrently-running test was
+        /// doing. The environment variable stays as the way to run the <i>whole</i> suite under it.
+        /// </remarks>
+        internal bool? VerifyFragmentPruningOverride { get; set; }
+
+        /// <summary>
         /// The top-left most location of the rendered html.<br/>
         /// This will offset the top-left corner of the rendered html.
         /// </summary>


### PR DESCRIPTION
`FragmentEmitter.EmitSlot` built each page's draft tree by recursing from the document root with no pruning at all. Measured on the css4.pub Icelandic Dictionary (~255,000 boxes): **~255,000 `BuildDraft` calls per page, flat**, whether emitting page 1 or page 40. Fragment emission cost **84.7s** against **6.5s** for all the layout it describes.

Progress on #572. It does not close it — see "What is left" below.

## When a subtree may be skipped

"The emitter walked it and it produced nothing" is **not** sufficient on its own, and that is the trap to know about here. `EmitPass(from, through)` freezes a whole *range* of slots in one go, **after** the pass that filled them has already flowed content into every one, with no layout in between. So at any slot below the frontier, "nothing here" equally describes content that is simply further down — and no write will ever come along to correct it.

Two separately-justified cases, deliberately never merged into one:

- **Behind the frontier** — the box is already in `_frozen`, so it has had its fragments and they were contiguous. Empty now means empty later.
- **Ahead of the frontier** — nothing has ever written to the box this generation, so it holds no positioned content anywhere. The write that first positions it necessarily lands before the pass placing it ends, hence before the slot needing it is frozen.

Excluded is the box *in between* — reached, laid out, simply not here — whose content may be in a slot the same `EmitPass` range is about to freeze.

## What the observation is deliberately not

It is never derived from live geometry. Several engines rewrite a box's extent well after its own layout pass finishes (`_flexBox.ActualBottom += shift`, the `ApplyHeight` epilogue, table row/row-group/cell aggregates), and the multi-column engine keeps each column's geometry in its own `BoxGeometrySnapshot` — so a box's own fields do not describe every fragment it has.

Instead it is discarded by the writes that could invalidate it. Two of those needed creating, because they notified nothing before:

- **`CssBox.Size`** — an auto-property until now, and the one every `ActualBottom`/`ActualRight` assignment passes through (~85 sites). Guarded on value change, since it sits on layout's hot path.
- **`CssRect.Top`** — the only place a word's position is settled, and a word is the one piece of content whose position lives nowhere on the box itself.

Plus `CssLineBox.AssignRectanglesToBoxes` for inline boxes' per-line rectangles, the existing `NotifyGeometryChanged` callers, and the emitter's own `Record*`/`Clear*` methods for facts recorded about a box between slots.

Boxes reached through a repeating-header proxy or inside a nested fragmentainer are never observed at all — both are visited several times within one slot against different geometry. Out-of-flow and fixed content is excluded because its fragments are not a contiguous run, and a single such descendant makes every ancestor unobservable too. Note that only the box's own contiguity propagates to ancestors: whether *this visit* could observe a box is a per-visit fact, and letting it propagate made every multi-column container unprunable — which on a mostly-multi-column document is the entire optimization.

## Verified by construction, not by inspection

Three earlier attempts at this each broke 460–480 tests and each was caught only by running the whole suite — never by review. So the oracle came first.

`PEACHPDF_VERIFY_FRAGMENT_PRUNING=1` (or, per render, `HtmlContainerInt.VerifyFragmentPruningOverride`) makes every slot build its draft tree **twice**, pruned and unpruned, and throw unless the two agree on all nineteen `Draft` members, on `hasPrintableContent`, and on the set of boxes holding fragments.

That last one is the point rather than a detail: per `.claude/invariants/fragmentation-which-drafts-exist-decides-whether-a-frozen-slot-is-emitted-again.md`, `_frozen` membership is the only gate on whether an already-frozen slot is emitted again, so a pruning bug can leave every draft identical and still change the whole document's emission order. `_frozen` is snapshotted and rolled back between the two builds (safe — `BuildDraft`'s only emitter mutation is the idempotent `_frozen.Add`).

It earned its keep immediately: the first run under it produced **22** failures, not ~470, each naming the diverging box and member. Both causes were real — a rewound keep-with-next pass whose observations were not retired, and inline content whose words move with no box-level write.

## Verification

- Full suite green **with and without** the self-check enabled (7376 passed / 0 failed / 9 skipped).
- `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings.
- Diff coverage 91%. The uncovered lines are the divergence-throw paths, which by design only execute when pruning is actually wrong.
- `dictionary.mhtml`: **9m24s → 7m38s**.

## What is left

7m38s is an improvement, not a fix, and #572 stays open. Instrumentation shows observations are still discarded roughly every pass (~195k boxes re-marked per slot), so most slots still take the full walk and only a few prune hard. Filed with the measurements and the diagnosis path:

- #581 — pruning is retired almost every pass; `PassRewind.RollBackTo` over a multi-column container's children is the prime suspect.
- #582 — `PdfGenerator` parses and cascades the whole document twice when CSS `@page size` differs from the configured size (~28s here, and a fixed cost that dominates small documents).
- #583 — `CssBox.OffsetRectangle` moves a rectangle with no notification; latent today, but it would fail silently if it ever goes live.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3hPZc4ntV2y6PiP7yS3YR)_