### PR TITLE
Resolve @page size in place instead of re-parsing the document

### DIFF
--- a/.claude/recent-fixes/2026-08-01-page-size-correction-no-longer-re-parses-the-whole-document.md
+++ b/.claude/recent-fixes/2026-08-01-page-size-correction-no-longer-re-parses-the-whole-document.md
@@ -1,0 +1,90 @@
+# `@page` size correction no longer re-parses the whole document
+
+Follow-up to `.claude/recent-fixes/2026-07-31-emission-no-longer-rewalks-the-whole-tree-per-page.md`,
+which flagged this as its own issue (#582): `PdfGenerator.AddPdfPages` called `SetContent` — full HTML
+parse, full CSS parse, the full per-box cascade, ~8 box-tree correction passes — once with the
+caller-configured page size, and then, only after that entire call returned, checked whether the
+document's own base `@page { size: ... }` disagreed with it. If it did, it threw the whole parse away
+and called `SetContent` a **second time**. Measured on the css4.pub Icelandic Dictionary: ~14s per
+`SetContent` call, ~28s total, a fixed cost paid by *any* document whose `@page` size differs from the
+configured one regardless of page count — dominant for small documents.
+
+## The load-bearing idea
+
+`DomParser.GenerateCssTree` already resolves `CssPageSize` early, inside `CascadeApplyPageStyles` —
+*before* `CascadeApplyStyles` (the expensive per-box cascade) and every correction pass even start. The
+mismatch was never actually unknown until late; it was known ~30 lines into a ~90-line method, and
+`PdfGenerator` was reacting to it one whole call stack up by discarding everything below that point.
+Correcting `htmlContainer.PageSize` right where the mismatch is discovered, and re-resolving the (cheap)
+page-styles pass once more in place, needed nothing from `PdfGenerator` at all — `CascadeApplyPageStyles`
+now does this itself, split into a thin outer method (resolve, compare, correct-and-retry) and an inner
+`ApplyPageStylesOnce` (the original body, now parameterized on `pixelsPerPoint` instead of computing it).
+`PdfGenerator.AddPdfPages` and `SetContent` needed small adjustments to keep reading the corrected size
+from the right place afterward, but they no longer call `SetHtml` a second time — this is now genuinely
+a single HTML parse, a single CSS parse, a single cascade, per render.
+
+## Why the retry is bounded to exactly one, and safe
+
+`ParsePageSizeToPdfPoints`/`ParseSizeDimensionToPdfPoints` resolve `CssPageSize` using only
+`PageLengthContext.EmPt`/`RemPt` (the font-size basis) for `em`/`rem` — **never**
+`HundredPercentPt` (the page-width basis; `%` is illegal for `size` itself per css-page-3 §7.1). So
+`CssPageSize`'s own value is independent of `htmlContainer.PageSize` and resolves identically whether
+`ApplyPageStylesOnce` runs once or twice. Only the **margins** resolved in the same pass (`%`/`em`
+`@page` margins, via `HundredPercentPt`) actually depend on the page width being correct — so a single
+retry, once `CssPageSize` is known, is sufficient. There is no scenario where a second retry could
+produce a different answer than the first, since nothing the second call reads changes between the two
+calls except `htmlContainer.PageSize` itself (already corrected) and `CssPageSize` (already fixed).
+
+## The trap: two unit spaces for "page size"
+
+`HtmlContainerInt.PageSize` is `RSize`, in `PixelsPerPoint`-scaled internal pixel space (usually == true
+points, but diverges under `ShrinkToFit`/`ScaleToPageSize` or a non-72 `PixelsPerInch`).
+`HtmlContainerInt.CssPageSize` is `XSize`, always true, unscaled PDF points (its own doc comment says
+so explicitly). The old code's comparison lived in `PdfGenerator.AddPdfPages`, comparing `CssPageSize`
+against the method's own `orgPageSize` local (always true points, by construction) — implicitly
+unit-consistent because it never touched `PageSize` directly. Moving the comparison down into
+`CascadeApplyPageStyles` meant it now has to compare against `htmlContainer.PageSize` (`RSize`)
+directly, so both directions go through `PeachPDF.Utilities.Utils.Convert(XSize/RSize, pixelsPerPoint)`
+explicitly. A second, smaller trap: `Utils` is ambiguous unqualified here — `DomParser.cs`'s namespace
+(`PeachPDF.Html.Core.Parse`) nests under `PeachPDF.Html.Core`, whose sibling `PeachPDF.Html.Core.Utils`
+*namespace* wins C#'s enclosing-namespace-before-using lookup order over the `PeachPDF.Utilities.Utils`
+*class* even with a `using PeachPDF.Utilities;` in scope (CS0234, "does not exist in the namespace
+...Utils"). Fully qualifying `PeachPDF.Utilities.Utils.Convert(...)` avoids the CS0234 shadowing
+outright, so the `using` was dropped rather than kept unused.
+
+## Downstream: `PdfGenerator` no longer owns the correction, but still needs the corrected value
+
+`AddPdfPages` used to update its own `orgPageSize` local only inside the now-removed second-`SetContent`
+branch; that local still feeds the measure/rescale pass, the `ShrinkToFit`/`ScaleToPageSize` third
+`SetContent` call, and every page's `page.Width`/`Height`/`MarginBoxRenderer`/`HandleLinks` call further
+down the method — so it still needs to be set unconditionally to `container.CssPageSize` when present,
+just without a second `SetContent` call to trigger on. `SetContent`'s own tail (which subtracts margins
+from the page size to get the final content-box `PageSize`) used to read its `orgPageSize` *parameter*
+directly — safe under the old two-call scheme, since the second call was invoked with the already-
+corrected size as that parameter. With only one call now, that tail reads `container.CssPageSize ??
+orgPageSize` instead, or it would silently clobber `CascadeApplyPageStyles`'s in-place correction with
+the stale, originally-configured size.
+
+## What was deliberately not done
+
+Directions 2 ("re-run only what depends on the page size") and 3 ("skip the re-parse when nothing
+observed the old size") from issue #582 were not pursued — Direction 1 fully eliminates the redundant
+pass with a smaller, more local change (one method split, no new state to track across the DOM), and was
+the issue's own recommended direction.
+
+## Evidence
+
+- Full `net8.0` suite green: 7378 passed, 0 failed, 9 skipped (up from 7376 passed pre-fix — two new
+  regression tests).
+- `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings.
+- `diff-cover` against `origin/main`: 100% on the two changed files' lines.
+- New regression tests (`PageSizeCorrectionMarginBasisIntegrationTests`) drive the actual mismatch
+  through `PdfGeneratorLayoutHarness.LayoutAsync` (the production page-size-resolution path) with a `%`
+  and an `em` `@page` margin — the fixture shape the issue's own "Verification" section called for, and
+  one no pre-existing test exercised (the existing `@page`-size/margin suites all pre-set
+  `HtmlContainerInt.PageSize` correctly before a single direct `SetHtml` call, never triggering the
+  mismatch/correction branch at all).
+- Not re-run: the multi-minute `dictionary.mhtml` stress benchmark from issue #582/PR #584. The fix is a
+  direct, provable elimination of a whole second `HtmlParser.ParseDocument`/`CascadeApplyStyles`/
+  correction-pass sequence (verified by code inspection: `PdfGenerator.AddPdfPages` now calls
+  `SetContent` exactly once), not a probabilistic win that needs re-measuring to confirm.

--- a/src/PeachPDF.Tests/Integration/PageSizeCorrectionMarginBasisIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/PageSizeCorrectionMarginBasisIntegrationTests.cs
@@ -1,0 +1,83 @@
+using PeachPDF.Tests.TestSupport;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Issue #582: when a document's own base <c>@page { size: ... }</c> differs from the configured
+    /// <see cref="PdfGenerateConfig"/> page size, <c>DomParser.CascadeApplyPageStyles</c> corrects
+    /// <c>HtmlContainerInt.PageSize</c> IN PLACE (before the expensive cascade runs) and re-resolves once
+    /// more, rather than <c>PdfGenerator</c> discarding the whole parse and calling
+    /// <c>SetContent</c>/<c>SetHtml</c> a second time. A percentage <c>@page</c> margin (css-page-3 §7.1)
+    /// is the fixture that proves this actually happened: it must resolve against the CSS-corrected page
+    /// width, not the originally-configured one. Goes through
+    /// <see cref="PdfGeneratorLayoutHarness.LayoutAsync"/> (the production page-size-resolution path), not
+    /// a manually pre-set <c>HtmlContainerInt.PageSize</c> - the existing
+    /// PageSizeUnitIntegrationTests/PageMarginUnitConsistencyIntegrationTests fixtures never exercise the
+    /// correction path at all, since they set the correct size before the one <c>SetHtml</c> call they
+    /// make.
+    /// </summary>
+    public class PageSizeCorrectionMarginBasisIntegrationTests
+    {
+        [Fact]
+        public async Task PercentageMargin_ResolvesAgainstFinalCssPageWidth_NotConfiguredWidth()
+        {
+            var config = new PdfGenerateConfig
+            {
+                ManualPageWidth = 400,
+                ManualPageHeight = 600,
+            };
+            config.SetMargins(0);
+
+            const string html = """
+                <!DOCTYPE html><html><head><style>
+                @page { size: 300pt 500pt; margin: 10%; }
+                body { margin: 0; }
+                </style></head><body><p>content</p></body></html>
+                """;
+
+            var (_, container) = await PdfGeneratorLayoutHarness.LayoutAsync(html, config);
+
+            // The correction actually happened: CssPageSize is the declared 300x500pt sheet.
+            Assert.NotNull(container.CssPageSize);
+            Assert.Equal(300.0, container.CssPageSize!.Value.Width, 3);
+            Assert.Equal(500.0, container.CssPageSize!.Value.Height, 3);
+
+            // 10% must resolve against the CSS-corrected 300pt page width (30pt), not the
+            // originally-configured 400pt sheet (40pt) - the wrong-answer value a shortcut that skipped
+            // the correction (or applied it after margins were already resolved) would produce.
+            // PixelsPerInch defaults to 72, so pixelsPerPoint == 1 and layout units equal points.
+            Assert.Equal(30.0, container.MarginLeft, 3);
+            Assert.Equal(30.0, container.MarginTop, 3);
+            Assert.Equal(30.0, container.MarginRight, 3);
+            Assert.Equal(30.0, container.MarginBottom, 3);
+        }
+
+        [Fact]
+        public async Task EmMargin_ResolvesAgainstPageFontSize_RegardlessOfSizeCorrection()
+        {
+            // Regression guard alongside the % case above: an em @page margin (issue #162 basis - the
+            // page context's own font-size, not root) must keep resolving identically whether or not a
+            // page-size correction pass ran, since ApplyPageStylesOnce's em/rem basis doesn't depend on
+            // PageSize.Width at all - only % does. font-size: 20pt => 2em = 40pt.
+            var config = new PdfGenerateConfig
+            {
+                ManualPageWidth = 400,
+                ManualPageHeight = 600,
+            };
+            config.SetMargins(0);
+
+            const string html = """
+                <!DOCTYPE html><html><head><style>
+                @page { size: 300pt 500pt; font-size: 20pt; margin-left: 2em; }
+                body { margin: 0; }
+                </style></head><body><p>content</p></body></html>
+                """;
+
+            var (_, container) = await PdfGeneratorLayoutHarness.LayoutAsync(html, config);
+
+            Assert.NotNull(container.CssPageSize);
+            Assert.Equal(40.0, container.MarginLeft, 3);
+        }
+    }
+}

--- a/src/PeachPDF.Tests/TestSupport/PdfGeneratorLayoutHarness.cs
+++ b/src/PeachPDF.Tests/TestSupport/PdfGeneratorLayoutHarness.cs
@@ -17,11 +17,12 @@ namespace PeachPDF.Tests.TestSupport
     /// <b>This exists because <see cref="LayoutHarness"/> is not the production path, and the difference
     /// has hidden a defect.</b> That harness calls <c>SetHtml</c> exactly once, never sees an
     /// <c>@page</c> rule, and hand-computes the content band. The generator resolves <c>@page</c> during
-    /// <c>SetHtml</c> and then, when the rule's page size differs from the configured one, throws the whole
-    /// box tree away and lays the document out again against the CSS size — so a document with an
-    /// <c>@page</c> rule is parsed twice and every once-per-layout decision is taken twice.
-    /// <see href="https://github.com/jhaygood86/PeachPDF/issues/439">#439</see> survived two green harness
-    /// tests and was visible only through this path.
+    /// that same <c>SetHtml</c> call: <c>DomParser.CascadeApplyPageStyles</c> corrects the container's
+    /// page size and margins in place, before the expensive cascade and box-tree correction passes run,
+    /// whenever the rule's page size differs from the configured one (issue #582) — so a document with
+    /// an <c>@page</c> rule still takes a materially different code path than <see cref="LayoutHarness"/>
+    /// models at all. <see href="https://github.com/jhaygood86/PeachPDF/issues/439">#439</see> survived
+    /// two green harness tests and was visible only through this path.
     /// </para>
     /// <para>
     /// Deliberately not the whole of <c>AddPdfPages</c>, and a fixture that needs any of the following
@@ -45,8 +46,8 @@ namespace PeachPDF.Tests.TestSupport
     {
         /// <summary>
         /// Lays <paramref name="html"/> out for <paramref name="config"/>, mirroring
-        /// <c>PdfGenerator.AddPdfPages</c>' page-size resolution, its <c>@page</c> re-layout, and its
-        /// <c>MaxSize</c>/<c>PerformLayout</c> pair.
+        /// <c>PdfGenerator.AddPdfPages</c>' page-size resolution (including its in-place <c>@page</c>
+        /// correction inside <c>SetContent</c>/<c>SetHtml</c>) and its <c>MaxSize</c>/<c>PerformLayout</c> pair.
         /// </summary>
         /// <param name="html">the document to lay out</param>
         /// <param name="config">the generator configuration whose page size and margins apply</param>
@@ -67,12 +68,6 @@ namespace PeachPDF.Tests.TestSupport
             var container = new HtmlContainer(adapter);
 
             await PdfGenerator.SetContent(container, config, html, null, orgPageSize);
-
-            // The @page arm: the CSS size wins, and the document is parsed and laid out a second time.
-            if (container.CssPageSize.HasValue && container.CssPageSize.Value != orgPageSize)
-            {
-                await PdfGenerator.SetContent(container, config, html, null, container.CssPageSize.Value);
-            }
 
             using var measure = XGraphics.CreateMeasureContext(
                 container.PageSize, XGraphicsUnit.Point, XPageDirection.Downwards);
@@ -112,11 +107,6 @@ namespace PeachPDF.Tests.TestSupport
             var container = new HtmlContainer(adapter);
 
             await PdfGenerator.SetContent(container, config, html, null, orgPageSize);
-
-            if (container.CssPageSize.HasValue && container.CssPageSize.Value != orgPageSize)
-            {
-                await PdfGenerator.SetContent(container, config, html, null, container.CssPageSize.Value);
-            }
 
             var measure = XGraphics.CreateMeasureContext(container.PageSize, XGraphicsUnit.Point, XPageDirection.Downwards);
 

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -270,6 +270,43 @@ namespace PeachPDF.Html.Core.Parse
             // PixelsPerPoint reconciliation for the identical, already-established pattern/precedent).
             var pixelsPerPoint = (htmlContainer.Adapter as PdfSharpAdapter)?.PixelsPerPoint ?? 1.0;
 
+            ApplyPageStylesOnce(htmlContainer, root, cssData, pixelsPerPoint);
+
+            // Issue #582 / "Direction 1": this method runs before CascadeApplyStyles and every box-tree
+            // correction pass in GenerateCssTree - none of that expensive work has started yet - so if
+            // the document's own base @page { size } rule differs from the page size ApplyPageStylesOnce
+            // just resolved margins/PageLengthContext against, correct htmlContainer.PageSize and resolve
+            // once more IN PLACE, instead of the old behavior (PdfGenerator.AddPdfPages discarding this
+            // whole parse pass and calling SetHtml a second time - a full HTML re-parse + CSS re-cascade +
+            // every correction pass, just to fix up a page-width-dependent margin). This preserves
+            // css-page-3 §7.1: a percentage/em @page margin must resolve against the true page-box width,
+            // which is only known once CssPageSize itself has been resolved.
+            //
+            // At most one retry, and it is safe: ParsePageSizeToPdfPoints (below) resolves CssPageSize
+            // using only context.EmPt/RemPt (the root/page font basis), never context.HundredPercentPt
+            // (the width basis) - so CssPageSize's own value does NOT depend on htmlContainer.PageSize and
+            // resolves to the identical value on the second call. Only the margins - which DO read
+            // HundredPercentPt for `%` - actually change between the two calls, becoming correct.
+            //
+            // PeachPDF.Utilities.Utils.Convert(htmlContainer.PageSize, pixelsPerPoint) reconstructs the
+            // caller-configured page size (an XSize, true points) from PageSize (an RSize,
+            // PixelsPerPoint-scaled internal pixel space, per HtmlContainerInt.PageSize's own doc
+            // comment) - nothing between PdfGenerator.SetContent assigning it and this point mutates it,
+            // so this is the same comparison PdfGenerator.AddPdfPages used to make one layer up, just
+            // before the expensive work starts instead of after. Fully qualified: this namespace
+            // (PeachPDF.Html.Core.Parse) nests under PeachPDF.Html.Core, whose sibling PeachPDF.Html.Core.
+            // Utils namespace would otherwise shadow the unqualified "Utils" name ahead of the `using
+            // PeachPDF.Utilities;` import.
+            if (htmlContainer.CssPageSize is { } cssPageSize &&
+                cssPageSize != PeachPDF.Utilities.Utils.Convert(htmlContainer.PageSize, pixelsPerPoint))
+            {
+                htmlContainer.PageSize = PeachPDF.Utilities.Utils.Convert(cssPageSize, pixelsPerPoint);
+                ApplyPageStylesOnce(htmlContainer, root, cssData, pixelsPerPoint);
+            }
+        }
+
+        private static void ApplyPageStylesOnce(HtmlContainerInt htmlContainer, CssBox root, CssData cssData, double pixelsPerPoint)
+        {
             // ParseLength's absolute-unit branches (pt/mm/cm/in/pc, and px at the spec-correct
             // 1px = 0.75pt via Length.PointsPerPx) resolve straight to raw, unscaled points - for
             // those, multiplying by pixelsPerPoint once at the end (below) is exactly the scaling

--- a/src/PeachPDF/PdfGenerator.cs
+++ b/src/PeachPDF/PdfGenerator.cs
@@ -210,11 +210,16 @@ namespace PeachPDF
 
             await SetContent(container, config, html, cssData, orgPageSize);
 
-            // If CSS @page { size: ... } overrides the configured page size, re-apply with the CSS size
-            if (container.CssPageSize.HasValue && container.CssPageSize.Value != orgPageSize)
+            // DomParser.CascadeApplyPageStyles (run inside SetContent's call to SetHtml, above) already
+            // corrects the container's own PageSize/margins in place when the document's @page { size }
+            // differs from orgPageSize (issue #582 - it runs before the expensive cascade/correction
+            // passes within the same parse, so nothing needs to be discarded and re-parsed). Keep this
+            // local variable in sync with that correction, since it - not container.PageSize - is what
+            // the measure/rescale pass below and each page's dimensions (page.Width/page.Height,
+            // MarginBoxRenderer, HandleLinks) use.
+            if (container.CssPageSize.HasValue)
             {
                 orgPageSize = container.CssPageSize.Value;
-                await SetContent(container, config, html, cssData, orgPageSize);
             }
 
             var measure = XGraphics.CreateMeasureContext(container.PageSize, XGraphicsUnit.Point, XPageDirection.Downwards);
@@ -491,8 +496,15 @@ namespace PeachPDF
                 container.HtmlContainerInt.DocumentLanguage = config.DefaultLanguage;
             }
 
-            // Just in case @page rules got applied
-            var pageSize = new XSize(orgPageSize.Width - container.MarginLeft - container.MarginRight, orgPageSize.Height - container.MarginTop - container.MarginBottom);
+            // Just in case @page rules got applied. SetContent is now only ever called once per render
+            // with the ORIGINAL orgPageSize parameter (DomParser.CascadeApplyPageStyles corrects
+            // PageSize/margins against the CSS @page size in place, inside SetHtml above, rather than a
+            // caller re-invoking SetContent a second time with the corrected size - issue #582) - so this
+            // must subtract margins from the CSS-resolved sheet size (falling back to orgPageSize when
+            // there is no @page { size } rule), or it would clobber that in-place correction with the
+            // stale, originally-configured size.
+            var sheetSize = container.CssPageSize ?? orgPageSize;
+            var pageSize = new XSize(sheetSize.Width - container.MarginLeft - container.MarginRight, sheetSize.Height - container.MarginTop - container.MarginBottom);
             container.PageSize = pageSize;
             container.Location = new XPoint(container.MarginLeft, container.MarginTop);
         }


### PR DESCRIPTION
## Summary

- `PdfGenerator.AddPdfPages` called `SetContent` (full HTML parse, full CSS cascade, ~8 box-tree correction passes) **twice** whenever a document's own base `@page { size: ... }` disagreed with the caller-configured page size — the mismatch was only discovered after the first full pass returned, so the whole thing was discarded and re-run from scratch just to get `%`/`em` `@page` margins resolving against the correct page width.
- `DomParser.CascadeApplyPageStyles` already resolves `CssPageSize` *before* `CascadeApplyStyles`/the correction passes even start, within the same `GenerateCssTree` call. Split it into a thin outer method and an `ApplyPageStylesOnce` inner method: resolve once, and if `CssPageSize` differs from the page size margins/`PageLengthContext` were computed against, correct `HtmlContainerInt.PageSize` and re-resolve the (cheap) page-styles pass once more, in place — never touching the expensive cascade/correction passes a second time.
- `PdfGenerator.AddPdfPages`/`SetContent` and the test-only `PdfGeneratorLayoutHarness` no longer call `SetContent` a second time; they just pick up the (now in-place-corrected) `CssPageSize` where needed.
- The retry is bounded to exactly one and provably safe: `CssPageSize`'s own resolution only reads the font-size basis (`em`/`rem`), never the page-width basis, so it resolves identically on both calls — only the margins (which do depend on page width for `%`) actually change.

Direction 1 from issue #582's own "Possible directions" section ("resolve the page size before committing to a full parse") — the issue's recommended, least invasive option; Directions 2/3 were not pursued.

## Test plan

- [x] Full `net8.0` suite: 7378 passed, 0 failed, 9 skipped (2 new regression tests, up from 7376 baseline)
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings
- [x] `diff-cover` against `origin/main` — 100% diff coverage on the changed lines
- [x] New `PageSizeCorrectionMarginBasisIntegrationTests` (through `PdfGeneratorLayoutHarness.LayoutAsync`, the production page-size-resolution path — no existing test drove the actual mismatch/correction branch): a `%` `@page` margin resolves against the CSS-corrected page width, not the originally-configured one; an `em` `@page` margin keeps resolving correctly regardless. Independently confirmed the `%` test actually catches the regression by reverting the fix and observing it fail (`Expected: 30, Actual: 40`).
- [x] Independent post-change review pass against the diff — no blocking findings (one documented, non-blocking observation about a pre-existing exact-double-equality pattern reused from the code this replaces)

Fixes #582