### PR TITLE
Walk a fan-out break token's per-child continuations in RecordChain

### DIFF
--- a/.claude/migration-notes/2026-08-02-a-table-cells-own-multi-page-content-no-longer-repaints-its-border-every-page.md
+++ b/.claude/migration-notes/2026-08-02-a-table-cells-own-multi-page-content-no-longer-repaints-its-border-every-page.md
@@ -1,0 +1,19 @@
+# A table cell's own multi-page content no longer repaints its border/background on every page
+
+**Landed:** 2026-08-02 — Walk a fan-out break token's per-child continuations in RecordChain (issue #590)
+**Doc section:** docs/html-css-support.md § [Page Breaks](../../docs/html-css-support.md#page-breaks)
+**Verified against v0.9.7:** `git show v0.9.7:src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs`'s
+`RecordChain` only walks a `BlockBreakToken`'s linear `ChildToken` chain, with no case for
+`TableBreakToken` (or `FlexBreakToken`/`GridBreakToken`/`FlexColumnBreakToken`) at all — confirmed the
+defect this note describes was present at the last release, not introduced afterward.
+
+A `<td>`/`<th>` (or a flex/grid item) whose own content genuinely spans more than one real page used to
+have every one of its fragments treat both its top and bottom edge as the box's own — so with a visible
+`border` or `background` the top edge repainted on every page the cell's content reached, rather than only
+the page it actually opened on, and likewise for the bottom edge on every page but the last
+(`box-decoration-break: slice`, the default). It now correctly slices: only the first fragment draws the
+top border/background edge and only the last draws the bottom one, exactly as an ordinary block box
+spanning pages already did. This did not affect a cell whose continuation was a content-free
+continuation-shell fragment (a finished cell continuing with its row, or a `rowspan` cell's span crossing a
+page boundary) — those were already correct; the gap was specific to a cell/item whose own content kept
+producing genuinely new fragments pass after pass.

--- a/.claude/recent-fixes/2026-08-02-a-fan-out-break-tokens-per-child-continuations-are-now-walked.md
+++ b/.claude/recent-fixes/2026-08-02-a-fan-out-break-tokens-per-child-continuations-are-now-walked.md
@@ -1,0 +1,62 @@
+# A fan-out break token's per-child continuations are now walked, not just its own top-level box
+
+Closes [#590](https://github.com/jhaygood86/PeachPDF/issues/590).
+
+## What was actually wrong
+
+`FragmentEmitter.RecordChain` (`FragmentEmitter.cs`) is what tells a materialized `BoxFragment` whether
+its own top/bottom edge is a real box edge or a fragmentation break — it walks the incoming/outgoing
+`BreakToken` of each pass and records `(box, slot)` into `_continuedFrom`/`_continuesInto`, which
+`Draft.ContinuedFromThePrevious`/`ContinuesIntoTheNext` (and from there `HasTopEdge`/`HasBottomEdge`) read
+back. Before this fix it only understood a linear chain — `BlockBreakToken.Box` → its one continuing
+child's own token, and so on via `ChildToken` — which is the right shape for ordinary block flow but wrong
+for `TableBreakToken`/`FlexBreakToken`/`GridBreakToken`/`FlexColumnBreakToken`: each of those names its
+*container* box only and fans out into several §2.1 parallel-flow continuations at once (`UnfinishedCells`,
+`UnfinishedItems`, `UnfinishedLines`), which `RecordChain` never descended into. The result: a table cell
+(or flex/grid item) whose own content genuinely produced more than one *real* per-pass fragment reported
+`HasTopEdge: true`/`HasBottomEdge: true` on every one of those fragments, not just the first/last — so
+`box-decoration-break: slice`'s border/background repainted on every page the cell's content spanned
+instead of being sliced. A cell whose continuation is a *stated shell* (`FragmentEmitter.RecordContinuationShell`)
+was unaffected, since the edge predicates already accept `Draft.ShellRect is not null` as an alternate
+signal; the gap was specifically a cell/item that keeps producing real content fragments pass after pass.
+
+Found while fixing #521 (rowspan cell content overflow) — confirmed independent of rowspan on a plain,
+non-rowspan multi-page `<td>`, and filed separately rather than folded into that fix.
+
+## The fix
+
+Added a `virtual IReadOnlyList<BreakToken> FanOutContinuations => []` member to the abstract `BreakToken`
+record, overridden by each of the four fan-out token kinds to expose its own per-child tokens
+(`UnfinishedCells.Select(c => c.Token)`, etc. — `UnfinishedLines.Select(l => l.ItemToken)` for the column
+shape). `RecordChain` now recurses into `link.FanOutContinuations` for a non-`BlockBreakToken` link instead
+of stopping. This is safe and correct without any extra bookkeeping because every one of these per-child
+tokens is `childBox.PendingBreakToken` at the point it was collected (confirmed at every construction site
+— `TableRowCursor.RecordIfUnfinished`, `CssLayoutEngineFlex.CommitLineContent`/`CommitColumnContent`,
+`CssLayoutEngineGrid.CommitRowContent`), and `CssBox.PendingBreakToken` is always set as `new
+XxxBreakToken(this, ...)` — so a child token's own `Box` already names the child itself, exactly the
+invariant `RecordChain`'s existing `into.Add((new FragmentKey(link.Box, null, 0), slot))` at the top of the
+loop depends on. No separate "mark the cell's own box" step was needed. The recursion also handles nesting
+for free — a fan-out token whose own per-child continuation is itself a further fan-out (a table nested in
+a table cell, say) walks correctly, since `RecordChain` is called on that continuation exactly as on any
+other token.
+
+## What was deliberately not done
+
+- No `(CssBox, BreakToken?)` tuple shape, despite the issue's own "What it would take" section suggesting
+  one. It isn't needed: since every fan-out continuation's `Token.Box` already equals its own child box (see
+  above), a plain `IReadOnlyList<BreakToken>` is sufficient — `RecordChain`'s existing per-link `Box` read
+  already recovers the child.
+
+## Evidence
+
+- New tests: `TableCellOwnContentBreakEdgesTests.cs` (`ACellsOwnContentSpanningSeveralBands_OwnsOnlyTheBlockEdgesTheBreakDidNotMake`,
+  with `ACellsOwnContentFittingOneBand_OwnsEveryEdgeOnItsOneFragment` as the control against a
+  vacuously-passing single-fragment fixture) — both verified to fail without the fix
+  (`ACellsOwnContentSpanningSeveralBands...` specifically: `Assert.Equal(false, slice.HasTopEdge)` on the
+  second fragment failed with `Actual: True` on `origin/main`).
+- `TableRowspanContinuationTests.ASpanningCellWhoseContentOverflowsItsBand_IsFragmentedAcrossEveryBandItOccupies`
+  — the comment recording this gap as out-of-scope (added by #521's own fix) replaced with real
+  `HasTopEdge`/`HasBottomEdge` assertions across every real fragment; passes.
+- Full `net8.0` suite: 7526 passed, 0 failed, 9 skipped (platform-gated, pre-existing).
+- `diff-cover` against `origin/main`: 100% on the changed lines.
+- `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings.

--- a/src/PeachPDF.Tests/Integration/TableCellOwnContentBreakEdgesTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableCellOwnContentBreakEdgesTests.cs
@@ -1,0 +1,116 @@
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Fragments;
+using PeachPDF.Tests.TestSupport;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// A table cell whose own content spans more than one real per-pass fragment slices its top/bottom
+    /// border like any other box under <c>box-decoration-break: slice</c>
+    /// (<see href="https://www.w3.org/TR/css-break-3/#break-decoration">css-break-3 §6.2</see>;
+    /// <see href="https://www.w3.org/TR/css-tables-3/#fragmentation">css-tables-3 §6.1</see> states the
+    /// same rule for cells specifically — "top borders must not be repainted in continuation fragments").
+    /// </summary>
+    /// <remarks>
+    /// Before <see href="https://github.com/jhaygood86/PeachPDF/issues/590">issue #590</see>,
+    /// <c>FragmentEmitter.RecordChain</c> only walked a <c>BlockBreakToken</c>'s linear <c>ChildToken</c>
+    /// chain, so it never descended into a <c>TableBreakToken</c>'s per-cell continuations
+    /// (<c>TableRowCursor.UnfinishedCells</c>) — a cell whose own content kept producing genuinely new
+    /// fragments (as against a stated continuation shell, which the edge predicates already recognized
+    /// through <c>Draft.ShellRect</c>) reported every one of its fragments as owning both its own top and
+    /// bottom edge. This is the plain, non-rowspan fixture the issue's own reproduction describes — a
+    /// single <c>&lt;td&gt;</c> with no second row and no rowspan, whose content alone spans several bands.
+    /// </remarks>
+    public class TableCellOwnContentBreakEdgesTests
+    {
+        private const double PageHeight = 300;
+        private const double Margin = 20;
+
+        private static string SingleCellSpanningSeveralBands() => LayoutHarness.Wrap(
+            "<table style='width:150pt;border-collapse:collapse'><tr>"
+            + "<td id='cell' style='border:1pt solid black'>"
+            + string.Join(" ", Enumerable.Range(0, 400).Select(i => $"word{i:0000}"))
+            + "</td></tr></table>");
+
+        private static IEnumerable<BoxFragment> Flatten(BoxFragment fragment)
+        {
+            yield return fragment;
+
+            foreach (var child in fragment.Children)
+            {
+                foreach (var descendant in Flatten(child)) yield return descendant;
+            }
+        }
+
+        /// <summary>
+        /// The cell's fragments, one entry per fragmentainer it appears in, in fill order.
+        /// </summary>
+        private static List<BoxFragment> CellFragments(HtmlContainerInt container) =>
+        [
+            .. container.FragmentTree!.Fragmentainers
+                .SelectMany(f => Flatten(f.Root))
+                .Where(f => f.Box.HtmlTag?.TryGetAttribute("id") == "cell")
+                .GroupBy(f => f.FragmentainerIndex)
+                .OrderBy(g => g.Key)
+                .Select(g => g.First())
+        ];
+
+        /// <summary>
+        /// A cell tall enough to need more than one real fragment reports a top edge only on the first
+        /// of them and a bottom edge only on the last — never on every fragment, which is what every one
+        /// of them reported before the fix (<c>RecordChain</c> never marked the cell as a continuation at
+        /// all, so every fragment fell back to "this is a real edge").
+        /// </summary>
+        [Fact]
+        public async Task ACellsOwnContentSpanningSeveralBands_OwnsOnlyTheBlockEdgesTheBreakDidNotMake()
+        {
+            var (_, container) = await LayoutHarness.LayoutAsync(
+                SingleCellSpanningSeveralBands(), pageHeight: PageHeight, margin: Margin);
+
+            var fragments = CellFragments(container);
+            var last = fragments.Count - 1;
+
+            Assert.True(last > 0,
+                "fixture produced only one fragment for the cell, so it asserts nothing about break edges");
+
+            for (var i = 0; i <= last; i++)
+            {
+                var slice = Assert.Single(fragments[i].Lines).Slice;
+
+                Assert.Equal(i == 0, slice.HasTopEdge);
+                Assert.Equal(i == last, slice.HasBottomEdge);
+
+                // A page's fragmentainers differ in the block axis alone, so the inline edges are nobody's
+                // break and both survive on every fragment.
+                Assert.True(slice.HasLeftEdge);
+                Assert.True(slice.HasRightEdge);
+            }
+        }
+
+        /// <summary>
+        /// The control: a cell whose content fits in one band is one fragment that owns every one of its
+        /// own edges — without this, "only the first/last fragment has an edge" would pass vacuously
+        /// against a fixture that never produced more than one fragment to begin with.
+        /// </summary>
+        [Fact]
+        public async Task ACellsOwnContentFittingOneBand_OwnsEveryEdgeOnItsOneFragment()
+        {
+            var (_, container) = await LayoutHarness.LayoutAsync(
+                LayoutHarness.Wrap(
+                    "<table style='width:150pt;border-collapse:collapse'>"
+                    + "<tr><td id='cell' style='border:1pt solid black'>short</td></tr></table>"),
+                pageHeight: PageHeight, margin: Margin);
+
+            var fragments = CellFragments(container);
+            var only = Assert.Single(fragments);
+            var slice = Assert.Single(only.Lines).Slice;
+
+            Assert.True(slice is { HasTopEdge: true, HasBottomEdge: true, HasLeftEdge: true, HasRightEdge: true });
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/TableRowspanContinuationTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableRowspanContinuationTests.cs
@@ -529,15 +529,22 @@ namespace PeachPDF.Tests.Integration
             Assert.NotEmpty(authoredWords);
             Assert.All(authoredWords, word => Assert.Contains(word, claimed));
 
-            // Deliberately not asserted here: which of these fragments' own top/bottom edges are break
-            // edges rather than the box's own. FragmentEmitter.RecordChain only walks a BlockBreakToken's
-            // linear ChildToken chain, so it never marks a TableBreakToken's per-cell continuations
-            // (TableRowCursor.UnfinishedCells) - a cell whose own content keeps producing genuinely new
-            // fragments (as against a stated shell, which ResumesAnEarlierFragment/ContinuesIntoALaterFragment
-            // also recognize) reports every fragment as owning both its own edges. That is a pre-existing
-            // gap independent of rowspan or this fix - confirmed on a plain, non-rowspan multi-page <td> -
-            // and is filed and out of scope here: see
-            // https://github.com/jhaygood86/PeachPDF/issues/590.
+            // And only the first of these real, content-holding fragments owns its own top edge, and only
+            // the last its own bottom edge - the class of gap issue #590 fixed: FragmentEmitter.RecordChain
+            // used to walk only a BlockBreakToken's linear ChildToken chain, never a TableBreakToken's
+            // per-cell continuations (TableRowCursor.UnfinishedCells), so a cell whose own content kept
+            // producing genuinely new fragments (as against a stated shell, which
+            // ResumesAnEarlierFragment/ContinuesIntoALaterFragment already recognized through
+            // Draft.ShellRect) reported every fragment as owning both its own edges.
+            var lastFragmentIndex = fragments.Count - 1;
+
+            for (var i = 0; i <= lastFragmentIndex; i++)
+            {
+                var slice = Assert.Single(fragments[i].Fragment.Lines).Slice;
+
+                Assert.Equal(i == 0, slice.HasTopEdge);
+                Assert.Equal(i == lastFragmentIndex, slice.HasBottomEdge);
+            }
         }
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Fragmentation/BreakToken.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/BreakToken.cs
@@ -30,7 +30,19 @@ namespace PeachPDF.Html.Core.Fragmentation
     /// an engine that positions its own children — so the fragmentainer it overflows is not in general
     /// the one after the fragmentainer the pass nominally started in.
     /// </param>
-    internal abstract record BreakToken(CssBox Box, int ResumeSlotIndex);
+    internal abstract record BreakToken(CssBox Box, int ResumeSlotIndex)
+    {
+        /// <summary>
+        /// This token's per-child continuations, for a token naming more than one — the
+        /// <see href="https://www.w3.org/TR/css-break-3/#parallel-flows">§2.1 parallel-flows</see> shape
+        /// <see cref="TableBreakToken"/>/<see cref="FlexBreakToken"/>/<see cref="GridBreakToken"/>/
+        /// <see cref="FlexColumnBreakToken"/> all share, each overriding this to expose its own
+        /// per-cell/per-item tokens. Empty for every other kind, whose one child (if any) is
+        /// <see cref="BlockBreakToken.ChildToken"/> instead — <see cref="FragmentEmitter.RecordChain"/> is
+        /// this member's one reader, and walks both shapes the same way.
+        /// </summary>
+        internal virtual IReadOnlyList<BreakToken> FanOutContinuations => [];
+    }
 
     /// <summary>
     /// A block container stopped part-way through its in-flow children.

--- a/src/PeachPDF/Html/Core/Fragmentation/FlexBreakToken.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/FlexBreakToken.cs
@@ -70,6 +70,10 @@ namespace PeachPDF.Html.Core.Fragmentation
         IReadOnlyList<CssBox> FinishedItems,
         RPoint PlacementOrigin) : BreakToken(Box, ResumeSlotIndex)
     {
+        /// <inheritdoc />
+        internal override IReadOnlyList<BreakToken> FanOutContinuations =>
+            UnfinishedItems.Select(item => item.Token).ToList();
+
         /// <summary>
         /// Compared by <b>contents</b>, for the same reason <see cref="TableBreakToken"/> states it: the
         /// driver's no-progress backstop is an equality test between consecutive passes' records, and a

--- a/src/PeachPDF/Html/Core/Fragmentation/FlexColumnBreakToken.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/FlexColumnBreakToken.cs
@@ -69,6 +69,10 @@ namespace PeachPDF.Html.Core.Fragmentation
         IReadOnlyList<int> FinishedLineIndexes,
         RPoint PlacementOrigin) : BreakToken(Box, ResumeSlotIndex)
     {
+        /// <inheritdoc />
+        internal override IReadOnlyList<BreakToken> FanOutContinuations =>
+            UnfinishedLines.Select(line => line.ItemToken).ToList();
+
         /// <summary>
         /// Compared by <b>contents</b>, for the same reason <see cref="FlexBreakToken"/> states it — see
         /// its own remarks for why <see cref="Lines"/>/<see cref="PlacementOrigin"/> are excluded.

--- a/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
@@ -1232,12 +1232,32 @@ namespace PeachPDF.Html.Core.Fragmentation
                 $"and '{full}' without it. Pruning must only ever decline to walk a subtree that would " +
                 $"have produced nothing.");
 
+        /// <summary>
+        /// Walks a break-token chain, marking every box it names as continuing in <paramref name="slot"/>.
+        /// A <see cref="BlockBreakToken"/> chain is linear (box → its one continuing child → ...), but a
+        /// fan-out token (<see cref="TableBreakToken"/> and its <see cref="BreakToken.FanOutContinuations"/>
+        /// siblings) names several §2.1 parallel flows at once — each is walked in turn, recursively, since
+        /// a cell/item's own continuation can itself be a linear chain or a further fan-out (a table nested
+        /// in a table cell, say).
+        /// </summary>
         private static void RecordChain(BreakToken? token, int slot, HashSet<(FragmentKey, int)> into)
         {
             for (var link = token; link is not null;)
             {
                 into.Add((new FragmentKey(link.Box, null, 0), slot));
-                link = link is BlockBreakToken { ChildToken: { } child } ? child : null;
+
+                if (link is BlockBreakToken { ChildToken: { } child })
+                {
+                    link = child;
+                    continue;
+                }
+
+                foreach (var continuation in link.FanOutContinuations)
+                {
+                    RecordChain(continuation, slot, into);
+                }
+
+                link = null;
             }
         }
 

--- a/src/PeachPDF/Html/Core/Fragmentation/GridBreakToken.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/GridBreakToken.cs
@@ -70,6 +70,10 @@ namespace PeachPDF.Html.Core.Fragmentation
         IReadOnlyDictionary<CssBox, GridSubgridContext> SubgridContexts,
         RPoint PlacementOrigin) : BreakToken(Box, ResumeSlotIndex)
     {
+        /// <inheritdoc />
+        internal override IReadOnlyList<BreakToken> FanOutContinuations =>
+            UnfinishedItems.Select(item => item.Token).ToList();
+
         /// <summary>
         /// Compared by <b>contents</b>, for the same reason <see cref="FlexBreakToken"/> states it: the
         /// driver's no-progress backstop is an equality test between consecutive passes' records, and a

--- a/src/PeachPDF/Html/Core/Fragmentation/TableBreakToken.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/TableBreakToken.cs
@@ -67,6 +67,10 @@ namespace PeachPDF.Html.Core.Fragmentation
         IReadOnlyList<CssBox> FinishedCells,
         IReadOnlyDictionary<int, IReadOnlyList<CssBox>> RowSpannedBoxes) : BreakToken(Box, ResumeSlotIndex)
     {
+        /// <inheritdoc />
+        internal override IReadOnlyList<BreakToken> FanOutContinuations =>
+            UnfinishedCells.Select(cell => cell.Token).ToList();
+
         /// <summary>
         /// Compared by <b>contents</b>, because the driver's no-progress backstop is an equality test.
         /// </summary>


### PR DESCRIPTION
## Summary

- `FragmentEmitter.RecordChain` only walked a `BlockBreakToken`'s linear `ChildToken` chain, so it never descended into `TableBreakToken`'s (or `FlexBreakToken`'s/`GridBreakToken`'s/`FlexColumnBreakToken`'s) per-child continuations. A table cell (or flex/grid item) whose own content spanned more than one real per-pass fragment therefore reported every one of its fragments as owning both its own top and bottom edge — repainting `box-decoration-break: slice`'s border/background on every page instead of slicing it.
- Adds a `virtual FanOutContinuations` member to `BreakToken`, overridden by each of the four fan-out token kinds (`TableBreakToken`, `FlexBreakToken`, `GridBreakToken`, `FlexColumnBreakToken`) to expose its own per-cell/per-item/per-line continuation tokens, and has `RecordChain` recurse into it instead of stopping.
- Every one of those per-child tokens already names its own box (`childBox.PendingBreakToken`), which is what makes the recursion correct without any extra bookkeeping — and it also handles nesting for free (a table nested inside a table cell, say).

Fixes #590.

## Test plan

- [x] New tests in `TableCellOwnContentBreakEdgesTests.cs` — a plain, non-rowspan `<td>` whose own content spans several pagination bands now reports a top edge only on its first fragment and a bottom edge only on its last (verified to fail without the fix), plus a single-fragment control.
- [x] `TableRowspanContinuationTests.ASpanningCellWhoseContentOverflowsItsBand_IsFragmentedAcrossEveryBandItOccupies` — replaced the comment recording this as an out-of-scope gap with real edge assertions.
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0`: 7526 passed, 0 failed, 9 skipped (platform-gated).
- [x] `diff-cover` against `main`: 100% on changed lines.
- [x] `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings.
