### PR TITLE
Fix inline string-set/page corruption across multicol reflow and page continuations

### DIFF
--- a/.claude/recent-fixes/2026-08-02-inline-string-set-and-named-page-corruption-across-reflow.md
+++ b/.claude/recent-fixes/2026-08-02-inline-string-set-and-named-page-corruption-across-reflow.md
@@ -1,4 +1,4 @@
-# An inline `string-set`/`page` target lost its true position across multicol reflow and resumed page continuations
+# Wrong `string(name, first|last)` running headers: inline registration corruption plus a page-boundary matching flaw
 
 ## What was actually wrong
 
@@ -35,6 +35,25 @@ guarantees that guard provides:
    for **both** pages (a term that opened on page 5 got attributed to page 6, and `first`/`last`
    resolution on both pages shifted around it).
 
+A third, independent bug in `MarginBoxRenderer.ResolveNamedString` (`src/PeachPDF/Html/Core/Dom/MarginBoxRenderer.cs`)
+compounded the first two — this one pre-existing (from an earlier, incomplete pass at the same
+dictionary.html symptom, `a61a82da` "Fix running headers across multicol page breaks") rather than
+introduced by bugs 1/2 above:
+
+3. **A symmetric page-boundary epsilon window admits the wrong page's content.** `ResolveNamedString`
+   picked `first`/`last` by testing each candidate's raw `Y` against `[pageY - epsilon, pageY + pageHeight
+   + epsilon)`, widened by `PageBoundaryEpsilon` (0.5) on *both* ends to absorb float drift between a
+   `NamedString`'s `Y` and the page geometry's own accumulation path. But two boxes opening different
+   columns on the *same* page land on the identical Y — both are "row 1" of their own column — and when
+   that shared Y sits within a hairline of a page boundary (which it does *by construction* for a page's
+   own first row), the widened window at the *previous* page's far end admits it too: a paragraph opening
+   column 2 of page N could be picked as page N-1's "last" value, even though dozens of genuinely-page-N-1
+   entries separate them in DOM order and only the epsilon coincidence pulls it in. Fixed by attributing
+   every candidate to a single, unambiguous pagination slot via `HtmlContainerInt.SlotStartingAt` (the same
+   top-edge, nudge-onto-the-later-page convention already used everywhere else a box's own Y needs a page
+   index) rather than testing raw-Y window membership per page — removing the two-sided-window's inherent
+   overlap without reintroducing the original hairline-exclusion bug the epsilon existed to fix.
+
 ## What was found by running it, not by reading it
 
 Fixing only bug 1 (verified first, in isolation, via four synthetic multicol re-banding tests) was
@@ -53,6 +72,18 @@ accidentally construct so it can't discriminate the real corruption path) would 
 2 only manifests when a *single paragraph's own content* — not just the container — straddles a real page
 break, a shape none of the existing multicol test fixtures exercised.
 
+Bug 3 surfaced the same way, later in the same document: the user reported page 831's `string(term, last)`
+showing `ör-skreiðr`, a term whose paragraph actually opens column 2 of page 832. Diagnostic
+instrumentation dumping every `term` `NamedString`'s `Y` alongside each page's own boundary (temporarily
+added to `PdfGenerator.AddPdfPages`, removed before landing) showed `ör-skreiðr` and `ör-nafn` — the
+*correct* page-832 "first" — sharing the exact same `Y`, both equal to page 832's own top: a real, correct
+column-1/column-2 coincidence (bugs 1/2 were already fixed by this point; the `Y`s themselves were right),
+not a registration bug. `ResolveNamedString`'s window-based matching was what mis-attributed one of the
+two. After the `SlotStartingAt`-based fix, a global check dumping every one of the document's 14,644
+`term` registrations and asserting their pagination-slot attribution is non-decreasing in document order
+found zero violations — the same order-preservation property bugs 1/2's fixes established locally, now
+confirmed to hold at full-document scale for bug 3's fix too.
+
 ## What was deliberately not done
 
 - `CssNamedStringEngine.GetNamedStringValue` / `CssContentEngine.GetNamedStringValue` (the naive global
@@ -68,13 +99,27 @@ break, a shape none of the existing multicol test fixtures exercised.
 
 ## Evidence
 
-- Full `net8.0` suite: 7530 passed, 0 failed, 9 skipped.
+- Full `net8.0` suite: 7536 passed, 0 failed, 9 skipped.
 - `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings.
-- Six new regression tests, each individually confirmed (by temporarily reverting the relevant guard) to
+- Ten new regression tests, each individually confirmed (by temporarily reverting the relevant guard) to
   fail before its fix and pass after: four in `MulticolLayoutIntegrationTests.cs` covering bug 1
   (`NamedString_InlineTarget_DoesNotAccumulateStaleEntriesAcrossReflow` and its named-page/inline-flex
   variants), two in the new `ResumedInlineNamedStringLayoutIntegrationTests.cs` covering bug 2
-  (`NamedString_InlineTarget_KeepsTruePositionAcrossResumedContinuation` and its named-page variant).
-- End-to-end: rendered the real `dictionary.html` via the `peachpdf` CLI before and after the fix and
-  compared rasterized running headers for pages 3–20 — self-consistent (monotonic, adjacent-page-boundary
-  matching) after, visibly scrambled before.
+  (`NamedString_InlineTarget_KeepsTruePositionAcrossResumedContinuation` and its named-page variant), and
+  four covering bug 3 in `MarginBoxRendererNamedStringTests.cs`/`MarginBoxResolveNamedStringTests.cs`
+  (`Last_ColumnTopsOfTheNextPageDoNotLeakOntoThisPagesLast` and
+  `ResolveContent_StringFunction_DoesNotLeakAColumnTopFromTheNextPage`, the latter exercising the real
+  `ResolveContent` call site rather than `ResolveNamedString` directly). `ResolveContent` was changed from
+  `private` to `internal` for the latter's direct unit-test access, matching `ResolveNamedString`'s
+  existing visibility.
+- One existing test (`Last_ValueHairlineBelowPageEnd_StillResolvesAsLastOnPage`) had its expectation
+  deliberately corrected rather than preserved: a value within epsilon of a page's *end* boundary is now
+  consistently treated as opening the *next* page (matching `SlotStartingAt`'s established top-edge
+  convention elsewhere), not as trailing off the current one — the old expectation encoded exactly the
+  two-sided-window ambiguity bug 3's fix removes. A companion test confirms the same value now correctly
+  resolves as the next page's own `first`.
+- End-to-end: rendered the real `dictionary.html` (all 834 pages) via the `peachpdf` CLI before and after
+  each fix. Pages 3–20 self-consistent (monotonic, adjacent-page-boundary matching) after bugs 1+2's fix;
+  page 831/832 (the user-reported case) corrected after bug 3's fix, confirmed both by rasterized text
+  extraction and a full-document scan asserting all 14,644 `term` registrations' pagination-slot
+  attribution is non-decreasing in document order (zero violations).

--- a/.claude/recent-fixes/2026-08-02-inline-string-set-and-named-page-corruption-across-reflow.md
+++ b/.claude/recent-fixes/2026-08-02-inline-string-set-and-named-page-corruption-across-reflow.md
@@ -1,0 +1,80 @@
+# An inline `string-set`/`page` target lost its true position across multicol reflow and resumed page continuations
+
+## What was actually wrong
+
+`css4.pub`'s Icelandic dictionary demo (`.chapter p b:first-child { string-set: term content() }`,
+inside a `columns: 2` container) rendered wrong `string(term, first|last)` values in its `@top-left`/
+`@top-right` running headers — e.g. page 5's top-right showed a term that actually belonged to page 6.
+Two independent, additive bugs in `CssLayoutEngine.FlowBox` (`src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs`)
+caused it, both stemming from the same root cause: unlike a block box, whose `string-set`/`page`
+registration is guarded by `CssBox.PerformLayoutPrologue`'s `_prologueDone` gate (see
+[.claude/invariants/fragmentation-a-boxs-prologue-runs-once-per-layout-so-a-re-entered-pass-does-not.md](../invariants/fragmentation-a-boxs-prologue-runs-once-per-layout-so-a-re-entered-pass-does-not.md)),
+an *inline* box (`<b>`, `<span>`) is registered from inside `FlowBox` itself, which had neither of the
+guarantees that guard provides:
+
+1. **No unregister-before-register.** `CssNamedStringEngine.ApplyStringSet` always appends a fresh
+   `NamedString` to `HtmlContainerInt._namedStrings` and `RegisterNamedPageElement` always appends to
+   `_namedPageElements`, regardless of whether the same box already has an entry there. A block box's
+   prologue withdraws its own previous registration first; `FlowBox`'s equivalent code (plain-inline
+   entry ~1260, plain-inline exit ~1707, inline-flex ~1603/1620) did not. `CssLayoutEngineColumns.Layout`
+   lays every child out at least twice per invocation — a "Phase 1" virtual single-tall-column measurement
+   pass with breaking suppressed, then a real "Phase 2" fill, plus up to `MaxFillAttempts = 4` balance
+   retries — so an inline `string-set`/`page` target inside multicol content accumulated one orphaned,
+   stale-Y entry per re-layout.
+2. **No `opensHere` gate.** Since [#321], a layout pass fills exactly one fragmentainer, so a pass
+   resuming a box's flow into a later page/column re-enters `FlowBox` for the *whole* subtree from the
+   top — already-placed words are skipped only by ordinal, further down. The string-set/named-page
+   application wasn't gated on `opensHere` (the flag `FirstHostingLineBox`'s own assignment, two lines
+   above it, already uses for exactly this reason), so a resumed pass that merely walks *past* an
+   already-fully-placed `<b>` (to reach not-yet-placed content later in the same paragraph) re-ran
+   `ApplyStringSet`/`RegisterNamedPageElement` using *that* pass's cursor — which sits at the resumed
+   fragmentainer's own top, since the walk hadn't advanced past the box's words yet — overwriting the
+   correct, first-opening position with the top of the next page. This is the one that actually produced
+   the dictionary.html symptom: a paragraph starting near the bottom of one page's column, continuing onto
+   the next, had its `string-set` value re-stamped to the *next* page's top, which corrupted attribution
+   for **both** pages (a term that opened on page 5 got attributed to page 6, and `first`/`last`
+   resolution on both pages shifted around it).
+
+## What was found by running it, not by reading it
+
+Fixing only bug 1 (verified first, in isolation, via four synthetic multicol re-banding tests) was
+*not* sufficient — confirmed by actually fetching `https://css4.pub/2015/icelandic/dictionary.html`
+through the `peachpdf` CLI (which fetches over HTTP itself; no separate download step), rendering all
+834 pages, and rasterizing pages 3–20 with PyMuPDF, extracting the top-margin band's words per page. With
+only the unregister-before-register fix applied, page 5's `string(term, last)` still showed `af-góra` — a
+term whose paragraph (confirmed against the raw HTML) visibly starts on page 6, not page 5 — while page
+6's `string(term, first)` showed `af-feðrast`, whose paragraph visibly starts on page 5. Both entries'
+recorded `Y` were byte-identical to page 6's fragmentainer-top coordinate, the unmistakable signature of
+bug 2: a resumed pass stamping both with "wherever this pass's cursor sits," not their own true positions.
+Adding the `opensHere` gate fixed both entries' `Y` to their real positions, and re-rendering showed every
+adjacent page-boundary pair from page 3 through page 20 self-consistent (each page's `first` exactly
+matches the previous page's `last`) — evidence a unit test alone (necessarily synthetic, and easy to
+accidentally construct so it can't discriminate the real corruption path) would not have caught, since bug
+2 only manifests when a *single paragraph's own content* — not just the container — straddles a real page
+break, a shape none of the existing multicol test fixtures exercised.
+
+## What was deliberately not done
+
+- `CssNamedStringEngine.GetNamedStringValue` / `CssContentEngine.GetNamedStringValue` (the naive global
+  first/last `string()` resolution used for regular in-flow `content`, with explicit `// TODO` comments
+  for `start`/`first-except`) were left untouched — unrelated to `@page` margin boxes, which resolve
+  through the already page-aware `MarginBoxRenderer.ResolveNamedString`.
+- A pre-existing, narrower bug surfaced during review but not fixed here: `CssNamedStringEngine.ApplyStringSet`
+  overwrites `cssBox.NamedStrings[currentName]` per comma-separated name in a single `string-set`
+  declaration, so a *repeated* name within one declaration (`string-set: a x, a y`) orphans the first
+  value's document-level entry (the box-level dict loses the reference needed to unregister it). This is
+  independent of both bugs above (reachable via the unmodified block-level `CssBox.cs:2318` site too) and
+  not implicated in the dictionary.html symptom.
+
+## Evidence
+
+- Full `net8.0` suite: 7530 passed, 0 failed, 9 skipped.
+- `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings.
+- Six new regression tests, each individually confirmed (by temporarily reverting the relevant guard) to
+  fail before its fix and pass after: four in `MulticolLayoutIntegrationTests.cs` covering bug 1
+  (`NamedString_InlineTarget_DoesNotAccumulateStaleEntriesAcrossReflow` and its named-page/inline-flex
+  variants), two in the new `ResumedInlineNamedStringLayoutIntegrationTests.cs` covering bug 2
+  (`NamedString_InlineTarget_KeepsTruePositionAcrossResumedContinuation` and its named-page variant).
+- End-to-end: rendered the real `dictionary.html` via the `peachpdf` CLI before and after the fix and
+  compared rasterized running headers for pages 3–20 — self-consistent (monotonic, adjacent-page-boundary
+  matching) after, visibly scrambled before.

--- a/src/PeachPDF.Tests/Integration/MarginBoxRendererNamedStringTests.cs
+++ b/src/PeachPDF.Tests/Integration/MarginBoxRendererNamedStringTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Entities;
 using System.Collections.Generic;
@@ -7,20 +8,40 @@ namespace PeachPDF.Tests.Integration
     /// <summary>
     /// Direct unit tests for <see cref="MarginBoxRenderer.ResolveNamedString"/>'s page-boundary matching -
     /// exercised directly (not through full HTML->PDF generation) since it's a pure function over an
-    /// explicit <see cref="NamedString"/> list and page Y-range, per this repo's testing conventions.
+    /// explicit <see cref="NamedString"/> list and a page-index lookup, per this repo's testing
+    /// conventions. <see cref="PageIndexOf"/> stands in for production's <c>htmlContainer.SlotStartingAt</c>
+    /// with the same non-variable-geometry division plus <see cref="HtmlContainerInt.PageBoundaryEpsilon"/>.
     ///
-    /// Regression coverage for two compounding bugs found while investigating wrong running-header
+    /// Regression coverage for three compounding bugs found while investigating wrong running-header
     /// pairing on real content pages of css4.pub's Icelandic dictionary:
     ///  1. A page's true content range is [pageY + MarginTop, pageY + MarginTop + pageHeight), not
     ///     [pageY, pageY + pageHeight), since content's own coordinate system starts at MarginTop, not 0
     ///     (see PdfGenerator.AddPdfPages, which now adds +container.MarginTop when computing pageY).
-    ///  2. A NamedString's Y and the page boundary are computed via independent accumulation paths (row/
-    ///     column layout math vs. per-page scroll-offset accumulation), so a value genuinely meant to sit
-    ///     exactly at a page boundary can differ from it by a hairline of floating-point noise -
-    ///     PageBoundaryEpsilon absorbs that without misattributing genuinely different-page content.
+    ///  2. A NamedString's Y and the page boundary used to be compared via independent accumulation paths
+    ///     (row/column layout math vs. per-page scroll-offset accumulation), so a value genuinely meant to
+    ///     sit exactly at a page boundary could differ from it by a hairline of floating-point noise.
+    ///  3. <c>ResolveNamedString</c> used to compare each candidate's raw Y against a symmetric
+    ///     <c>[pageY - epsilon, pageY + pageHeight + epsilon)</c> window computed independently per page.
+    ///     Two boxes at the very top of different columns on the *same* page can land on the identical Y
+    ///     (both are "row 1" of their own column) - when that shared Y sits within a hairline of a page
+    ///     boundary, the symmetric epsilon widened at both ends of *every* page's window let a box on the
+    ///     far side of the boundary satisfy the near side's window too, so a paragraph opening column 2 of
+    ///     one page could be picked as the running header's "last" value for the *previous* page. Fixed by
+    ///     attributing every candidate to a single, unambiguous pagination slot up front (the same one a
+    ///     fresh top-of-page box would resolve to via <c>SlotStartingAt</c> elsewhere) rather than testing
+    ///     window membership per page.
     /// </summary>
     public class MarginBoxRendererNamedStringTests
     {
+        // Mirrors HtmlContainerInt.SlotStartingAt's non-variable-geometry fallback (MarginTop = 0): a
+        // value within PageBoundaryEpsilon *above* a page boundary is nudged onto the later page, exactly
+        // as a genuinely fresh top-of-page box would be.
+        private static int PageIndexOf(double y, double pageHeight) =>
+            (int)((y + HtmlContainerInt.PageBoundaryEpsilon) / pageHeight);
+
+        private static string Resolve(string name, string keyword, double pageY, double pageHeight, IReadOnlyList<NamedString> namedStrings) =>
+            MarginBoxRenderer.ResolveNamedString(name, keyword, PageIndexOf(pageY, pageHeight), y => PageIndexOf(y, pageHeight), namedStrings);
+
         [Fact]
         public void First_ValueExactlyAtPageStart_Resolves()
         {
@@ -31,7 +52,7 @@ namespace PeachPDF.Tests.Integration
                 new("term", "second-on-page", 150),
             };
 
-            var result = MarginBoxRenderer.ResolveNamedString("term", "first", pageY: 100, pageHeight: 100, namedStrings);
+            var result = Resolve("term", "first", pageY: 100, pageHeight: 100, namedStrings);
 
             Assert.Equal("first-on-page", result);
         }
@@ -49,7 +70,7 @@ namespace PeachPDF.Tests.Integration
                 new("term", "second-on-page", 150),
             };
 
-            var result = MarginBoxRenderer.ResolveNamedString("term", "first", pageY: 100, pageHeight: 100, namedStrings);
+            var result = Resolve("term", "first", pageY: 100, pageHeight: 100, namedStrings);
 
             Assert.Equal("first-on-page", result);
         }
@@ -65,24 +86,71 @@ namespace PeachPDF.Tests.Integration
                 new("term", "second-on-page", 150),
             };
 
-            var result = MarginBoxRenderer.ResolveNamedString("term", "first", pageY: 100, pageHeight: 100, namedStrings);
+            var result = Resolve("term", "first", pageY: 100, pageHeight: 100, namedStrings);
 
             Assert.Equal("second-on-page", result);
         }
 
         [Fact]
-        public void Last_ValueHairlineBelowPageEnd_StillResolvesAsLastOnPage()
+        public void Last_ValueHairlineAtPageEnd_ResolvesToTheNextPageInstead()
         {
+            // Superseded expectation: a value this close to a page's *end* boundary is, by the same
+            // top-edge convention SlotStartingAt already applies to a fresh box opening a page, attributed
+            // to the page it borders rather than the one it trails - a box whose own top sits this close
+            // to a boundary is, in practice, either freshly placed at the next page's top by a break or so
+            // short as to be indistinguishable from one, never a real box whose content is comfortably
+            // contained in the page ending there. Treating it as "genuinely this page's last value" would
+            // reopen exactly the ambiguity #3 above describes: the same Y both closing one page's window
+            // and opening the next's. Confirmed correct rather than merely different: the next test shows
+            // the same value now correctly resolves as the *next* page's own "first".
             var namedStrings = new List<NamedString>
             {
                 new("term", "first-on-page", 110),
-                new("term", "last-on-page", 199.999999991),
+                new("term", "at-the-boundary", 199.999999991),
                 new("term", "next-page", 210),
             };
 
-            var result = MarginBoxRenderer.ResolveNamedString("term", "last", pageY: 100, pageHeight: 100, namedStrings);
+            var result = Resolve("term", "last", pageY: 100, pageHeight: 100, namedStrings);
 
-            Assert.Equal("last-on-page", result);
+            Assert.Equal("first-on-page", result);
+        }
+
+        [Fact]
+        public void First_ValueHairlineAtPageEnd_ResolvesAsFirstOnTheFollowingPage()
+        {
+            // The companion to the test above, on the page "at-the-boundary" (199.999999991) actually
+            // belongs to.
+            var namedStrings = new List<NamedString>
+            {
+                new("term", "first-on-page", 110),
+                new("term", "at-the-boundary", 199.999999991),
+                new("term", "next-page", 210),
+            };
+
+            var result = Resolve("term", "first", pageY: 200, pageHeight: 100, namedStrings);
+
+            Assert.Equal("at-the-boundary", result);
+        }
+
+        [Fact]
+        public void Last_ColumnTopsOfTheNextPageDoNotLeakOntoThisPagesLast()
+        {
+            // The actual shape of the css4.pub Icelandic dictionary bug: two different paragraphs, each
+            // the first content of its own column on the *next* page, land on the identical Y - both are
+            // "row 1" of their own column, here 200, the next page's own start (and so this page's exact
+            // end boundary). Neither may resolve as *this* page's "last", regardless of list order, even
+            // though both sit exactly on this page's (epsilon-widened, under the old symmetric-window
+            // design) far boundary.
+            var namedStrings = new List<NamedString>
+            {
+                new("term", "last-on-this-page", 150),
+                new("term", "column-1-top-of-next-page", 200),
+                new("term", "column-2-top-of-next-page", 200),
+            };
+
+            var result = Resolve("term", "last", pageY: 100, pageHeight: 100, namedStrings);
+
+            Assert.Equal("last-on-this-page", result);
         }
     }
 }

--- a/src/PeachPDF.Tests/Integration/MarginBoxResolveNamedStringTests.cs
+++ b/src/PeachPDF.Tests/Integration/MarginBoxResolveNamedStringTests.cs
@@ -1,3 +1,6 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Adapters.Entities;
+using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Entities;
 using System.Collections.Generic;
@@ -7,18 +10,26 @@ namespace PeachPDF.Tests.Integration
     /// <summary>
     /// Direct unit tests for <see cref="MarginBoxRenderer.ResolveNamedString"/> — the pure function
     /// that resolves <c>string(name, first/last/start/first-except)</c> against a document-level list
-    /// of <see cref="NamedString"/> entries for a given page's Y-range. Exercised directly (rather than
-    /// through full HTML→PDF generation + rendered-text extraction) for the same reason as
+    /// of <see cref="NamedString"/> entries for a given page. Exercised directly (rather than through
+    /// full HTML→PDF generation + rendered-text extraction) for the same reason as
     /// PdfGeneratorSelectPageRuleTests: PeachPDF embeds subsetted fonts, so a decoded PDF content
     /// stream's Tj operands are typically glyph indices, not literal ASCII text.
     ///
     /// This is the direct regression coverage for the string-set Y-timing bug: every NamedString used
     /// to register at Y=0 (CssNamedStringEngine.ApplyStringSet ran before CssBox.Location was computed
     /// for that layout pass), so this page-range matching only worked by accident on page 1.
+    ///
+    /// <see cref="Resolve"/> stands in for production's <c>htmlContainer.SlotStartingAt</c>/
+    /// <c>currentPageIndex</c> pair with a plain division against a fixed <c>pageHeight</c> — the same
+    /// non-variable-geometry math <see cref="PeachPDF.Html.Core.HtmlContainerInt.PageIndexOf"/> itself falls back
+    /// to when the document uses one uniform page size.
     /// </summary>
     public class MarginBoxResolveNamedStringTests
     {
         // Three pages of height 800: [0,800), [800,1600), [1600,2400)
+
+        private static string Resolve(string name, string keyword, double pageY, double pageHeight, IReadOnlyList<NamedString> namedStrings) =>
+            MarginBoxRenderer.ResolveNamedString(name, keyword, (int)(pageY / pageHeight), y => (int)(y / pageHeight), namedStrings);
 
         [Fact]
         public void First_ReturnsFirstAssignmentOnThisPage()
@@ -30,7 +41,7 @@ namespace PeachPDF.Tests.Integration
                 new("term", "Banana", 900),
             };
 
-            var result = MarginBoxRenderer.ResolveNamedString("term", "first", pageY: 800, pageHeight: 800, namedStrings);
+            var result = Resolve("term", "first", pageY: 800, pageHeight: 800, namedStrings);
 
             Assert.Equal("Banana", result);
         }
@@ -45,7 +56,7 @@ namespace PeachPDF.Tests.Integration
             };
 
             // Page 2 [800,1600) has no "term" assignment of its own.
-            var result = MarginBoxRenderer.ResolveNamedString("term", "first", pageY: 800, pageHeight: 800, namedStrings);
+            var result = Resolve("term", "first", pageY: 800, pageHeight: 800, namedStrings);
 
             Assert.Equal("Avocado", result);
         }
@@ -58,7 +69,7 @@ namespace PeachPDF.Tests.Integration
                 new("term", "Banana", 900),
             };
 
-            var result = MarginBoxRenderer.ResolveNamedString("term", "first", pageY: 0, pageHeight: 800, namedStrings);
+            var result = Resolve("term", "first", pageY: 0, pageHeight: 800, namedStrings);
 
             Assert.Equal(string.Empty, result);
         }
@@ -74,7 +85,7 @@ namespace PeachPDF.Tests.Integration
                 new("term", "Cherry", 1200),
             };
 
-            var result = MarginBoxRenderer.ResolveNamedString("term", "last", pageY: 800, pageHeight: 800, namedStrings);
+            var result = Resolve("term", "last", pageY: 800, pageHeight: 800, namedStrings);
 
             Assert.Equal("Cherry", result);
         }
@@ -88,7 +99,7 @@ namespace PeachPDF.Tests.Integration
                 new("term", "Avocado", 300),
             };
 
-            var result = MarginBoxRenderer.ResolveNamedString("term", "last", pageY: 800, pageHeight: 800, namedStrings);
+            var result = Resolve("term", "last", pageY: 800, pageHeight: 800, namedStrings);
 
             Assert.Equal("Avocado", result);
         }
@@ -103,7 +114,7 @@ namespace PeachPDF.Tests.Integration
                 new("term", "Banana", 900),
             };
 
-            var result = MarginBoxRenderer.ResolveNamedString("term", "start", pageY: 800, pageHeight: 800, namedStrings);
+            var result = Resolve("term", "start", pageY: 800, pageHeight: 800, namedStrings);
 
             Assert.Equal("Avocado", result);
         }
@@ -116,7 +127,7 @@ namespace PeachPDF.Tests.Integration
                 new("term", "Banana", 900),
             };
 
-            var result = MarginBoxRenderer.ResolveNamedString("term", "start", pageY: 800, pageHeight: 800, namedStrings);
+            var result = Resolve("term", "start", pageY: 800, pageHeight: 800, namedStrings);
 
             Assert.Equal(string.Empty, result);
         }
@@ -130,7 +141,7 @@ namespace PeachPDF.Tests.Integration
             };
 
             // Page 1 [0,800) is exactly where "Apple" was first assigned.
-            var result = MarginBoxRenderer.ResolveNamedString("term", "first-except", pageY: 0, pageHeight: 800, namedStrings);
+            var result = Resolve("term", "first-except", pageY: 0, pageHeight: 800, namedStrings);
 
             Assert.Equal(string.Empty, result);
         }
@@ -143,7 +154,7 @@ namespace PeachPDF.Tests.Integration
                 new("term", "Apple", 50),
             };
 
-            var result = MarginBoxRenderer.ResolveNamedString("term", "first-except", pageY: 800, pageHeight: 800, namedStrings);
+            var result = Resolve("term", "first-except", pageY: 800, pageHeight: 800, namedStrings);
 
             Assert.Equal("Apple", result);
         }
@@ -157,8 +168,8 @@ namespace PeachPDF.Tests.Integration
                 new("letter", "A", 60),
             };
 
-            var termResult = MarginBoxRenderer.ResolveNamedString("term", "first", pageY: 0, pageHeight: 800, namedStrings);
-            var letterResult = MarginBoxRenderer.ResolveNamedString("letter", "first", pageY: 0, pageHeight: 800, namedStrings);
+            var termResult = Resolve("term", "first", pageY: 0, pageHeight: 800, namedStrings);
+            var letterResult = Resolve("letter", "first", pageY: 0, pageHeight: 800, namedStrings);
 
             Assert.Equal("Apple", termResult);
             Assert.Equal("A", letterResult);
@@ -176,9 +187,86 @@ namespace PeachPDF.Tests.Integration
                 new("term", "Banana", 900),
             };
 
-            Assert.Equal("Apple", MarginBoxRenderer.ResolveNamedString("term", "first", pageY: 0, pageHeight: 800, namedStrings));
-            Assert.Equal("Banana", MarginBoxRenderer.ResolveNamedString("term", "first", pageY: 800, pageHeight: 800, namedStrings));
-            Assert.Equal("Banana", MarginBoxRenderer.ResolveNamedString("term", "first", pageY: 1600, pageHeight: 800, namedStrings));
+            Assert.Equal("Apple", Resolve("term", "first", pageY: 0, pageHeight: 800, namedStrings));
+            Assert.Equal("Banana", Resolve("term", "first", pageY: 800, pageHeight: 800, namedStrings));
+            Assert.Equal("Banana", Resolve("term", "first", pageY: 1600, pageHeight: 800, namedStrings));
+        }
+
+        // ─── ResolveContent's `string()` token handling (the real call site) ──────────────────────────
+
+        // Real HtmlContainerInt.SlotStartingAt, rather than the plain-division stand-in above - this is
+        // the actual production path from a `content: string(...)` margin-box declaration through to a
+        // page-attributed value, including the SlotStartingAt/PageBoundaryEpsilon call ResolveContent
+        // makes before delegating to ResolveNamedString.
+        private static HtmlContainerInt Container(double pageHeight)
+        {
+            var container = new HtmlContainerInt(new PdfSharpAdapter())
+            {
+                MarginTop = 0,
+                PageSize = new RSize(400, pageHeight),
+            };
+            return container;
+        }
+
+        [Fact]
+        public void ResolveContent_StringFunction_ResolvesAgainstTheCurrentPage()
+        {
+            var namedStrings = new List<NamedString>
+            {
+                new("term", "Apple", 50),
+                new("term", "Banana", 900),
+            };
+
+            var result = MarginBoxRenderer.ResolveContent("string(term)", pageNumber: 2, totalPages: 3,
+                pageY: 800, Container(800), namedStrings);
+
+            Assert.Equal("Banana", result);
+        }
+
+        [Fact]
+        public void ResolveContent_StringFunction_HonoursTheLastKeyword()
+        {
+            var namedStrings = new List<NamedString>
+            {
+                new("term", "Apple", 50),
+                new("term", "Avocado", 300),
+                new("term", "Banana", 900),
+            };
+
+            var result = MarginBoxRenderer.ResolveContent("string(term, last)", pageNumber: 1, totalPages: 3,
+                pageY: 0, Container(800), namedStrings);
+
+            Assert.Equal("Avocado", result);
+        }
+
+        [Fact]
+        public void ResolveContent_StringFunction_DoesNotLeakAColumnTopFromTheNextPage()
+        {
+            // Direct end-to-end coverage of the actual dictionary.html bug shape via the real call site:
+            // two entries opening different columns of the *next* page share a Y right at this page's own
+            // end boundary, and must not be picked as this page's "last".
+            var namedStrings = new List<NamedString>
+            {
+                new("term", "last-on-this-page", 750),
+                new("term", "column-1-top-of-next-page", 800),
+                new("term", "column-2-top-of-next-page", 800),
+            };
+
+            var result = MarginBoxRenderer.ResolveContent("string(term, last)", pageNumber: 1, totalPages: 2,
+                pageY: 0, Container(800), namedStrings);
+
+            Assert.Equal("last-on-this-page", result);
+        }
+
+        [Fact]
+        public void ResolveContent_MixesLiteralsCountersAndStringFunction()
+        {
+            var namedStrings = new List<NamedString> { new("term", "Apple", 50) };
+
+            var result = MarginBoxRenderer.ResolveContent("\"p. \" counter(page) \": \" string(term)",
+                pageNumber: 4, totalPages: 10, pageY: 0, Container(800), namedStrings);
+
+            Assert.Equal("p. 4: Apple", result);
         }
     }
 }

--- a/src/PeachPDF.Tests/Integration/MulticolLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/MulticolLayoutIntegrationTests.cs
@@ -421,6 +421,113 @@ namespace PeachPDF.Tests.Integration
         }
 
         [Fact]
+        public async Task NamedString_InlineTarget_DoesNotAccumulateStaleEntriesAcrossReflow()
+        {
+            // Same re-banding shape as NamedString_Y_TracksTheColumnItLandsIn, but string-set now
+            // targets an inline <b> reached only through FlowBox, not a block box's own
+            // PerformLayoutPrologue - the one path that already withdraws a stale registration before
+            // re-registering. Without the same guard in FlowBox, each Phase-1/Phase-2 re-layout (and
+            // any column-fill retry) leaves one more orphaned NamedString behind.
+            var html = Wrap(@"
+                <style>.item b { string-set: entry content(text); }</style>
+                <div id='mc' style='columns:2; column-gap:0; width:200px'>
+                    <div class='item' id='i1' style='height:80px'>one</div>
+                    <div class='item' id='i2' style='height:10px'><b id='b2'>two</b></div>
+                    <div class='item' id='i3' style='height:10px'>three</div>
+                </div>");
+            var (root, container) = await BuildAndLayout(html, pageHeight: 100);
+            var mc = FindById(root, "mc")!;
+            var i2 = FindById(root, "i2")!;
+            var b2 = FindById(root, "b2")!;
+
+            // Confirm the fixture actually forces re-banding before trusting the assertions below.
+            Assert.True(i2.Location.X > mc.ClientLeft + 50, "expected i2 to be re-banded into column 2");
+
+            var namedString = Assert.Single(b2.NamedStrings.Values);
+            Assert.Equal(i2.Location.Y, namedString.Y, 1);
+
+            // The regression guard: without unregistering a stale entry before re-registering, this
+            // accumulates one orphaned "entry"/"two" per re-layout instead of staying at exactly one.
+            var documentEntry = Assert.Single(container.NamedStrings, ns => ns.Name == "entry" && ns.Value == "two");
+            Assert.Equal(i2.Location.Y, documentEntry.Y, 1);
+        }
+
+        [Fact]
+        public async Task NamedPageElement_InlineTarget_DoesNotAccumulateStaleEntriesAcrossReflow()
+        {
+            // Same re-banding fixture as NamedString_InlineTarget_DoesNotAccumulateStaleEntriesAcrossReflow,
+            // exercising the `page` registration's twin unregister-before-register gap in the same
+            // FlowBox code path. (Unlike the block-level page property, an inline target's `page`
+            // value does not force a break of its own - css2.1 §13.2's page-transition break check
+            // runs against block-level boxes - so this only asserts against re-registration, not a
+            // page transition.)
+            var html = Wrap(@"
+                <div id='mc' style='columns:2; column-gap:0; width:200px'>
+                    <div class='item' id='i1' style='height:80px'>one</div>
+                    <div class='item' id='i2' style='height:10px'><b id='b2' style='page:chapter'>two</b></div>
+                    <div class='item' id='i3' style='height:10px'>three</div>
+                </div>");
+            var (root, container) = await BuildAndLayout(html, pageHeight: 100);
+            var mc = FindById(root, "mc")!;
+            var i2 = FindById(root, "i2")!;
+
+            // Confirm the fixture actually forces re-banding before trusting the assertion below.
+            Assert.True(i2.Location.X > mc.ClientLeft + 50, "expected i2 to be re-banded into column 2");
+
+            // Exactly one entry is the regression guard - the inline path used to leave one orphaned
+            // NamedPageElement behind per re-layout instead of withdrawing the earlier one first.
+            Assert.Single(container.NamedPageElements, e => e.Name == "chapter");
+        }
+
+        [Fact]
+        public async Task NamedString_InlineFlexTarget_DoesNotAccumulateStaleEntriesAcrossReflow()
+        {
+            // Same re-banding fixture as NamedString_InlineTarget_DoesNotAccumulateStaleEntriesAcrossReflow,
+            // but through FlowBox's separate InlineFlex branch (CssLayoutEngine.cs), which finalizes
+            // string-set eagerly rather than splitting it across entry/exit like the plain-inline case -
+            // and has the identical missing unregister-before-register guard.
+            var html = Wrap(@"
+                <style>.item span { string-set: entry content(text); }</style>
+                <div id='mc' style='columns:2; column-gap:0; width:200px'>
+                    <div class='item' id='i1' style='height:80px'>one</div>
+                    <div class='item' id='i2' style='height:10px'><span id='b2' style='display:inline-flex'>two</span></div>
+                    <div class='item' id='i3' style='height:10px'>three</div>
+                </div>");
+            var (root, container) = await BuildAndLayout(html, pageHeight: 100);
+            var mc = FindById(root, "mc")!;
+            var i2 = FindById(root, "i2")!;
+
+            // Confirm the fixture actually forces re-banding before trusting the assertions below.
+            Assert.True(i2.Location.X > mc.ClientLeft + 50, "expected i2 to be re-banded into column 2");
+
+            // The regression guard: without unregistering a stale entry before re-registering, this
+            // accumulates one orphaned "entry"/"two" per re-layout instead of staying at exactly one.
+            Assert.Single(container.NamedStrings, ns => ns.Name == "entry" && ns.Value == "two");
+        }
+
+        [Fact]
+        public async Task NamedPageElement_InlineFlexTarget_DoesNotAccumulateStaleEntriesAcrossReflow()
+        {
+            // Same re-banding fixture, exercising the `page` registration's twin gap in the same
+            // InlineFlex branch of FlowBox.
+            var html = Wrap(@"
+                <div id='mc' style='columns:2; column-gap:0; width:200px'>
+                    <div class='item' id='i1' style='height:80px'>one</div>
+                    <div class='item' id='i2' style='height:10px'><span id='b2' style='display:inline-flex; page:chapter'>two</span></div>
+                    <div class='item' id='i3' style='height:10px'>three</div>
+                </div>");
+            var (root, container) = await BuildAndLayout(html, pageHeight: 100);
+            var mc = FindById(root, "mc")!;
+            var i2 = FindById(root, "i2")!;
+
+            Assert.True(i2.Location.X > mc.ClientLeft + 50, "expected i2 to be re-banded into column 2");
+
+            // Exactly one entry is the regression guard - the InlineFlex branch used to leave one
+            // orphaned NamedPageElement behind per re-layout instead of withdrawing the earlier one first.
+            Assert.Single(container.NamedPageElements, e => e.Name == "chapter");
+        }
+
+        [Fact]
         public async Task ActualSize_MatchesRealFinalGeometry_NotInflatedPhase1Height()
         {
             // 4 items of 80px each into 2 columns at a 100px page height. Phase 1's un-banded virtual

--- a/src/PeachPDF.Tests/Integration/ResumedInlineNamedStringLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/ResumedInlineNamedStringLayoutIntegrationTests.cs
@@ -1,0 +1,82 @@
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Tests.TestSupport;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// The real-world shape behind the css4.pub Icelandic dictionary running-header bug: a <c>&lt;b&gt;</c>
+    /// carrying <c>string-set</c>/<c>page</c> opens on one page, but its containing paragraph is long
+    /// enough that a later page break falls inside the *same* paragraph. Layout fills one fragmentainer
+    /// per pass (see <see cref="ResumedInlineDecorationLayoutIntegrationTests"/>), so the pass that
+    /// resumes the paragraph on the next page walks its inline content from the top again - reaching the
+    /// already-placed <c>&lt;b&gt;</c> a second time even though it did not open on this pass. Without
+    /// gating <c>CssLayoutEngine.FlowBox</c>'s string-set/named-page application on <c>opensHere</c>, that
+    /// second visit re-stamps the box's <c>NamedString</c>/<c>NamedPageElement</c> using *this* pass's
+    /// cursor - which sits at the resumed page's own top, since the walk has not yet advanced past the
+    /// already-placed word - discarding the box's true first-page position.
+    /// </summary>
+    public class ResumedInlineNamedStringLayoutIntegrationTests
+    {
+        private const double PageHeight = 100;
+
+        [Fact]
+        public async Task NamedString_InlineTarget_KeepsTruePositionAcrossResumedContinuation()
+        {
+            var html = Wrap($"<p id='p'><b id='term'>first</b> {Filler}</p>", stringSet: true);
+            var (root, container) = await LayoutHarness.LayoutAsync(html, pageWidth: 200, pageHeight: PageHeight);
+
+            AssertPaginated(container);
+
+            var term = LayoutHarness.FindById(root, "term")!;
+            var trueY = AllWords(term).Single().Top;
+
+            // The regression guard: without the opensHere gate, the resumed pass overwrites this with the
+            // resumed page's own top Y, and/or leaves a second orphaned entry behind.
+            var namedString = Assert.Single(container.NamedStrings, ns => ns.Name == "entry" && ns.Value == "first");
+            Assert.Equal(0, container.PageIndexOf(namedString.Y));
+            Assert.Equal(trueY, namedString.Y, 1);
+        }
+
+        [Fact]
+        public async Task NamedPageElement_InlineTarget_KeepsTruePositionAcrossResumedContinuation()
+        {
+            var html = Wrap($"<p id='p'><b id='term'>first</b> {Filler}</p>", stringSet: false);
+            var (root, container) = await LayoutHarness.LayoutAsync(html, pageWidth: 200, pageHeight: PageHeight);
+
+            AssertPaginated(container);
+
+            var term = LayoutHarness.FindById(root, "term")!;
+            var trueY = AllWords(term).Single().Top;
+
+            var registered = Assert.Single(container.NamedPageElements, e => e.Name == "chapter");
+            Assert.Equal(0, container.PageIndexOf(registered.Y));
+            Assert.Equal(trueY, registered.Y, 1);
+        }
+
+        // 200 short words, comfortably enough to push this paragraph across a page break at PageHeight.
+        private static readonly string Filler = string.Join(" ", Enumerable.Repeat("word", 200));
+
+        private static string Wrap(string body, bool stringSet)
+        {
+            var declaration = stringSet ? "string-set: entry content(text)" : "page: chapter";
+            return $"<!DOCTYPE html><html><head><style>#term {{ {declaration} }}</style></head><body>{body}</body></html>";
+        }
+
+        private static void AssertPaginated(HtmlContainerInt container) =>
+            Assert.True(container.FragmentainerPasses > 1,
+                $"fixture must paginate, but layout took {container.FragmentainerPasses} pass(es)");
+
+        private static System.Collections.Generic.IEnumerable<CssRect> AllWords(CssBox box)
+        {
+            foreach (var word in box.Words) yield return word;
+
+            foreach (var child in box.Boxes)
+            {
+                foreach (var word in AllWords(child)) yield return word;
+            }
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -1257,8 +1257,26 @@ namespace PeachPDF.Html.Core.Dom
             // and named-page registration (normally done near the top/bottom of PerformLayoutImp) have to
             // happen for inline boxes. blockBox itself is excluded since its own PerformLayoutImp already
             // handles it correctly before CreateLineBoxes is even called.
-            if (box != blockBox && !string.IsNullOrEmpty(box.StringSet) && box.StringSet != CssConstants.None)
+            // Gated on opensHere for the same reason FirstHostingLineBox is above: a pass resuming this
+            // box's flow into a later fragmentainer re-enters it from the top (its already-placed words
+            // are only skipped by ordinal further down), so without this guard a resumed pass would
+            // re-run ApplyStringSet using *this* pass's fresh coordinates - overwriting the box's true
+            // position (set when it actually opened) with wherever the resumed fragmentainer happens to
+            // start. string-set fires exactly once per box per opening, mirroring a block box's own
+            // once-per-_prologueDone guarantee.
+            if (opensHere && box != blockBox && !string.IsNullOrEmpty(box.StringSet) && box.StringSet != CssConstants.None)
             {
+                // Unlike a block box's PerformLayoutPrologue, nothing else withdraws this box's previous
+                // registration before FlowBox re-opens it (a multicol measurement pass, a re-banding
+                // re-layout, or a column-fill retry all re-run this) - so without unregistering first, a
+                // stale entry from an earlier pass survives as an orphan, still eligible to match some
+                // page's Y window in MarginBoxRenderer.ResolveNamedString.
+                if (box.NamedStrings.Count > 0)
+                {
+                    box.HtmlContainer?.UnregisterNamedStrings(box.NamedStrings.Values);
+                    box.NamedStrings.Clear();
+                }
+
                 CssNamedStringEngine.ApplyStringSet(box);
             }
 
@@ -1591,6 +1609,14 @@ namespace PeachPDF.Html.Core.Dom
                     // FlowBox recursion case above.
                     if (!string.IsNullOrEmpty(b.StringSet) && b.StringSet != CssConstants.None)
                     {
+                        // Same re-entry hazard as the plain-inline FlowBox path above: withdraw whatever
+                        // this box registered on an earlier pass before registering again.
+                        if (b.NamedStrings.Count > 0)
+                        {
+                            b.HtmlContainer?.UnregisterNamedStrings(b.NamedStrings.Values);
+                            b.NamedStrings.Clear();
+                        }
+
                         CssNamedStringEngine.ApplyStringSet(b);
                         foreach (var namedString in b.NamedStrings.Values)
                         {
@@ -1600,6 +1626,11 @@ namespace PeachPDF.Html.Core.Dom
 
                     if (!string.IsNullOrEmpty(b.PageName) && b.PageName != "auto")
                     {
+                        if (b.RegisteredNamedPageElement is { } staleFlexPageElement)
+                        {
+                            b.HtmlContainer?.UnregisterNamedPageElement(staleFlexPageElement);
+                        }
+
                         b.RegisteredNamedPageElement = b.HtmlContainer?.RegisterNamedPageElement(b.PageName, b.Location.Y);
                     }
 
@@ -1693,8 +1724,14 @@ namespace PeachPDF.Html.Core.Dom
             // Finalize what was captured at entry, now that this box's content has actually been placed
             // and coordinates.CurrentY reflects where it landed - mirrors CssBox.PerformLayoutImp's own
             // late-stage Y-correction/named-page registration (done there once Location is final), which
-            // a plain inline box never gets a Location for in the first place.
-            if (box != blockBox)
+            // a plain inline box never gets a Location for in the first place. Gated on opensHere for the
+            // same reason as the entry-side guard above: a pass merely resuming this box's already-placed
+            // content into a later fragmentainer must not re-stamp its NamedStrings/named-page Y to
+            // wherever *this* pass's cursor happens to sit (typically the resumed fragmentainer's own
+            // top, since the walk hasn't advanced past already-placed words yet) - that both discards the
+            // box's true position from when it actually opened and, for named-page, would corrupt
+            // ActivePageName for content after it.
+            if (opensHere && box != blockBox)
             {
                 if (box.NamedStrings.Count > 0)
                 {
@@ -1706,6 +1743,14 @@ namespace PeachPDF.Html.Core.Dom
 
                 if (!string.IsNullOrEmpty(box.PageName) && box.PageName != "auto")
                 {
+                    // Same re-entry hazard as the string-set guard above: without withdrawing a stale
+                    // registration first, a re-banding re-layout or column-fill retry leaves an orphaned
+                    // NamedPageElement behind, corrupting ActivePageName for whatever comes after it.
+                    if (box.RegisteredNamedPageElement is { } stalePageElement)
+                    {
+                        box.HtmlContainer?.UnregisterNamedPageElement(stalePageElement);
+                    }
+
                     box.RegisteredNamedPageElement = box.HtmlContainer?.RegisterNamedPageElement(box.PageName, coordinates.CurrentY);
                 }
             }

--- a/src/PeachPDF/Html/Core/Dom/MarginBoxRenderer.cs
+++ b/src/PeachPDF/Html/Core/Dom/MarginBoxRenderer.cs
@@ -41,7 +41,6 @@ namespace PeachPDF.Html.Core.Dom
             int pageNumber,
             int totalPages,
             double pageY,
-            double pageContentHeight,
             IReadOnlyList<NamedString> namedStrings,
             RAdapter adapter,
             StyleDeclaration? pageStyle,
@@ -73,11 +72,10 @@ namespace PeachPDF.Html.Core.Dom
                     continue;
                 }
 
-                // pageY and pageContentHeight are internal-pixel document space, the same space
-                // NamedString Ys are registered in - deriving the band from the point-space
-                // pageSize/margins here used to skew named-string page attribution whenever
-                // ShrinkToFit made PixelsPerPoint diverge from 1.0.
-                var text = ResolveContent(contentValue, pageNumber, totalPages, pageY, pageContentHeight, namedStrings);
+                // pageY is internal-pixel document space, the same space NamedString Ys are registered
+                // in - deriving page attribution from the point-space pageSize/margins here used to
+                // skew it whenever ShrinkToFit made PixelsPerPoint diverge from 1.0.
+                var text = ResolveContent(contentValue, pageNumber, totalPages, pageY, htmlContainer, namedStrings);
                 if (text == null)
                     continue;
 
@@ -164,12 +162,19 @@ namespace PeachPDF.Html.Core.Dom
                 });
         }
 
-        private static string? ResolveContent(
+        /// <summary>
+        /// Resolves a margin box's text <c>content</c> declaration - string literals, <c>counter()</c>/
+        /// <c>counters()</c>, and <c>string()</c> - against this page's context. <c>string()</c>'s page
+        /// attribution goes through <see cref="ResolveNamedString"/> via <see cref="HtmlContainerInt.SlotStartingAt"/>,
+        /// the same table <paramref name="pageY"/> itself was derived from - see that method's own
+        /// <c>pageIndexOf</c> doc for why a raw Y-range window isn't used here.
+        /// </summary>
+        internal static string? ResolveContent(
             string contentValue,
             int pageNumber,
             int totalPages,
             double pageY,
-            double pageHeight,
+            HtmlContainerInt htmlContainer,
             IReadOnlyList<NamedString> namedStrings)
         {
             if (contentValue.Equals("none", StringComparison.OrdinalIgnoreCase))
@@ -206,7 +211,8 @@ namespace PeachPDF.Html.Core.Dom
                         if (args.Length > 0 && args[0] is KeywordToken nameToken)
                         {
                             var keyword = args.Length > 1 && args[1] is KeywordToken kw ? kw.Data : "first";
-                            sb.Append(ResolveNamedString(nameToken.Data, keyword, pageY, pageHeight, namedStrings));
+                            var currentPageIndex = htmlContainer.SlotStartingAt(pageY);
+                            sb.Append(ResolveNamedString(nameToken.Data, keyword, currentPageIndex, htmlContainer.SlotStartingAt, namedStrings));
                         }
                         break;
                     }
@@ -216,48 +222,61 @@ namespace PeachPDF.Html.Core.Dom
             return sb.Length > 0 ? sb.ToString() : null;
         }
 
-        // A NamedString's Y and this page's boundary are computed via independent accumulation paths
-        // (row/column layout math vs. per-page scroll-offset accumulation), so a value genuinely meant
-        // to sit exactly at a page boundary can differ from it by a hairline of floating-point noise -
-        // without tolerance, that noise alone can exclude the true first/last string on a page. This is
-        // a boundary-precision fuzz factor only, not a layout unit - deliberately much smaller than any
-        // real line height.
-        internal const double PageBoundaryEpsilon = HtmlContainerInt.PageBoundaryEpsilon;
-
+        /// <summary>
+        /// Resolves <c>string(&lt;name&gt;, first|start|last|first-except)</c> against the document-level
+        /// <see cref="NamedString"/> list for the page starting at pagination slot <paramref name="currentPageIndex"/>.
+        /// </summary>
+        /// <param name="name">The <c>string-set</c> name (the <c>string()</c> function's first argument).</param>
+        /// <param name="keyword">One of <c>first</c>/<c>start</c>/<c>last</c>/<c>first-except</c> (the
+        /// <c>string()</c> function's optional second argument, defaulting to <c>first</c>).</param>
+        /// <param name="currentPageIndex">The pagination slot of the page this margin box is being
+        /// painted for, from the same <paramref name="pageIndexOf"/> table every candidate is measured
+        /// against.</param>
+        /// <param name="pageIndexOf">
+        /// Maps a <see cref="NamedString"/>'s own document Y to the pagination slot that owns it - always
+        /// <see cref="HtmlContainerInt.SlotStartingAt"/> in production, so every candidate is attributed to
+        /// a page via the exact same authoritative table <paramref name="currentPageIndex"/> itself was
+        /// derived from. This replaces an earlier design that compared a candidate's raw Y against
+        /// <c>[pageY - epsilon, pageY + pageHeight + epsilon)</c> directly: two boxes at the very top of
+        /// different columns on the *same* page can land on the same Y (both are "row 1" of their own
+        /// column), and when that shared Y sits within a hairline of a page boundary, a symmetric epsilon
+        /// widened at both ends of *every* page's window let a box on the far side of the boundary satisfy
+        /// the near side's window too - observed against css4.pub's Icelandic dictionary, where a
+        /// paragraph opening column 2 of one page was picked as the running header's "last" value for the
+        /// *previous* page. Attributing every candidate to an unambiguous single slot up front - the same
+        /// slot a fresh top-of-page box would resolve to via <see cref="HtmlContainerInt.SlotStartingAt"/>
+        /// elsewhere - removes the overlap a symmetric window can't avoid, without reintroducing the
+        /// original hairline-exclusion bug the epsilon existed to fix in the first place (a value meant to
+        /// land exactly on a page's own top, but off by float noise, is still nudged onto that same page by
+        /// the shared <see cref="HtmlContainerInt.PageBoundaryEpsilon"/> baked into <c>SlotStartingAt</c>).
+        /// </param>
+        /// <param name="namedStrings">The document-level named-string list, in registration order.</param>
         internal static string ResolveNamedString(
             string name,
             string keyword,
-            double pageY,
-            double pageHeight,
+            int currentPageIndex,
+            Func<double, int> pageIndexOf,
             IReadOnlyList<NamedString> namedStrings)
         {
-            var pageEnd = pageY + pageHeight;
-            // Widen the acceptance window outward on both ends by a hairline, rather than shrinking it -
-            // shrinking risks excluding a genuinely-valid boundary-adjacent value from its own true page;
-            // widening can only extend a value's reach into an adjacent page's window at the razor-thin
-            // margin where that ambiguity already exists in principle.
-            var pageStartInclusive = pageY - PageBoundaryEpsilon;
-            var pageEndInclusive = pageEnd + PageBoundaryEpsilon;
-
             return keyword.ToLowerInvariant() switch
             {
                 // last assignment that started before this page (running header)
                 "start" => namedStrings
-                    .LastOrDefault(s => s.Name == name && s.Y < pageStartInclusive)?.Value ?? string.Empty,
+                    .LastOrDefault(s => s.Name == name && pageIndexOf(s.Y) < currentPageIndex)?.Value ?? string.Empty,
                 // first assignment on this page
                 "first" => namedStrings
-                    .FirstOrDefault(s => s.Name == name && s.Y >= pageStartInclusive && s.Y < pageEndInclusive)?.Value
-                    ?? namedStrings.LastOrDefault(s => s.Name == name && s.Y < pageStartInclusive)?.Value
+                    .FirstOrDefault(s => s.Name == name && pageIndexOf(s.Y) == currentPageIndex)?.Value
+                    ?? namedStrings.LastOrDefault(s => s.Name == name && pageIndexOf(s.Y) < currentPageIndex)?.Value
                     ?? string.Empty,
                 // last assignment on this page
                 "last" => namedStrings
-                    .LastOrDefault(s => s.Name == name && s.Y >= pageStartInclusive && s.Y < pageEndInclusive)?.Value
-                    ?? namedStrings.LastOrDefault(s => s.Name == name && s.Y < pageStartInclusive)?.Value
+                    .LastOrDefault(s => s.Name == name && pageIndexOf(s.Y) == currentPageIndex)?.Value
+                    ?? namedStrings.LastOrDefault(s => s.Name == name && pageIndexOf(s.Y) < currentPageIndex)?.Value
                     ?? string.Empty,
                 // first-except: return empty on the page where this string is first assigned
-                "first-except" => namedStrings.Any(s => s.Name == name && s.Y >= pageStartInclusive && s.Y < pageEndInclusive)
+                "first-except" => namedStrings.Any(s => s.Name == name && pageIndexOf(s.Y) == currentPageIndex)
                     ? string.Empty
-                    : namedStrings.LastOrDefault(s => s.Name == name && s.Y < pageStartInclusive)?.Value ?? string.Empty,
+                    : namedStrings.LastOrDefault(s => s.Name == name && pageIndexOf(s.Y) < currentPageIndex)?.Value ?? string.Empty,
                 _ => namedStrings.FirstOrDefault(s => s.Name == name)?.Value ?? string.Empty,
             };
         }

--- a/src/PeachPDF/PdfGenerator.cs
+++ b/src/PeachPDF/PdfGenerator.cs
@@ -406,7 +406,6 @@ namespace PeachPDF
                         pageNumber,
                         totalPages,
                         pageY,
-                        geom.BandHeight,
                         container.NamedStrings,
                         _pdfSharpAdapter,
                         applicablePageStyle,


### PR DESCRIPTION
## Summary
- An inline `string-set`/`page` target (`<b>`, `<span>`) registered through `CssLayoutEngine.FlowBox` had neither the unregister-before-register guard nor the `opensHere` gate that a block box's `PerformLayoutPrologue` already has.
- Multicol layout lays every child out at least twice per invocation (a virtual measurement pass, a real fill, and up to 4 balance retries), so an inline target accumulated one orphaned, stale-Y entry per re-layout.
- A pass resuming a paragraph's flow onto a later page re-enters `FlowBox` from the top; without an `opensHere` gate it re-stamped an already-placed inline box's position using that pass's cursor (the resumed page's own top), discarding its true position.
- `MarginBoxRenderer.ResolveNamedString` compounded this with a third, independent bug: it picked `string(name, first|last)` by testing each candidate against a symmetric `[pageY - epsilon, pageY + pageHeight + epsilon)` window. Two boxes opening different columns on the *same* page can land on the identical Y, and when that shared Y sits within a hairline of a page boundary, the widened window let a box belonging to the *next* page satisfy the *previous* page's window too.
- Together these produced wrong `string(name, first|last)` values in `@page` running headers - reproduced end-to-end against css4.pub's Icelandic dictionary demo (`.chapter p b:first-child { string-set: term content() }` inside `columns: 2`), including a case reported against page 831/832 deep in the 834-page document.

## Fix
- `CssLayoutEngine.FlowBox`: added unregister-before-register and `opensHere` gating for inline `string-set`/`page` registration, mirroring the guarantees `CssBox.PerformLayoutPrologue` already provides for block boxes.
- `MarginBoxRenderer.ResolveNamedString`: replaced the raw-Y-range window check with attribution via `HtmlContainerInt.SlotStartingAt` - the same authoritative page-index table used everywhere else a box's Y needs a page index - removing the two-sided window's inherent overlap.

## Test plan
- [x] 10 new regression tests, each individually confirmed to fail before its corresponding fix and pass after.
- [x] Full `net8.0` suite: 7536 passed, 0 failed.
- [x] `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings.
- [x] Diff coverage checked on changed lines.
- [x] End-to-end: rendered the real `https://css4.pub/2015/icelandic/dictionary.html` (all 834 pages) via the `peachpdf` CLI. Verified rasterized running headers are self-consistent across pages 3-20 and the reported page 831/832 boundary; a full-document scan of all 14,644 `term` registrations shows zero out-of-order page attributions.