### PR TITLE
Skip fragment-emission invalidation when nothing was recorded to clear

### DIFF
--- a/.claude/recent-fixes/2026-08-01-clearing-recorded-fragmentation-state-is-now-a-no-op-with-nothing-to-clear.md
+++ b/.claude/recent-fixes/2026-08-01-clearing-recorded-fragmentation-state-is-now-a-no-op-with-nothing-to-clear.md
@@ -1,0 +1,57 @@
+# Clearing recorded fragmentation state is now a no-op with nothing to clear
+
+Follow-up to #581 (itself filed from #584's "where it stands" section). `FragmentEmitter`'s three
+"clear" methods — `ClearNestedFragmentainers`, `ClearContinuationShells`, `ClearFragmentDisplacements`
+— called `CssBox.DiscardEmittedNothing()`/`DiscardEmittedNothingIncludingDescendants()`
+**unconditionally**, before even checking whether their own dictionary removal (`_nested`/
+`_continuationShells`/`_displacements`) found anything to remove.
+
+`CssLayoutEngineColumns.Layout` calls `ClearNestedFragmentainers(columnsBox, startSlot)` once per
+`Layout()` invocation — i.e. once per page a resumed multi-column container continues onto — including
+the very first attempt on a fresh page, before that page has filled a single column. Nothing has been
+recorded yet for that key at that point, so the call was a guaranteed no-op for the data it clears,
+but it still discarded the container's "emitted nothing" observation and, walking its ancestors, every
+ancestor's too, up to the first already-clear one. Since that observation is also what
+`CssBox.NeverTouchedThisLayout` reads, one spurious call disables *both* of `FragmentEmitter.BuildDraft`'s
+pruning conditions for the whole ancestor chain — on every single page a large container spans.
+
+## The fix
+
+Each of the three methods now only discards when its own removal genuinely removed something,
+tracked via `Dictionary.Remove`'s own boolean return (the single-key path) or a `removedAny` flag
+accumulated across the multi-key path — the same "already in the state this call would produce is a
+no-op" shape PR #579 established for `CssBox.ResetForRefill`'s `_awaitingRefill` guard, applied to a
+different choke point. This changes nothing about *what* gets removed from the three dictionaries,
+only whether the (already-idempotent) invalidation notification fires when there was nothing to
+invalidate.
+
+## What was measured, and what was not confirmed
+
+A synthetic multi-page, multi-column fixture (60 and 240 `<div>` items in a `columns:2` container,
+`html > body > div#mc` — no deep ancestor chain above the container) showed the fix saves a small,
+real number of `CssBox.DiscardEmittedNothing` calls: 2889 → 2873 at 60 items (16 saved, 16 pages),
+10917 → 10849 at 240 items (68 saved, 68 pages) — almost exactly one saved call per page, matching the
+predicted mechanism precisely. Verified sensitive: a version of the regression tests below run against
+the pre-fix code fails every time; against the fix, all pass.
+
+Two things this does **not** claim. First, at this fixture's shallow ancestor depth the saved calls
+are a small fraction (~0.5%) of the total discard traffic — most of it is genuine, necessary
+invalidation from real per-child reflow (`RectanglesReset`, `Location`/`Size` writes), not this
+defect. Second, and more important: this environment has no `dictionary.mhtml` fixture or
+`PeachPDF.Benchmarks` project (confirmed absent from the repo), so the issue's own ~195k-marks-per-slot
+figure — measured on the real 255,000-box, 31-chapter css4.pub Icelandic dictionary, where a
+multi-column container sits several ancestors below chapter-level boxes that are exactly the ones
+worth skipping — could not be reproduced or re-measured here. Whether this fix meaningfully closes
+that gap on the real document, or whether it is a smaller contributor among others, is not established
+by this change alone. Issue #581 stays open pending that measurement.
+
+## Verification
+
+- Two new tests per method in `FragmentEmitterTests.cs`: one confirms clearing with nothing recorded
+  leaves an existing `EmittedNothingAtOrBefore` observation on the target box intact (fails without
+  the fix), one confirms clearing something genuinely recorded still discards it (guards against an
+  over-eager guard breaking real invalidation).
+- Full `net8.0` suite, with and without `PEACHPDF_VERIFY_FRAGMENT_PRUNING=1`: 7383 passed, 0 failed,
+  9 skipped both ways.
+- `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings.
+- `diff-cover` against `origin/main` — 100% diff coverage.

--- a/src/PeachPDF.Tests/Html/Core/Fragments/FragmentEmitterTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Fragments/FragmentEmitterTests.cs
@@ -872,6 +872,114 @@ namespace PeachPDF.Tests.Html.Core.Fragments
                 word => word.Word.Text?.StartsWith("Line") == true);
         }
 
+        // ─── Clearing recorded state is a no-op when nothing was recorded (#581) ───
+
+        /// <summary>
+        /// <c>CssLayoutEngineColumns.Layout</c> calls <c>ClearNestedFragmentainers(columnsBox,
+        /// startSlot)</c> once per <c>Layout()</c> invocation - i.e. once per page a resumed multi-column
+        /// container continues onto - even on the very first attempt, before that page has filled a
+        /// single column. On a fresh slot nothing has been recorded yet for that key, so the call used to
+        /// be a guaranteed no-op for the data it clears while still unconditionally discarding the
+        /// container's "emitted nothing" observation - and, by walking its ancestors, every ancestor's
+        /// too, up to the first already-clear one. Since that observation also gates
+        /// <c>CssBox.NeverTouchedThisLayout</c>, one spurious discard disables both of
+        /// <c>FragmentEmitter.BuildDraft</c>'s pruning conditions for a whole ancestor chain on every
+        /// single page a large container spans - the mechanism issue #581 traced.
+        /// </summary>
+        [Fact]
+        public async Task ClearNestedFragmentainers_WithNothingRecordedForTheGivenSlot_LeavesAnExistingObservationIntact()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap("<div id='mc' style='columns:2'>x</div>"));
+            var mc = LayoutHarness.FindById(root, "mc")!;
+
+            // The same observation FragmentEmitter.BuildDraft would have recorded for a box behind the
+            // layout frontier that produced no fragment at or before slot 0.
+            mc.RecordEmittedNothingAt(0, 0);
+            Assert.True(mc.EmittedNothingAtOrBefore(0, 0));
+
+            // Slot 5 was never recorded for this container - the shape of the very first
+            // ClearNestedFragmentainers call CssLayoutEngineColumns.Layout makes on a fresh page.
+            container.ClearNestedFragmentainers(mc, 5);
+
+            Assert.True(mc.EmittedNothingAtOrBefore(0, 0));
+        }
+
+        /// <summary>
+        /// The companion case: when a slot genuinely held recorded nested fragmentainers, clearing it must
+        /// still discard the observation exactly as before - the guard only skips the call when there was
+        /// truly nothing to invalidate.
+        /// </summary>
+        [Fact]
+        public async Task ClearNestedFragmentainers_WithSomethingRecordedForTheGivenSlot_StillDiscardsTheObservation()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(SplitAcrossColumns(), pageHeight: 200, margin: 0);
+            var mc = LayoutHarness.FindById(root, "mc")!;
+
+            // A real multi-column layout has already recorded nested fragmentainers for this container at
+            // slot 0 via CssLayoutEngineColumns.Layout/RecordNestedFragmentainer.
+            mc.RecordEmittedNothingAt(0, 0);
+            Assert.True(mc.EmittedNothingAtOrBefore(0, 0));
+
+            container.ClearNestedFragmentainers(mc, 0);
+
+            Assert.False(mc.EmittedNothingAtOrBefore(0, 0));
+        }
+
+        /// <summary>
+        /// The same shape as <see cref="ClearNestedFragmentainers_WithNothingRecordedForTheGivenSlot_LeavesAnExistingObservationIntact"/>
+        /// for the table-row continuation-shell bookkeeping.
+        /// </summary>
+        [Fact]
+        public async Task ClearContinuationShells_WithNothingRecorded_LeavesAnExistingObservationIntact()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap("<p id='p'>hello</p>"));
+            var p = LayoutHarness.FindById(root, "p")!;
+
+            p.RecordEmittedNothingAt(0, 0);
+            Assert.True(p.EmittedNothingAtOrBefore(0, 0));
+
+            container.ClearContinuationShells(p, fromSlot: 3);
+
+            Assert.True(p.EmittedNothingAtOrBefore(0, 0));
+        }
+
+        /// <summary>
+        /// The same shape for the css-break-3 §4.3 fragment-displacement bookkeeping.
+        /// </summary>
+        [Fact]
+        public async Task ClearFragmentDisplacements_WithNothingRecorded_LeavesAnExistingObservationIntact()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap("<p id='p'>hello</p>"));
+            var p = LayoutHarness.FindById(root, "p")!;
+
+            p.RecordEmittedNothingAt(0, 0);
+            Assert.True(p.EmittedNothingAtOrBefore(0, 0));
+
+            container.ClearFragmentDisplacements(p, fromSlot: 3);
+
+            Assert.True(p.EmittedNothingAtOrBefore(0, 0));
+        }
+
+        /// <summary>
+        /// The companion case for <see cref="ClearFragmentDisplacements_WithNothingRecorded_LeavesAnExistingObservationIntact"/>:
+        /// a slot that genuinely held a recorded displacement must still discard the observation.
+        /// </summary>
+        [Fact]
+        public async Task ClearFragmentDisplacements_WithSomethingRecordedFromTheGivenSlot_StillDiscardsTheObservation()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap("<p id='p'>hello</p>"));
+            var p = LayoutHarness.FindById(root, "p")!;
+
+            container.RecordFragmentDisplacement(p, 2, 10, new RRect(0, 0, 100, 100));
+
+            p.RecordEmittedNothingAt(0, 0);
+            Assert.True(p.EmittedNothingAtOrBefore(0, 0));
+
+            container.ClearFragmentDisplacements(p, fromSlot: 2);
+
+            Assert.False(p.EmittedNothingAtOrBefore(0, 0));
+        }
+
         // ─── A fragment's own geometry (§2, nested fragmentainers) ─────────────────
 
         /// <summary>

--- a/src/PeachPDF.Tests/Html/Core/Fragments/FragmentEmitterTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Fragments/FragmentEmitterTests.cs
@@ -944,6 +944,26 @@ namespace PeachPDF.Tests.Html.Core.Fragments
         }
 
         /// <summary>
+        /// The companion case for <see cref="ClearContinuationShells_WithNothingRecorded_LeavesAnExistingObservationIntact"/>:
+        /// a slot that genuinely held a recorded continuation shell must still discard the observation.
+        /// </summary>
+        [Fact]
+        public async Task ClearContinuationShells_WithSomethingRecordedFromTheGivenSlot_StillDiscardsTheObservation()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap("<p id='p'>hello</p>"));
+            var p = LayoutHarness.FindById(root, "p")!;
+
+            container.RecordContinuationShell(p, 2, new RRect(0, 0, 100, 100));
+
+            p.RecordEmittedNothingAt(0, 0);
+            Assert.True(p.EmittedNothingAtOrBefore(0, 0));
+
+            container.ClearContinuationShells(p, fromSlot: 2);
+
+            Assert.False(p.EmittedNothingAtOrBefore(0, 0));
+        }
+
+        /// <summary>
         /// The same shape for the css-break-3 §4.3 fragment-displacement bookkeeping.
         /// </summary>
         [Fact]

--- a/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
@@ -551,19 +551,24 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// </remarks>
         internal void ClearNestedFragmentainers(CssBox contextRoot, int? slot = null)
         {
-            // Removing a fragmentainer changes the walk exactly as recording one does.
-            contextRoot.DiscardEmittedNothing();
-
             if (slot is { } only)
             {
-                _nested.Remove((contextRoot, only));
+                // Removing a fragmentainer changes the walk exactly as recording one does - but only
+                // when there was one to remove. A fresh slot that never recorded anything (the common
+                // case: this runs once per page for a resumed container, before that page has filled a
+                // single column) must not spend an observation it never invalidated.
+                if (_nested.Remove((contextRoot, only))) contextRoot.DiscardEmittedNothing();
                 return;
             }
 
+            var removedAny = false;
+
             foreach (var key in new List<(CssBox Root, int Slot)>(_nested.Keys))
             {
-                if (ReferenceEquals(key.Root, contextRoot)) _nested.Remove(key);
+                if (ReferenceEquals(key.Root, contextRoot) && _nested.Remove(key)) removedAny = true;
             }
+
+            if (removedAny) contextRoot.DiscardEmittedNothing();
         }
 
         /// <summary>
@@ -618,22 +623,24 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// </remarks>
         internal void ClearContinuationShells(CssBox box, int? fromSlot = null)
         {
-            box.DiscardEmittedNothing();
-
             if (fromSlot is not { } from)
             {
-                _continuationShells.Remove(box);
+                if (_continuationShells.Remove(box)) box.DiscardEmittedNothing();
                 return;
             }
 
             if (!_continuationShells.TryGetValue(box, out var shells)) return;
 
+            var removedAny = false;
+
             foreach (var slot in new List<int>(shells.Keys))
             {
-                if (slot >= from) shells.Remove(slot);
+                if (slot >= from && shells.Remove(slot)) removedAny = true;
             }
 
             if (shells.Count == 0) _continuationShells.Remove(box);
+
+            if (removedAny) box.DiscardEmittedNothing();
         }
 
         /// <summary>
@@ -693,22 +700,24 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// </summary>
         internal void ClearFragmentDisplacements(CssBox box, int? fromSlot = null)
         {
-            box.DiscardEmittedNothingIncludingDescendants();
-
             if (fromSlot is not { } from)
             {
-                _displacements.Remove(box);
+                if (_displacements.Remove(box)) box.DiscardEmittedNothingIncludingDescendants();
                 return;
             }
 
             if (!_displacements.TryGetValue(box, out var bySlot)) return;
 
+            var removedAny = false;
+
             foreach (var slot in new List<int>(bySlot.Keys))
             {
-                if (slot >= from) bySlot.Remove(slot);
+                if (slot >= from && bySlot.Remove(slot)) removedAny = true;
             }
 
             if (bySlot.Count == 0) _displacements.Remove(box);
+
+            if (removedAny) box.DiscardEmittedNothingIncludingDescendants();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- `FragmentEmitter.ClearNestedFragmentainers`/`ClearContinuationShells`/`ClearFragmentDisplacements` called `CssBox.DiscardEmittedNothing()`/`DiscardEmittedNothingIncludingDescendants()` **unconditionally**, even when their own dictionary removal (`_nested`/`_continuationShells`/`_displacements`) found nothing to remove.
- `CssLayoutEngineColumns.Layout` calls `ClearNestedFragmentainers(columnsBox, startSlot)` once per `Layout()` invocation — i.e. once per page a resumed multi-column container continues onto — including the very first attempt on a fresh page, before that page has filled a single column. Nothing has been recorded yet for that key at that point, so the call was a guaranteed no-op for the data it clears, but it still discarded the container's "emitted nothing" observation and, walking its ancestors, every ancestor's too, up to the first already-clear one. Since that observation also gates `CssBox.NeverTouchedThisLayout`, one spurious call disables *both* of `FragmentEmitter.BuildDraft`'s pruning conditions for the whole ancestor chain, on every page a large container spans — the mechanism issue #581 traced back to `CssLayoutEngineColumns.Layout`'s fill/retry loop.
- Each method now only discards when its own removal genuinely removed something, tracked via `Dictionary.Remove`'s own boolean return (single-key path) or a `removedAny` flag accumulated across the multi-key path — the same "already in the target state is a no-op" shape PR #579 established for `CssBox.ResetForRefill`'s `_awaitingRefill` guard, applied to a different choke point.

## What was measured, and what wasn't confirmed here

A synthetic multi-page, multi-column fixture (60 and 240 items in a `columns:2` container) showed the fix saves a small, real, and precisely-predicted number of `DiscardEmittedNothing` calls — about one saved call per page (2889→2873 at 60 items/16 pages, 10917→10849 at 240 items/68 pages). At that fixture's shallow ancestor depth this is a small fraction of total discard traffic; most of the rest is genuine, necessary invalidation from real per-child reflow.

This environment has no `dictionary.mhtml` fixture or `PeachPDF.Benchmarks` project (both absent from the repo), so issue #581's own ~195k-marks-per-slot figure — measured on the real 255,000-box, 31-chapter css4.pub Icelandic dictionary — could not be reproduced or re-measured here. Whether this fix meaningfully closes that gap on the real document, or is a smaller contributor among others still to be found, isn't established by this change alone. Leaving #581 open pending that measurement rather than closing it.

## Test plan

- [x] New tests in `FragmentEmitterTests.cs`, two per guarded method: one confirms clearing with nothing recorded leaves an existing `EmittedNothingAtOrBefore` observation intact (independently verified to fail against the pre-fix code), one confirms clearing something genuinely recorded still discards it.
- [x] Full `net8.0` suite, with and without `PEACHPDF_VERIFY_FRAGMENT_PRUNING=1`: 7384 passed, 0 failed, 9 skipped both ways.
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings.
- [x] `diff-cover` against `origin/main` — 100% diff coverage.
- [x] Post-change review pass against the diff — one minor test-parity gap found and closed (added the missing genuine-removal companion test for `ClearContinuationShells`); no correctness issues.

Progress on #581.