### PR TITLE
Implement CSS Container Queries (CSS Containment 3)

### DIFF
--- a/.claude/accepted-gaps/container-condition-cannot-mix-style-and-size-feature-queries.md
+++ b/.claude/accepted-gaps/container-condition-cannot-mix-style-and-size-feature-queries.md
@@ -1,0 +1,15 @@
+# A single `@container` condition can't mix `style()` and size-feature queries
+
+CSS Containment 3's `<container-condition>` grammar lets `style(...)` queries and plain size-feature
+queries (`(min-width: ...)`) both appear as `<query-in-parens>` alternatives in the same condition,
+combined with `and`/`or`/`not` at the top level — e.g.
+`@container (min-width: 300px) and style(--theme: dark) { ... }` is valid per spec.
+
+`StylesheetComposer.CreateContainer` decides, once, whether a rule's whole condition is a size-feature
+`MediaList` or a `style()` query tree, based on whether the token immediately following the optional
+`<container-name>` is a `style(` function call — the two forms are mutually exclusive per rule. A
+condition that mixes both at the top level (a leading size feature followed by `and style(...)`, or
+vice versa) is not supported.
+
+Real-world `@container` usage is overwhelmingly a single query form per rule. Tracked as
+[#618](https://github.com/jhaygood86/PeachPDF/issues/618).

--- a/.claude/accepted-gaps/container-query-convergence-loop-is-bounded-not-guaranteed.md
+++ b/.claude/accepted-gaps/container-query-convergence-loop-is-bounded-not-guaranteed.md
@@ -1,0 +1,17 @@
+# The `@container` convergence loop is bounded at 4 passes, not guaranteed to converge
+
+`HtmlContainerInt.PerformLayout`'s container-query convergence loop (1 baseline pass + up to 3
+refinement passes, each a full re-parse/re-cascade/re-layout) stops either when a size query
+container's resolved size stops changing pass-over-pass, or when the pass cap is hit — whichever
+comes first. On cap exceeded, the last pass's result is accepted silently rather than detecting or
+specially resolving the non-convergence. This mirrors the same "bounded, not perfect" stance already
+accepted for `UseVariablePageWidth`'s own 3-iteration reflow loop (see the "named-page L/R reflow"
+note in `docs/architecture.md`'s per-page reflow section).
+
+CSS Containment 3 doesn't define a pass limit; a spec-conformant UA is expected to reach a stable
+result. A pathological stylesheet where a container's own size depends, directly or transitively
+(e.g. through `fit-content`/auto sizing of content that is itself `@container`-gated against that
+same container's own breakpoint), on its own `@container` condition could in principle oscillate
+indefinitely and never settle within 4 passes. No real-world reproduction is known to actually hit
+this — real `@container` usage doesn't construct such cycles — but the gap is real in principle.
+Tracked as [#614](https://github.com/jhaygood86/PeachPDF/issues/614).

--- a/.claude/accepted-gaps/container-query-size-not-reresolved-per-page-under-variable-page-width.md
+++ b/.claude/accepted-gaps/container-query-size-not-reresolved-per-page-under-variable-page-width.md
@@ -1,0 +1,17 @@
+# `@container` size queries don't re-resolve per page under per-page `@page` width overrides
+
+PeachPDF supports per-page `@page :left`/`:right`/named-page margin overrides that vary a page's own
+content-box width, re-flowing main-column block content to each page's own measure
+(`HtmlContainerInt.UseVariablePageWidth` — see "Per-page content bands" in `docs/architecture.md`).
+
+The `@container` size-query convergence loop (`HtmlContainerInt.PerformLayout`) runs independently of
+that per-page reflow and resolves each size query container's size **once per whole-document layout
+pass**, not per page. If a size query container's own width happens to vary across the pages it spans
+because of `UseVariablePageWidth`'s per-page reflow, the container-query loop does not re-evaluate
+`@container` conditions against each page's own resolved width — it uses whichever width that
+container resolved to on the pass that recorded it.
+
+This is a narrow, compounding-features gap (`@page` per-page margins × `@container` size queries), not
+expected to matter for the common case (an explicit-width size container, or one that never spans a
+page boundary with varying margins). Tracked as
+[#617](https://github.com/jhaygood86/PeachPDF/issues/617).

--- a/.claude/accepted-gaps/container-relative-units-resolve-to-zero-with-no-ancestor-container.md
+++ b/.claude/accepted-gaps/container-relative-units-resolve-to-zero-with-no-ancestor-container.md
@@ -1,0 +1,16 @@
+# `cqw`/`cqh`/`cqi`/`cqb`/`cqmin`/`cqmax` resolve to 0 with no eligible ancestor query container
+
+Per CSS Values and Units / CSS Containment 3, a container-relative length unit with no eligible
+ancestor query container in the relevant axis falls back to the corresponding small-viewport unit
+(`cqw`→`svw`, `cqh`→`svh`, `cqi`→`svi`, `cqb`→`svb`, `cqmin`→`svmin`, `cqmax`→`svmax`), not to `0`.
+
+PeachPDF has no viewport-unit implementation at all — `vw`/`vh`/`vmin`/`vmax` already resolve to a
+hardcoded `0` in `Length.ToPixels` (the same file `cq*` units are implemented in). `cq*` follows the
+exact same fallback chain the spec describes, it just terminates at a numerator (`sv*`) PeachPDF
+doesn't implement yet, landing on `0` for the same reason `vw`/`vh` do.
+
+This only affects the misuse case — a `cq*` unit with no `container-type: size`/`inline-size`
+ancestor anywhere above it. The idiomatic case (a `cq*` unit inside the subtree of the element
+declaring `container-type`) resolves correctly against the real container size, which
+`CssBox.FindNearestQueryContainer` finds. Tracked as
+[#615](https://github.com/jhaygood86/PeachPDF/issues/615).

--- a/.claude/accepted-gaps/font-size-container-relative-units-resolve-to-zero-for-text-content.md
+++ b/.claude/accepted-gaps/font-size-container-relative-units-resolve-to-zero-for-text-content.md
@@ -1,0 +1,28 @@
+# `font-size: Ncqw` (container-relative units) resolves to 0 for any box with text content
+
+`font-size` accepts `cqw`/`cqh`/`cqi`/`cqb`/`cqmin`/`cqmax`, and `FontSizeResolver.Resolve`/
+`DerivedStyle.ActualFont` do thread a container inline/block size basis through to
+`CssValueParser.ParseLength` when one is available (`CssBox.GetContainerRelativeUnitBasis`). In
+practice that basis is never available for a box that contains text: `DomParser.CorrectTextBoxes`
+splits text into words (`CssBox.ParseToWords` → `AddWord` → `NeedsPerCodepointFont`) during
+`DomParser.GenerateCssTree` - cascade/tree-correction, which runs entirely before any layout pass
+exists - and that word-splitting reads `CssBox.ActualFont` to decide per-codepoint font matching.
+`DerivedStyle.ActualFont` caches the resolved font (and therefore the resolved size) on first
+access and never invalidates it, so touching it during word-splitting permanently locks in a
+container basis of `(null, null)` (0), even though the real ancestor container's size becomes
+known later in that same layout pass.
+
+This is different from (and narrower than) the general
+[`cq*`-with-no-ancestor-container gap](container-relative-units-resolve-to-zero-with-no-ancestor-container.md):
+a real, eligible ancestor `container-type: size`/`inline-size` box exists here, and every other
+`cq*` consumer (`width`, `calc()`, etc. - all read post-layout, not cached pre-layout) resolves
+against it correctly. Only font-size, and only for text content, hits this pre-layout caching
+order problem.
+
+A real fix likely needs `ActualFont`'s container lookup to consult the layout convergence loop's
+`ContainerQuerySizes` snapshot from the *previous* pass (the same source `@container` rule
+matching already reads) instead of live, not-yet-laid-out box geometry, since a pass's own
+word-splitting runs before that pass's own layout but after the *previous* pass's layout finished.
+That's a materially larger change than the parameter-threading the rest of `cq*` support needed, so
+it's tracked separately. Tracked as
+[#619](https://github.com/jhaygood86/PeachPDF/issues/619).

--- a/.claude/accepted-gaps/style-query-comparison-is-literal-text-not-computed-value-equivalence.md
+++ b/.claude/accepted-gaps/style-query-comparison-is-literal-text-not-computed-value-equivalence.md
@@ -1,0 +1,16 @@
+# `@container style()` compares resolved values as trimmed literal text, not computed-value equivalence
+
+`StyleDeclarationCondition.Check` (the `style(<property>: <value>)` leaf, CSS Containment 3 §7.3)
+compares the query container's resolved value for `<property>` against the queried `<value>` text via
+a trimmed, ordinal string match. Neither side is normalized through the property's own computed-value
+pipeline before comparing, so a query and a container can express the same computed value in
+textually different forms and fail to match — e.g. `style(color: red)` does not match a container
+whose resolved `color` serializes as `rgb(255, 0, 0)`, even though `red` and `rgb(255, 0, 0)` are the
+same computed color.
+
+This is spec-correct for the common cases: any custom-property (`--foo`) comparison (values are
+opaque author-controlled text with no separate computed serialization to diverge from), and a
+standard-property comparison whose authored value already matches PeachPDF's own canonical stored
+form (e.g. keyword values like `style(display: block)`). It's incorrect for a standard property whose
+authored and computed serializations genuinely differ. Tracked as
+[#616](https://github.com/jhaygood86/PeachPDF/issues/616).

--- a/.claude/migration-notes/2026-08-03-container-queries-now-evaluate.md
+++ b/.claude/migration-notes/2026-08-03-container-queries-now-evaluate.md
@@ -1,0 +1,42 @@
+# `@container` now actually evaluates, instead of always dropping the block
+
+**Landed:** 2026-08-03 — Implement CSS Container Queries (CSS Containment 3)
+**Doc section:** docs/html-css-support.md § [CSS At-Rules](../../docs/html-css-support.md#css-at-rules) (the
+`@container` row) and the new § [CSS Container Queries](../../docs/html-css-support.md#css-container-queries)
+
+Previously, every `@container { ... }` block was unconditionally ignored — its condition (whether a
+size-feature form like `@container (min-width: 300px)` or, once parsing existed for it, a `style()`
+form) was never evaluated, so the inner rules never applied regardless of whether the condition would
+have been true. This was a deliberate stopgap (tracked at old issue #284): unlike `@supports` (a
+static, parse-time-decidable fact), a container query's truthiness depends on the nearest matched
+element's own post-layout size, which a single-pass cascade-then-layout pipeline has no way to know
+before cascade runs. `container-type`/`container-name` were parsed at the CSS-OM level but never
+wired onto the box tree, so no element could actually be recognized as a query container either.
+
+Both are now genuinely supported:
+
+- **`container-type: size | inline-size | normal`** and **`container-name`** (plus the `container`
+  shorthand) are cascaded onto every element, establishing size and/or named query containers.
+- **Size queries** (`@container (min-width: 300px) { ... }`) evaluate against the nearest eligible
+  ancestor's real resolved content-box size, via a bounded convergence loop that re-cascades and
+  re-lays-out the document (up to 4 total passes) whenever a size container's resolved size changes
+  pass-over-pass — see `HtmlContainerInt.PerformLayout`.
+- **`style()` queries** (`@container style(--theme: dark) { ... }`) evaluate against the nearest
+  eligible ancestor's own resolved style (any `container-type`, including `normal`, qualifies — a
+  style query needs no layout containment), including `and`/`or`/`not` combinators.
+- **Container-relative units** `cqw`/`cqh`/`cqi`/`cqb`/`cqmin`/`cqmax` now parse and resolve against
+  the nearest ancestor query container's own size (falling back to `0` with no eligible container,
+  same as the existing `vw`/`vh`/`vmin`/`vmax` fallback).
+
+A document that previously worked around the always-ignored behavior — for example, by putting
+`@container`-guarded styles' content directly at top level, or by relying on `container-type`/
+`container-name` having no observable effect — will now see `@container` blocks apply or not apply
+based on the real evaluated condition, matching real browser behavior. In particular, a document using
+a CSS framework whose responsive components are built on container queries (rather than media
+queries) will now render those components' container-relative breakpoints correctly instead of always
+falling back to their base/no-match styling.
+
+Not yet supported: `scroll-state()` queries (a different, newer module - CSS Containment 4). A
+`style()` query's value comparison is a trimmed literal-text match against the container's resolved
+value, not full computed-value equivalence — see the `style()` row in
+[CSS Container Queries](../../docs/html-css-support.md#css-container-queries) for the exact boundary.

--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -775,7 +775,7 @@ Limitations:
 | `@media` | Supported; `print` and `all` media types apply, `screen` is ignored, and **feature queries** (`min-width`/`max-width`/range syntax, `orientation`, `resolution`, `prefers-color-scheme`, …) are evaluated against the page box and renderer characteristics; see [CSS Media Queries](#css-media-queries) below |
 | `@keyframes` | Not supported |
 | `@supports` | Supported ([CSS Conditional Rules 3/4](https://developer.mozilla.org/en-US/docs/Web/CSS/@supports)). `(property: value)`, `not (…)`, `(…) and (…)`, `(…) or (…)`, and arbitrary nesting are evaluated against PeachPDF's actual implemented property set, not just whether the value parses — `animation-name` parses but reports unsupported (never rendered), while SVG-only properties like `fill`/`stroke` correctly report supported. A shorthand is supported only when the CSS-OM expands it into longhands that are all themselves supported, not merely by recognizing the shorthand's name. The five CSS-wide keywords (`inherit`/`initial`/`unset`/`revert`/`revert-layer`) are always accepted. Two known, narrow gaps: a property with no dedicated grammar falls back to CSS-OM parse-validity rather than a full layout/paint-verified check, and a few hand-dispatched properties (`mask`, `marker`/`marker-start`/`marker-mid`/`marker-end`, SVG `clip-path`) aren't covered by this oracle and report unsupported despite working. Any at-rule may appear inside a true-condition block and is collected normally |
-| `@container` | **The whole block is ignored** — the container-size condition depends on the nearest matched element's own layout, which (unlike `@supports`'s condition) isn't a static, parse-time-decidable fact, so it cannot be evaluated; the inner rules never apply. Container-relative units (`cqw`/`cqi`/etc.) are not supported |
+| `@container` | Supported ([CSS Containment 3](https://developer.mozilla.org/en-US/docs/Web/CSS/@container)). Size queries (`@container (min-width: 300px) { … }`) and `style()` queries (`@container style(--theme: dark) { … }`) are both evaluated, against the nearest ancestor query container's real resolved size/style — see [CSS Container Queries](#css-container-queries) below for the full support table and behavior |
 | `@layer` | [Cascade layers](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer) are supported. Both the block form (`@layer name { … }`, including anonymous `@layer { … }`) and the statement form (`@layer a, b, c;`, which declares layer order) are parsed and honored. Layer precedence follows CSS Cascade 5: for **normal** declarations an unlayered rule beats any layered rule, and among layers a later-declared layer beats an earlier one — this ordering is applied **ahead of specificity**, so a low-specificity rule in a later layer wins over a high-specificity rule in an earlier layer. Specificity then source order break ties within a single layer. For **`!important`** declarations the layer order **reverses**: an earlier layer beats a later one, and a layered `!important` rule beats an unlayered one. **Nested layers** are ordered as a tree — a parent layer's whole subtree is contiguous and its sub-layers are ordered by first appearance within that parent (so `@layer a.b; @layer c; @layer a.d;` ranks `a.b`, `a.d`, then `c`). An `@font-face`/`@property`/`@page` rule nested inside an `@layer` block (or an `@media`/`@supports` within one) is collected. Remaining simplification: when a single layer mixes direct rules with its own nested sub-layers, the parent's direct rules are ranked before those sub-layers (the exact interleaving is not modeled) |
 | `@import` | Full support; the imported stylesheet is fetched and its rules merged in place, including transitively nested `@import`s (with circular-import protection). Relative `url()` references inside an imported stylesheet — including `@font-face src` — resolve against that stylesheet's own location, not the document's |
 
@@ -977,6 +977,45 @@ PeachPDF renders to PDF, so only media queries that target the `print` medium (o
 | `prefers-reduced-motion` | Yes | Reports `reduce` (a static PDF has no motion) |
 | `prefers-contrast`, `prefers-reduced-transparency` | Yes | Report `no-preference` |
 | A feature name PeachPDF doesn't recognize | No | The whole media query is invalid and its block does not apply (per Media Queries 4, an unknown feature is false) |
+
+---
+
+## CSS Container Queries
+
+Supported ([CSS Containment 3](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries)). An element opts in to being a query container with the `container-type`/`container-name` properties (or the `container` shorthand); `@container` rules then apply based on that container's own resolved size or style rather than the page. Both forms — size queries and `style()` queries — evaluate against the **nearest eligible ancestor** query container, walking up from the matched element; an unnamed query uses the nearest eligible ancestor regardless of its name, and a named query (`@container sidebar (...)`) skips straight to the nearest ancestor declaring that name in its own `container-name`, even if a nearer ancestor is eligible but unnamed.
+
+```css
+.card-list {
+  container-type: inline-size;
+  container-name: cards;
+}
+
+/* applies once .card-list's own content-box width reaches 400px */
+@container cards (min-width: 400px) {
+  .card { display: flex; }
+}
+
+/* style queries read a container's own resolved value, most commonly a custom property */
+@container style(--theme: dark) {
+  .card { background: black; color: white; }
+}
+```
+
+| Property/at-rule | Notes |
+|---|---|
+| `container-type` | `normal` (initial — no size containment), `size` (tracks both the inline and block axis), `inline-size` (tracks only the inline axis) |
+| `container-name` | `none` (initial) or a space-separated list of `<custom-ident>`s an `@container` rule can name to target this container specifically |
+| `container` shorthand | `container: <name> / <type>` — expands to the two longhands above; the `/ <type>` half is optional and resets `container-type` to `normal` when omitted |
+| `@container <condition> { }` | Unnamed size query — applies against the nearest ancestor with `container-type: size` or `inline-size` |
+| `@container <name> <condition> { }` | Named size query — applies against the nearest ancestor whose own `container-name` includes `<name>` and whose `container-type` is `size`/`inline-size` |
+| `width`/`min-width`/`max-width`/`inline-size` (and the `min-`/`max-`/range-syntax forms) | Evaluated against the container's own resolved inline-axis size |
+| `height`/`min-height`/`max-height`/`block-size`, `aspect-ratio`, `orientation` | Evaluated against the container's own resolved block-axis size — **only meaningful against a `container-type: size` container**; against an `inline-size`-only container these never match (it tracks the inline axis only), regardless of the container's actual height |
+| `style(<property>: <value>)` | Matches when the nearest eligible ancestor query container's own resolved value for `<property>` equals `<value>`. Unlike size queries, **any** query container is eligible regardless of `container-type` — `container-type: normal` (the initial value, so effectively any element) still qualifies, since a style query needs no layout containment. `and`/`or`/`not` combine multiple `style()` feature checks; a combined operand needs its own parenthesized declaration (`style((--a: 1) and (--b: 2))`), matching `@supports`'s own grammar. Comparison is a trimmed, literal-text match against the container's resolved value — reliable for custom properties (values are opaque, author-controlled text) and for a standard property whose authored value already matches PeachPDF's own canonical serialization (e.g. keyword values like `style(display: block)`), but not full computed-value equivalence (`style(color: red)` won't match a container that resolves to `rgb(255, 0, 0)`) |
+| `cqw`, `cqi` | 1% of the nearest ancestor query container's own resolved inline-axis size |
+| `cqh`, `cqb` | 1% of the nearest ancestor query container's own resolved block-axis size (only meaningful against a `size` container — `0` against an `inline-size`-only one, which doesn't track that axis) |
+| `cqmin`, `cqmax` | The smaller/larger of `cqi` and `cqb` |
+| Container-relative unit with no eligible ancestor container | Resolves to `0` — the same documented fallback `vw`/`vh`/`vmin`/`vmax` already use (PeachPDF has no viewport-unit numerator to fall back to either) |
+| Container-relative unit in `font-size` (e.g. `font-size: 10cqw`) | Resolves to `0` for any element with text content — a font-caching order limitation, not the general no-ancestor-container fallback above; a real ancestor container is found, but its size isn't available yet at the point text content first resolves the font. Works only for the uncommon case of an element with no text content of its own |
 
 ---
 
@@ -1271,6 +1310,7 @@ PeachPDF supports [`calc()`](https://developer.mozilla.org/en-US/docs/Web/CSS/ca
 | Divide-by-zero / invalid category mixes (`calc(10px + 5)`, `calc(1px * 1px)`, `calc(10px + 5deg)`) | Rejected | The whole declaration is treated as invalid, the same as any other malformed CSS value |
 | Time and resolution units (`s`, `dpi`) inside a math function | Not supported | PeachPDF doesn't support these unit categories at all, with or without a math function |
 | Viewport units (`vw`/`vh`/`vmin`/`vmax`) inside a math function | Not supported | PeachPDF has no viewport-unit support anywhere |
+| Container-relative units (`cqw`/`cqi`/`cqb`/`cqmin`/`cqmax`) inside a math function | Full | Resolved against the nearest ancestor query container's own size, the same basis the plain (non-`calc()`) unit form uses — see [CSS Container Queries](#css-container-queries) |
 | A math function inside CSS Grid track sizing | Full | A `calc()`/`min()`/`max()`/`clamp()` length resolves as a grid track size — bare, and inside `minmax()`/`fit-content()`/`repeat()` arguments (a wrong-category math function, e.g. an angle, drops the whole track list at parse time) |
 | A math function for an `<integer>`-typed property (`z-index`, `order`, `widows`) | Full | Must type-check as a plain `<number>` (a length/percentage/angle-category expression is rejected); the result is rounded to the nearest integer, ties away from zero, and folded to a literal at parse time — the same as a `<number>`-typed property, calc() is resolved eagerly rather than kept symbolic, since an integer-category expression has no relative unit to defer to layout |
 
@@ -1367,4 +1407,4 @@ The following CSS features are not supported:
 - **`word-wrap` / `overflow-wrap`**
 - **`outline`** and `outline-*` properties
 - **CSS selectors** — see the [CSS Selectors](#css-selectors) section above for what is and is not supported
-- **Viewport units** (`vw`, `vh`, `vmin`, `vmax`) and container-relative units (`cqw`, `cqi`, etc.) — note responsive `@media` feature queries (`min-width`, `prefers-color-scheme`, …) **are** supported (see [CSS Media Queries](#css-media-queries)); it is the viewport/container length *units* that are not
+- **Viewport units** (`vw`, `vh`, `vmin`, `vmax`) — note responsive `@media` feature queries (`min-width`, `prefers-color-scheme`, …) **are** supported (see [CSS Media Queries](#css-media-queries)); it is the viewport length *units* that are not. Container-relative units (`cqw`/`cqi`/`cqb`/`cqmin`/`cqmax`) **are** now supported when resolved against a real ancestor query container (see [CSS Container Queries](#css-container-queries)); only the no-eligible-container fallback still resolves to `0` rather than falling through to a small-viewport unit, since PeachPDF has no viewport-unit numerator to fall back to either

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -6365,6 +6365,66 @@ await SaveShowcaseAsync("responsive_media_dark", "Responsive Design", "Dark Mode
         PreferredColorScheme = PdfColorScheme.Dark
     });
 
+// ── Responsive @container size queries ─────────────────────────────────────
+// Proves @container is NOT @media in a different name: one page, one stylesheet, one card
+// component - three containers of different declared widths, each a `container-type: inline-size`
+// query container. The @container (min-width: ...) breakpoint is evaluated against each container's
+// OWN resolved width, not the page's, so the identical .card markup lays out differently in each
+// one purely because of the width its own wrapper declares.
+const string containerQueryHtml = """
+    <!DOCTYPE html>
+    <html>
+    <head>
+    <style>
+      html, body { margin: 0; font-family: sans-serif; background: #ffffff; color: #1f2937; }
+      .wrap { padding: 28px; }
+      h1 { font-size: 20pt; margin: 0 0 6px; }
+      h1 code { background: #f3f4f6; padding: 2px 6px; border-radius: 5px; font-size: 15pt; }
+      p.lede { font-size: 10.5pt; color: #475569; margin: 0 0 20px; max-width: 640px; }
+      .container { container-type: inline-size; container-name: card-shelf; border: 1px dashed #94a3b8; border-radius: 10px; padding: 14px; margin-bottom: 18px; }
+      .container-label { font-size: 9pt; color: #64748b; margin: 0 0 10px; font-family: monospace; }
+      .card { display: flex; flex-direction: column; gap: 10px; background: #eff6ff; border: 1px solid #bfdbfe; border-radius: 10px; padding: 14px; }
+      .card .thumb { width: 100%; height: 40px; border-radius: 6px; background: linear-gradient(135deg, #60a5fa, #2563eb); flex: none; }
+      .card .card-text { display: flex; flex-direction: column; gap: 4px; }
+      .card h2 { margin: 0; font-size: 12pt; color: #1d4ed8; }
+      .card p { margin: 0; font-size: 9.5pt; line-height: 1.4; color: #475569; }
+      /* Applies once THIS container's own content-box width reaches 400px - independent of every
+         other .container on the page, and independent of the page width itself. */
+      @container card-shelf (min-width: 400px) {
+        .card { flex-direction: row; align-items: center; }
+        .card .thumb { width: 80px; height: 56px; }
+      }
+    </style>
+    </head>
+    <body>
+      <div class="wrap">
+        <h1>Responsive <code>@container</code></h1>
+        <p class="lede">The same <code>.card</code> component, unmodified, in three containers of different widths on one page. Each stacks or goes horizontal purely from its own container's width crossing <code>@container (min-width: 400px)</code> - not the page's.</p>
+        <div class="container" style="width: 220px;">
+          <p class="container-label">container-type: inline-size; width: 220px</p>
+          <div class="card"><div class="thumb"></div><div class="card-text"><h2>Stacked</h2><p>Narrower than 400px, so the card stays a column.</p></div></div>
+        </div>
+        <div class="container" style="width: 500px;">
+          <p class="container-label">container-type: inline-size; width: 500px</p>
+          <div class="card"><div class="thumb"></div><div class="card-text"><h2>Horizontal</h2><p>500px crosses the 400px breakpoint, so the same rule flips this card to a row.</p></div></div>
+        </div>
+        <div class="container" style="width: 320px;">
+          <p class="container-label">container-type: inline-size; width: 320px</p>
+          <div class="card"><div class="thumb"></div><div class="card-text"><h2>Stacked</h2><p>320px is still under 400px, so this one stays stacked too - despite being on the exact same page as the 500px one above.</p></div></div>
+        </div>
+      </div>
+    </body>
+    </html>
+    """;
+
+await SaveShowcaseAsync("container_queries", "Responsive Design", "Responsive @container (size queries)",
+    "Three `container-type: inline-size` containers of different declared widths on one page, all " +
+    "using the identical `.card` component. The `@container card-shelf (min-width: 400px)` rule " +
+    "applies independently per container - the 500px one flips to a horizontal layout while the " +
+    "220px and 320px ones stay stacked, proving the breakpoint reads each container's own resolved " +
+    "width rather than the page's.",
+    containerQueryHtml, new PdfGenerateConfig { PageSize = PageSize.A4 });
+
 // Color fonts (COLR/CPAL) rendered as vector content. The hero row is a subset of the real COLRv1
 // build of Noto Color Emoji; the feature breakdown uses a small hand-authored public-domain COLRv1
 // fixture whose glyphs isolate each paint feature.

--- a/src/PeachPDF.Tests/CSS/ConditionGroupingRuleIntegrationTests.cs
+++ b/src/PeachPDF.Tests/CSS/ConditionGroupingRuleIntegrationTests.cs
@@ -9,14 +9,19 @@ using PeachPDF.Svg;
 namespace PeachPDF.Tests.CSS;
 
 /// <summary>
-/// <c>@supports</c> and <c>@container</c> block handling. <c>@supports</c>'s condition is now genuinely
+/// <c>@supports</c> and <c>@container</c> block handling. <c>@supports</c>'s condition is genuinely
 /// evaluated (<see cref="CssData.IndexRules"/>/<see cref="CssData.FlattenRules"/> resolve
 /// <c>IConditionFunction.Check()</c> once, statically, since the condition takes no arguments and can't
 /// vary per query) against the actual set of HTML/SVG properties PeachPDF's renderer implements — see
 /// <see cref="PeachPDF.CSS.DeclarationCondition"/> and CLAUDE.md's "CSS/SVG property registry generator"
-/// section. <c>@container</c> still has no evaluatable condition (truthiness depends on the nearest
-/// matched element's own container size, which isn't known at parse time the way <c>@supports</c>'s is),
-/// so it's still ignored entirely — the inner rules are never indexed. Tracked at #284.
+/// section. <c>@container</c>'s condition is genuinely evaluated too, per-candidate-box, against the
+/// nearest ancestor <c>container-type: size</c>/<c>inline-size</c> element's resolved size — see
+/// <see cref="ContainerQueryMatcher"/> and <see cref="HtmlContainerInt.PerformLayout"/>'s convergence
+/// loop for how a layout-derived fact (size) feeds back into cascade. This file only covers the two
+/// tests that fit this class's narrow "does the block apply at all" shape (an established container
+/// matching, and no eligible container existing); the full feature (size features, named/unnamed
+/// queries, the convergence loop itself, <c>style()</c> queries) is
+/// <see cref="ContainerQueryLayoutIntegrationTests"/>.
 /// </summary>
 public class ConditionGroupingRuleIntegrationTests
 {
@@ -113,8 +118,22 @@ public class ConditionGroupingRuleIntegrationTests
     }
 
     [Fact]
-    public async Task Container_InnerRules_AreIgnored()
+    public async Task Container_InnerRules_Apply_WhenAnEligibleAncestorContainerMatches()
     {
+        var html = Html(
+            "#box { container-type: inline-size; width: 300px; } " +
+            "@container (min-width: 200px) { p { color: #0000ff; } }",
+            "<div id=\"box\"><p>text</p></div>");
+        var box = await FindBoxByTag(html, "p");
+        Assert.Equal(Blue, box.Color);
+    }
+
+    [Fact]
+    public async Task Container_InnerRules_DoNotApply_WhenNoAncestorEstablishesAQueryContainer()
+    {
+        // No ancestor declares container-type: size/inline-size - CSS Containment 3 §7.2's "unknown"
+        // query-container state, which is falsy for @container (unlike @media's permissive-on-missing-
+        // geometry stance for width/height - see ContainerQueryMatcher's remarks).
         var html = Html(
             "@container (min-width: 100px) { p { color: #0000ff; } }",
             "<p>text</p>");

--- a/src/PeachPDF.Tests/CSS/LengthTests.cs
+++ b/src/PeachPDF.Tests/CSS/LengthTests.cs
@@ -30,6 +30,12 @@ namespace PeachPDF.Tests.CSS
         [InlineData((int)Length.Unit.Vh, false)]
         [InlineData((int)Length.Unit.Vmin, false)]
         [InlineData((int)Length.Unit.Vmax, false)]
+        [InlineData((int)Length.Unit.Cqw, false)]
+        [InlineData((int)Length.Unit.Cqh, false)]
+        [InlineData((int)Length.Unit.Cqi, false)]
+        [InlineData((int)Length.Unit.Cqb, false)]
+        [InlineData((int)Length.Unit.Cqmin, false)]
+        [InlineData((int)Length.Unit.Cqmax, false)]
         public void IsAbsolute_And_IsRelative_MatchUnitCategory(int unitValue, bool expectedAbsolute)
         {
             var length = new Length(1f, (Length.Unit)unitValue);
@@ -53,6 +59,12 @@ namespace PeachPDF.Tests.CSS
         [InlineData((int)Length.Unit.Vh, "vh")]
         [InlineData((int)Length.Unit.Vmin, "vmin")]
         [InlineData((int)Length.Unit.Vmax, "vmax")]
+        [InlineData((int)Length.Unit.Cqw, "cqw")]
+        [InlineData((int)Length.Unit.Cqh, "cqh")]
+        [InlineData((int)Length.Unit.Cqi, "cqi")]
+        [InlineData((int)Length.Unit.Cqb, "cqb")]
+        [InlineData((int)Length.Unit.Cqmin, "cqmin")]
+        [InlineData((int)Length.Unit.Cqmax, "cqmax")]
         [InlineData((int)Length.Unit.Percent, "%")]
         [InlineData((int)Length.Unit.None, "")]
         public void UnitString_MatchesUnitName(int unitValue, string expected)
@@ -77,6 +89,12 @@ namespace PeachPDF.Tests.CSS
         [InlineData("vmax", (int)Length.Unit.Vmax)]
         [InlineData("vmin", (int)Length.Unit.Vmin)]
         [InlineData("vw", (int)Length.Unit.Vw)]
+        [InlineData("cqw", (int)Length.Unit.Cqw)]
+        [InlineData("cqh", (int)Length.Unit.Cqh)]
+        [InlineData("cqi", (int)Length.Unit.Cqi)]
+        [InlineData("cqb", (int)Length.Unit.Cqb)]
+        [InlineData("cqmin", (int)Length.Unit.Cqmin)]
+        [InlineData("cqmax", (int)Length.Unit.Cqmax)]
         [InlineData("%", (int)Length.Unit.Percent)]
         [InlineData("bogus", (int)Length.Unit.None)]
         public void GetUnit_ParsesKnownSuffixes(string suffix, int expectedValue)
@@ -171,6 +189,36 @@ namespace PeachPDF.Tests.CSS
             var length = new Length(50f, Length.Unit.Percent);
 
             Assert.Equal(100d, length.ToPixels(0, 0, 200));
+        }
+
+        [Theory]
+        [InlineData((int)Length.Unit.Cqw, 200d, 100d, 100d)]  // 50% of the 200pt container inline size
+        [InlineData((int)Length.Unit.Cqi, 200d, 100d, 100d)]  // same as cqw (inline axis, horizontal writing mode)
+        [InlineData((int)Length.Unit.Cqh, 100d, 200d, 100d)]  // 50% of the 200pt container block size
+        [InlineData((int)Length.Unit.Cqb, 100d, 200d, 100d)]  // same as cqh
+        [InlineData((int)Length.Unit.Cqmin, 300d, 100d, 50d)] // min(300,100) = 100 -> 50% = 50
+        [InlineData((int)Length.Unit.Cqmax, 300d, 100d, 150d)] // max(300,100) = 300 -> 50% = 150
+        public void ToPixels_ContainerRelativeUnit_UsesContainerSize(int unitValue, double inlinePt, double blockPt, double expected)
+        {
+            var length = new Length(50f, (Length.Unit)unitValue);
+
+            Assert.Equal(expected, length.ToPixels(0, 0, 0, inlinePt, blockPt));
+        }
+
+        [Theory]
+        [InlineData((int)Length.Unit.Cqw)]
+        [InlineData((int)Length.Unit.Cqh)]
+        [InlineData((int)Length.Unit.Cqi)]
+        [InlineData((int)Length.Unit.Cqb)]
+        [InlineData((int)Length.Unit.Cqmin)]
+        [InlineData((int)Length.Unit.Cqmax)]
+        public void ToPixels_ContainerRelativeUnit_WithNoAncestorContainer_ResolvesToZero(int unitValue)
+        {
+            // No container size supplied (both null) - the same documented-accepted 0 fallback vw/vh/
+            // vmin/vmax already use, since PeachPDF has no viewport-unit numerator to fall back to either.
+            var length = new Length(50f, (Length.Unit)unitValue);
+
+            Assert.Equal(0d, length.ToPixels(0, 0, 0));
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Html/Core/Dom/ComputedStyleTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/ComputedStyleTests.cs
@@ -295,12 +295,13 @@ namespace PeachPDF.Tests.Html.Core.Dom
         /// silently reintroducing a correctness bug) if a future area/property addition breaks the
         /// no-op assumption the fast path depends on.
         /// <para>
-        /// <c>direction</c>/<c>unicode-bidi</c>/<c>writing-mode</c> joined the exception set for the same
-        /// reason <c>grid-template-columns</c>/<c>-rows</c> are already here: all five are
-        /// <see cref="CSS.CssProperty{T}"/>-typed (a <see langword="sealed class"/> with no value equality),
-        /// so <c>CssProperty{T}.FromCssText</c> re-parsing the same initial-value string always produces a
-        /// new, reference-distinct instance even when the parsed value is identical - the cascade's
-        /// copy-on-write comparison has no way to see through that and always clones the area.
+        /// <c>direction</c>/<c>unicode-bidi</c>/<c>writing-mode</c>/<c>container-type</c> joined the
+        /// exception set for the same reason <c>grid-template-columns</c>/<c>-rows</c> are already here:
+        /// all six are <see cref="CSS.CssProperty{T}"/>-typed (a <see langword="sealed class"/> with no
+        /// value equality), so <c>CssProperty{T}.FromCssText</c> re-parsing the same initial-value
+        /// string always produces a new, reference-distinct instance even when the parsed value is
+        /// identical - the cascade's copy-on-write comparison has no way to see through that and always
+        /// clones the area.
         /// </para>
         /// </summary>
         [Fact]
@@ -314,6 +315,7 @@ namespace PeachPDF.Tests.Html.Core.Dom
                 PropertyNames.Direction,
                 PropertyNames.UnicodeBidirectional,
                 PropertyNames.WritingMode,
+                PropertyNames.ContainerType,
             };
             var parser = new CssValueParser(new PdfSharpAdapter());
             var unexpectedlyNotNoOp = new List<string>();

--- a/src/PeachPDF.Tests/Integration/ContainerQueryLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/ContainerQueryLayoutIntegrationTests.cs
@@ -1,0 +1,482 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Utils;
+using PeachPDF.PdfSharpCore.Drawing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// End-to-end coverage for <c>@container</c> size-query evaluation (issue #610). Each positive-match
+    /// case necessarily exercises <see cref="HtmlContainerInt.PerformLayout"/>'s convergence loop: pass 1
+    /// always starts with no container-size data (every <c>@container</c> condition false, matching the
+    /// pre-fix behavior), so a case that expects the gated rule to apply can only pass if the loop's
+    /// second pass - now armed with the first pass's resolved container size - actually re-cascades and
+    /// re-layouts. Mirrors <see cref="MediaQueryLayoutIntegrationTests"/>'s harness idiom (bare
+    /// <c>HtmlContainerInt</c> + <c>SetHtml</c>/<c>PerformLayout</c>, no <c>PdfGenerator</c>).
+    /// <c>style()</c> queries are covered separately once implemented (issue #610's follow-on).
+    /// </summary>
+    public class ContainerQueryLayoutIntegrationTests
+    {
+        private const string Blue = "rgb(0, 0, 255)";
+        private const string Red = "rgb(255, 0, 0)";
+
+        // ── container-type establishing (or not) a size query container ─────────
+
+        [Theory]
+        [InlineData("normal", false)]      // normal establishes no SIZE query container
+        [InlineData("size", true)]
+        [InlineData("inline-size", true)]
+        public async Task ContainerType_GatesWhetherASizeQueryContainerIsEstablished(string containerType, bool shouldApply)
+        {
+            var html = Html(
+                $"#box {{ container-type: {containerType}; width: 300px; }} " +
+                "p { color: #ff0000; } " +
+                "@container (min-width: 100px) { p { color: #0000ff; } }",
+                "<div id='box'><p>text</p></div>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(shouldApply ? Blue : Red, box.Color);
+        }
+
+        // ── the container shorthand (name / type) establishes the same container ─
+
+        [Fact]
+        public async Task ContainerShorthand_EstablishesTheSameQueryContainerAsTheLonghands()
+        {
+            var html = Html(
+                "#box { container: sidebar / inline-size; width: 300px; } " +
+                "p { color: #ff0000; } " +
+                "@container sidebar (min-width: 100px) { p { color: #0000ff; } }",
+                "<div id='box'><p>text</p></div>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(Blue, box.Color);
+        }
+
+        // ── cqw/cqh/cqi/cqb/cqmin/cqmax resolve against the nearest ancestor query container ─
+        // (independent of @container rules entirely - a single top-down layout pass, no convergence
+        // loop needed, since the container's own size is already known by the time its descendant's
+        // width is resolved - see CssValueParser.ParseLength's box-aware overload.)
+
+        [Theory]
+        [InlineData("width: 50cqw", 150d)]   // 50% of the 300px (225pt) container inline size
+        [InlineData("width: 50cqi", 150d)]
+        public async Task ContainerRelativeUnit_ResolvesAgainstTheNearestAncestorContainer(string declaration, double expectedPx)
+        {
+            var html = Html(
+                "#box { container-type: inline-size; width: 300px; } " +
+                $"#target {{ {declaration}; height: 10px; }}",
+                "<div id='box'><div id='target'></div></div>");
+
+            var root = await BuildRoot(html);
+            var target = DomUtils.GetBoxById(root, "target");
+            Assert.NotNull(target);
+            // ActualBoxSizingWidth is in points; 0.75pt per px (Length.PointsPerPx).
+            Assert.Equal(expectedPx * 0.75, target!.ActualBoxSizingWidth, 1);
+        }
+
+        [Fact]
+        public async Task ContainerRelativeUnit_WithNoAncestorContainer_ResolvesToZero()
+        {
+            var html = Html("#target { width: 50cqw; height: 10px; }", "<div id='target'></div>");
+
+            var root = await BuildRoot(html);
+            var target = DomUtils.GetBoxById(root, "target");
+            Assert.NotNull(target);
+            Assert.Equal(0d, target!.ActualBoxSizingWidth, 1);
+        }
+
+        [Fact]
+        public async Task ContainerRelativeUnit_ResolvesInsideCalc()
+        {
+            var html = Html(
+                "#box { container-type: inline-size; width: 300px; } " +
+                "#target { width: calc(50cqw + 10px); height: 10px; }",
+                "<div id='box'><div id='target'></div></div>");
+
+            var root = await BuildRoot(html);
+            var target = DomUtils.GetBoxById(root, "target");
+            Assert.NotNull(target);
+            // 50% of the 300px (225pt) container inline size (112.5pt) + 10px (7.5pt) = 120pt.
+            Assert.Equal(120d, target!.ActualBoxSizingWidth, 1);
+        }
+
+        // font-size threads the same container basis width/calc() do (DerivedStyle.ActualFont), but
+        // for a box with text content it never actually resolves against it - word-splitting reads
+        // ActualFont during cascade, before any layout pass has determined the ancestor container's
+        // size, and the resolved font is cached forever from that first (pre-layout) read. See
+        // .claude/accepted-gaps/font-size-container-relative-units-resolve-to-zero-for-text-content.md.
+        [Fact]
+        public async Task ContainerRelativeUnit_ForFontSize_ResolvesToZero_ForTextContent()
+        {
+            var html = Html(
+                "#box { container-type: inline-size; width: 300px; } " +
+                "#target { font-size: 10cqw; }",
+                "<div id='box'><p id='target'>text</p></div>");
+
+            var root = await BuildRoot(html);
+            var target = DomUtils.GetBoxById(root, "target");
+            Assert.NotNull(target);
+            Assert.Equal(0d, target!.ActualFont.Size, 1);
+        }
+
+        // ── width / min-width / max-width / inline-size against an inline-size container ─
+
+        [Theory]
+        [InlineData("(min-width: 200px)", true)]
+        [InlineData("(min-width: 400px)", false)]
+        [InlineData("(max-width: 400px)", true)]
+        [InlineData("(max-width: 200px)", false)]
+        [InlineData("(width >= 300px)", true)]
+        [InlineData("(inline-size >= 300px)", true)]
+        [InlineData("(inline-size >= 400px)", false)]
+        public async Task SizeFeature_MatchesAgainstTheInlineSizeContainersOwnWidth(string condition, bool shouldApply)
+        {
+            var html = Html(
+                "#box { container-type: inline-size; width: 300px; } " +
+                "p { color: #ff0000; } " +
+                "@container " + condition + " { p { color: #0000ff; } }",
+                "<div id='box'><p>text</p></div>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(shouldApply ? Blue : Red, box.Color);
+        }
+
+        // ── height / block-size / aspect-ratio / orientation against a `size` container ─
+
+        [Theory]
+        [InlineData("(min-height: 100px)", true)]
+        [InlineData("(min-height: 300px)", false)]
+        [InlineData("(block-size >= 200px)", true)]
+        [InlineData("(orientation: landscape)", true)]
+        [InlineData("(orientation: portrait)", false)]
+        [InlineData("(min-aspect-ratio: 1/1)", true)]
+        [InlineData("(min-aspect-ratio: 3/1)", false)]
+        public async Task SizeFeature_MatchesAgainstTheSizeContainersOwnHeight(string condition, bool shouldApply)
+        {
+            var html = Html(
+                "#box { container-type: size; width: 400px; height: 200px; } " +
+                "p { color: #ff0000; } " +
+                "@container " + condition + " { p { color: #0000ff; } }",
+                "<div id='box'><p>text</p></div>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(shouldApply ? Blue : Red, box.Color);
+        }
+
+        // The key axis-restriction regression test: an `inline-size` container tracks only the inline
+        // axis, so a block-axis condition must never match against it, however tall it actually is.
+        [Theory]
+        [InlineData("(min-height: 10px)")]
+        [InlineData("(block-size >= 10px)")]
+        [InlineData("(orientation: landscape)")]
+        [InlineData("(min-aspect-ratio: 1/100)")]
+        public async Task BlockAxisFeature_NeverMatchesAgainstAnInlineSizeOnlyContainer(string condition)
+        {
+            var html = Html(
+                "#box { container-type: inline-size; width: 400px; height: 200px; } " +
+                "p { color: #ff0000; } " +
+                "@container " + condition + " { p { color: #0000ff; } }",
+                "<div id='box'><p>text</p></div>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(Red, box.Color);
+        }
+
+        // ── named containers: nearest match wins, a non-matching name never applies ─
+
+        [Fact]
+        public async Task NamedQuery_MatchesTheNearestAncestorDeclaringThatName()
+        {
+            var html = Html(
+                "#outer { container-type: inline-size; container-name: outer; width: 500px; } " +
+                "#inner { container-type: inline-size; container-name: inner; width: 150px; } " +
+                "p { color: #ff0000; } " +
+                "@container inner (min-width: 100px) { p { color: #0000ff; } }",
+                "<div id='outer'><div id='inner'><p>text</p></div></div>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(Blue, box.Color);
+        }
+
+        [Fact]
+        public async Task NamedQuery_SkipsANearerAncestorThatDoesNotDeclareTheQueriedName()
+        {
+            // #inner (150px) doesn't satisfy 200px on its own, and the queried name "outer" must skip
+            // straight past #inner (which doesn't carry that name) to #outer (500px, satisfies 200px) -
+            // not fall back to whichever ancestor is nearest regardless of name.
+            var html = Html(
+                "#outer { container-type: inline-size; container-name: outer; width: 500px; } " +
+                "#inner { container-type: inline-size; container-name: inner; width: 150px; } " +
+                "p { color: #ff0000; } " +
+                "@container outer (min-width: 200px) { p { color: #0000ff; } }",
+                "<div id='outer'><div id='inner'><p>text</p></div></div>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(Blue, box.Color);
+        }
+
+        [Fact]
+        public async Task NamedQuery_DoesNotApply_WhenNoAncestorDeclaresThatName()
+        {
+            var html = Html(
+                "#box { container-type: inline-size; container-name: sidebar; width: 500px; } " +
+                "p { color: #ff0000; } " +
+                "@container nomatch (min-width: 100px) { p { color: #0000ff; } }",
+                "<div id='box'><p>text</p></div>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(Red, box.Color);
+        }
+
+        // ── container-name: none | <custom-ident>+ - `none` is only valid alone ─────
+
+        [Fact]
+        public async Task ContainerName_NoneCombinedWithOtherIdentifiers_IsRejected()
+        {
+            // "none outer" is not valid container-name syntax (CSS Containment 3 §2) - the whole
+            // declaration must be dropped, leaving #box's container-name at its initial "none"
+            // (unnamed), so a query for the name "outer" still never matches it.
+            var html = Html(
+                "#box { container-type: inline-size; container-name: none outer; width: 500px; } " +
+                "p { color: #ff0000; } " +
+                "@container outer (min-width: 100px) { p { color: #0000ff; } }",
+                "<div id='box'><p>text</p></div>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(Red, box.Color);
+        }
+
+        // ── no eligible ancestor at all → CSS Containment 3 §7.2's "unknown", which is falsy ─
+
+        [Fact]
+        public async Task Query_DoesNotApply_WhenNoAncestorEstablishesAQueryContainer()
+        {
+            var html = Html(
+                "p { color: #ff0000; } @container (min-width: 1px) { p { color: #0000ff; } }",
+                "<p>text</p>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(Red, box.Color);
+        }
+
+        // ── style() queries (CSS Containment 3 §7.3) ─────────────────────────────
+
+        [Fact]
+        public async Task StyleQuery_Matches_WhenTheNearestAncestorsCustomPropertyEqualsTheQueriedValue()
+        {
+            var html = Html(
+                "p { color: #ff0000; } @container style(--theme: dark) { p { color: #0000ff; } }",
+                "<div id='box' style='--theme: dark;'><p>text</p></div>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(Blue, box.Color);
+        }
+
+        [Fact]
+        public async Task StyleQuery_DoesNotMatch_WhenTheCustomPropertyHasADifferentValue()
+        {
+            var html = Html(
+                "p { color: #ff0000; } @container style(--theme: dark) { p { color: #0000ff; } }",
+                "<div id='box' style='--theme: light;'><p>text</p></div>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(Red, box.Color);
+        }
+
+        // The key eligibility-divergence regression test vs. size queries: container-type: normal (the
+        // property's own initial value) does NOT disqualify an element as a style-query container, only
+        // as a size-query one (BlockAxisFeature_NeverMatchesAgainstAnInlineSizeOnlyContainer's converse).
+        [Fact]
+        public async Task StyleQuery_Matches_AgainstAContainerTypeNormalAncestor()
+        {
+            var html = Html(
+                "#box { container-type: normal; --theme: dark; } " +
+                "p { color: #ff0000; } " +
+                "@container style(--theme: dark) { p { color: #0000ff; } }",
+                "<div id='box'><p>text</p></div>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(Blue, box.Color);
+        }
+
+        [Fact]
+        public async Task StyleQuery_MatchesAStandardProperty_NotOnlyCustomProperties()
+        {
+            var html = Html(
+                "#box { display: block; } " +
+                "p { color: #ff0000; } " +
+                "@container style(display: block) { p { color: #0000ff; } }",
+                "<div id='box'><p>text</p></div>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(Blue, box.Color);
+        }
+
+        [Theory]
+        [InlineData("(--a: 1) and (--b: 2)", "1", "2", true)]
+        [InlineData("(--a: 1) and (--b: 2)", "1", "9", false)]
+        [InlineData("(--a: 1) or (--b: 2)", "9", "2", true)]
+        [InlineData("(--a: 1) or (--b: 2)", "9", "9", false)]
+        [InlineData("not (--a: 9)", "1", "2", true)]
+        [InlineData("not (--a: 1)", "1", "2", false)]
+        public async Task StyleQuery_AndOrNotCombinators_EvaluateEndToEnd(string query, string aValue, string bValue, bool shouldApply)
+        {
+            var html = Html(
+                $"#box {{ --a: {aValue}; --b: {bValue}; }} " +
+                "p { color: #ff0000; } " +
+                "@container style(" + query + ") { p { color: #0000ff; } }",
+                "<div id='box'><p>text</p></div>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(shouldApply ? Blue : Red, box.Color);
+        }
+
+        [Fact]
+        public async Task StyleQuery_ThreeOperandAndChain_EvaluatesEndToEnd()
+        {
+            var html = Html(
+                "#box { --a: 1; --b: 2; --c: 3; } " +
+                "p { color: #ff0000; } " +
+                "@container style((--a: 1) and (--b: 2) and (--c: 3)) { p { color: #0000ff; } }",
+                "<div id='box'><p>text</p></div>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(Blue, box.Color);
+        }
+
+        [Fact]
+        public async Task StyleQuery_ThreeOperandAndChain_DoesNotApply_WhenTheThirdOperandFails()
+        {
+            var html = Html(
+                "#box { --a: 1; --b: 2; --c: 9; } " +
+                "p { color: #ff0000; } " +
+                "@container style((--a: 1) and (--b: 2) and (--c: 3)) { p { color: #0000ff; } }",
+                "<div id='box'><p>text</p></div>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(Red, box.Color);
+        }
+
+        [Fact]
+        public async Task StyleQuery_UnrecognizedLeafToken_NeverMatches()
+        {
+            // A malformed style() argument (starts with neither an ident, "not", nor "(") - the parser's
+            // fallback null-return path, exercised end-to-end rather than just at the parser-unit level.
+            var html = Html(
+                "p { color: #ff0000; } @container style(123) { p { color: #0000ff; } }",
+                "<p>text</p>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(Red, box.Color);
+        }
+
+        [Fact]
+        public async Task StyleQuery_NamedQuery_MatchesTheNearestAncestorDeclaringThatName()
+        {
+            var html = Html(
+                "#outer { container-name: outer; --theme: dark; } " +
+                "#inner { container-name: inner; --theme: light; } " +
+                "p { color: #ff0000; } " +
+                "@container inner style(--theme: light) { p { color: #0000ff; } }",
+                "<div id='outer'><div id='inner'><p>text</p></div></div>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(Blue, box.Color);
+        }
+
+        [Fact]
+        public async Task StyleQuery_DoesNotApply_WhenNoAncestorDeclaresTheQueriedName()
+        {
+            var html = Html(
+                "#box { container-name: sidebar; --theme: dark; } " +
+                "p { color: #ff0000; } " +
+                "@container nomatch style(--theme: dark) { p { color: #0000ff; } }",
+                "<div id='box'><p>text</p></div>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(Red, box.Color);
+        }
+
+        // The nested/chained convergence test: an outer size @container block sets a custom property on
+        // an inner element, whose own @container style(...) condition queries that same property. Pass 1
+        // (no size data) leaves the custom property unset, so the style query is false and the paragraph
+        // stays red - only a full re-cascade pass, armed with #sizebox's real resolved width, both sets
+        // the custom property AND re-evaluates the style query against it in the same pass, turning the
+        // paragraph blue. This is the one test that actually exercises the full-rebuild-per-pass design
+        // doing real cross-container work, not just a single-pass evaluation.
+        [Fact]
+        public async Task NestedContainerQueries_SizeGatedCustomPropertyFeedsAStyleQuery_ConvergesToTheCorrectAnswer()
+        {
+            var html = Html(
+                "#sizebox { container-type: inline-size; width: 300px; } " +
+                "p { color: #ff0000; } " +
+                "@container (min-width: 200px) { #stylebox { --theme: dark; } } " +
+                "@container style(--theme: dark) { p { color: #0000ff; } }",
+                "<div id='sizebox'><div id='stylebox'><p>text</p></div></div>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(Blue, box.Color);
+        }
+
+        // ── the convergence loop must be a genuine no-op when nothing gates on it ─
+
+        [Fact]
+        public async Task DocumentWithASizeContainerButNoContainerRule_RendersUnaffected()
+        {
+            // HasSizeContainers is true here (there IS a size container), so PerformLayout's loop does
+            // run its extra pass(es) - but with no @container rule anywhere, nothing should change.
+            var html = Html(
+                "#box { container-type: inline-size; width: 300px; } p { color: #ff0000; }",
+                "<div id='box'><p>text</p></div>");
+
+            var box = await FindByTag(html, "p");
+            Assert.Equal(Red, box.Color);
+        }
+
+        // ── prior behavior for a document with neither a size container nor a rule ─
+
+        [Fact]
+        public async Task DocumentWithNoContainerFeatureAtAll_RendersUnaffected()
+        {
+            var html = Html("p { color: #ff0000; }", "<p>text</p>");
+            var box = await FindByTag(html, "p");
+            Assert.Equal(Red, box.Color);
+        }
+
+        // ─── Harness ──────────────────────────────────────────────────────────
+
+        private static string Html(string css, string body) =>
+            $"<!DOCTYPE html><html><head><style>{css}</style></head><body>{body}</body></html>";
+
+        private static async Task<CssBox> FindByTag(string html, string tag)
+        {
+            var root = await BuildRoot(html);
+            var box = DomUtils.GetBoxByTagName(root, tag);
+            Assert.NotNull(box);
+            return box!;
+        }
+
+        private static async Task<CssBox> BuildRoot(string html)
+        {
+            var adapter = new PdfSharpAdapter { PixelsPerPoint = 1.0 };
+            var container = new HtmlContainerInt(adapter);
+
+            var size = new XSize(800, 600);
+            container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+            container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+            await container.SetHtml(html, null);
+
+            var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            return container.Root!;
+        }
+    }
+}

--- a/src/PeachPDF/CSS/Calc/CalcEvaluator.cs
+++ b/src/PeachPDF/CSS/Calc/CalcEvaluator.cs
@@ -10,12 +10,15 @@ namespace PeachPDF.CSS
     /// </summary>
     internal readonly struct CalcContext
     {
-        public CalcContext(double hundredPercent, double emFactor, double remFactor, bool returnPoints = false)
+        public CalcContext(double hundredPercent, double emFactor, double remFactor, bool returnPoints = false,
+            double? containerInlineSizePt = null, double? containerBlockSizePt = null)
         {
             HundredPercent = hundredPercent;
             EmFactor = emFactor;
             RemFactor = remFactor;
             ReturnPoints = returnPoints;
+            ContainerInlineSizePt = containerInlineSizePt;
+            ContainerBlockSizePt = containerBlockSizePt;
         }
 
         public double HundredPercent { get; }
@@ -28,11 +31,16 @@ namespace PeachPDF.CSS
         /// must bypass the normal pt-&gt;px factor rather than being converted into this already-points space.
         /// </summary>
         public bool ReturnPoints { get; }
+
+        /// <summary>See <see cref="Length.ToPixels"/>'s parameter of the same name - the nearest ancestor
+        /// query container's resolved size, for a <c>cqw</c>/<c>cqi</c>/<c>cqb</c>/etc. leaf inside calc().</summary>
+        public double? ContainerInlineSizePt { get; }
+        public double? ContainerBlockSizePt { get; }
     }
 
     /// <summary>
     /// Evaluates a validated calc-family AST to a pixel-space number. This is the one place calc()
-    /// numbers actually get computed — called only from Layer B (<see cref="PeachPDF.Html.Core.Parse.CssValueParser.ParseLength(string, double, double, double, string, bool)"/>),
+    /// numbers actually get computed — called only from Layer B (<see cref="PeachPDF.Html.Core.Parse.CssValueParser.ParseLength(string, double, double, double, string, bool, double?, double?)"/>),
     /// since only layout has the <see cref="CalcContext"/> a percentage/em/rem leaf needs to resolve.
     /// Reuses <see cref="Length.ToPixels"/> for every leaf, so no unit-conversion arithmetic is duplicated
     /// here. A null result signals a divide-by-zero; per the type-checker's rules every legal divisor is
@@ -53,7 +61,8 @@ namespace PeachPDF.CSS
 
                 case DimensionCalcNode dimension:
                     return new Length((float)dimension.Value, dimension.Unit)
-                        .ToPixels(context.EmFactor, context.RemFactor, context.HundredPercent);
+                        .ToPixels(context.EmFactor, context.RemFactor, context.HundredPercent,
+                            context.ContainerInlineSizePt, context.ContainerBlockSizePt);
 
                 case PercentageCalcNode percentage:
                     return new Length((float)percentage.Value, Length.Unit.Percent)

--- a/src/PeachPDF/CSS/Calc/CalcParser.cs
+++ b/src/PeachPDF/CSS/Calc/CalcParser.cs
@@ -236,7 +236,9 @@ namespace PeachPDF.CSS
         private static bool IsSupportedLengthUnit(Length.Unit unit)
         {
             return unit is Length.Unit.Em or Length.Unit.Rem or Length.Unit.Ex or Length.Unit.Px or
-                Length.Unit.Mm or Length.Unit.Cm or Length.Unit.In or Length.Unit.Pt or Length.Unit.Pc;
+                Length.Unit.Mm or Length.Unit.Cm or Length.Unit.In or Length.Unit.Pt or Length.Unit.Pc or
+                Length.Unit.Cqw or Length.Unit.Cqh or Length.Unit.Cqi or Length.Unit.Cqb or
+                Length.Unit.Cqmin or Length.Unit.Cqmax;
         }
 
         /// <summary>Whether <paramref name="name"/> is one of calc/min/max/clamp (case-insensitive).</summary>

--- a/src/PeachPDF/CSS/Calc/CalcSerializer.cs
+++ b/src/PeachPDF/CSS/Calc/CalcSerializer.cs
@@ -186,7 +186,14 @@ namespace PeachPDF.CSS
                     pixels = number.Value;
                     return true;
 
-                case DimensionCalcNode dimension when dimension.Unit is not (Length.Unit.Em or Length.Unit.Rem or Length.Unit.Ex):
+                // Container-relative units (like em/rem/ex) need layout context this Layer-A-only fold has
+                // none of - a `50cqw` leaf folded here with no container size in scope would permanently
+                // bake in 0 as the canonical CssText, losing the unit before layout ever gets a chance to
+                // resolve it against a real container (see CalcParser.IsSupportedLengthUnit, which accepts
+                // these units into calc() specifically so layout's own CalcEvaluator can resolve them).
+                case DimensionCalcNode dimension when dimension.Unit is not (Length.Unit.Em or Length.Unit.Rem or
+                    Length.Unit.Ex or Length.Unit.Cqw or Length.Unit.Cqh or Length.Unit.Cqi or Length.Unit.Cqb or
+                    Length.Unit.Cqmin or Length.Unit.Cqmax):
                     pixels = new Length((float)dimension.Value, dimension.Unit).ToPixels(0, 0, 0);
                     return true;
 

--- a/src/PeachPDF/CSS/Conditions/Style/IStyleQueryCondition.cs
+++ b/src/PeachPDF/CSS/Conditions/Style/IStyleQueryCondition.cs
@@ -1,0 +1,24 @@
+using PeachPDF.Html.Core.Dom;
+
+namespace PeachPDF.CSS
+{
+    /// <summary>
+    /// A parsed <c>@container style(...)</c> condition tree (CSS Containment 3 SS7). Structurally mirrors
+    /// <see cref="IConditionFunction"/>'s <c>and</c>/<c>or</c>/<c>not</c>/group grammar shape (the exact
+    /// one already implemented for <c>@supports</c> in <c>StylesheetComposer</c>'s
+    /// <c>ExtractCondition</c>/<c>AggregateCondition</c>/<c>MultipleConditions</c> - this file's parser
+    /// methods of the same "Style"-prefixed names mirror them token-for-token), but truthiness is
+    /// per-element rather than static - a style query's leaf compares the queried declaration against a
+    /// specific candidate query container's own resolved style, which <see cref="IConditionFunction.Check"/>'s
+    /// argument-free signature can't express. See <see cref="StyleDeclarationCondition"/> for the leaf,
+    /// and <see cref="StyleAndCondition"/>/<see cref="StyleOrCondition"/>/<see cref="StyleNotCondition"/>
+    /// for the boolean combinators. A parenthesized group needs no distinct wrapper type the way
+    /// <c>GroupCondition</c> exists for <c>@supports</c> - that type exists there only to round-trip
+    /// <c>ToCss</c> serialization, which a one-shot-evaluated style query never needs; the parser simply
+    /// returns the inner parsed condition for a <c>(...)</c> group.
+    /// </summary>
+    internal interface IStyleQueryCondition
+    {
+        bool Check(CssBox container);
+    }
+}

--- a/src/PeachPDF/CSS/Conditions/Style/StyleAndCondition.cs
+++ b/src/PeachPDF/CSS/Conditions/Style/StyleAndCondition.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Linq;
+using PeachPDF.Html.Core.Dom;
+
+namespace PeachPDF.CSS
+{
+    internal sealed class StyleAndCondition : IStyleQueryCondition
+    {
+        private readonly List<IStyleQueryCondition> _conditions;
+
+        internal StyleAndCondition(List<IStyleQueryCondition> conditions)
+        {
+            _conditions = conditions;
+        }
+
+        public bool Check(CssBox container) => _conditions.All(condition => condition.Check(container));
+    }
+}

--- a/src/PeachPDF/CSS/Conditions/Style/StyleDeclarationCondition.cs
+++ b/src/PeachPDF/CSS/Conditions/Style/StyleDeclarationCondition.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Utils;
+
+namespace PeachPDF.CSS
+{
+    /// <summary>
+    /// A single <c>style(&lt;property&gt;: &lt;value&gt;)</c> leaf (CSS Containment 3 SS7.3): true when
+    /// the candidate query container's own resolved value for the queried property equals the queried
+    /// value. A custom property (<c>--foo</c>) is looked up in the container's own
+    /// <see cref="CssBox.CustomProperties"/> dictionary (the same one <c>var()</c> resolution reads); a
+    /// standard property goes through <see cref="CssUtils.GetPropertyValue"/> - the same registry-backed
+    /// dispatch the cascade itself uses - to read the container's already-cascaded value.
+    /// </summary>
+    /// <remarks>
+    /// Comparison is a trimmed, ordinal string match against the authored query value text, not full
+    /// computed-value equivalence (e.g. <c>style(color: red)</c> won't match a container whose resolved
+    /// <c>color</c> serializes as <c>rgb(255, 0, 0)</c>, since the two sides are never normalized through
+    /// the same value pipeline before comparing) - a documented, narrower-than-spec simplification. It
+    /// still gets the common cases right: any custom-property comparison (values are opaque, author-
+    /// controlled text with no separate "computed" serialization to diverge from) and a standard-property
+    /// comparison whose authored value already matches the engine's own canonical form (e.g. keyword
+    /// values like <c>style(display: block)</c>).
+    /// </remarks>
+    internal sealed class StyleDeclarationCondition : IStyleQueryCondition
+    {
+        private readonly string _propertyName;
+        private readonly string _value;
+
+        internal StyleDeclarationCondition(string propertyName, string value)
+        {
+            _propertyName = propertyName;
+            _value = value.Trim();
+        }
+
+        public bool Check(CssBox container)
+        {
+            var actual = _propertyName.StartsWith("--", StringComparison.Ordinal)
+                ? container.CustomProperties?.GetValueOrDefault(_propertyName)
+                : CssUtils.GetPropertyValue(container, _propertyName);
+
+            return actual is not null && string.Equals(actual.Trim(), _value, StringComparison.Ordinal);
+        }
+    }
+}

--- a/src/PeachPDF/CSS/Conditions/Style/StyleNotCondition.cs
+++ b/src/PeachPDF/CSS/Conditions/Style/StyleNotCondition.cs
@@ -1,0 +1,16 @@
+using PeachPDF.Html.Core.Dom;
+
+namespace PeachPDF.CSS
+{
+    internal sealed class StyleNotCondition : IStyleQueryCondition
+    {
+        private readonly IStyleQueryCondition _content;
+
+        internal StyleNotCondition(IStyleQueryCondition content)
+        {
+            _content = content;
+        }
+
+        public bool Check(CssBox container) => !_content.Check(container);
+    }
+}

--- a/src/PeachPDF/CSS/Conditions/Style/StyleOrCondition.cs
+++ b/src/PeachPDF/CSS/Conditions/Style/StyleOrCondition.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Linq;
+using PeachPDF.Html.Core.Dom;
+
+namespace PeachPDF.CSS
+{
+    internal sealed class StyleOrCondition : IStyleQueryCondition
+    {
+        private readonly List<IStyleQueryCondition> _conditions;
+
+        internal StyleOrCondition(List<IStyleQueryCondition> conditions)
+        {
+            _conditions = conditions;
+        }
+
+        public bool Check(CssBox container) => _conditions.Any(condition => condition.Check(container));
+    }
+}

--- a/src/PeachPDF/CSS/Enumerations/FunctionNames.cs
+++ b/src/PeachPDF/CSS/Enumerations/FunctionNames.cs
@@ -71,5 +71,6 @@ namespace PeachPDF.CSS
         public static readonly string ImageSet = "image-set";
         public static readonly string CrossFade = "cross-fade";
         public static readonly string Element = "element";
+        public static readonly string Style = "style";
     }
 }

--- a/src/PeachPDF/CSS/Enumerations/PropertyNames.cs
+++ b/src/PeachPDF/CSS/Enumerations/PropertyNames.cs
@@ -92,6 +92,7 @@ namespace PeachPDF.CSS
         public static readonly string ClipRule = "clip-rule";
         public static readonly string Color = "color";
         public static readonly string ColorInterpolationFilters = "color-interpolation-filters";
+        public static readonly string Container = "container";
         public static readonly string ContainerName = "container-name";
         public static readonly string ContainerType = "container-type";
         public static readonly string Content = "content";

--- a/src/PeachPDF/CSS/Enumerations/UnitNames.cs
+++ b/src/PeachPDF/CSS/Enumerations/UnitNames.cs
@@ -28,5 +28,11 @@ namespace PeachPDF.CSS
         public static readonly string Rem = "rem";
         public static readonly string Pc = "pc";
         public static readonly string Percent = "%";
+        public static readonly string Cqw = "cqw";
+        public static readonly string Cqh = "cqh";
+        public static readonly string Cqi = "cqi";
+        public static readonly string Cqb = "cqb";
+        public static readonly string Cqmin = "cqmin";
+        public static readonly string Cqmax = "cqmax";
     }
 }

--- a/src/PeachPDF/CSS/Factories/PropertyFactory.cs
+++ b/src/PeachPDF/CSS/Factories/PropertyFactory.cs
@@ -241,6 +241,8 @@ namespace PeachPDF.CSS
             AddLonghand(PropertyNames.Clear, () => new ClearProperty());
             AddLonghand(PropertyNames.Clip, () => new ClipProperty(), true);
             AddLonghand(PropertyNames.Color, () => new ColorProperty(), true);
+            AddShorthand(PropertyNames.Container, () => new ContainerProperty(),
+                PropertyNames.ContainerName, PropertyNames.ContainerType);
             AddLonghand(PropertyNames.ContainerName, () => new ContainerNameProperty());
             AddLonghand(PropertyNames.ContainerType, () => new ContainerTypeProperty());
             AddLonghand(PropertyNames.Content, () => new ContentProperty());

--- a/src/PeachPDF/CSS/Model/Converters.cs
+++ b/src/PeachPDF/CSS/Model/Converters.cs
@@ -307,6 +307,7 @@ namespace PeachPDF.CSS
         public static readonly IValueConverter FloatingConverter = Map.FloatingModes.ToConverter();
         public static readonly IValueConverter DisplayModeConverter = Map.DisplayModes.ToConverter();
         public static readonly IValueConverter ContainerTypeConverter = Map.ContainerTypes.ToConverter();
+        public static readonly IValueConverter ContainerShorthandConverter = new ContainerShorthandConverter();
         public static readonly IValueConverter ClearModeConverter = Map.ClearModes.ToConverter();
         public static readonly IValueConverter FontStretchConverter = Map.FontStretches.ToConverter();
         // "oblique" alone matches via the plain keyword map (tried first); "oblique <angle>" (CSS Fonts

--- a/src/PeachPDF/CSS/Parser/StylesheetComposer.cs
+++ b/src/PeachPDF/CSS/Parser/StylesheetComposer.cs
@@ -289,8 +289,37 @@ namespace PeachPDF.CSS
             ParseComments(ref token);
             rule.Name = GetRuleName(ref token);
             ParseComments(ref token);
-            FillMediaList(rule.Media, TokenType.CurlyBracketOpen, ref token);
-            ParseComments(ref token);
+
+            // A style() condition (CSS Containment 3 SS7.3) replaces the ordinary size-feature MediaList
+            // grammar entirely for this rule - the two forms are mutually exclusive per rule, a v1
+            // simplification against the spec's single shared <container-condition> grammar (which in
+            // principle lets a top-level and/or mix style() and size-feature alternatives). See
+            // ContainerQueryMatcher's remarks.
+            //
+            // Unlike @supports's bare `(...)` condition grouping (RoundBracketOpen, walked live off the
+            // shared lexer stream via NextToken() - see ExtractCondition), `style(...)` is an actual
+            // function call: the lexer already tokenizes its entire argument list into one self-contained
+            // FunctionToken (see FunctionToken.ArgumentTokens) before ever returning it, so a NextToken()
+            // call here would skip straight past the whole function to whatever follows it (the rule's
+            // `{`), not step into its contents. The style-query grammar below is therefore parsed from
+            // that already-materialized token list with its own local index cursor, not from the shared
+            // lexer/NextToken() state ExtractCondition's family relies on.
+            if (token.Type == TokenType.Function && token.Data.Isi(FunctionNames.Style) && token is FunctionToken styleFunction)
+            {
+                // Not .ToList() - ValueExtensions.ToList(this IEnumerable<Token>) is a comma-splitting
+                // helper (List<List<Token>>) that shadows System.Linq's for this exact parameter type.
+                var styleTokens = new List<Token>(styleFunction.ArgumentTokens);
+                var styleIndex = 0;
+                rule.StyleCondition = AggregateStyleCondition(styleTokens, ref styleIndex);
+
+                token = NextToken();
+                ParseComments(ref token);
+            }
+            else
+            {
+                FillMediaList(rule.Media, TokenType.CurlyBracketOpen, ref token);
+                ParseComments(ref token);
+            }
 
             if (token.Type != TokenType.CurlyBracketOpen)
                 while (token.Type != TokenType.EndOfFile)
@@ -1347,6 +1376,126 @@ namespace PeachPDF.CSS
 
                 token = NextToken();
                 ParseComments(ref token);
+            }
+
+            return list;
+        }
+
+        // ── @container style(...) (CSS Containment 3 SS7.3) ─────────────────────────────────
+        //
+        // Mirrors AggregateCondition/ExtractCondition/MultipleConditions above token-for-token, but
+        // produces an IStyleQueryCondition tree (per-candidate-box Check(CssBox), not IConditionFunction's
+        // argument-free Check()). Per <style-query>'s grammar, <style-feature> = ( <declaration> ) - a
+        // combined operand needs its own parens exactly like @supports's <declaration> leaf does
+        // (style((--a: 1) and (--b: 2))) - but style()'s own outer parens already supply that grouping
+        // for the single/unparenthesized-combinator-free form (style(--a: 1)), so ExtractStyleCondition
+        // additionally accepts a bare declaration starting directly on an Ident token, which
+        // ExtractCondition (@supports) never does.
+
+        // The style()-argument token list has no meaningful EndOfFile token of its own (FunctionToken.
+        // ArgumentTokens strips the trailing RoundBracketClose), so "no more tokens" is simply
+        // index >= tokens.Count throughout this family, mirroring how the live-stream methods above
+        // check token.Type == TokenType.EndOfFile.
+        private static void SkipStyleWhitespace(List<Token> tokens, ref int index)
+        {
+            while (index < tokens.Count && tokens[index].Type is TokenType.Whitespace or TokenType.Comment)
+                index++;
+        }
+
+        private IStyleQueryCondition AggregateStyleCondition(List<Token> tokens, ref int index)
+        {
+            var condition = ExtractStyleCondition(tokens, ref index);
+
+            if (condition == null) return null;
+
+            SkipStyleWhitespace(tokens, ref index);
+            if (index >= tokens.Count) return condition;
+
+            var conjunction = tokens[index].Data;
+
+            if (conjunction.Isi(Keywords.And) || conjunction.Isi(Keywords.Or))
+            {
+                index++;
+                SkipStyleWhitespace(tokens, ref index);
+                var conditions = MultipleStyleConditions(tokens, ref index, condition, conjunction);
+                condition = conjunction.Isi(Keywords.And)
+                    ? new StyleAndCondition(conditions)
+                    : new StyleOrCondition(conditions);
+            }
+
+            return condition;
+        }
+
+        private IStyleQueryCondition ExtractStyleCondition(List<Token> tokens, ref int index)
+        {
+            if (index >= tokens.Count) return null;
+            var token = tokens[index];
+
+            if (token.Type == TokenType.RoundBracketOpen)
+            {
+                index++;
+                SkipStyleWhitespace(tokens, ref index);
+                var condition = AggregateStyleCondition(tokens, ref index);
+
+                SkipStyleWhitespace(tokens, ref index);
+                if (index < tokens.Count && tokens[index].Type == TokenType.RoundBracketClose) index++;
+
+                return condition;
+            }
+
+            if (token.Data.Isi(Keywords.Not))
+            {
+                index++;
+                SkipStyleWhitespace(tokens, ref index);
+                return new StyleNotCondition(ExtractStyleCondition(tokens, ref index));
+            }
+
+            if (token.Type == TokenType.Ident)
+            {
+                return ExtractStyleDeclaration(tokens, ref index);
+            }
+
+            return null;
+        }
+
+        private IStyleQueryCondition ExtractStyleDeclaration(List<Token> tokens, ref int index)
+        {
+            var propertyName = tokens[index].Data;
+            index++;
+            SkipStyleWhitespace(tokens, ref index);
+
+            if (index >= tokens.Count || tokens[index].Type != TokenType.Colon) return null;
+            index++;
+            SkipStyleWhitespace(tokens, ref index);
+
+            var valueTokens = new List<Token>();
+            while (index < tokens.Count && tokens[index].Type != TokenType.RoundBracketClose)
+            {
+                valueTokens.Add(tokens[index]);
+                index++;
+            }
+
+            var value = new TokenValue(valueTokens).Text;
+            return new StyleDeclarationCondition(propertyName, value);
+        }
+
+        private List<IStyleQueryCondition> MultipleStyleConditions(List<Token> tokens, ref int index, IStyleQueryCondition condition, string connector)
+        {
+            var list = new List<IStyleQueryCondition> { condition };
+
+            while (index < tokens.Count)
+            {
+                condition = ExtractStyleCondition(tokens, ref index);
+
+                if (condition == null) break;
+
+                list.Add(condition);
+
+                SkipStyleWhitespace(tokens, ref index);
+                if (index >= tokens.Count || !tokens[index].Data.Isi(connector)) break;
+
+                index++;
+                SkipStyleWhitespace(tokens, ref index);
             }
 
             return list;

--- a/src/PeachPDF/CSS/Rules/ContainerRule.cs
+++ b/src/PeachPDF/CSS/Rules/ContainerRule.cs
@@ -25,9 +25,16 @@ namespace PeachPDF.CSS
 
         public string Name { get; set; }
 
+        public IStyleQueryCondition StyleCondition { get; set; }
+
         public string ConditionText
         {
-            get => Media.MediaText;
+            // A style() condition has no MediaList content (Media stays empty) - StylesheetComposer.
+            // CreateContainer parses it into StyleCondition instead, so ToCss falls back to a fixed
+            // placeholder rather than reconstructing the original style() text (this rule's condition
+            // tree isn't retained in a serializable form - a known simplification, since re-serializing
+            // a style() query is not needed by anything layout/evaluation-side reads).
+            get => StyleCondition is not null ? "style(...)" : Media.MediaText;
             set => Media.MediaText = value;
         }
     }

--- a/src/PeachPDF/CSS/Rules/IContainer.cs
+++ b/src/PeachPDF/CSS/Rules/IContainer.cs
@@ -4,5 +4,14 @@ namespace PeachPDF.CSS
     {
         string Name { get; set; }
         MediaList Media { get; }
+
+        /// <summary>
+        /// The parsed <c>style(...)</c> condition tree (CSS Containment 3 SS7.3), when this rule's
+        /// condition is a style query rather than a size-feature one - exactly one of this and
+        /// <see cref="Media"/>'s own feature content is meaningful for a given rule (see
+        /// <c>StylesheetComposer.CreateContainer</c>'s <c>style(</c> detection). <c>null</c> for an
+        /// ordinary size-feature <c>@container</c> condition.
+        /// </summary>
+        IStyleQueryCondition StyleCondition { get; set; }
     }
 }

--- a/src/PeachPDF/CSS/StyleProperties/Container/ContainerNameProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Container/ContainerNameProperty.cs
@@ -1,9 +1,23 @@
-﻿namespace PeachPDF.CSS
+﻿#nullable disable
+
+using System;
+using System.Collections.Generic;
+
+namespace PeachPDF.CSS
 {
+    /// <summary>
+    /// <c>container-name: none | &lt;custom-ident&gt;+</c> (CSS Containment 3 §2) - a space-separated
+    /// list of bare identifiers, NOT a quoted CSS &lt;string&gt;. <see cref="Converters.LiteralsConverter"/>
+    /// (the same converter <c>font-family</c>'s unquoted form uses to accept consecutive Ident tokens
+    /// joined by whitespace) already accepts exactly this shape, including the single-token "none" case
+    /// - but its shared grammar doesn't know <c>none</c> is only valid alone here (unlike font-family's
+    /// own identifier list, which has no such restriction), so that's enforced with a thin wrapper
+    /// instead of forking a second copy of the identifier-list walk.
+    /// </summary>
     internal sealed class ContainerNameProperty : Property
     {
         private static readonly IValueConverter StyleConverter =
-            Converters.StringConverter.OrDefault();
+            new IdentifierValueConverter(ToContainerNameList).OrDefault();
 
         internal ContainerNameProperty()
             : base(PropertyNames.ContainerName)
@@ -11,5 +25,14 @@
         }
 
         internal override IValueConverter Converter => StyleConverter;
+
+        private static string ToContainerNameList(IEnumerable<Token> value)
+        {
+            var literals = ValueExtensions.ToLiterals(value);
+            if (literals is null) return null;
+
+            var parts = literals.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            return parts.Length > 1 && Array.IndexOf(parts, Keywords.None) >= 0 ? null : literals;
+        }
     }
 }

--- a/src/PeachPDF/CSS/StyleProperties/Container/ContainerProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Container/ContainerProperty.cs
@@ -1,0 +1,15 @@
+namespace PeachPDF.CSS
+{
+    /// <summary>The <c>container</c> shorthand (CSS Containment 3 SS2): <c>&lt;'container-name'&gt; [ / &lt;'container-type'&gt; ]?</c>.</summary>
+    internal sealed class ContainerProperty : ShorthandProperty
+    {
+        private static readonly IValueConverter StyleConverter = Converters.ContainerShorthandConverter.OrDefault();
+
+        internal ContainerProperty()
+            : base(PropertyNames.Container)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/PeachPDF/CSS/ValueConverters/ContainerShorthandConverter.cs
+++ b/src/PeachPDF/CSS/ValueConverters/ContainerShorthandConverter.cs
@@ -1,0 +1,94 @@
+#nullable disable
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PeachPDF.CSS
+{
+    /// <summary>
+    /// The <c>container</c> shorthand (CSS Containment 3 SS2):
+    /// <c>&lt;'container-name'&gt; [ / &lt;'container-type'&gt; ]?</c>. Mirrors
+    /// <see cref="BorderRadiusConverter"/>'s slash-splitting shape, simplified for two non-periodic,
+    /// heterogeneously-typed fields rather than four periodic same-typed corners - container-name uses
+    /// <see cref="Converters.LiteralsConverter"/> (the same bare-identifier-list acceptance
+    /// <see cref="ContainerNameProperty"/> already uses standalone) and container-type uses
+    /// <see cref="Converters.ContainerTypeConverter"/>. An omitted type resets to its initial value
+    /// (<c>normal</c>) via <see cref="ShorthandProperty.Export"/>'s existing empty-TokenValue handling.
+    /// </summary>
+    internal sealed class ContainerShorthandConverter : IValueConverter
+    {
+        public IPropertyValue Convert(IEnumerable<Token> value)
+        {
+            var front = new List<Token>();
+            var back = new List<Token>();
+            var current = front;
+
+            foreach (var token in value)
+            {
+                if (token.Type == TokenType.Delim && token.Data.Is("/"))
+                {
+                    if (current == back) return null;
+                    current = back;
+                }
+                else
+                {
+                    current.Add(token);
+                }
+            }
+
+            var name = Converters.LiteralsConverter.Convert(front);
+            if (name == null) return null;
+
+            var hasType = current == back;
+            var type = hasType ? Converters.ContainerTypeConverter.Convert(back) : null;
+            if (hasType && type == null) return null;
+
+            return new ContainerShorthandValue(name, type, new TokenValue(value));
+        }
+
+        public IPropertyValue Construct(Property[] properties)
+        {
+            if (properties.Length != 2) return null;
+
+            var nameProperty = properties.FirstOrDefault(p => p.Name.Is(PropertyNames.ContainerName));
+            var typeProperty = properties.FirstOrDefault(p => p.Name.Is(PropertyNames.ContainerType));
+            if (nameProperty?.DeclaredValue is not { } nameValue || typeProperty?.DeclaredValue is not { } typeValue)
+                return null;
+
+            var name = Converters.LiteralsConverter.Convert(nameValue.Original);
+            var type = Converters.ContainerTypeConverter.Convert(typeValue.Original);
+            if (name == null || type == null) return null;
+
+            var original = new TokenValue(nameValue.Original
+                .Concat([new Token(TokenType.Delim, "/", TextPosition.Empty)])
+                .Concat(typeValue.Original));
+
+            return new ContainerShorthandValue(name, type, original);
+        }
+
+        private sealed class ContainerShorthandValue : IPropertyValue
+        {
+            private readonly IPropertyValue _name;
+            private readonly IPropertyValue _type;
+
+            public ContainerShorthandValue(IPropertyValue name, IPropertyValue type, TokenValue original)
+            {
+                _name = name;
+                _type = type;
+                Original = original;
+            }
+
+            public string CssText =>
+                _type is null ? _name.CssText : string.Concat(_name.CssText, " / ", _type.CssText);
+
+            public TokenValue Original { get; }
+
+            public TokenValue ExtractFor(string name)
+            {
+                if (name.Is(PropertyNames.ContainerName)) return _name.Original;
+                if (name.Is(PropertyNames.ContainerType)) return _type?.Original ?? TokenValue.Empty;
+                return TokenValue.Empty;
+            }
+        }
+    }
+}

--- a/src/PeachPDF/CSS/Values/Length.cs
+++ b/src/PeachPDF/CSS/Values/Length.cs
@@ -120,6 +120,18 @@ namespace PeachPDF.CSS
                         return UnitNames.Vmax;
                     case Unit.Percent:
                         return UnitNames.Percent;
+                    case Unit.Cqw:
+                        return UnitNames.Cqw;
+                    case Unit.Cqh:
+                        return UnitNames.Cqh;
+                    case Unit.Cqi:
+                        return UnitNames.Cqi;
+                    case Unit.Cqb:
+                        return UnitNames.Cqb;
+                    case Unit.Cqmin:
+                        return UnitNames.Cqmin;
+                    case Unit.Cqmax:
+                        return UnitNames.Cqmax;
                     default:
                         return string.Empty;
                 }
@@ -217,6 +229,12 @@ namespace PeachPDF.CSS
                 "vmax" => Unit.Vmax,
                 "vmin" => Unit.Vmin,
                 "vw" => Unit.Vw,
+                "cqw" => Unit.Cqw,
+                "cqh" => Unit.Cqh,
+                "cqi" => Unit.Cqi,
+                "cqb" => Unit.Cqb,
+                "cqmin" => Unit.Cqmin,
+                "cqmax" => Unit.Cqmax,
                 "%" => Unit.Percent,
                 _ => Unit.None
             };
@@ -239,7 +257,18 @@ namespace PeachPDF.CSS
         /// <param name="emFactor">Pixels per 1em, i.e. the relevant font size in pixels.</param>
         /// <param name="remFactor">Pixels per 1rem, i.e. the root element's font size in pixels.</param>
         /// <param name="hundredPercent">The pixel value equivalent to 100%.</param>
-        internal double ToPixels(double emFactor, double remFactor, double hundredPercent)
+        /// <param name="containerInlineSizePt">The nearest ancestor query container's own resolved
+        /// inline-axis (width) size in points, for <c>cqw</c>/<c>cqi</c>/<c>cqmin</c>/<c>cqmax</c> -
+        /// <c>null</c> when there is no eligible ancestor container (see
+        /// <see cref="Html.Core.Dom.CssBox.FindNearestQueryContainer"/>), which resolves those units to 0
+        /// (the same documented-accepted fallback <c>vw</c>/<c>vh</c>/<c>vmin</c>/<c>vmax</c> already
+        /// use).</param>
+        /// <param name="containerBlockSizePt">The nearest ancestor query container's own resolved
+        /// block-axis (height) size in points, for <c>cqh</c>/<c>cqb</c>/<c>cqmin</c>/<c>cqmax</c> -
+        /// <c>null</c> with no eligible container, or when the eligible container is
+        /// <c>inline-size</c>-only (it doesn't track the block axis either).</param>
+        internal double ToPixels(double emFactor, double remFactor, double hundredPercent,
+            double? containerInlineSizePt = null, double? containerBlockSizePt = null)
         {
             // The engine's internal layout unit is 1 point (PixelsPerInch defaults to 72), so
             // physical units (in/cm/mm/pc/pt) resolve directly against points. CSS px resolves
@@ -262,6 +291,10 @@ namespace PeachPDF.CSS
                 Unit.Cm => // 1 cm = 72/2.54 pt
                     (72d / 2.54d) * Value,
                 Unit.Percent => hundredPercent / 100d * Value,
+                Unit.Cqw or Unit.Cqi => (containerInlineSizePt ?? 0d) / 100d * Value,
+                Unit.Cqh or Unit.Cqb => (containerBlockSizePt ?? 0d) / 100d * Value,
+                Unit.Cqmin => Math.Min(containerInlineSizePt ?? 0d, containerBlockSizePt ?? 0d) / 100d * Value,
+                Unit.Cqmax => Math.Max(containerInlineSizePt ?? 0d, containerBlockSizePt ?? 0d) / 100d * Value,
                 _ => 0d
             };
         }
@@ -310,7 +343,18 @@ namespace PeachPDF.CSS
             Vh,
             Vmin,
             Vmax,
-            Percent
+            Percent,
+            // CSS Containment 3 §6.2 container-relative units. Resolved against the nearest ancestor
+            // query container's own content-box size (CssBox.FindNearestQueryContainer) - see ToPixels'
+            // containerInlineSizePt/containerBlockSizePt parameters. With no eligible ancestor container,
+            // these fall through to 0 in ToPixels, the same documented-accepted fallback vw/vh/vmin/vmax
+            // already use (PeachPDF has no small-viewport-unit numerator to fall back to either).
+            Cqw,
+            Cqh,
+            Cqi,
+            Cqb,
+            Cqmin,
+            Cqmax
         }
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/ContainerQueryContext.cs
+++ b/src/PeachPDF/Html/Core/ContainerQueryContext.cs
@@ -1,0 +1,22 @@
+#nullable enable
+
+namespace PeachPDF.Html.Core
+{
+    /// <summary>
+    /// One eligible <c>@container</c> query container's resolved size geometry for the current layout
+    /// pass - the per-container analogue of <see cref="MediaQueryContext"/>'s single, page-wide context.
+    /// Built by <see cref="HtmlContainerInt"/> after each layout pass (see
+    /// <see cref="ContainerQuerySizes"/>) for every box whose resolved <c>container-type</c> is
+    /// <c>size</c> or <c>inline-size</c>.
+    /// </summary>
+    /// <param name="InlineSizePt">The container's resolved inline-axis (width, in a horizontal writing
+    /// mode) size in points.</param>
+    /// <param name="BlockSizePt">The container's resolved block-axis (height) size in points, or
+    /// <c>null</c> when the container is <c>inline-size</c>-only - it does not track the block axis, so
+    /// <c>height</c>/<c>block-size</c>/<c>aspect-ratio</c>/<c>orientation</c> conditions against it never
+    /// match (CSS Containment 3).</param>
+    /// <param name="ContainerName">The container's own declared <c>container-name</c> list (raw,
+    /// space-separated text, or <c>"none"</c>), for informational/debugging purposes - name matching
+    /// itself happens earlier, in <see cref="Dom.CssBox.FindNearestQueryContainer"/>.</param>
+    internal readonly record struct ContainerQueryContext(double InlineSizePt, double? BlockSizePt, string ContainerName);
+}

--- a/src/PeachPDF/Html/Core/ContainerQueryMatcher.cs
+++ b/src/PeachPDF/Html/Core/ContainerQueryMatcher.cs
@@ -1,0 +1,115 @@
+#nullable enable
+
+using System.Linq;
+using PeachPDF.CSS;
+using PeachPDF.Html.Core.Dom;
+
+namespace PeachPDF.Html.Core
+{
+    /// <summary>
+    /// Evaluates an <c>@container</c> rule's enclosing-container chain (<see cref="CssData.ContainerCondition"/>[])
+    /// against a specific candidate box, per CSS Containment 3 SS7. The per-element analogue of
+    /// <see cref="MediaQueryMatcher"/>: where <c>@media</c>'s truthiness is a single fact resolved once
+    /// per render (page geometry doesn't vary per box), <c>@container</c>'s truthiness depends on which
+    /// ancestor the candidate box's own nearest matching query container resolves to
+    /// (<see cref="CssBox.FindNearestQueryContainer"/>), so this is evaluated per candidate box, in
+    /// <see cref="CssData"/>'s <c>GatherMatchedRules.Collect</c>.
+    /// </summary>
+    /// <remarks>
+    /// A size condition's grammar is the same <see cref="MediaList"/>/<see cref="Medium"/>/<see cref="MediaFeature"/>
+    /// tree <c>@media</c> already parses through (<c>ContainerRule</c> reuses <c>FillMediaList</c>
+    /// wholesale) - conjunctive nesting levels, comma-OR within a level, <c>not</c> via
+    /// <c>Medium.IsInverse</c>, exactly mirroring <see cref="MediaQueryMatcher.Matches"/>'s shape. A
+    /// <c>Medium.Type</c> is never meaningfully set for a container condition (there is no container
+    /// "type" keyword the way <c>screen</c>/<c>print</c> exist for <c>@media</c>), so it is not checked
+    /// here.
+    /// </remarks>
+    internal static class ContainerQueryMatcher
+    {
+        internal static bool Matches(CssData.ContainerCondition[]? enclosingContainers, CssBox node, ContainerQuerySizes? sizes)
+        {
+            if (enclosingContainers is null) return true;
+
+            foreach (var level in enclosingContainers)
+            {
+                if (level.StyleCondition is { } styleCondition)
+                {
+                    var styleContainer = node.FindNearestQueryContainer(level.Name, CssBox.QueryKind.Style);
+                    // CSS Containment 3 §7.2: no eligible container at all is the "unknown" state, which
+                    // is falsy for @container - a deliberate divergence from @media's permissive-on-
+                    // missing-geometry stance (a missing container here is invalid authoring, not a
+                    // missing render context).
+                    if (styleContainer is null || !styleCondition.Check(styleContainer)) return false;
+                    continue;
+                }
+
+                if (level.SizeCondition is not { } sizeCondition) return false;
+
+                var sizeContainer = node.FindNearestQueryContainer(level.Name, CssBox.QueryKind.Size);
+                if (sizeContainer is null) return false;
+
+                // No size data yet (the convergence loop's bootstrap pass) or this container isn't a
+                // size-tracking one after all (shouldn't happen given FindNearestQueryContainer's own
+                // Size-kind filter, but the lookup can still miss if a size box hasn't been visited by
+                // BuildContainerQuerySizes for some reason) - falsy either way, not permissive.
+                if (sizes is null || !sizes.TryGet(sizeContainer.Id, out var ctx)) return false;
+
+                var anyMediumMatches = false;
+                foreach (var medium in sizeCondition)
+                {
+                    var matches = medium.Features.All(feature => FeatureMatches(feature, ctx));
+                    if (medium.IsInverse) matches = !matches;
+                    if (matches)
+                    {
+                        anyMediumMatches = true;
+                        break;
+                    }
+                }
+
+                if (!anyMediumMatches) return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// The container-valid feature subset (CSS Containment 3 SS7.3) - narrower than <c>@media</c>'s:
+        /// no <c>color</c>/<c>resolution</c>/<c>hover</c>/etc., since those describe the output device,
+        /// not a container's own box. <c>height</c>/<c>block-size</c>/<c>aspect-ratio</c>/<c>orientation</c>
+        /// are false (not permissive) against an <c>inline-size</c>-only container, since it tracks only
+        /// the inline axis (<see cref="ContainerQueryContext.BlockSizePt"/> is <c>null</c> there).
+        /// </summary>
+        private static bool FeatureMatches(MediaFeature feature, ContainerQueryContext ctx)
+        {
+            var name = feature.Name.ToLowerInvariant();
+            if (name.StartsWith("min-", System.StringComparison.Ordinal)) name = name[4..];
+            else if (name.StartsWith("max-", System.StringComparison.Ordinal)) name = name[4..];
+
+            switch (name)
+            {
+                case "width":
+                case "inline-size":
+                    return MediaQueryMatcher.CompareLength(feature, ctx.InlineSizePt);
+
+                case "height":
+                case "block-size":
+                    return ctx.BlockSizePt is { } blockPt && MediaQueryMatcher.CompareLength(feature, blockPt);
+
+                case "aspect-ratio":
+                    if (ctx.BlockSizePt is not { } aspectHeight || aspectHeight <= 0) return false;
+                    if (feature.AsRatio() is not { } ratio) return false;
+                    return MediaQueryMatcher.CompareNumeric(ctx.InlineSizePt / aspectHeight, ratio, feature.Comparison);
+
+                case "orientation":
+                    if (ctx.BlockSizePt is not { } orientationHeight) return false;
+                    var orientation = ctx.InlineSizePt > orientationHeight ? "landscape" : "portrait";
+                    return !feature.HasValue
+                        || string.Equals(feature.Value, orientation, System.StringComparison.OrdinalIgnoreCase);
+
+                default:
+                    // Any other feature (color, resolution, hover, ...) is @media-only.
+                    return false;
+            }
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/ContainerQuerySizes.cs
+++ b/src/PeachPDF/Html/Core/ContainerQuerySizes.cs
@@ -1,0 +1,60 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace PeachPDF.Html.Core
+{
+    /// <summary>
+    /// Every eligible <c>@container</c> query container's resolved size for one layout pass, keyed by
+    /// <see cref="Dom.CssBox.Id"/> - stable across the repeated re-parses of identical HTML the
+    /// container-query convergence loop performs (see <see cref="HtmlContainerInt.PerformLayout"/>),
+    /// since a real element's <c>Id</c> is assigned purely during HTML parsing, before any cascade or
+    /// layout runs. <c>null</c> on the loop's first pass, when no container size is known yet - every
+    /// <c>@container</c> condition is then falsy (<see cref="ContainerQueryMatcher.Matches"/>), which is
+    /// also today's (pre-fix) behavior and the correct bootstrap for the loop.
+    /// </summary>
+    internal sealed class ContainerQuerySizes
+    {
+        private readonly Dictionary<uint, ContainerQueryContext> _byId;
+
+        internal ContainerQuerySizes(Dictionary<uint, ContainerQueryContext> byId)
+        {
+            _byId = byId;
+        }
+
+        internal bool TryGet(uint boxId, out ContainerQueryContext context) => _byId.TryGetValue(boxId, out context);
+
+        /// <summary>
+        /// Whether this and <paramref name="other"/> record the same set of size containers with the
+        /// same sizes, within a small epsilon - the convergence test <see cref="HtmlContainerInt.PerformLayout"/>'s
+        /// container-query loop stops on. Real-element <c>CssBox.Id</c>s are stable across the loop's
+        /// repeated re-parses of identical HTML (see this class's own remarks), so a differing key set
+        /// would mean a size container's own existence changed pass-over-pass (a container-gated rule
+        /// toggling display, e.g.) - also treated as "not converged", since that is itself a size-
+        /// relevant change the next pass needs to react to.
+        /// </summary>
+        internal bool SizesEqual(ContainerQuerySizes other)
+        {
+            const double epsilonPt = 0.01;
+
+            if (_byId.Count != other._byId.Count) return false;
+
+            foreach (var (id, context) in _byId)
+            {
+                if (!other._byId.TryGetValue(id, out var otherContext)) return false;
+                if (Math.Abs(context.InlineSizePt - otherContext.InlineSizePt) > epsilonPt) return false;
+
+                var blockDiffers = (context.BlockSizePt, otherContext.BlockSizePt) switch
+                {
+                    (null, null) => false,
+                    (double a, double b) => Math.Abs(a - b) > epsilonPt,
+                    _ => true
+                };
+                if (blockDiffers) return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/CssData.cs
+++ b/src/PeachPDF/Html/Core/CssData.cs
@@ -64,7 +64,19 @@ namespace PeachPDF.Html.Core
         // (null = unlayered). The layer's numeric precedence rank is resolved lazily at sort time from
         // _layerRanks - which is only known after the whole layer tree has been walked (a nested
         // sub-layer's rank depends on where its parent first appeared), so it can't be baked in here.
-        private readonly record struct IndexedRule(IStyleRule Rule, bool IsUserAgent, int DocumentOrder, MediaList[]? EnclosingMedia, string? LayerName);
+        private readonly record struct IndexedRule(IStyleRule Rule, bool IsUserAgent, int DocumentOrder, MediaList[]? EnclosingMedia, ContainerCondition[]? EnclosingContainers, string? LayerName);
+
+        /// <summary>
+        /// One level of an <c>@container</c> nesting chain a rule is indexed under: the rule's own
+        /// declared <c>&lt;container-name&gt;</c> (null when unnamed) and its condition, either a plain
+        /// size-feature <see cref="MediaList"/> (reusing <c>@media</c>'s grammar - see
+        /// <see cref="ContainerRule"/>) or a <c>style()</c> query tree. Exactly one of
+        /// <see cref="SizeCondition"/>/<see cref="StyleCondition"/> is non-null. Carried forward the same
+        /// way <see cref="MediaList"/>[] EnclosingMedia is - deferred, per-candidate-box evaluation
+        /// (<see cref="ContainerQueryMatcher"/>) rather than resolved once at index-build time, since
+        /// (unlike <c>@supports</c>) neither form is a static, argument-free fact.
+        /// </summary>
+        internal readonly record struct ContainerCondition(string? Name, MediaList? SizeCondition, IStyleQueryCondition? StyleCondition);
 
         // A style rule paired with its resolved @layer rank, for the cascade's author passes (which
         // need the rank both to reverse layer order for !important and to band rules by layer for
@@ -102,7 +114,7 @@ namespace PeachPDF.Html.Core
 
             foreach (var stylesheet in Stylesheets)
             {
-                IndexRules(stylesheet.Rules, stylesheet.IsUserAgent, null, null, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order);
+                IndexRules(stylesheet.Rules, stylesheet.IsUserAgent, null, null, null, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order);
             }
 
             _layerRanks = layerRegistry.ComputeRanks();
@@ -208,15 +220,16 @@ namespace PeachPDF.Html.Core
         }
 
         /// <summary>
-        /// Walks a rule list in true document order, recursing into <c>@media</c> blocks (any
-        /// nesting depth) in place, and buckets every style rule found - assigning each an
+        /// Walks a rule list in true document order, recursing into <c>@media</c>/<c>@container</c>
+        /// blocks (any nesting depth) in place, and buckets every style rule found - assigning each an
         /// ever-increasing <see cref="IndexedRule.DocumentOrder"/> and recording the chain of
-        /// enclosing media conditions it's nested under, if any.
+        /// enclosing media/container conditions it's nested under, if any.
         /// </summary>
         private static void IndexRules(
             IEnumerable<IRule> rules,
             bool isUserAgent,
             MediaList[]? enclosingMedia,
+            ContainerCondition[]? enclosingContainers,
             string? currentLayer,
             Dictionary<string, List<IndexedRule>> tagIndex,
             Dictionary<string, List<IndexedRule>> classIndex,
@@ -231,7 +244,7 @@ namespace PeachPDF.Html.Core
                 switch (rule)
                 {
                     case IStyleRule styleRule:
-                        var indexedRule = new IndexedRule(styleRule, isUserAgent, order++, enclosingMedia, currentLayer);
+                        var indexedRule = new IndexedRule(styleRule, isUserAgent, order++, enclosingMedia, enclosingContainers, currentLayer);
 
                         keys.Clear();
                         CollectIndexKeys(styleRule.Selector, keys);
@@ -263,14 +276,14 @@ namespace PeachPDF.Html.Core
                         // media/@layer context and right after the parent in document order (so it wins
                         // ties by source order, matching its textual position after the parent).
                         if (styleRule.NestedRules.Count > 0)
-                            IndexRules(styleRule.NestedRules, isUserAgent, enclosingMedia, currentLayer, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order);
+                            IndexRules(styleRule.NestedRules, isUserAgent, enclosingMedia, enclosingContainers, currentLayer, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order);
                         break;
 
                     case IMediaRule mediaRule:
                         var nestedMedia = enclosingMedia is null
                             ? [mediaRule.Media]
                             : (MediaList[])[.. enclosingMedia, mediaRule.Media];
-                        IndexRules(mediaRule.Rules, isUserAgent, nestedMedia, currentLayer, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order);
+                        IndexRules(mediaRule.Rules, isUserAgent, nestedMedia, enclosingContainers, currentLayer, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order);
                         break;
 
                     // @layer statement (`@layer a, b, c;`) only declares layer order — register each
@@ -288,7 +301,7 @@ namespace PeachPDF.Html.Core
                             : QualifyLayer(currentLayer, layerRule.Name);
                         if (!string.IsNullOrEmpty(layerRule.Name))
                             layerRegistry.Register(qualified);
-                        IndexRules(layerRule.Rules, isUserAgent, enclosingMedia, qualified, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order);
+                        IndexRules(layerRule.Rules, isUserAgent, enclosingMedia, enclosingContainers, qualified, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order);
                         break;
 
                     // @supports: the condition is invariant (IConditionFunction.Check() takes no
@@ -301,14 +314,28 @@ namespace PeachPDF.Html.Core
                     // up, just decided by the real condition now instead of unconditionally.
                     case ISupportsRule supportsRule:
                         if (supportsRule.Condition.Check())
-                            IndexRules(supportsRule.Rules, isUserAgent, enclosingMedia, currentLayer, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order);
+                            IndexRules(supportsRule.Rules, isUserAgent, enclosingMedia, enclosingContainers, currentLayer, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order);
                         break;
 
-                    // @container: PeachPDF cannot evaluate the condition (truthiness depends on the
-                    // nearest matched element's own container size, not a static parse-time fact the
-                    // way @supports's condition is - there is no element in scope here to test against),
-                    // so the whole block is IGNORED — its inner rules are not indexed and therefore never
-                    // apply. Tracked at #284. @keyframes/@document/etc. are likewise not indexed.
+                    // @container: truthiness depends on the nearest matched element's own container
+                    // size/style, a per-candidate-box fact - unconditionally descend and carry the
+                    // condition forward as deferred state, exactly like @media's EnclosingMedia chain
+                    // (see ContainerQueryMatcher.Matches, consulted lazily in GatherMatchedRules.Collect).
+                    case IContainerRule containerRule:
+                        var containerName = string.IsNullOrEmpty(containerRule.Name) ? null : containerRule.Name;
+                        // ContainerRule.Media is a non-null (but empty) MediaList even on the style()
+                        // branch - AppendChild(new MediaList(...)) runs unconditionally in its constructor
+                        // - so SizeCondition must be nulled out explicitly here to keep this record's own
+                        // documented "exactly one of SizeCondition/StyleCondition is set" invariant true.
+                        var condition = new ContainerCondition(
+                            containerName,
+                            containerRule.StyleCondition is null ? containerRule.Media : null,
+                            containerRule.StyleCondition);
+                        var nestedContainers = enclosingContainers is null
+                            ? [condition]
+                            : (ContainerCondition[])[.. enclosingContainers, condition];
+                        IndexRules(containerRule.Rules, isUserAgent, enclosingMedia, nestedContainers, currentLayer, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order);
+                        break;
                 }
             }
         }
@@ -318,14 +345,15 @@ namespace PeachPDF.Html.Core
 
         /// <summary>
         /// Enumerates every rule in every stylesheet, descending into the grouping at-rules whose
-        /// contents participate directly in the document (<c>@layer</c>/<c>@media</c>/a
+        /// contents participate directly in the document (<c>@layer</c>/<c>@media</c>/<c>@container</c>/a
         /// true-condition <c>@supports</c>) so an <c>@font-face</c>/<c>@property</c>/<c>@page</c>
         /// nested inside one is still found — including one guarded by <c>@supports</c>, per CSS
         /// Conditional Rules 3/4 §3 (any at-rule may appear inside a supports-rule's block).
-        /// <c>@container</c> is NOT descended — its condition can't be evaluated (see
-        /// <see cref="IndexRules"/>'s matching case), so the whole block is ignored. Source order is
-        /// preserved (a grouping rule's children are yielded at the grouping rule's own position), so
-        /// last-declared-wins collection stays correct.
+        /// <c>@media</c>/<c>@container</c> are descended unconditionally, same as <c>@layer</c> - their
+        /// per-candidate-box truthiness has no bearing on whether a font/registration nested inside is
+        /// collected (see the matching <c>IMediaRule</c> case's identical unconditional descent). Source
+        /// order is preserved (a grouping rule's children are yielded at the grouping rule's own
+        /// position), so last-declared-wins collection stays correct.
         /// </summary>
         internal IEnumerable<IRule> EnumerateRulesRecursive()
         {
@@ -352,12 +380,15 @@ namespace PeachPDF.Html.Core
                         foreach (var child in FlattenRules(mediaRule.Rules))
                             yield return child;
                         break;
+                    case IContainerRule containerRule:
+                        foreach (var child in FlattenRules(containerRule.Rules))
+                            yield return child;
+                        break;
                     case ISupportsRule supportsRule:
                         if (supportsRule.Condition.Check())
                             foreach (var child in FlattenRules(supportsRule.Rules))
                                 yield return child;
                         break;
-                    // @container is intentionally not descended — its block is ignored.
                 }
             }
         }
@@ -452,14 +483,14 @@ namespace PeachPDF.Html.Core
             return await parser.ParseStyleSheet(stylesheet, combineWithDefault);
         }
 
-        internal IEnumerable<IStyleRule> GetStyleRules(MediaQueryContext media, ICssDomNode node) =>
-            GetStyleRulesByOrigin(media, node, userAgentOnly: null);
+        internal IEnumerable<IStyleRule> GetStyleRules(MediaQueryContext media, ICssDomNode node, ContainerQuerySizes? containerSizes = null) =>
+            GetStyleRulesByOrigin(media, node, userAgentOnly: null, containerSizes: containerSizes);
 
-        internal IEnumerable<IStyleRule> GetUserAgentStyleRules(MediaQueryContext media, ICssDomNode node) =>
-            GetStyleRulesByOrigin(media, node, userAgentOnly: true);
+        internal IEnumerable<IStyleRule> GetUserAgentStyleRules(MediaQueryContext media, ICssDomNode node, ContainerQuerySizes? containerSizes = null) =>
+            GetStyleRulesByOrigin(media, node, userAgentOnly: true, containerSizes: containerSizes);
 
-        internal IEnumerable<IStyleRule> GetAuthorStyleRules(MediaQueryContext media, ICssDomNode node) =>
-            GetStyleRulesByOrigin(media, node, userAgentOnly: false);
+        internal IEnumerable<IStyleRule> GetAuthorStyleRules(MediaQueryContext media, ICssDomNode node, ContainerQuerySizes? containerSizes = null) =>
+            GetStyleRulesByOrigin(media, node, userAgentOnly: false, containerSizes: containerSizes);
 
         /// <summary>
         /// Same candidate-gathering (tag/class/id/universal index buckets) as
@@ -471,8 +502,8 @@ namespace PeachPDF.Html.Core
         /// pass to re-match against, so this is the only way its declarations are ever gathered at all.
         /// See <c>DomParser.ResolveFirstLineStyle</c>, its only caller.
         /// </summary>
-        internal IEnumerable<IStyleRule> GetFirstLineStyleRules(MediaQueryContext media, CssBox box, bool userAgentOnly) =>
-            GetStyleRulesByOrigin(media, box, userAgentOnly, firstLineOnly: true);
+        internal IEnumerable<IStyleRule> GetFirstLineStyleRules(MediaQueryContext media, CssBox box, bool userAgentOnly, ContainerQuerySizes? containerSizes = null) =>
+            GetStyleRulesByOrigin(media, box, userAgentOnly, firstLineOnly: true, containerSizes: containerSizes);
 
         /// <summary>
         /// Author style rules for the HTML cascade, in BOTH the normal-declaration order and the
@@ -489,9 +520,9 @@ namespace PeachPDF.Html.Core
         /// <c>revert-layer</c>. Only the HTML cascade (<c>DomParser.CascadeApplyStyles</c>) needs this;
         /// UA/first-line/SVG paths keep <see cref="GetStyleRulesByOrigin"/>.
         /// </summary>
-        internal (List<LayeredStyleRule> Normal, List<LayeredStyleRule> Important) GetAuthorStyleRulesForCascade(MediaQueryContext media, ICssDomNode node)
+        internal (List<LayeredStyleRule> Normal, List<LayeredStyleRule> Important) GetAuthorStyleRulesForCascade(MediaQueryContext media, ICssDomNode node, ContainerQuerySizes? containerSizes = null)
         {
-            var matched = GatherMatchedRules(media, node, userAgentOnly: false, firstLineOnly: false);
+            var matched = GatherMatchedRules(media, node, userAgentOnly: false, firstLineOnly: false, containerSizes);
 
             List<LayeredStyleRule> Sort(bool importantOrder)
             {
@@ -513,9 +544,9 @@ namespace PeachPDF.Html.Core
             return (normal, important);
         }
 
-        private IEnumerable<IStyleRule> GetStyleRulesByOrigin(MediaQueryContext media, ICssDomNode node, bool? userAgentOnly, bool firstLineOnly = false)
+        private IEnumerable<IStyleRule> GetStyleRulesByOrigin(MediaQueryContext media, ICssDomNode node, bool? userAgentOnly, bool firstLineOnly = false, ContainerQuerySizes? containerSizes = null)
         {
-            var matched = GatherMatchedRules(media, node, userAgentOnly, firstLineOnly);
+            var matched = GatherMatchedRules(media, node, userAgentOnly, firstLineOnly, containerSizes);
 
             // Stable sort by specificity, tie-broken by DocumentOrder (true source order, including
             // across the plain-rule/@media boundary, assigned once up front by IndexRules) - equal-
@@ -544,7 +575,7 @@ namespace PeachPDF.Html.Core
         /// apply their own cascade ordering. Extracted so the normal and <c>!important</c> author
         /// orderings can share one matching pass (see <see cref="GetAuthorStyleRulesForCascade"/>).
         /// </summary>
-        private List<IndexedRule> GatherMatchedRules(MediaQueryContext media, ICssDomNode node, bool? userAgentOnly, bool firstLineOnly)
+        private List<IndexedRule> GatherMatchedRules(MediaQueryContext media, ICssDomNode node, bool? userAgentOnly, bool firstLineOnly, ContainerQuerySizes? containerSizes = null)
         {
             EnsureIndex();
 
@@ -558,6 +589,12 @@ namespace PeachPDF.Html.Core
             {
                 if (userAgentOnly.HasValue && indexed.IsUserAgent != userAgentOnly.Value) return;
                 if (!MediaQueryMatcher.Matches(indexed.EnclosingMedia, media)) return;
+                // @container is HTML-only (no query-container concept for SVG) - an SVG node (never a
+                // CssBox) permissively skips the check the same way a rule with no @container nesting
+                // does, since ContainerQueryMatcher.Matches needs a CssBox to walk ParentBox from.
+                if (indexed.EnclosingContainers is not null && node is CssBox containerCandidate
+                    && !ContainerQueryMatcher.Matches(indexed.EnclosingContainers, containerCandidate, containerSizes))
+                    return;
                 // firstLineOnly is HTML-cascade-only (DomParser.ResolveFirstLineStyle), always a CssBox.
                 var isMatch = firstLineOnly
                     ? MatchesAsFirstLineSelector(indexed.Rule.Selector, (CssBox)node)

--- a/src/PeachPDF/Html/Core/Dom/ComputedStyleAreas.cs
+++ b/src/PeachPDF/Html/Core/Dom/ComputedStyleAreas.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 // The Text area below declares a property literally named WritingMode, which shadows the CSS-OM enum
 // type of the same name within this file - alias it so the enum stays referenceable.
 using WritingModeEnum = PeachPDF.CSS.WritingMode;
+// Same shadowing issue for the DisplayPositioning area's ContainerType property below.
+using ContainerTypeEnum = PeachPDF.CSS.ContainerType;
 
 namespace PeachPDF.Html.Core.Dom
 {
@@ -238,6 +240,12 @@ namespace PeachPDF.Html.Core.Dom
         public string Position { get; init; } = CssDefaults.GetInitialValue(PropertyNames.Position)!;
         public string ZIndex { get; init; } = CssDefaults.GetInitialValue(PropertyNames.ZIndex)!;
         public string Overflow { get; init; } = CssDefaults.GetInitialValue(PropertyNames.Overflow)!;
+
+        // ContainerType carries its parsed enum through the cascade (CssProperty<T>), same as
+        // Direction/UnicodeBidi/WritingMode in the Text area below.
+        public CssProperty<ContainerTypeEnum> ContainerType { get; init; } =
+            CssProperty<ContainerTypeEnum>.FromCssText(CssDefaults.GetInitialValue(PropertyNames.ContainerType)!, Map.ContainerTypes, ContainerTypeEnum.Normal);
+        public string ContainerName { get; init; } = CssDefaults.GetInitialValue(PropertyNames.ContainerName)!;
     }
 
     #endregion

--- a/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
@@ -982,6 +982,28 @@ namespace PeachPDF.Html.Core.Dom
             }
         }
 
+        public CssProperty<ContainerType> ContainerType
+        {
+            get => _computedStyle.DisplayPositioning.ContainerType;
+            set
+            {
+                var area = _computedStyle.DisplayPositioning;
+                var newArea = area.SetPropertyValue(area.ContainerType, value, static (a, v) => a with { ContainerType = v });
+                _computedStyle = _computedStyle.AdoptArea(area, newArea, static (s, a) => s with { DisplayPositioning = a });
+            }
+        }
+
+        public string ContainerName
+        {
+            get => _computedStyle.DisplayPositioning.ContainerName;
+            set
+            {
+                var area = _computedStyle.DisplayPositioning;
+                var newArea = area.SetPropertyValue(area.ContainerName, value, static (a, v) => a with { ContainerName = v });
+                _computedStyle = _computedStyle.AdoptArea(area, newArea, static (s, a) => s with { DisplayPositioning = a });
+            }
+        }
+
         public string Clear
         {
             get => _computedStyle.DisplayPositioning.Clear;

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -29,6 +29,10 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using PeachPDF.Html.Core.Fragments;
+// CssBox declares a property literally named ContainerType, which shadows the CSS-OM enum type of the
+// same name within this file - alias it so the enum stays referenceable (same trick ComputedStyleAreas
+// uses for WritingMode).
+using ContainerTypeEnum = PeachPDF.CSS.ContainerType;
 
 namespace PeachPDF.Html.Core.Dom
 {
@@ -429,6 +433,81 @@ namespace PeachPDF.Html.Core.Dom
 
                 return box;
             }
+        }
+
+        /// <summary>
+        /// Which kind of <c>@container</c> eligibility <see cref="FindNearestQueryContainer"/> should
+        /// check. CSS Containment 3 SS7.2: a <c>size</c>/<c>inline-size</c> query container is required for
+        /// size-feature conditions (<c>width</c>/<c>height</c>/etc.), but a style-feature (<c>style()</c>)
+        /// query is eligible against any element that declares <c>container-type</c> at all - including
+        /// its initial <c>normal</c> value, which only opts an element out of *size* containment, not out
+        /// of being a query container for style queries.
+        /// </summary>
+        internal enum QueryKind { Size, Style }
+
+        /// <summary>
+        /// Walks ancestors (starting at <see cref="ParentBox"/>, never this box itself) for the nearest
+        /// one eligible as an <c>@container</c> query container, per CSS Containment 3 SS7.2. With
+        /// <paramref name="name"/> given, the ancestor's own <see cref="CssBox.ContainerName"/> list
+        /// (whitespace-separated <c>&lt;custom-ident&gt;</c>s, case-sensitive) must contain it; with no
+        /// name, the nearest eligible ancestor wins regardless of its own name. Returns <c>null</c> when no
+        /// eligible ancestor exists - CSS Containment 3's "unknown" query-container state, which callers
+        /// must treat as falsy for <c>@container</c> (a deliberate divergence from how <c>@media</c>
+        /// features fall back to permissive-true on missing viewport geometry - a missing container here
+        /// is invalid authoring, not a missing render context).
+        /// </summary>
+        internal CssBox? FindNearestQueryContainer(string? name, QueryKind kind = QueryKind.Size)
+        {
+            var candidate = ParentBox;
+            while (candidate is not null)
+            {
+                // Style queries: every element is container-type-bearing (normal is the initial value),
+                // so only size queries actually restrict eligibility to Size/InlineSize containers.
+                var isEligible = kind != QueryKind.Size
+                    || candidate.ContainerType.Value is ContainerTypeEnum.Size or ContainerTypeEnum.InlineSize;
+
+                if (isEligible && (name is null || ContainerNameMatches(candidate.ContainerName, name)))
+                    return candidate;
+
+                candidate = candidate.ParentBox;
+            }
+
+            return null;
+        }
+
+        private static bool ContainerNameMatches(string containerName, string queriedName)
+        {
+            if (string.IsNullOrEmpty(containerName) || containerName == CssConstants.None) return false;
+
+            foreach (var part in containerName.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            {
+                // <custom-ident> is case-sensitive.
+                if (string.Equals(part, queriedName, StringComparison.Ordinal)) return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// The nearest unnamed ancestor <c>@container</c> size query container's current content-box
+        /// size, resolved for <c>cqw</c>/<c>cqi</c>/<c>cqh</c>/<c>cqb</c>/<c>cqmin</c>/<c>cqmax</c> unit
+        /// resolution (CSS Containment 3 SS6.2) - shared by every length-resolution call site (<see
+        /// cref="Parse.CssValueParser.ParseLength(string, double, CssBox)"/>, font-size) so there is one
+        /// place that decides how a box's nearest container's size is measured, not one per caller.
+        /// Block size is only ever non-null for a <c>size</c> container - an <c>inline-size</c> container
+        /// doesn't track the block axis at all.
+        /// </summary>
+        internal (double? InlineSizePt, double? BlockSizePt) GetContainerRelativeUnitBasis()
+        {
+            var container = FindNearestQueryContainer(name: null);
+            if (container is null) return (null, null);
+
+            double? inlinePt = container.ClientRight - container.ClientLeft;
+            double? blockPt = container.ContainerType.Value == ContainerTypeEnum.Size
+                ? container.ClientBottom - container.ClientTop
+                : null;
+
+            return (inlinePt, blockPt);
         }
 
         public bool IsHeightCalculated { get; set; } = false;

--- a/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
+++ b/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
@@ -852,7 +852,14 @@ namespace PeachPDF.Html.Core.Dom
                     remSize = CssConstants.FontSize;
                 }
 
-                var fsize = FontSizeResolver.Resolve(Style.Font.FontSize, parentSize, remSize);
+                // For a box with text content this basis is unreachable in practice - word-splitting
+                // (DomParser.CorrectTextBoxes, during cascade) reads ActualFont before any layout pass
+                // exists, caching this size permanently against a container that hasn't been laid out yet.
+                // Correct only for a box whose ActualFont happens to first be read post-layout - see
+                // .claude/accepted-gaps/font-size-container-relative-units-resolve-to-zero-for-text-content.md.
+                var (containerInlinePt, containerBlockPt) = Owner.GetContainerRelativeUnitBasis();
+                var fsize = FontSizeResolver.Resolve(Style.Font.FontSize, parentSize, remSize,
+                    containerInlinePt, containerBlockPt);
 
                 _actualFont = Owner.GetCachedFont(Style.Font.FontFamily!, fsize, st, ActualNumericWeight, ActualStretch, ActualObliqueSkewSinus)
                               ?? Owner.GetCachedFont(CssConstants.DefaultFont, fsize, st, ActualNumericWeight, ActualStretch, ActualObliqueSkewSinus);

--- a/src/PeachPDF/Html/Core/HtmlContainerInt.cs
+++ b/src/PeachPDF/Html/Core/HtmlContainerInt.cs
@@ -515,6 +515,15 @@ namespace PeachPDF.Html.Core
         internal bool HasCloneDecorations { get; private set; }
 
         /// <summary>
+        /// Whether any box in the current document establishes a <c>@container</c> size query container
+        /// (<c>container-type: size</c>/<c>inline-size</c>). Gates the container-query convergence loop
+        /// in <see cref="PerformLayout"/> - a document with none (the overwhelming majority) never pays
+        /// for more than this one settling walk plus the one unconditional baseline layout pass every
+        /// document already took before this feature existed.
+        /// </summary>
+        internal bool HasSizeContainers { get; private set; }
+
+        /// <summary>
         /// Whether any box in the current document is out-of-flow (floated, absolutely positioned, or
         /// fixed). Computed alongside <see cref="HasFloatedBoxes"/> and used by
         /// <see cref="Paint.FragmentPainter"/> to decide whether Bounds-based page-visibility pruning is safe (an
@@ -676,16 +685,29 @@ namespace PeachPDF.Html.Core
         /// </summary>
         /// <param name="htmlSource">the html to init with, init empty if not given</param>
         /// <param name="baseCssData">optional: the stylesheet to init with, init default if not given</param>
-        public async Task SetHtml(string htmlSource, CssData? baseCssData = null)
+        /// <param name="containerSizes">Every eligible <c>@container</c> query container's resolved size
+        /// from the previous layout pass - see <see cref="DomParser.GenerateCssTree"/>. <c>null</c> for
+        /// every caller except <see cref="PerformLayout"/>'s own container-query convergence loop, which
+        /// re-invokes this method between passes via <see cref="_lastHtmlSource"/>/<see cref="_lastBaseCssData"/>.</param>
+        public async Task SetHtml(string htmlSource, CssData? baseCssData = null, ContainerQuerySizes? containerSizes = null)
         {
+            _lastHtmlSource = htmlSource;
+            _lastBaseCssData = baseCssData;
+
             Clear();
             if (string.IsNullOrEmpty(htmlSource)) return;
 
             CssData = baseCssData ?? await Adapter.GetDefaultCssData();
 
             DomParser parser = new(CssParser);
-            (Root, CssData, DocumentMetadata) = await parser.GenerateCssTree(htmlSource, this, CssData);
+            (Root, CssData, DocumentMetadata) = await parser.GenerateCssTree(htmlSource, this, CssData, containerSizes);
         }
+
+        // Remembered so PerformLayout's container-query convergence loop can re-invoke SetHtml itself
+        // between passes (a full re-parse + re-cascade, the same "wholesale redo" PdfGenerator.SetContent's
+        // ShrinkToFit path already trusts) without its caller having to hold onto the original html/cssData.
+        private string? _lastHtmlSource;
+        private CssData? _lastBaseCssData;
 
         /// <summary>
         /// Clear the content of the HTML container releasing any resources used to render previously existing content.
@@ -753,10 +775,74 @@ namespace PeachPDF.Html.Core
         /// Measures the bounds of box and children, recursively.
         /// </summary>
         /// <param name="g">Device context to draw</param>
+        /// <summary>
+        /// Lays out the document, then - if it declares any <c>@container</c> size query container -
+        /// runs a bounded convergence loop on top: <see cref="PerformLayoutOnePass"/>'s first invocation
+        /// is the correct bootstrap (no container size data yet, so every <c>@container</c> condition
+        /// evaluates false, exactly today's pre-fix behavior), after which every size container's
+        /// resolved content-box size is read off the finished tree and, if it differs from the previous
+        /// pass's (or this is the first refinement pass), a full re-parse + re-cascade + re-layout is run
+        /// against the new sizes - the same "wholesale redo" <see cref="PdfGenerator.SetContent"/>'s
+        /// ShrinkToFit path already trusts, just re-triggered per container size rather than once per
+        /// global scale factor. Capped at 3 refinement passes (4 total, matching
+        /// <see cref="UseVariablePageWidth"/>'s own established 3-iteration cap): on cap exceeded, the
+        /// last pass's result is accepted silently, the same bounded-not-perfect stance already used
+        /// there for a structurally identical layout-depends-on-layout problem. A document with no size
+        /// container anywhere - the overwhelming majority - pays for exactly one extra tree walk
+        /// (<see cref="HasSizeContainers"/>) beyond what layout already cost before this feature existed.
+        /// </summary>
         public async ValueTask PerformLayout(RGraphics g)
         {
             ArgumentNullException.ThrowIfNull(g);
 
+            await PerformLayoutOnePass(g);
+
+            if (!HasSizeContainers) return;
+
+            var previous = BuildContainerQuerySizes();
+            const int maxRefinementPasses = 3;
+            for (var pass = 0; pass < maxRefinementPasses; pass++)
+            {
+                if (_lastHtmlSource is null) break; // SetHtml was never actually called with real content
+
+                await SetHtml(_lastHtmlSource, _lastBaseCssData, previous);
+                await PerformLayoutOnePass(g);
+
+                var current = BuildContainerQuerySizes();
+                if (previous.SizesEqual(current)) break;
+                previous = current;
+            }
+        }
+
+        /// <summary>Builds the container-size-by-Id map <see cref="PerformLayout"/>'s convergence loop
+        /// compares pass-over-pass and feeds into the next pass's cascade - see
+        /// <see cref="ContainerQuerySizes"/>'s own remarks on why <see cref="Dom.CssBox.Id"/> is a safe
+        /// cross-pass key.</summary>
+        private ContainerQuerySizes BuildContainerQuerySizes()
+        {
+            var byId = new Dictionary<uint, ContainerQueryContext>();
+
+            void Walk(CssBox box)
+            {
+                if (box.ContainerType.Value is CSS.ContainerType.Size or CSS.ContainerType.InlineSize)
+                {
+                    var isSize = box.ContainerType.Value == CSS.ContainerType.Size;
+                    byId[box.Id] = new ContainerQueryContext(
+                        InlineSizePt: box.ClientRight - box.ClientLeft,
+                        BlockSizePt: isSize ? box.ClientBottom - box.ClientTop : null,
+                        ContainerName: box.ContainerName);
+                }
+
+                foreach (var child in box.Boxes)
+                    Walk(child);
+            }
+
+            if (Root is not null) Walk(Root);
+            return new ContainerQuerySizes(byId);
+        }
+
+        private async ValueTask PerformLayoutOnePass(RGraphics g)
+        {
             ActualSize = RSize.Empty;
             FloatScanCalls = 0;
             FloatScanBoxVisits = 0;
@@ -777,6 +863,11 @@ namespace PeachPDF.Html.Core
             // Depends on cascaded style only, and layout itself consults it, so it has to be settled before
             // the first pass rather than alongside the post-layout flags below.
             HasCloneDecorations = DomUtils.AnyBoxClonesDecorations(Root);
+
+            // Also cascade-only, and cheap enough to recompute every pass (a document declaring a size
+            // container is rare, and PerformLayout's own convergence loop already needs this exact
+            // answer to decide whether to run at all).
+            HasSizeContainers = DomUtils.AnyBoxEstablishesSizeContainer(Root);
 
             // Also purely cascade-driven, and also needed *during* the passes now that fragments are emitted
             // as each one ends: CSS Paged Media 3 §3.2's content-empty-page rule reads

--- a/src/PeachPDF/Html/Core/MediaQueryMatcher.cs
+++ b/src/PeachPDF/Html/Core/MediaQueryMatcher.cs
@@ -143,7 +143,14 @@ namespace PeachPDF.Html.Core
             }
         }
 
-        private static bool CompareLength(MediaFeature feature, double? actualPt)
+        /// <summary>
+        /// Compares a length-valued feature (e.g. <c>min-width</c>) against a known size in points.
+        /// Shared with <see cref="ContainerQueryMatcher"/> (container size queries use the exact same
+        /// feature/comparison model @media does, just against a container's size instead of the page's) -
+        /// see CLAUDE.md's "don't write two parsers for the same grammar" rule; this is the numeric-
+        /// comparison half of that, not grammar, but still one algorithm that shouldn't fork.
+        /// </summary>
+        internal static bool CompareLength(MediaFeature feature, double? actualPt)
         {
             if (actualPt is not { } actual) return true;   // no page geometry → permissive
             if (feature.AsLength() is not { } length) return true;
@@ -174,7 +181,8 @@ namespace PeachPDF.Html.Core
             return string.Equals(feature.Value, deviceValue, StringComparison.OrdinalIgnoreCase);
         }
 
-        private static bool CompareNumeric(double actual, double value, MediaFeatureComparison comparison)
+        /// <summary>Shared with <see cref="ContainerQueryMatcher"/> - see <see cref="CompareLength"/>'s remarks.</summary>
+        internal static bool CompareNumeric(double actual, double value, MediaFeatureComparison comparison)
         {
             const double epsilon = 1e-6;
             return comparison switch

--- a/src/PeachPDF/Html/Core/Parse/CssValueParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/CssValueParser.cs
@@ -151,7 +151,7 @@ namespace PeachPDF.Html.Core.Parse
         /// callers that do their own lightweight text scanning of a length string (like
         /// <see cref="Dom.CssBox"/>'s FontSize setter, which regex-searches for a bare "Nem"
         /// substring to eagerly convert em to points) know to leave a calc() expression alone rather than
-        /// mangling it, deferring to <see cref="ParseLength(string, double, double, double, string, bool)"/>'s
+        /// mangling it, deferring to <see cref="ParseLength(string, double, double, double, string, bool, double?, double?)"/>'s
         /// real evaluation instead.
         /// </summary>
         public static bool IsCalcFunction(string value)
@@ -162,7 +162,7 @@ namespace PeachPDF.Html.Core.Parse
         /// <summary>
         /// Recognizes a length string that is a single calc-family (calc/min/max/clamp) function, e.g. for
         /// the syntactic gate in <see cref="IsValidLength"/> and the evaluation branch in
-        /// <see cref="ParseLength(string, double, double, double, string, bool)"/>. Real
+        /// <see cref="ParseLength(string, double, double, double, string, bool, double?, double?)"/>. Real
         /// grammar/type validation already happened in Layer A's CalcValueConverter for any value that
         /// didn't arrive via the var() substitution bypass; this is a syntactic recognizer only.
         /// </summary>
@@ -239,7 +239,10 @@ namespace PeachPDF.Html.Core.Parse
         /// <returns>the parsed length value with adjustments</returns>
         public static double ParseLength(string length, double hundredPercent, CssBox box)
         {
-            return ParseLength(length, hundredPercent, box.GetEmHeight(), box.GetRemHeight(), null, false);
+            var (containerInlinePt, containerBlockPt) = box.GetContainerRelativeUnitBasis();
+
+            return ParseLength(length, hundredPercent, box.GetEmHeight(), box.GetRemHeight(), null, false,
+                containerInlinePt, containerBlockPt);
         }
 
         /// <summary>
@@ -251,8 +254,14 @@ namespace PeachPDF.Html.Core.Parse
         /// <param name="remFactor"></param>
         /// <param name="defaultUnit"></param>
         /// <param name="returnPoints">Allows the return double to be in points. If false, result will be pixels</param>
+        /// <param name="containerInlineSizePt">See <see cref="Length.ToPixels"/>'s parameter of the same
+        /// name. <c>null</c> for every call site with no candidate box in scope (media queries, `@page`
+        /// margins) - `cq*` units then resolve to 0, same as the box-aware overload's own container-less
+        /// fallback.</param>
+        /// <param name="containerBlockSizePt">See <see cref="Length.ToPixels"/>'s parameter of the same name.</param>
         /// <returns>the parsed length value with adjustments</returns>
-        public static double ParseLength(string length, double hundredPercent, double emFactor, double remFactor, string? defaultUnit, bool returnPoints)
+        public static double ParseLength(string length, double hundredPercent, double emFactor, double remFactor, string? defaultUnit, bool returnPoints,
+            double? containerInlineSizePt = null, double? containerBlockSizePt = null)
         {
             //Return zero if no length specified, zero specified
             if (string.IsNullOrEmpty(length) || length == "0")
@@ -265,7 +274,7 @@ namespace PeachPDF.Html.Core.Parse
                 // result here should be unreachable, but 0 is the same "can't make sense of this" fallback
                 // used elsewhere in this method for any other degenerate input.
                 var node = CalcParser.Parse(calcFunction);
-                var context = new CalcContext(hundredPercent, emFactor, remFactor, returnPoints);
+                var context = new CalcContext(hundredPercent, emFactor, remFactor, returnPoints, containerInlineSizePt, containerBlockSizePt);
                 var pixels = node is not null ? CalcEvaluator.Evaluate(node, context) : null;
 
                 return pixels ?? 0d;
@@ -286,7 +295,7 @@ namespace PeachPDF.Html.Core.Parse
 
             var lengthUnit = unit is not null ? Length.GetUnit(unit) : Length.Unit.None;
 
-            return new Length((float)number!.Value, lengthUnit).ToPixels(emFactor, remFactor, hundredPercent);
+            return new Length((float)number!.Value, lengthUnit).ToPixels(emFactor, remFactor, hundredPercent, containerInlineSizePt, containerBlockSizePt);
         }
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -56,8 +56,12 @@ namespace PeachPDF.Html.Core.Parse
         /// <param name="html">the html to parse</param>
         /// <param name="htmlContainer">the html container to use for reference resolve</param>
         /// <param name="cssData">the css data to use</param>
+        /// <param name="containerSizes">Every eligible <c>@container</c> query container's resolved size
+        /// from the previous layout pass, or <c>null</c> on the container-query convergence loop's first
+        /// pass (<see cref="HtmlContainerInt.PerformLayout"/>) - every <c>@container</c> condition then
+        /// evaluates false, the correct bootstrap. <c>null</c> for every caller that isn't that loop.</param>
         /// <returns>the root of the generated tree</returns>
-        public async Task<(CssBox cssBox, CssData cssData, HtmlDocumentMetadata metadata)> GenerateCssTree(string html, HtmlContainerInt htmlContainer, CssData cssData)
+        public async Task<(CssBox cssBox, CssData cssData, HtmlDocumentMetadata metadata)> GenerateCssTree(string html, HtmlContainerInt htmlContainer, CssData cssData, ContainerQuerySizes? containerSizes = null)
         {
             CssBox.ClearCounter();
             var root = HtmlParser.ParseDocument(html);
@@ -119,11 +123,11 @@ namespace PeachPDF.Html.Core.Parse
             // can't corrupt the structure SvgTreeBuilder reads. The *restructuring* passes below
             // (block/inline/anonymous-table normalization) DO reparent boxes, so each guards against
             // descending into a CssBoxSvg - see their `if (box is CssBoxSvg) return;` and issue #159.
-            CascadeApplyStyles(cssValueParser, root, cssData, media);
+            CascadeApplyStyles(cssValueParser, root, cssData, media, containerSizes);
 
-            EnsureListItemMarkers(cssValueParser, root, cssData, media);
+            EnsureListItemMarkers(cssValueParser, root, cssData, media, containerSizes);
 
-            ApplyFirstLetterPseudoElements(cssValueParser, root, cssData, media);
+            ApplyFirstLetterPseudoElements(cssValueParser, root, cssData, media, containerSizes);
 
             // Must run after the cascade (it reads each box's resolved Direction/UnicodeBidi) and
             // before CorrectTextBoxes (the first place that calls CssBox.ParseToWords, which consults
@@ -571,7 +575,8 @@ namespace PeachPDF.Html.Core.Parse
         /// <param name="box">the box to apply the style to</param>
         /// <param name="cssData">the style data for the html</param>
         /// <param name="media">The media type to apply styles to</param>
-        private static void CascadeApplyStyles(CssValueParser valueParser, CssBox box, CssData cssData, MediaQueryContext media)
+        /// <param name="containerSizes">See <see cref="GenerateCssTree"/>'s parameter of the same name.</param>
+        private static void CascadeApplyStyles(CssValueParser valueParser, CssBox box, CssData cssData, MediaQueryContext media, ContainerQuerySizes? containerSizes = null)
         {
             // 1. Defaulting (CSS Cascade & Inheritance 4 §2.1): every property starts at its initial value,
             //    drawn from the single initial-value store. The cascade phases below then override, and the
@@ -625,11 +630,11 @@ namespace PeachPDF.Html.Core.Parse
             // Matched rules are already sorted by CssData (specificity ascending, then true source
             // order) - materialize each origin once so both the normal and important passes below
             // reuse the same matched/sorted list instead of re-querying CssData twice per origin.
-            var uaRules = cssData.GetUserAgentStyleRules(media, box).ToList();
+            var uaRules = cssData.GetUserAgentStyleRules(media, box, containerSizes).ToList();
             // Author rules come in BOTH the normal-declaration order and the reversed !important layer
             // order (CSS Cascade 5 §6.4.2), matched once; each rule carries its @layer rank so the
             // author passes below can band rules by layer for revert-layer.
-            var (authorNormal, authorImportant) = cssData.GetAuthorStyleRulesForCascade(media, box);
+            var (authorNormal, authorImportant) = cssData.GetAuthorStyleRulesForCascade(media, box, containerSizes);
 
             // Inline style is parsed up front - parsing is pure text -> rule with no cascade side
             // effects, so hoisting it here (ahead of TranslateAttributes, which still runs at its
@@ -756,12 +761,12 @@ namespace PeachPDF.Html.Core.Parse
             if (!box.FirstLineProcessed)
             {
                 box.FirstLineProcessed = true;
-                ResolveFirstLineStyle(valueParser, box, cssData, media);
+                ResolveFirstLineStyle(valueParser, box, cssData, media, containerSizes);
             }
 
             foreach (var childBox in box.Boxes)
             {
-                CascadeApplyStyles(valueParser, childBox, cssData, media);
+                CascadeApplyStyles(valueParser, childBox, cssData, media, containerSizes);
             }
         }
 
@@ -803,10 +808,10 @@ namespace PeachPDF.Html.Core.Parse
         /// same declaration-application machinery as the real cascade. No inline-style handling either -
         /// inline style can never carry a <c>::first-line</c> suffix, so it plays no part here.
         /// </summary>
-        private static void ResolveFirstLineStyle(CssValueParser valueParser, CssBox box, CssData cssData, MediaQueryContext media)
+        private static void ResolveFirstLineStyle(CssValueParser valueParser, CssBox box, CssData cssData, MediaQueryContext media, ContainerQuerySizes? containerSizes = null)
         {
-            var firstLineUaRules = cssData.GetFirstLineStyleRules(media, box, userAgentOnly: true).ToList();
-            var firstLineAuthorRules = cssData.GetFirstLineStyleRules(media, box, userAgentOnly: false).ToList();
+            var firstLineUaRules = cssData.GetFirstLineStyleRules(media, box, userAgentOnly: true, containerSizes).ToList();
+            var firstLineAuthorRules = cssData.GetFirstLineStyleRules(media, box, userAgentOnly: false, containerSizes).ToList();
 
             if (firstLineUaRules.Count == 0 && firstLineAuthorRules.Count == 0) return;
 
@@ -848,7 +853,7 @@ namespace PeachPDF.Html.Core.Parse
         /// <see cref="CorrectTextBoxes"/> (so the new box's content gets resolved by that same pass,
         /// same as every other marker box).
         /// </summary>
-        private static void EnsureListItemMarkers(CssValueParser valueParser, CssBox box, CssData cssData, MediaQueryContext media)
+        private static void EnsureListItemMarkers(CssValueParser valueParser, CssBox box, CssData cssData, MediaQueryContext media, ContainerQuerySizes? containerSizes = null)
         {
             if (box.Display == CssConstants.ListItem && !box.Boxes.Any(b => b.IsMarkerPseudoElement))
             {
@@ -858,14 +863,14 @@ namespace PeachPDF.Html.Core.Parse
                 // No InheritStyle() call here: CascadeApplyStyles below unconditionally re-defaults
                 // (its own step 1) and re-inherits (step 2, box.InheritStyle()) as soon as it starts, so
                 // a pre-emptive inherit here would just be immediately discarded and redone.
-                CascadeApplyStyles(valueParser, markerBox, cssData, media);
+                CascadeApplyStyles(valueParser, markerBox, cssData, media, containerSizes);
             }
 
             foreach (var childBox in box.Boxes.ToArray())
             {
                 if (!childBox.IsMarkerPseudoElement)
                 {
-                    EnsureListItemMarkers(valueParser, childBox, cssData, media);
+                    EnsureListItemMarkers(valueParser, childBox, cssData, media, containerSizes);
                 }
             }
         }
@@ -884,7 +889,7 @@ namespace PeachPDF.Html.Core.Parse
         /// matched element - see <see cref="CssBox.MatchesFirstLetterSelector"/>'s doc comment for why
         /// that forces this into a separate, later pass instead.
         /// </summary>
-        private static void ApplyFirstLetterPseudoElements(CssValueParser valueParser, CssBox box, CssData cssData, MediaQueryContext media)
+        private static void ApplyFirstLetterPseudoElements(CssValueParser valueParser, CssBox box, CssData cssData, MediaQueryContext media, ContainerQuerySizes? containerSizes = null)
         {
             if (box.MatchesFirstLetterSelector && !box.FirstLetterProcessed)
             {
@@ -893,7 +898,7 @@ namespace PeachPDF.Html.Core.Parse
                 var textBox = FindFirstLetterTargetTextBox(box);
                 if (textBox != null)
                 {
-                    SplitFirstLetter(valueParser, cssData, media, box, textBox);
+                    SplitFirstLetter(valueParser, cssData, media, box, textBox, containerSizes);
                 }
             }
 
@@ -901,7 +906,7 @@ namespace PeachPDF.Html.Core.Parse
             {
                 if (!childBox.IsFirstLetterPseudoElement)
                 {
-                    ApplyFirstLetterPseudoElements(valueParser, childBox, cssData, media);
+                    ApplyFirstLetterPseudoElements(valueParser, childBox, cssData, media, containerSizes);
                 }
             }
         }
@@ -961,7 +966,7 @@ namespace PeachPDF.Html.Core.Parse
         /// declarations actually apply on top of that inherited baseline, the same as
         /// <see cref="EnsureListItemMarkers"/> does for its own synthesized marker box.
         /// </summary>
-        private static void SplitFirstLetter(CssValueParser valueParser, CssData cssData, MediaQueryContext media, CssBox originatingBox, CssBox textBox)
+        private static void SplitFirstLetter(CssValueParser valueParser, CssData cssData, MediaQueryContext media, CssBox originatingBox, CssBox textBox, ContainerQuerySizes? containerSizes = null)
         {
             var text = textBox.Text!;
             var idx = 0;
@@ -1000,7 +1005,7 @@ namespace PeachPDF.Html.Core.Parse
             // No InheritStyle() call here: CascadeApplyStyles below unconditionally re-defaults (its
             // own step 1) and re-inherits (step 2, box.InheritStyle()) as soon as it starts, so a
             // pre-emptive inherit here would just be immediately discarded and redone.
-            CascadeApplyStyles(valueParser, firstLetterBox, cssData, media);
+            CascadeApplyStyles(valueParser, firstLetterBox, cssData, media, containerSizes);
         }
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Utils/DomUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/DomUtils.cs
@@ -751,6 +751,27 @@ namespace PeachPDF.Html.Core.Utils
         }
 
         /// <summary>
+        /// Whether any box in <paramref name="box"/>'s subtree establishes a <c>@container</c> size query
+        /// container (<c>container-type: size</c> or <c>inline-size</c> - <c>normal</c> doesn't count,
+        /// since it establishes no size containment). Gates
+        /// <see cref="HtmlContainerInt.PerformLayout"/>'s container-query convergence loop: the
+        /// overwhelming majority of documents declare no size container at all, and for those the loop
+        /// must cost nothing beyond this one tree walk (the same cost category as
+        /// <see cref="AnyBoxClonesDecorations"/>, already run at the same point every pass).
+        /// </summary>
+        internal static bool AnyBoxEstablishesSizeContainer(CssBox box)
+        {
+            if (box.ContainerType.Value is PeachPDF.CSS.ContainerType.Size or PeachPDF.CSS.ContainerType.InlineSize) return true;
+
+            foreach (var child in box.Boxes)
+            {
+                if (AnyBoxEstablishesSizeContainer(child)) return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// The block-start border and padding that <c>box-decoration-break: clone</c> re-inserts when a
         /// fragmentation break lands inside a box
         /// (<see href="https://www.w3.org/TR/css-break-3/#break-decoration">css-break-3 §6.2</see>): each

--- a/src/PeachPDF/Html/Core/Utils/FontSizeResolver.cs
+++ b/src/PeachPDF/Html/Core/Utils/FontSizeResolver.cs
@@ -5,7 +5,7 @@ namespace PeachPDF.Html.Core.Utils
 {
     /// <summary>
     /// Resolves a CSS font-size value (absolute keyword, <c>smaller</c>/<c>larger</c>, or any length unit
-    /// <see cref="CssValueParser.ParseLength(string, double, double, double, string?, bool)"/>
+    /// <see cref="CssValueParser.ParseLength(string, double, double, double, string?, bool, double?, double?)"/>
     /// understands) to a numeric size. Extracted from <c>CssBox.ActualFont</c>'s original inline
     /// switch so in-flow content and <c>MarginBoxRenderer.BuildFont</c> (@page margin boxes, which have no
     /// real inheritance chain and pass <see cref="Utils.CssConstants.FontSize"/> for both
@@ -16,7 +16,15 @@ namespace PeachPDF.Html.Core.Utils
         /// <param name="fontSizeValue">The raw CSS font-size value (keyword or length).</param>
         /// <param name="parentSize">Reference size for <c>smaller</c>/<c>larger</c>/<c>em</c>.</param>
         /// <param name="remSize">Reference size for <c>rem</c>.</param>
-        internal static double Resolve(string fontSizeValue, double parentSize, double remSize)
+        /// <param name="containerInlineSizePt">See <see cref="PeachPDF.CSS.Length.ToPixels"/>'s parameter
+        /// of the same name - the nearest ancestor <c>@container</c> size query container's content-box
+        /// inline size, for <c>cqw</c>/<c>cqi</c>/<c>cqmin</c>/<c>cqmax</c> resolution. <c>null</c> for
+        /// callers with no real box in scope (<c>MarginBoxRenderer.BuildFont</c>'s page margin boxes),
+        /// which resolves those units to 0, same as the box-aware length overload's own fallback.</param>
+        /// <param name="containerBlockSizePt">See <see cref="PeachPDF.CSS.Length.ToPixels"/>'s parameter of
+        /// the same name.</param>
+        internal static double Resolve(string fontSizeValue, double parentSize, double remSize,
+            double? containerInlineSizePt = null, double? containerBlockSizePt = null)
         {
             var fsize = fontSizeValue switch
             {
@@ -29,7 +37,8 @@ namespace PeachPDF.Html.Core.Utils
                 CssConstants.XXLarge => CssConstants.FontSize + 4,
                 CssConstants.Smaller => parentSize - 2,
                 CssConstants.Larger => parentSize + 2,
-                _ => CssValueParser.ParseLength(fontSizeValue, parentSize, parentSize, remSize, null, true)
+                _ => CssValueParser.ParseLength(fontSizeValue, parentSize, parentSize, remSize, null, true,
+                    containerInlineSizePt, containerBlockSizePt)
             };
 
             // A legitimately-parsed font-size of 0 (or any other small value) must be honored, not

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -1342,6 +1342,36 @@
       }
     },
     {
+      "name": "container-type",
+      "comment": "CSS Containment 3 SS2. Establishes this box as a query container for @container: 'size' contains both axes (inline + block), 'inline-size' only the inline axis, 'normal' establishes no size query container (but still a style-query container - see CssBox.FindNearestQueryContainer's QueryKind.Style branch). Not inherited.",
+      "inherited": false,
+      "initialValue": "normal",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "ContainerType",
+        "keywordMap": "Map.ContainerTypes",
+        "fallback": "ContainerType.Normal"
+      },
+      "html": {
+        "propertyPath": "ContainerType",
+        "csharpDataType": "CssProperty<ContainerType>",
+        "area": "DisplayPositioningArea",
+        "getterExpression": "{box}.ContainerType.ToString()"
+      }
+    },
+    {
+      "name": "container-name",
+      "comment": "CSS Containment 3 SS2. Raw space-separated <custom-ident>+ list (or 'none'), stored as text - PeachPDF.CSS.ContainerNameProperty does not yet validate full custom-ident grammar (an existing simplification), so this delegates to it rather than re-deriving a second parser (see CLAUDE.md's 'one parser' rule). Splitting on whitespace and matching against an @container rule's queried name happens at container-resolution time (CssBox.FindNearestQueryContainer), not here.",
+      "inherited": false,
+      "initialValue": "none",
+      "cssDataType": "cssom",
+      "html": {
+        "propertyPath": "ContainerName",
+        "csharpDataType": "string",
+        "area": "DisplayPositioningArea"
+      }
+    },
+    {
       "name": "float",
       "inherited": false,
       "initialValue": "none",


### PR DESCRIPTION
## Summary

`@container` rules parsed successfully but their contents were unconditionally dropped — evaluating a container's condition depends on that element's own post-layout size, which a single-pass cascade-then-layout pipeline had no way to know before cascade runs. This implements the feature genuinely, per CSS Containment 3:

- `container-type: normal | size | inline-size`, `container-name`, and the `container` shorthand are now cascaded onto every element, establishing size and/or named query containers.
- **Size queries** (`@container (min-width: 300px) { ... }`) evaluate against the nearest eligible ancestor container's real resolved content-box size, via a bounded convergence loop that re-cascades and re-lays-out the document (up to 4 total passes) whenever a size container's resolved size changes pass-over-pass (`HtmlContainerInt.PerformLayout`).
- **`style()` queries** (`@container style(--theme: dark) { ... }`) evaluate against the nearest eligible ancestor's own resolved style (any `container-type`, including the initial `normal`, qualifies), including `and`/`or`/`not` combinators — mirroring `@supports`'s existing grammar shape with a new per-element `IStyleQueryCondition` tree.
- Container-relative units `cqw`/`cqh`/`cqi`/`cqb`/`cqmin`/`cqmax` parse and resolve against the nearest ancestor query container's own size, including inside `calc()`/`min()`/`max()`/`clamp()`.
- Nested/chained `@container` conditions (a query referencing a container itself gated by another `@container`) converge correctly since every pass does a full top-down re-cascade.

A new showcase in the TestHarness demonstrates a component whose layout changes based on its own container width rather than the page width, rasterized and visually verified through both PDFium and MuPDF per this repo's paint-verification convention.

## Scope boundaries

Six deliberately-scoped-out edges are recorded as accepted gaps with tracked issues (`.claude/accepted-gaps/`):
- The convergence loop's pass cap is bounded, not proven to converge (#614)
- Container-relative units resolve to `0` with no eligible ancestor container, same as the existing `vw`/`vh` fallback (#615)
- `style()` query value comparison is trimmed literal text, not full computed-value equivalence (#616)
- A size container's resolved size isn't re-resolved per page under `@page` per-page width overrides (#617)
- A single `@container` condition can't mix `style()` and size-feature queries (#618)
- `font-size: Ncqw` resolves to `0` for any element with text content, because word-splitting resolves fonts during cascade, before any layout pass has determined the container's size (#619)

## Test plan

- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 7740 passed, 9 skipped (pre-existing platform-specific), 0 failed
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net10.0` — same result
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings, 0 errors across all TFMs/projects
- [x] Diff coverage against `origin/main` — 98% (gate is 90%)
- [x] New showcase rasterized through both PDFium and MuPDF and visually confirmed
- [x] Independent post-change review pass against C# conventions, current C#/.NET API idioms, and CSS Containment 3 spec text; all findings fixed (a `calc()`-unit whitelist gap, `font-size` not threading container size — which surfaced the caching-order gap above, a data-modeling invariant in `CssData.ContainerCondition`, and `container-name: none foo` incorrectly accepted)

Fixes #610


---
_Generated by [Claude Code](https://claude.ai/code/session_01Va4F49XXvrHa8KeKaQeLfB)_