### PR TITLE
Delete dead OffsetRectangle geometry-notification landmine (closes #583)

### DIFF
--- a/.claude/recent-fixes/2026-08-01-stale-slot-replay-writes-investigated-and-found-not-to-help.md
+++ b/.claude/recent-fixes/2026-08-01-stale-slot-replay-writes-investigated-and-found-not-to-help.md
@@ -1,0 +1,95 @@
+# Writable marks during `Finish()`'s stale-slot replay: investigated, found safe but useless
+
+Follow-up to #572/#587's own "not pursued further" note, and closes #583 as a separate, unrelated
+cleanup found during the same audit.
+
+## #583: `CssBox.OffsetRectangle` deleted
+
+`CssLineBox.SetBaseLine` set its own `Rectangles[b] = newr` (the gap-adjusted rectangle) *before*
+calling `b.OffsetRectangle(this, gap)` — and `AssignRectanglesToBoxes` (the only thing that ever
+populates `CssBox.Rectangles`) runs later still, copying that already-adjusted value straight in. So
+`OffsetRectangle` was provably dead (its lookup always missed) and had no valid ordering under which it
+would be both reachable and correct: called before `AssignRectanglesToBoxes`, today's no-op; called
+after, a silent double-application of the gap. Deleted the method and its one call site rather than
+adding the `NotifyGeometryChanged` call the issue itself suggested — patching would have preserved a
+method that produces wrong geometry if it ever became reachable, just with correct notifications about
+the wrong geometry.
+
+## The stale-slot-replay follow-up: safe, and worth recording exactly why it doesn't help
+
+#587 split `FragmentEmitter._pruningSuspended`'s two duties (blocking new pruning marks vs. blocking
+*reads* of existing ones) so `Finish()`'s stale-slot replay and `EmitReservedBlankSlots` could at least
+read pre-existing marks. Writing new marks during those passes stayed blocked, and #587's own note
+flagged this as the likely next win: on the real `dictionary.mhtml` document, ~68 million of the
+~79.3 million remaining `BuildDraft` calls were attributed to exactly this restriction.
+
+**The hypothesis tested**: replaying `_stale` in descending slot order (instead of `InvalidateFrom`'s
+own ascending accumulation) removes the specific danger the original ascending-order code was written
+against — `CssBox.EmittedNothingAtOrBefore` only ever lets a mark recorded while processing slot `S`
+suppress a *later* query at a slot `>= S`, so in descending order every stale slot above `S` has
+already been fully walked by the time `S` is processed, and nothing left to visit can reach back and
+be wrongly suppressed by a mark made at `S`.
+
+This reasoning is correct — implemented it (`EmitSlot`'s `mayWrite`/`mayVerify` split, `Finish()`
+visiting `_stale.Reverse()`), and it passed the full suite and `PEACHPDF_VERIFY_FRAGMENT_PRUNING=1`
+cleanly. **But instrumented per-slot on the real document, it produced zero measurable improvement**
+(same 79,285,091 `BuildDraft` calls as before, wall-clock unchanged within noise). The per-slot trace
+explains why precisely:
+
+```
+DIAG   replay slot=761 calls=1651      <- first (highest) slot: cheap, benefits from PRE-EXISTING marks
+DIAG   replay slot=760 calls=1663
+...
+DIAG   replay slot=5   calls=255228    <- cost climbs back to a full unpruned walk
+DIAG   replay slot=4   calls=255213
+DIAG   replay slot=3   calls=255420
+DIAG   replay slot=2   calls=255191    <- last (lowest) slot: essentially the whole tree, every time
+```
+
+The directional check (`slotIndex >= _emittedNothingAtSlot`) means a mark only ever helps a query at an
+*equal or higher* slot than where it was recorded. In a descending sweep, every mark gets written at a
+progressively *lower* index than the last — but there is nothing left to visit below it in the same
+pass by construction. The reordering that makes writing safe is exactly the reordering that makes the
+writes useless: safety and payoff pull in opposite directions here. Ascending order is the only order
+in which an early (low) mark could help a later (high) query in the same sweep — which is exactly the
+order the original code was unsafe to write in, for a real reason (a box could be wrongly marked
+"empty from here on" while its actual content is still ahead, undiscovered, in the same batch).
+
+## What a genuinely effective fix would need
+
+Not pursued here, and flagged for whoever picks this up next: making *ascending* replay safe to write
+in requires a stronger completeness argument than "haven't reached higher ground yet in this pass" —
+something closer to confirming, before writing any mark, that a box's `_frozen` membership reflects its
+*current*, post-invalidation state rather than a historical fragment from before the reopening that
+caused it to become stale in the first place. Whether `_frozen` can go stale in exactly that way across
+an `InvalidateFrom` call is the open question worth answering first, before attempting another design —
+answering it blind, the way this attempt did, costs a full implementation-and-measurement cycle to find
+out it doesn't pay off.
+
+## What was deliberately not done
+
+- `EmitReservedBlankSlots` was not given the same treatment: it has a different, boundary-based safety
+  argument (categorically past everywhere real content was ever bounded to reach) that isn't backed by
+  an invariant anywhere today, and it only ever covers 0-1 slots per document, so the same verification
+  burden isn't worth it regardless of the ordering question above.
+- The `EmitSlot` parameter split (`mayWrite`/`mayVerify`, decoupled from the single overloaded
+  `mayPrune`) was kept even though `Finish()` ends up passing `mayWrite: false` (unchanged from before
+  #587) — it disentangles two concerns that were conflated before this investigation started and reads
+  more clearly regardless of this attempt's outcome.
+
+## Evidence
+
+- Full `net8.0` suite: 7384 passed, 0 failed, 9 skipped (confirmed across multiple runs; one run hit an
+  unrelated, pre-existing timing-coincidence flake in `FontSynthesisIntegrationTests` — see the
+  separately-filed follow-up — and one run hit a catastrophic native test-process crash that did not
+  reproduce on immediate retry, consistent with this machine's known BIOS/hardware instability rather
+  than a code defect).
+- Same, with `PEACHPDF_VERIFY_FRAGMENT_PRUNING=1`: 7384 passed, 0 failed, 9 skipped.
+- `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings.
+- `diff-cover` against `origin/main`: 100% (7 of 7 coverable lines).
+- Per-slot `BuildDraft` call counts (above), measured against the real `dictionary.mhtml` with a
+  temporary counter and harness (removed before landing, same pattern as #587's own measurement).
+
+Issue #572 can close on this: #583 is resolved, and the remaining performance idea from #587's own note
+has been tried, measured, and found not to pay off as designed — with the reason recorded here so it
+isn't re-attempted blind.

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -5703,18 +5703,6 @@ namespace PeachPDF.Html.Core.Dom
         }
 
         /// <summary>
-        /// Offsets the rectangle of the specified linebox by the specified gap,
-        /// and goes deep for rectangles of children in that linebox.
-        /// </summary>
-        /// <param name="lineBox"></param>
-        /// <param name="gap"></param>
-        internal void OffsetRectangle(CssLineBox lineBox, double gap)
-        {
-            if (!Rectangles.TryGetValue(lineBox, out var r)) return;
-            Rectangles[lineBox] = new RRect(r.X, r.Y + gap, r.Width, r.Height);
-        }
-
-        /// <summary>
         /// Resets the <see cref="Rectangles"/> array
         /// </summary>
         internal void RectanglesReset()

--- a/src/PeachPDF/Html/Core/Dom/CssLineBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLineBox.cs
@@ -253,7 +253,6 @@ namespace PeachPDF.Html.Core.Dom
                 double recttop = newtop - gap;
                 RRect newr = new(r.X, recttop, r.Width, r.Height);
                 Rectangles[b] = newr;
-                b.OffsetRectangle(this, gap);
             }
             else
             {

--- a/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
@@ -377,17 +377,23 @@ namespace PeachPDF.Html.Core.Fragmentation
 
         /// <summary>
         /// Set while the verification build above is running, and by the emission paths that may not
-        /// prune at all, to make <see cref="BuildDraft"/> withhold new "emitted nothing" observations for
-        /// the slot being built.
+        /// write at all (<see cref="EmitReservedBlankSlots"/>, <see cref="Finish"/>'s stale-slot
+        /// replay), to make <see cref="BuildDraft"/> withhold new "emitted nothing" observations for the
+        /// slot being built.
         /// </summary>
         /// <remarks>
         /// Withholding <i>new</i> observations is the only thing every one of those callers actually
-        /// needs. The reserved-blank-slot pass and <see cref="Finish"/>'s stale-slot replay both run out
-        /// of forward order, so a subtree found empty there might simply not have been reached yet by a
-        /// slot still to come in the same replay — but an <i>existing</i>, already-validated observation
-        /// (see <see cref="InvalidationHistory"/>) says something different: that the box's fragments are
-        /// entirely behind a slot no replay in this batch could still be filling, which is just as true
-        /// out of order as in it. Reading is gated separately, by <see cref="_forcingUnprunedReferenceWalk"/>.
+        /// needs. <see cref="CssBox.EmittedNothingAtOrBefore"/> only ever lets a mark recorded while
+        /// processing slot <c>S</c> suppress a later query at a slot <c>&gt;= S</c> — a direction that
+        /// makes writing safe within a single out-of-order sweep only in ascending order (an earlier,
+        /// low-slot mark can help a later, high-slot query in the same sweep), which is exactly the
+        /// order <see cref="Finish"/>'s replay was found unsafe to write in (see its own remarks; a
+        /// descending reordering removes that risk but was measured to help nothing in return, since a
+        /// mark made late in a descending sweep has nothing lower left to suppress). Reading an
+        /// <i>existing</i>, already-validated observation (see <see cref="InvalidationHistory"/>) is
+        /// gated separately, by <see cref="_forcingUnprunedReferenceWalk"/>: it describes ground behind
+        /// every slot any of these callers could still be touching, which is sound out of order as much
+        /// as in it.
         /// </remarks>
         private bool _pruningSuspended;
 
@@ -769,14 +775,15 @@ namespace PeachPDF.Html.Core.Fragmentation
                 RecordChain(incoming, slot, _continuedFrom);
                 RecordChain(outgoing, slot, _continuesInto);
 
-                // The one path that may prune: these are the slots the pass that has just ended filled,
-                // frozen while the geometry it produced is still what the box tree says.
+                // The one path that verifies against the full walk: these are the slots the pass that has
+                // just ended filled, frozen while the geometry it produced is still what the box tree says.
                 //
                 // Only the last slot of the range, and only if the range genuinely reaches past
                 // everything emitted so far, may an observation be drawn from - see
                 // RecordEmptyObservations. Every earlier slot of the range still USES observations
                 // already made; it just may not make new ones.
-                EmitSlot(slot, mayPrune: true, frontier: slot == throughSlot && slot >= _lastEmittedSlot);
+                EmitSlot(slot, mayWrite: true, mayVerify: true,
+                    frontier: slot == throughSlot && slot >= _lastEmittedSlot);
             }
         }
 
@@ -785,6 +792,14 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// slot the passes reached — the trailing <c>break-after</c> case, which is settled only once the
         /// final document height is known and so cannot be stated by a pass.
         /// </summary>
+        /// <remarks>
+        /// Stays conservative (<c>mayWrite: false</c>): these slots are categorically past everywhere any
+        /// real content was ever bounded to reach, which would make writing here safe by a different
+        /// argument than <see cref="Finish"/>'s (ordering-based, and found not to pay off there anyway —
+        /// see its own remarks) — but that boundary isn't backed by an invariant anywhere today, and this
+        /// pass only ever covers 0-1 slots per document (a directional break's own reserved page), so the
+        /// payoff doesn't justify the verification burden. Revisit only if that changes.
+        /// </remarks>
         internal void EmitReservedBlankSlots()
         {
             if (container.MaxReservedBlankSlot is not { } reserved) return;
@@ -793,7 +808,7 @@ namespace PeachPDF.Html.Core.Fragmentation
             {
                 // Runs once every pass is over, so a subtree observed empty here could never be
                 // un-observed by a later layout - nothing may be concluded from it.
-                EmitSlot(slot, mayPrune: false);
+                EmitSlot(slot, mayWrite: false);
             }
         }
 
@@ -852,13 +867,23 @@ namespace PeachPDF.Html.Core.Fragmentation
 
             // Slots a later pass's mover disturbed, emitted again now that layout has settled.
             //
-            // Never prunes, and the reason is the sharp one: `_stale` is a contiguous ASCENDING range
-            // (see InvalidateFrom), replayed here with layout already over, so no write could ever
-            // invalidate a conclusion drawn while replaying it. The lowest stale slot would otherwise
-            // observe every subtree that lives in a higher band as empty and skip the rest of the range.
+            // Never writes, and the reason is the sharp one: a mark recorded while processing slot S
+            // only ever suppresses a FUTURE query at a slot >= S (CssBox.EmittedNothingAtOrBefore), so
+            // within a single sweep over this batch, only a mark written EARLY (at a low slot) could
+            // help a query LATER in the same sweep (at a higher slot) - the natural direction is
+            // ascending, not descending. But ascending order is exactly what makes writing unsafe here:
+            // the lowest stale slot would run before the higher slots holding its own subtree's real
+            // content have been walked at all, so a box could be wrongly marked "empty from here on" when
+            // its actual content is still ahead, undiscovered, in the same batch. (Reordering to
+            // descending order removes that specific risk but was tried and measured to help nothing in
+            // return: marks written late in a descending sweep are only usable by slots lower than where
+            // they were made, and there is nothing left to visit below them by construction - see
+            // .claude/recent-fixes/ for the measurement.) Reading an existing, already-validated
+            // observation remains safe and unrestricted here regardless - see
+            // FragmentEmitter._forcingUnprunedReferenceWalk.
             foreach (var slot in new List<int>(_stale))
             {
-                EmitSlot(slot, mayPrune: false);
+                EmitSlot(slot, mayWrite: false);
             }
 
             if (_emitted.Count == 0) return new FragmentTree([]);
@@ -971,15 +996,21 @@ namespace PeachPDF.Html.Core.Fragmentation
             a.Slot != b.Slot ? a.Slot < b.Slot : a.Instance < b.Instance;
 
         /// <param name="index">the pagination slot to freeze</param>
-        /// <param name="mayPrune">
-        /// whether <see cref="BuildDraft"/> may skip a subtree it has already observed to be empty.
-        /// False for the emission paths whose slot is not the one the geometry was just produced for —
-        /// see each call site.
+        /// <param name="mayWrite">
+        /// whether <see cref="BuildDraft"/> may collect new "emitted nothing"/"produced something"
+        /// observations for this slot at all. False only for <see cref="EmitReservedBlankSlots"/>, which
+        /// deliberately stays as conservative as before — see its own remarks.
+        /// </param>
+        /// <param name="mayVerify">
+        /// whether the differential-verification oracle (<see cref="VerifyPruningAgainstFullWalk"/>) may
+        /// run for this slot. Kept independent of <paramref name="mayWrite"/>: only <see cref="EmitPass"/>
+        /// passes true here — <see cref="VerifyAgainstTheFullWalk"/>'s before/after frozen-state
+        /// comparison assumes an ordinary, in-order pass.
         /// </param>
         /// <param name="frontier">
         /// whether this is the furthest slot layout has reached — see <see cref="RecordEmptyObservations"/>.
         /// </param>
-        private void EmitSlot(int index, bool mayPrune, bool frontier = false)
+        private void EmitSlot(int index, bool mayWrite, bool mayVerify = false, bool frontier = false)
         {
             var bandTop = container.PageTopOf(index);
 
@@ -993,7 +1024,7 @@ namespace PeachPDF.Html.Core.Fragmentation
             var root = container.Root!;
 
             var wasSuspended = _pruningSuspended;
-            var verifying = VerifiesPruning && mayPrune && !wasSuspended;
+            var verifying = VerifiesPruning && mayVerify && !wasSuspended;
 
             if (verifying)
             {
@@ -1001,7 +1032,7 @@ namespace PeachPDF.Html.Core.Fragmentation
                 _frozenBeforeSlot.UnionWith(_frozen);
             }
 
-            _pruningSuspended = wasSuspended || !mayPrune;
+            _pruningSuspended = wasSuspended || !mayWrite;
 
             var hasPrintableContent = false;
             var prunable = true;
@@ -1017,7 +1048,7 @@ namespace PeachPDF.Html.Core.Fragmentation
                 _pruningSuspended = wasSuspended;
             }
 
-            RecordEmptyObservations(index, frontier && mayPrune && !wasSuspended);
+            RecordEmptyObservations(index, frontier && mayWrite && !wasSuspended);
 
             if (verifying)
             {


### PR DESCRIPTION
## Summary

- **Closes #583**: `CssBox.OffsetRectangle` is deleted, along with its one call site in `CssLineBox.SetBaseLine`. Traced precisely: `SetBaseLine` sets its own `Rectangles[b]` to the already gap-adjusted value *before* calling `OffsetRectangle`, and `AssignRectanglesToBoxes` (the only thing that ever populates `CssBox.Rectangles`) runs later still, copying that adjusted value straight in. There is no ordering under which `OffsetRectangle` is both reachable and correct — called before `AssignRectanglesToBoxes` it's today's no-op, called after it would silently double-apply the gap. Deleting removes the landmine outright rather than patching it to notify correctly about geometry that would still be wrong.
- Cleans up `FragmentEmitter.EmitSlot`'s `mayPrune` parameter, which conflated two unrelated concerns (whether new pruning marks may be collected vs. whether the differential-verification oracle should run for this slot) into one bool. Split into `mayWrite`/`mayVerify` — no behavior change for either existing caller (`EmitPass`, `EmitReservedBlankSlots`).
- **Investigated and reverted**: reordering `FragmentEmitter.Finish()`'s stale-slot replay to descending order, to allow writing new pruning marks during that out-of-order pass (the follow-up flagged in #587's own note, expected to address ~68M of the ~79M remaining `BuildDraft` calls on the real `dictionary.mhtml` document). The reordering is provably *safe* (verified under `PEACHPDF_VERIFY_FRAGMENT_PRUNING=1`) but measured to produce **zero improvement**: a mark only ever helps a *future* query at a slot `>= ` where it was recorded, so in a descending sweep every mark is written at a progressively *lower* index than the last, with nothing left below it in the same pass to benefit from it. Per-slot instrumentation confirmed this exactly (cost climbs back to a full ~255K-box walk as replay descends). Full reasoning and the measured trace are in the recent-fix note.

## Test plan

- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 7384 passed, 0 failed
- [x] Same, with `PEACHPDF_VERIFY_FRAGMENT_PRUNING=1` — 7384 passed, 0 failed
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings
- [x] `diff-cover` against `origin/main` — 100% (7/7 coverable lines)
- [x] Re-measured against the real `dictionary.mhtml` fixture (confirmed no change, as expected — this PR's net effect is the `#583` deletion plus a parameter-naming cleanup, not a performance change)