### PR TITLE
Add typed keyword-or-value union storage; convert z-index as the pilot

### DIFF
--- a/src/PeachPDF.SourceGenerators.Tests/GeneratorDiagnosticTests.cs
+++ b/src/PeachPDF.SourceGenerators.Tests/GeneratorDiagnosticTests.cs
@@ -611,5 +611,67 @@ namespace PeachPDF.SourceGenerators.Tests
 
             Assert.Empty(result.Diagnostics);
         }
+
+        [Fact]
+        public void KeywordOrValue_DataType_Parses_Without_Diagnostics()
+        {
+            var json = """
+                {
+                  "properties": [
+                    { "name": "z-index", "inherited": false, "initialValue": "auto",
+                      "cssDataType": { "type": "keyword-or-value", "enumType": "AutoKeyword", "keywordMap": "Map.AutoKeywords",
+                        "fallback": "AutoKeyword.Auto", "valueType": "integer" },
+                      "html": { "propertyPath": "Transform", "csharpDataType": "string", "area": "VisualEffectsArea" } }
+                  ]
+                }
+                """;
+
+            var result = GeneratorTestHost.Run(json, StubSources.MinimalCssBoxAndSvgElement);
+
+            Assert.Empty(result.Diagnostics);
+        }
+
+        [Fact]
+        public void PPG011_Passes_Against_The_Real_CssBox_For_A_KeywordOrValue_Entry()
+        {
+            var json = """
+                {
+                  "properties": [
+                    { "name": "z-index", "inherited": false, "initialValue": "auto",
+                      "cssDataType": { "type": "keyword-or-value", "enumType": "AutoKeyword", "keywordMap": "Map.AutoKeywords",
+                        "fallback": "AutoKeyword.Auto", "valueType": "integer" },
+                      "html": { "propertyPath": "ZIndex", "csharpDataType": "CssProperty<CssKeywordOrValue<AutoKeyword, int>>", "area": "DisplayPositioningArea" } }
+                  ]
+                }
+                """;
+
+            var result = GeneratorTestHost.Run(json, includePeachPdfReference: true);
+
+            Assert.DoesNotContain("PPG011", IdsOf(result));
+        }
+
+        [Fact]
+        public void KeywordOrValue_UnrecognizedValueType_FailsGenerationLoudly()
+        {
+            // valueType is only editor/schema-validated ("integer"/"length"), not re-checked at C# parse
+            // time — KeywordOrValueGrammar.Resolve is the one place that guards against an author (or a
+            // future value-type addition nobody wired up yet) writing something neither
+            // ValidatorExpressionBuilder nor RegistryEmitter know how to turn into real C#.
+            var json = """
+                {
+                  "properties": [
+                    { "name": "z-index", "inherited": false, "initialValue": "auto",
+                      "cssDataType": { "type": "keyword-or-value", "enumType": "AutoKeyword", "keywordMap": "Map.AutoKeywords",
+                        "fallback": "AutoKeyword.Auto", "valueType": "banana" },
+                      "html": { "propertyPath": "Transform", "csharpDataType": "string", "area": "VisualEffectsArea" } }
+                  ]
+                }
+                """;
+
+            var result = GeneratorTestHost.Run(json, StubSources.MinimalCssBoxAndSvgElement);
+
+            Assert.Contains("CS8785", IdsOf(result));
+            Assert.Contains(result.Diagnostics, d => d.GetMessage().Contains("valueType \"banana\""));
+        }
     }
 }

--- a/src/PeachPDF.SourceGenerators.Tests/GeneratorGoldenFileTests.cs
+++ b/src/PeachPDF.SourceGenerators.Tests/GeneratorGoldenFileTests.cs
@@ -226,6 +226,62 @@ namespace PeachPDF.SourceGenerators.Tests
         }
 
         [Fact]
+        public void Emits_KeywordOrValue_Validation_And_Storage_For_An_Integer_Or_Auto_Property()
+        {
+            var json = """
+                {
+                  "properties": [
+                    { "name": "z-index", "inherited": false, "initialValue": "auto",
+                      "cssDataType": { "type": "keyword-or-value", "enumType": "AutoKeyword", "keywordMap": "Map.AutoKeywords",
+                        "fallback": "AutoKeyword.Auto", "valueType": "integer" },
+                      "html": { "propertyPath": "Transform", "csharpDataType": "string", "area": "VisualEffectsArea" } }
+                  ]
+                }
+                """;
+
+            var result = GeneratorTestHost.Run(json, StubSources.MinimalCssBoxAndSvgElement);
+
+            var generated = result.Results.Single().GeneratedSources
+                .Single(s => s.HintName == "CssPropertyRegistry.g.cs").SourceText.ToString();
+
+            Assert.Contains(
+                "private static bool Validate_ZIndex(CssValueParser parser, string value) => " +
+                "Map.AutoKeywords.ContainsKey(value) || int.TryParse(value, out _);",
+                generated);
+            Assert.Contains(
+                "box.Transform = global::PeachPDF.CSS.CssKeywordOrValueParser.FromCssText<AutoKeyword, int>(value, Map.AutoKeywords, int.TryParse, AutoKeyword.Auto);",
+                generated);
+        }
+
+        [Fact]
+        public void Emits_KeywordOrValue_Validation_And_Storage_For_A_Length_Or_Auto_Property()
+        {
+            var json = """
+                {
+                  "properties": [
+                    { "name": "column-width", "inherited": false, "initialValue": "auto",
+                      "cssDataType": { "type": "keyword-or-value", "enumType": "AutoKeyword", "keywordMap": "Map.AutoKeywords",
+                        "fallback": "AutoKeyword.Auto", "valueType": "length" },
+                      "html": { "propertyPath": "Transform", "csharpDataType": "string", "area": "VisualEffectsArea" } }
+                  ]
+                }
+                """;
+
+            var result = GeneratorTestHost.Run(json, StubSources.MinimalCssBoxAndSvgElement);
+
+            var generated = result.Results.Single().GeneratedSources
+                .Single(s => s.HintName == "CssPropertyRegistry.g.cs").SourceText.ToString();
+
+            Assert.Contains(
+                "private static bool Validate_ColumnWidth(CssValueParser parser, string value) => " +
+                "Map.AutoKeywords.ContainsKey(value) || global::PeachPDF.Html.Core.Parse.CssValueParser.IsValidLength(value);",
+                generated);
+            Assert.Contains(
+                "box.Transform = global::PeachPDF.CSS.CssKeywordOrValueParser.FromCssText<AutoKeyword, global::PeachPDF.CSS.Length>(value, Map.AutoKeywords, global::PeachPDF.CSS.Length.TryParse, AutoKeyword.Auto);",
+                generated);
+        }
+
+        [Fact]
         public void Emits_False_For_An_Unsupported_Property()
         {
             var json = """

--- a/src/PeachPDF.SourceGenerators/Emit/KeywordOrValueGrammar.cs
+++ b/src/PeachPDF.SourceGenerators/Emit/KeywordOrValueGrammar.cs
@@ -1,0 +1,40 @@
+using System;
+using PeachPDF.SourceGenerators.Model;
+
+namespace PeachPDF.SourceGenerators.Emit
+{
+    /// <summary>
+    /// The single place a <c>DataTypeKind.KeywordOrValue</c> entry's <c>valueType</c> ("integer"/"length")
+    /// maps to real C# — the value-side validation clause, the storage type, and the <c>TryParse</c>-shaped
+    /// parser to hand to <see cref="global::PeachPDF.CSS.CssKeywordOrValueParser.FromCssText{TEnum,TValue}"/>.
+    /// <see cref="ValidatorExpressionBuilder"/> and <see cref="RegistryEmitter"/> both consult this rather
+    /// than each declaring (and separately guarding) their own copy of the valueType switch.
+    /// </summary>
+    internal static class KeywordOrValueGrammar
+    {
+        public readonly struct Resolved
+        {
+            public Resolved(string valueClause, string csharpType, string tryParseMethod)
+            {
+                ValueClause = valueClause;
+                CSharpType = csharpType;
+                TryParseMethod = tryParseMethod;
+            }
+
+            public string ValueClause { get; }
+            public string CSharpType { get; }
+            public string TryParseMethod { get; }
+        }
+
+        public static Resolved Resolve(PropertyEntry entry, DataTypeSpec dt) => dt.ValueType switch
+        {
+            "integer" => new Resolved("int.TryParse(value, out _)", "int", "int.TryParse"),
+            "length" => new Resolved(
+                "global::PeachPDF.Html.Core.Parse.CssValueParser.IsValidLength(value)",
+                "global::PeachPDF.CSS.Length", "global::PeachPDF.CSS.Length.TryParse"),
+            _ => throw new NotSupportedException(
+                $"\"{entry.Name}\" declares a keyword-or-value cssDataType with valueType \"{dt.ValueType}\", " +
+                "which KeywordOrValueGrammar does not yet implement."),
+        };
+    }
+}

--- a/src/PeachPDF.SourceGenerators/Emit/RegistryEmitter.cs
+++ b/src/PeachPDF.SourceGenerators/Emit/RegistryEmitter.cs
@@ -141,6 +141,16 @@ namespace PeachPDF.SourceGenerators.Emit
                 return $"box.{html.PropertyPath} = CssProperty<{dt.EnumType}>.FromCssText(value, {dt.KeywordMap}, {dt.Fallback});";
             }
 
+            if (entry.CssDataTypes.Count == 1 && entry.CssDataTypes[0].Kind == DataTypeKind.KeywordOrValue)
+            {
+                var dt = entry.CssDataTypes[0];
+                var resolved = KeywordOrValueGrammar.Resolve(entry, dt);
+                // Explicit type arguments: a method-group argument (int.TryParse) doesn't drive generic
+                // inference for TValue the way a concrete delegate instance would.
+                return $"box.{html.PropertyPath} = global::PeachPDF.CSS.CssKeywordOrValueParser.FromCssText<{dt.EnumType}, {resolved.CSharpType}>" +
+                       $"(value, {dt.KeywordMap}, {resolved.TryParseMethod}, {dt.Fallback});";
+            }
+
             // A case-insensitively-matched keyword (plain "keyword", or the keyword side of a union like
             // "length" | "keyword") must be stored in its canonical (as-authored-in-JSON) casing, not the
             // raw input — every downstream layout/paint comparison against this field is an ordinal match

--- a/src/PeachPDF.SourceGenerators/Emit/ValidatorExpressionBuilder.cs
+++ b/src/PeachPDF.SourceGenerators/Emit/ValidatorExpressionBuilder.cs
@@ -39,6 +39,7 @@ namespace PeachPDF.SourceGenerators.Emit
             DataTypeKind.Integer => BuildIntegerClause(dt),
             DataTypeKind.Number => "double.TryParse(value, global::System.Globalization.NumberStyles.Float, global::System.Globalization.CultureInfo.InvariantCulture, out _)",
             DataTypeKind.EnumKeyword => $"{dt.KeywordMap}.ContainsKey(value)",
+            DataTypeKind.KeywordOrValue => BuildKeywordOrValueClause(entry, dt),
             DataTypeKind.SvgPaint => "global::PeachPDF.Svg.SvgValueParsers.TryParsePaint(value, ctx.Adapter, ctx.ContextColor, out _)",
             DataTypeKind.SvgOpacity => "global::PeachPDF.Svg.SvgValueParsers.TryParseOpacity(value, out _)",
             DataTypeKind.SvgLength => "global::PeachPDF.Svg.SvgValueParsers.ParseLength(value, ctx.ViewportDiagonal) is not null",
@@ -87,6 +88,13 @@ namespace PeachPDF.SourceGenerators.Emit
 
             return string.Join(" || ", values.Select(v => $"value.Equals(\"{Escape(v)}\", {comparison})"));
         }
+
+        /// <summary>A "&lt;value&gt; | keyword" union (e.g. <c>z-index</c>'s <c>&lt;integer&gt; | auto</c>) —
+        /// the keyword side is matched case-insensitively via its own <see cref="DataTypeSpec.KeywordMap"/>
+        /// (same as <see cref="DataTypeKind.EnumKeyword"/>), the value side reuses the real grammar for
+        /// <see cref="DataTypeSpec.ValueType"/> (<see cref="KeywordOrValueGrammar"/>).</summary>
+        private static string BuildKeywordOrValueClause(PropertyEntry entry, DataTypeSpec dt) =>
+            $"{dt.KeywordMap}.ContainsKey(value) || {KeywordOrValueGrammar.Resolve(entry, dt).ValueClause}";
 
         private static string BuildIntegerClause(DataTypeSpec dt)
         {

--- a/src/PeachPDF.SourceGenerators/Model/DataTypeSpec.cs
+++ b/src/PeachPDF.SourceGenerators/Model/DataTypeSpec.cs
@@ -17,6 +17,7 @@ namespace PeachPDF.SourceGenerators.Model
         Number,
         Parsed,
         EnumKeyword,
+        KeywordOrValue,
         SvgPaint,
         SvgOpacity,
         SvgLength,
@@ -45,14 +46,17 @@ namespace PeachPDF.SourceGenerators.Model
         public string? ResultType { get; }
         public string? TypedValueType { get; }
 
-        // "enum-keyword"
+        // "enum-keyword", "keyword-or-value"
         public string? EnumType { get; }
         public string? KeywordMap { get; }
         public string? Fallback { get; }
 
+        // "keyword-or-value" — the non-keyword side's grammar/C# type ("integer" or "length")
+        public string? ValueType { get; }
+
         public DataTypeSpec(DataTypeKind kind, double? min = null, double? max = null,
             string? converter = null, string? resultType = null, string? typedValueType = null,
-            string? enumType = null, string? keywordMap = null, string? fallback = null)
+            string? enumType = null, string? keywordMap = null, string? fallback = null, string? valueType = null)
         {
             Kind = kind;
             Min = min;
@@ -63,6 +67,7 @@ namespace PeachPDF.SourceGenerators.Model
             EnumType = enumType;
             KeywordMap = keywordMap;
             Fallback = fallback;
+            ValueType = valueType;
         }
 
         public static DataTypeSpec Simple(DataTypeKind kind) => new(kind);

--- a/src/PeachPDF.SourceGenerators/Model/PropertyModelParser.cs
+++ b/src/PeachPDF.SourceGenerators/Model/PropertyModelParser.cs
@@ -337,6 +337,15 @@ namespace PeachPDF.SourceGenerators.Model
                         return new DataTypeSpec(DataTypeKind.EnumKeyword,
                             enumType: enumTypeValue.StringValue, keywordMap: keywordMapValue.StringValue, fallback: fallbackValue.StringValue);
 
+                    case "keyword-or-value":
+                        json.TryGetProperty("enumType", out var korvEnumTypeValue);
+                        json.TryGetProperty("keywordMap", out var korvKeywordMapValue);
+                        json.TryGetProperty("fallback", out var korvFallbackValue);
+                        json.TryGetProperty("valueType", out var korvValueTypeValue);
+                        return new DataTypeSpec(DataTypeKind.KeywordOrValue,
+                            enumType: korvEnumTypeValue.StringValue, keywordMap: korvKeywordMapValue.StringValue,
+                            fallback: korvFallbackValue.StringValue, valueType: korvValueTypeValue.StringValue);
+
                     default:
                         diagnostics.Add(Error(DiagnosticCode.UnknownDataType,
                             $"\"{name}\" declares an unknown cssDataType object shape \"{typeValue.StringValue}\".", json));

--- a/src/PeachPDF.Tests/CSS/CssKeywordOrValueTests.cs
+++ b/src/PeachPDF.Tests/CSS/CssKeywordOrValueTests.cs
@@ -1,0 +1,108 @@
+namespace PeachPDF.Tests.CSS
+{
+    using PeachPDF.CSS;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for <see cref="CssKeywordOrValue{TEnum,TValue}"/> and <see cref="CssKeywordOrValueParser"/> —
+    /// the "&lt;value&gt; | keyword" union backing properties like <c>z-index</c> (see
+    /// <see cref="CssPropertyTests"/> for the plain <see cref="CssProperty{T}"/> factories this mirrors).
+    /// Note: <see cref="CssProperty{T}"/>'s own <c>Value</c> is <typeparamref name="T"/> itself, not
+    /// <c>Nullable&lt;T&gt;</c> — T is unconstrained on that class, so a struct T isn't Nullable-wrapped
+    /// the way <see cref="CssKeywordOrValue{TEnum,TValue}"/>'s own (struct-constrained) Keyword/Value
+    /// members are. When <c>IsGlobalValue</c>/<c>IsUnresolved</c> is set, the outer Value is simply
+    /// <c>default(CssKeywordOrValue&lt;TEnum,TValue&gt;)</c> — a zeroed struct where both sides are unset.
+    /// </summary>
+    public class CssKeywordOrValueTests
+    {
+        [Fact]
+        public void Constructor_BothNull_Throws()
+        {
+            Assert.Throws<System.ArgumentException>(() => new CssKeywordOrValue<AutoKeyword, int>(null, null));
+        }
+
+        [Fact]
+        public void Constructor_BothProvided_Throws()
+        {
+            Assert.Throws<System.ArgumentException>(() => new CssKeywordOrValue<AutoKeyword, int>(AutoKeyword.Auto, 5));
+        }
+
+        [Fact]
+        public void FromCssText_Keyword_IsKeywordSide()
+        {
+            var p = CssKeywordOrValueParser.FromCssText<AutoKeyword, int>("auto", Map.AutoKeywords, int.TryParse, AutoKeyword.Auto);
+
+            Assert.False(p.IsGlobalValue);
+            Assert.False(p.IsUnresolved);
+            Assert.True(p.Value is { IsKeyword: true, IsValue: false });
+            Assert.Equal(AutoKeyword.Auto, p.Value.Keyword);
+            Assert.Equal("auto", p.ToString());
+        }
+
+        [Fact]
+        public void FromCssText_Value_IsValueSide()
+        {
+            var p = CssKeywordOrValueParser.FromCssText<AutoKeyword, int>("7", Map.AutoKeywords, int.TryParse, AutoKeyword.Auto);
+
+            Assert.True(p.Value is { IsKeyword: false, IsValue: true, Value: 7 });
+            Assert.Equal("7", p.ToString());
+        }
+
+        [Theory]
+        [InlineData("inherit")]
+        [InlineData("initial")]
+        [InlineData("unset")]
+        public void FromCssText_GlobalKeyword_IsGlobalValue(string text)
+        {
+            var p = CssKeywordOrValueParser.FromCssText<AutoKeyword, int>(text, Map.AutoKeywords, int.TryParse, AutoKeyword.Auto);
+
+            Assert.True(p.IsGlobalValue);
+            Assert.False(p.IsUnresolved);
+            Assert.False(p.Value.IsKeyword);
+            Assert.False(p.Value.IsValue);
+            Assert.Equal(text, p.ToString());
+        }
+
+        [Fact]
+        public void FromCssText_VarReference_IsUnresolved()
+        {
+            var p = CssKeywordOrValueParser.FromCssText<AutoKeyword, int>("var(--z)", Map.AutoKeywords, int.TryParse, AutoKeyword.Auto);
+
+            Assert.True(p.IsUnresolved);
+            Assert.False(p.IsGlobalValue);
+            Assert.False(p.Value.IsKeyword);
+            Assert.False(p.Value.IsValue);
+            Assert.Equal("var(--z)", p.ToString());
+        }
+
+        [Fact]
+        public void FromCssText_NeitherKeywordNorValue_FallsBackToKeyword()
+        {
+            // Set_* only ever calls FromCssText after Validate_* has already confirmed the value matches
+            // one side of the union, so this path is unreachable through the real cascade — this proves
+            // the fallback itself is total (never throws) rather than that any caller hits it.
+            var p = CssKeywordOrValueParser.FromCssText<AutoKeyword, int>("banana", Map.AutoKeywords, int.TryParse, AutoKeyword.Auto);
+
+            Assert.True(p.Value is { IsKeyword: true, Value: null });
+            Assert.Equal(AutoKeyword.Auto, p.Value.Keyword);
+        }
+
+        [Fact]
+        public void Equals_SameKeyword_AreEqual()
+        {
+            var a = new CssKeywordOrValue<AutoKeyword, int>(AutoKeyword.Auto, null);
+            var b = new CssKeywordOrValue<AutoKeyword, int>(AutoKeyword.Auto, null);
+
+            Assert.Equal(a, b);
+        }
+
+        [Fact]
+        public void Equals_KeywordVsValue_AreNotEqual()
+        {
+            var keyword = new CssKeywordOrValue<AutoKeyword, int>(AutoKeyword.Auto, null);
+            var value = new CssKeywordOrValue<AutoKeyword, int>(null, 0);
+
+            Assert.NotEqual(keyword, value);
+        }
+    }
+}

--- a/src/PeachPDF.Tests/CSS/GridTrackListGrammarTests.cs
+++ b/src/PeachPDF.Tests/CSS/GridTrackListGrammarTests.cs
@@ -204,5 +204,45 @@ namespace PeachPDF.Tests.CSS
         {
             Assert.Null(GridTrackListGrammar.TryParseTrackSizeList(CssValueParser.GetCssTokens(value)));
         }
+
+        // ── value equality — GridTemplate/GridTrackSize are the CssProperty<T> type argument for
+        // grid-template-columns/-rows, so the cascade's copy-on-write comparison depends on two separately
+        // parsed instances of the same authored text comparing equal (see CssProperty<T>'s own remarks). ──
+
+        [Theory]
+        [InlineData("100px 1fr auto")]
+        [InlineData("minmax(100px, 1fr) minmax(min-content, max-content)")]
+        [InlineData("[start] 100px [middle] 1fr [end]")]
+        [InlineData("repeat(auto-fill, minmax(200px, 1fr))")]
+        [InlineData("100px repeat(2, 1fr) 100px")]
+        public void GridTemplate_TwoSeparateParsesOfTheSameText_AreEqual(string value)
+        {
+            var a = Parse(value);
+            var b = Parse(value);
+
+            Assert.NotSame(a, b);
+            Assert.Equal(a, b);
+            Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        }
+
+        [Theory]
+        [InlineData("100px 1fr", "100px 2fr")]                 // different track
+        [InlineData("100px 1fr", "100px 1fr 1fr")]              // different track count
+        [InlineData("[a] 100px", "[b] 100px")]                  // different line name
+        [InlineData("repeat(auto-fill, 100px)", "repeat(auto-fit, 100px)")] // different auto-repeat kind
+        public void GridTemplate_DifferingText_AreNotEqual(string a, string b)
+        {
+            Assert.NotEqual(Parse(a), Parse(b));
+        }
+
+        [Fact]
+        public void GridTemplate_SubgridWithNoNamedLines_EqualsAnotherEmptySubgrid()
+        {
+            var a = Parse("subgrid");
+            var b = Parse("subgrid");
+
+            Assert.Equal(a, b);
+            Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        }
     }
 }

--- a/src/PeachPDF.Tests/Html/Core/Dom/ComputedStyleTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/ComputedStyleTests.cs
@@ -295,13 +295,17 @@ namespace PeachPDF.Tests.Html.Core.Dom
         /// silently reintroducing a correctness bug) if a future area/property addition breaks the
         /// no-op assumption the fast path depends on.
         /// <para>
-        /// <c>direction</c>/<c>unicode-bidi</c>/<c>writing-mode</c>/<c>container-type</c> joined the
-        /// exception set for the same reason <c>grid-template-columns</c>/<c>-rows</c> are already here:
-        /// all six are <see cref="CSS.CssProperty{T}"/>-typed (a <see langword="sealed class"/> with no
-        /// value equality), so <c>CssProperty{T}.FromCssText</c> re-parsing the same initial-value
-        /// string always produces a new, reference-distinct instance even when the parsed value is
-        /// identical - the cascade's copy-on-write comparison has no way to see through that and always
-        /// clones the area.
+        /// Every <see cref="CSS.CssProperty{T}"/>-backed property (<c>direction</c>/<c>unicode-bidi</c>/
+        /// <c>writing-mode</c>/<c>container-type</c>/<c>z-index</c>/<c>grid-template-columns</c>/
+        /// <c>-rows</c>) is exempt from needing an exception here: <see cref="CSS.CssProperty{T}"/> is a
+        /// record, and every T it's instantiated with (an enum, <see cref="CSS.CssKeywordOrValue{TEnum,TValue}"/>,
+        /// or <see cref="CSS.GridTemplate"/> — the latter two records too, with <see cref="CSS.GridTemplate"/>
+        /// giving its list/dictionary-typed members explicit content equality since the BCL collection
+        /// types don't have that by default) compares by value, so re-parsing the same initial-value
+        /// string twice correctly produces an equal <see cref="CSS.CssProperty{T}"/> and the cascade's
+        /// copy-on-write comparison sees the real no-op. Only <c>font-family</c> remains, for an unrelated
+        /// reason: its setter is a multi-field write (<c>FontFamily</c> + <c>FontFamilyList</c> from one
+        /// declaration), not a <see cref="CSS.CssProperty{T}"/> reference-equality artifact.
         /// </para>
         /// </summary>
         [Fact]
@@ -310,12 +314,6 @@ namespace PeachPDF.Tests.Html.Core.Dom
             var knownExceptions = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase)
             {
                 PropertyNames.FontFamily,
-                PropertyNames.GridTemplateColumns,
-                PropertyNames.GridTemplateRows,
-                PropertyNames.Direction,
-                PropertyNames.UnicodeBidirectional,
-                PropertyNames.WritingMode,
-                PropertyNames.ContainerType,
             };
             var parser = new CssValueParser(new PdfSharpAdapter());
             var unexpectedlyNotNoOp = new List<string>();

--- a/src/PeachPDF.Tests/Html/Core/Utils/CssUtilsTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Utils/CssUtilsTests.cs
@@ -26,7 +26,7 @@ namespace PeachPDF.Tests.Html.Core.Utils
             Assert.Equal(box.Overflow, CssUtils.GetPropertyValue(box, "overflow"));
             Assert.Equal(box.TextAlign, CssUtils.GetPropertyValue(box, "text-align"));
             Assert.Equal(box.FontWeight, CssUtils.GetPropertyValue(box, "font-weight"));
-            Assert.Equal(box.ZIndex, CssUtils.GetPropertyValue(box, "z-index"));
+            Assert.Equal(box.ZIndex.ToString(), CssUtils.GetPropertyValue(box, "z-index"));
         }
 
         [Fact]
@@ -172,10 +172,12 @@ namespace PeachPDF.Tests.Html.Core.Utils
             var (box, parser) = await FindDivBoxAndParser("");
 
             CssUtils.SetPropertyValue(parser, box, "z-index", "auto");
-            Assert.Equal("auto", box.ZIndex);
+            Assert.Equal("auto", box.ZIndex.ToString());
+            Assert.True(box.ZIndex.Value is { IsKeyword: true });
 
             CssUtils.SetPropertyValue(parser, box, "z-index", "5");
-            Assert.Equal("5", box.ZIndex);
+            Assert.Equal("5", box.ZIndex.ToString());
+            Assert.True(box.ZIndex.Value is { IsValue: true, Value: 5 });
         }
 
         [Fact]
@@ -185,7 +187,7 @@ namespace PeachPDF.Tests.Html.Core.Utils
 
             CssUtils.SetPropertyValue(parser, box, "z-index", "not-a-number");
 
-            Assert.Equal("3", box.ZIndex);
+            Assert.Equal("3", box.ZIndex.ToString());
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/ZIndexCalcIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/ZIndexCalcIntegrationTests.cs
@@ -10,8 +10,9 @@ namespace PeachPDF.Tests.Integration
     /// Level 4 §10.9), through the full cascade pipeline - not just the CSS-OM parser level covered by
     /// <c>WptCssPositionInsetLogicalParsingTests</c>. <c>CssUtils.cs</c>'s DOM-application step gates
     /// z-index on <c>int.TryParse</c> before assigning <see cref="CssBox.ZIndex"/>, and
-    /// <c>StackingOrder</c> later does a bare <c>int.Parse(box.ZIndex)</c> - both would break if a
-    /// z-index calc() only got as far as parsing without also being folded to a literal integer string.
+    /// <c>StackingOrder</c> later reads <c>box.ZIndex.Value.Value</c> (the resolved
+    /// <c>CssKeywordOrValue&lt;AutoKeyword,int&gt;</c>'s int side) - both would break if a z-index calc()
+    /// only got as far as parsing without also being folded to a literal integer string.
     /// </summary>
     public class ZIndexCalcIntegrationTests
     {
@@ -24,7 +25,8 @@ namespace PeachPDF.Tests.Integration
             var box = LayoutHarness.FindById(root, "t");
 
             Assert.NotNull(box);
-            Assert.Equal("1", box!.ZIndex);
+            Assert.Equal("1", box!.ZIndex.ToString());
+            Assert.True(box.ZIndex.Value is { IsValue: true, Value: 1 });
         }
 
         [Fact]
@@ -36,7 +38,8 @@ namespace PeachPDF.Tests.Integration
             var box = LayoutHarness.FindById(root, "t");
 
             Assert.NotNull(box);
-            Assert.Equal("-6", box!.ZIndex);
+            Assert.Equal("-6", box!.ZIndex.ToString());
+            Assert.True(box.ZIndex.Value is { IsValue: true, Value: -6 });
         }
     }
 }

--- a/src/PeachPDF/CSS/CssKeywordOrValue.cs
+++ b/src/PeachPDF/CSS/CssKeywordOrValue.cs
@@ -12,6 +12,15 @@ namespace PeachPDF.CSS
     /// manual stand-in for a real C# union type, which would replace this once the language has one. A
     /// record struct so the outer <see cref="CssProperty{T}"/>'s own record equality sees through to real
     /// value equality here too, instead of falling back to the default (reflection-based) struct equality.
+    /// <para>
+    /// The "exactly one is set" invariant is enforced by <see cref="CssKeywordOrValue{TEnum,TValue}(TEnum?,TValue?)"/>,
+    /// not by the type itself — <c>default(CssKeywordOrValue{TEnum,TValue})</c> (both null) bypasses it
+    /// entirely, and is exactly what <see cref="CssProperty{T}"/>'s <c>Value</c> holds whenever
+    /// <c>IsGlobalValue</c>/<c>IsUnresolved</c> is set instead (see <see cref="CssKeywordOrValueParser.FromCssText{TEnum,TValue}"/>).
+    /// A caller must check <see cref="CssProperty{T}.IsGlobalValue"/>/<see cref="CssProperty{T}.IsUnresolved"/>
+    /// before trusting <see cref="IsKeyword"/>/<see cref="IsValue"/> to mean "the property actually has a
+    /// keyword/value" rather than "neither, because there's no resolved value at all right now".
+    /// </para>
     /// </summary>
     internal readonly record struct CssKeywordOrValue<TEnum, TValue>
         where TEnum : struct, Enum

--- a/src/PeachPDF/CSS/CssKeywordOrValue.cs
+++ b/src/PeachPDF/CSS/CssKeywordOrValue.cs
@@ -1,0 +1,72 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace PeachPDF.CSS
+{
+    /// <summary>
+    /// A resolved <see cref="CssProperty{T}"/> value for a property whose grammar is a keyword <b>or</b> a
+    /// typed value (e.g. <c>z-index</c>'s <c>&lt;integer&gt; | auto</c>, <c>column-width</c>'s
+    /// <c>&lt;length&gt; | auto</c>) — exactly one of <see cref="Keyword"/>/<see cref="Value"/> is set. A
+    /// manual stand-in for a real C# union type, which would replace this once the language has one. A
+    /// record struct so the outer <see cref="CssProperty{T}"/>'s own record equality sees through to real
+    /// value equality here too, instead of falling back to the default (reflection-based) struct equality.
+    /// </summary>
+    internal readonly record struct CssKeywordOrValue<TEnum, TValue>
+        where TEnum : struct, Enum
+        where TValue : struct
+    {
+        public CssKeywordOrValue(TEnum? keyword, TValue? value)
+        {
+            if (keyword is null == value is null)
+                throw new ArgumentException("Exactly one of keyword or value must be provided.");
+
+            Keyword = keyword;
+            Value = value;
+        }
+
+        public TEnum? Keyword { get; init; }
+        public TValue? Value { get; init; }
+
+        public bool IsKeyword => Keyword is not null;
+        public bool IsValue => Value is not null;
+    }
+
+    internal static class CssKeywordOrValueParser
+    {
+        public delegate bool TryParseValue<TValue>(string text, out TValue value) where TValue : struct;
+
+        /// <summary>
+        /// Parses a <see cref="CssKeywordOrValue{TEnum,TValue}"/>-backed <see cref="CssProperty{T}"/> from
+        /// its authored text, mirroring <see cref="CssProperty{T}.FromCssText"/>'s CSS-wide-keyword/
+        /// <c>var()</c>/keyword-map handling — the only addition is a <paramref name="tryParseValue"/>
+        /// fallback for the non-keyword side of the union, tried once the keyword map misses.
+        /// </summary>
+        public static CssProperty<CssKeywordOrValue<TEnum, TValue>> FromCssText<TEnum, TValue>(
+            string value, IReadOnlyDictionary<string, TEnum> keywordMap, TryParseValue<TValue> tryParseValue,
+            TEnum fallback)
+            where TEnum : struct, Enum
+            where TValue : struct
+        {
+            if (CssGlobalKeywords.TryParse(value, out var globalKeyword))
+                return CssProperty<CssKeywordOrValue<TEnum, TValue>>.Global(globalKeyword);
+
+            if (value.Contains("var(", StringComparison.OrdinalIgnoreCase))
+                return CssProperty<CssKeywordOrValue<TEnum, TValue>>.Unresolved(value);
+
+            if (keywordMap.TryGetValue(value.Trim(), out var keyword))
+                return CssProperty<CssKeywordOrValue<TEnum, TValue>>.FromValue(
+                    value, new CssKeywordOrValue<TEnum, TValue>(keyword, null));
+
+            if (tryParseValue(value, out var parsed))
+                return CssProperty<CssKeywordOrValue<TEnum, TValue>>.FromValue(
+                    value, new CssKeywordOrValue<TEnum, TValue>(null, parsed));
+
+            // Set_* only ever calls this after Validate_* has confirmed the value matches the keyword map
+            // or the value grammar, so this is unreachable in practice — kept total, like FromCssText.
+            return CssProperty<CssKeywordOrValue<TEnum, TValue>>.FromValue(
+                value, new CssKeywordOrValue<TEnum, TValue>(fallback, null));
+        }
+    }
+}

--- a/src/PeachPDF/CSS/CssProperty.cs
+++ b/src/PeachPDF/CSS/CssProperty.cs
@@ -28,8 +28,17 @@ namespace PeachPDF.CSS
     /// The authored/keyword text is retained so the string-based getter/snapshot/revert cascade path keeps
     /// working (<see cref="ToString"/>). Grid templates (<c>T = GridTemplate</c>) are the first adopter; the
     /// mechanism is intended to eventually back every box property.
+    /// <para>
+    /// A <c>record</c>, not a plain class: the cascade's copy-on-write comparison (<c>ComputedStyleAreas
+    /// .SetPropertyValue</c>) needs to see that re-parsing the same authored text twice (e.g. the cascade
+    /// defaulting loop re-applying a property's own initial value to a fresh box) produces an <i>equal</i>
+    /// value, not just an equal-looking one — value equality here is what lets that stay a real no-op
+    /// instead of always cloning the area. (Whether <typeparamref name="T"/> itself compares by value
+    /// still depends on T — an enum or record T like <see cref="CssKeywordOrValue{TEnum,TValue}"/> gets a
+    /// real no-op; a plain-class T like <c>GridTemplate</c> falls back to reference equality on Value.)
+    /// </para>
     /// </summary>
-    internal sealed class CssProperty<T>
+    internal sealed record CssProperty<T>
     {
         private readonly string _cssText;
 

--- a/src/PeachPDF/CSS/CssProperty.cs
+++ b/src/PeachPDF/CSS/CssProperty.cs
@@ -30,12 +30,20 @@ namespace PeachPDF.CSS
     /// mechanism is intended to eventually back every box property.
     /// <para>
     /// A <c>record</c>, not a plain class: the cascade's copy-on-write comparison (<c>ComputedStyleAreas
-    /// .SetPropertyValue</c>) needs to see that re-parsing the same authored text twice (e.g. the cascade
-    /// defaulting loop re-applying a property's own initial value to a fresh box) produces an <i>equal</i>
-    /// value, not just an equal-looking one — value equality here is what lets that stay a real no-op
-    /// instead of always cloning the area. (Whether <typeparamref name="T"/> itself compares by value
-    /// still depends on T — an enum or record T like <see cref="CssKeywordOrValue{TEnum,TValue}"/> gets a
-    /// real no-op; a plain-class T like <c>GridTemplate</c> falls back to reference equality on Value.)
+    /// .SetPropertyValue</c>) needs to see that re-parsing the <i>same authored text</i> twice (e.g. the
+    /// cascade defaulting loop re-applying a property's own initial value to a fresh box) produces an
+    /// <i>equal</i> value, not just an equal-looking one — that's what lets it stay a real no-op instead of
+    /// always cloning the area. Because a record's synthesized equality compares every instance field —
+    /// including the raw authored text (<c>_cssText</c>), not just <see cref="Value"/> — this is "same
+    /// authored text and same resolved state", not pure semantic equality: two differently-cased or
+    /// differently-whitespaced spellings of the same value (e.g. <c>"AUTO"</c> vs <c>"auto"</c>) do NOT
+    /// compare equal even when they'd resolve to the same <typeparamref name="T"/>. That's sufficient for
+    /// the defaulting-loop no-op (which always re-applies the literal initial-value string), but a future
+    /// caller comparing two independently-authored declarations for semantic equality needs to compare
+    /// <see cref="Value"/> directly instead. Whether <typeparamref name="T"/> itself then compares by value
+    /// depends on T — an enum, or a record/record-struct T like <see cref="CssKeywordOrValue{TEnum,TValue}"/>
+    /// or <c>GridTemplate</c>, gets real structural equality; a plain class T with no equality override
+    /// would fall back to reference equality on <see cref="Value"/>.
     /// </para>
     /// </summary>
     internal sealed record CssProperty<T>

--- a/src/PeachPDF/CSS/Enumerations/AutoKeyword.cs
+++ b/src/PeachPDF/CSS/Enumerations/AutoKeyword.cs
@@ -1,0 +1,8 @@
+namespace PeachPDF.CSS
+{
+    /// <summary>The keyword side of a <c>&lt;value&gt; | auto</c>-shaped property's <see cref="CssKeywordOrValue{TEnum,TValue}"/>.</summary>
+    internal enum AutoKeyword
+    {
+        Auto
+    }
+}

--- a/src/PeachPDF/CSS/GridTrackListGrammar.cs
+++ b/src/PeachPDF/CSS/GridTrackListGrammar.cs
@@ -1,5 +1,6 @@
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -25,9 +26,12 @@ namespace PeachPDF.CSS
     /// <summary>
     /// A single grid <c>&lt;track-size&gt;</c>. Fixed/percentage/fit-content values keep their authored
     /// component string (<see cref="Value"/>) for Layer B to resolve against the container; <c>fr</c> keeps
-    /// its numeric factor (<see cref="Flex"/>); <c>minmax()</c> keeps its two sub-breadths.
+    /// its numeric factor (<see cref="Flex"/>); <c>minmax()</c> keeps its two sub-breadths. A record (not a
+    /// plain class) so the value it carries through <see cref="CssProperty{T}"/> compares by content, not
+    /// by reference — every field here is itself value-equal (Kind/Value/Flex directly, Min/Max
+    /// recursively through this same record equality), so no custom Equals/GetHashCode is needed.
     /// </summary>
-    internal sealed class GridTrackSize
+    internal sealed record GridTrackSize
     {
         public GridTrackKind Kind { get; private init; }
         public string Value { get; private init; }
@@ -51,7 +55,16 @@ namespace PeachPDF.CSS
     /// <c>repeat(N,…)</c>-expanded) tracks, plus at most one layout-time <c>repeat(auto-fill|auto-fit,…)</c>
     /// section recorded as an insertion point since its count is resolved during layout.
     /// </summary>
-    internal sealed class GridTemplate
+    /// <remarks>
+    /// A record, like <see cref="GridTrackSize"/>, so it compares by content through
+    /// <see cref="CssProperty{T}"/> — but three members are collections, which the .NET BCL never gives
+    /// structural equality by default (<c>List{T}</c>/<c>Dictionary{TKey,TValue}</c> both fall back to
+    /// reference equality), so a record's synthesized <c>Equals</c>/<c>GetHashCode</c> alone would not
+    /// actually be content-based for <see cref="Tracks"/>/<see cref="AutoRepeatTracks"/>/
+    /// <see cref="LineNames"/>. <see cref="Equals(GridTemplate)"/>/<see cref="GetHashCode"/> below replace
+    /// the synthesized members with ones that walk those collections explicitly.
+    /// </remarks>
+    internal sealed record GridTemplate
     {
         /// <summary>The fixed tracks (with the auto-repeat section, if any, NOT included here — it is
         /// spliced in at <see cref="AutoRepeatInsertIndex"/> at layout time).</summary>
@@ -76,6 +89,36 @@ namespace PeachPDF.CSS
         public bool IsSubgrid { get; init; }
 
         public bool IsNone => !IsSubgrid && Tracks.Count == 0 && AutoRepeat == GridAutoRepeatKind.None;
+
+        public bool Equals(GridTemplate other) =>
+            other is not null &&
+            AutoRepeat == other.AutoRepeat &&
+            AutoRepeatInsertIndex == other.AutoRepeatInsertIndex &&
+            IsSubgrid == other.IsSubgrid &&
+            Tracks.SequenceEqual(other.Tracks) &&
+            (AutoRepeatTracks ?? []).SequenceEqual(other.AutoRepeatTracks ?? []) &&
+            LineNamesEqual(LineNames, other.LineNames);
+
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            hash.Add(AutoRepeat);
+            hash.Add(AutoRepeatInsertIndex);
+            hash.Add(IsSubgrid);
+            foreach (var track in Tracks) hash.Add(track);
+            foreach (var track in AutoRepeatTracks ?? []) hash.Add(track);
+            foreach (var (name, lines) in LineNames.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+            {
+                hash.Add(name);
+                foreach (var line in lines) hash.Add(line);
+            }
+            return hash.ToHashCode();
+        }
+
+        private static bool LineNamesEqual(
+            IReadOnlyDictionary<string, IReadOnlyList<int>> a, IReadOnlyDictionary<string, IReadOnlyList<int>> b) =>
+            a.Count == b.Count &&
+            a.All(kv => b.TryGetValue(kv.Key, out var otherLines) && kv.Value.SequenceEqual(otherLines));
     }
 
     /// <summary>

--- a/src/PeachPDF/CSS/Model/Map.cs
+++ b/src/PeachPDF/CSS/Model/Map.cs
@@ -267,6 +267,11 @@ namespace PeachPDF.CSS
                 {Keywords.Ltr, DirectionMode.Ltr},
                 {Keywords.Rtl, DirectionMode.Rtl}
             }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        public static readonly FrozenDictionary<string, AutoKeyword> AutoKeywords =
+            new Dictionary<string, AutoKeyword>(StringComparer.OrdinalIgnoreCase)
+            {
+                {Keywords.Auto, AutoKeyword.Auto}
+            }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
         public static readonly FrozenDictionary<string, WritingMode> WritingModes =
             new Dictionary<string, WritingMode>(StringComparer.OrdinalIgnoreCase)
             {

--- a/src/PeachPDF/Html/Core/Dom/ComputedStyleAreas.cs
+++ b/src/PeachPDF/Html/Core/Dom/ComputedStyleAreas.cs
@@ -238,7 +238,11 @@ namespace PeachPDF.Html.Core.Dom
         public string Float { get; init; } = CssDefaults.GetInitialValue(PropertyNames.Float)!;
         public string Clear { get; init; } = CssDefaults.GetInitialValue(PropertyNames.Clear)!;
         public string Position { get; init; } = CssDefaults.GetInitialValue(PropertyNames.Position)!;
-        public string ZIndex { get; init; } = CssDefaults.GetInitialValue(PropertyNames.ZIndex)!;
+        // Issue #598's follow-up: typed union storage (CssKeywordOrValue<AutoKeyword, int>) instead of a
+        // raw string, same mechanism as Direction/UnicodeBidi/WritingMode below.
+        public CssProperty<CssKeywordOrValue<AutoKeyword, int>> ZIndex { get; init; } =
+            CssKeywordOrValueParser.FromCssText<AutoKeyword, int>(
+                CssDefaults.GetInitialValue(PropertyNames.ZIndex)!, Map.AutoKeywords, int.TryParse, AutoKeyword.Auto);
         public string Overflow { get; init; } = CssDefaults.GetInitialValue(PropertyNames.Overflow)!;
 
         // ContainerType carries its parsed enum through the cascade (CssProperty<T>), same as

--- a/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
@@ -1436,7 +1436,7 @@ namespace PeachPDF.Html.Core.Dom
 
         #region Z-index
 
-        public string ZIndex
+        public CssProperty<CssKeywordOrValue<AutoKeyword, int>> ZIndex
         {
             get => _computedStyle.DisplayPositioning.ZIndex;
             set

--- a/src/PeachPDF/Html/Core/Paint/StackingOrder.cs
+++ b/src/PeachPDF/Html/Core/Paint/StackingOrder.cs
@@ -183,9 +183,9 @@ namespace PeachPDF.Html.Core.Paint
             {
                 var zIndex = 0;
 
-                if (participant.Box.ZIndex is not CssConstants.Auto)
+                if (participant.Box.ZIndex.Value is { IsValue: true } zIndexValue)
                 {
-                    zIndex = int.Parse(participant.Box.ZIndex);
+                    zIndex = zIndexValue.Value.GetValueOrDefault();
                 }
 
                 if (!boxesByLayer.TryGetValue(zIndex, out var layer))

--- a/src/PeachPDF/Html/Core/Utils/DomUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/DomUtils.cs
@@ -904,7 +904,7 @@ namespace PeachPDF.Html.Core.Utils
                 return true;
             }
 
-            if (box.Position is CssConstants.Absolute or CssConstants.Relative && box.ZIndex is not CssConstants.Auto)
+            if (box.Position is CssConstants.Absolute or CssConstants.Relative && box.ZIndex.Value is { IsValue: true })
             {
                 return true;
             }
@@ -917,7 +917,7 @@ namespace PeachPDF.Html.Core.Utils
             // Flex item with a z-index other than auto establishes a stacking context even without a
             // `position` value of its own (CSS Flexible Box Layout §z-order), unlike a plain block/
             // inline child, which needs position:relative/absolute for z-index to have any effect at all.
-            if (box.ZIndex is not CssConstants.Auto &&
+            if (box.ZIndex.Value is { IsValue: true } &&
                 box.ParentBox?.Display is CssConstants.Flex or CssConstants.InlineFlex)
             {
                 return true;

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -1456,20 +1456,21 @@
     },
     {
       "name": "z-index",
+      "comment": "CssKeywordOrValue<AutoKeyword, int>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText.",
       "inherited": false,
       "initialValue": "auto",
-      "cssDataType": [
-        "keyword",
-        "integer"
-      ],
-      "supportedValues": [
-        "auto"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "keyword-or-value",
+        "enumType": "AutoKeyword",
+        "keywordMap": "Map.AutoKeywords",
+        "fallback": "AutoKeyword.Auto",
+        "valueType": "integer"
+      },
       "html": {
         "propertyPath": "ZIndex",
-        "csharpDataType": "string",
-        "area": "DisplayPositioningArea"
+        "csharpDataType": "CssProperty<CssKeywordOrValue<AutoKeyword, int>>",
+        "area": "DisplayPositioningArea",
+        "getterExpression": "{box}.ZIndex.ToString()"
       }
     },
     {

--- a/src/PeachPDF/css-properties.schema.json
+++ b/src/PeachPDF/css-properties.schema.json
@@ -128,6 +128,18 @@
             "keywordMap": { "type": "string" },
             "fallback": { "type": "string" }
           }
+        },
+        {
+          "type": "object",
+          "required": ["type", "enumType", "keywordMap", "fallback", "valueType"],
+          "description": "A CssProperty<CssKeywordOrValue<TEnum,TValue>>-backed property for a '<value> | keyword' grammar (z-index's <integer> | auto, column-width's <length> | auto, ...) that can't use plain 'keyword' or 'enum-keyword' since it isn't keyword-only. Validation checks keywordMap's own keys (case-insensitive, like enum-keyword) OR the valueType grammar; no separate supportedValues/keywordComparison needed. CssKeywordOrValueParser.FromCssText mirrors CssProperty<T>.FromCssText's fallback behavior.",
+          "properties": {
+            "type": { "const": "keyword-or-value" },
+            "enumType": { "type": "string" },
+            "keywordMap": { "type": "string" },
+            "fallback": { "type": "string" },
+            "valueType": { "type": "string", "enum": ["integer", "length"], "description": "The non-keyword side's grammar and TValue — must match a TryParse-shaped parser (int.TryParse, Length.TryParse) RegistryEmitter knows how to call." }
+          }
         }
       ]
     },


### PR DESCRIPTION
## Summary

Follow-up to #598 (already fixed and merged in #627 — this PR is architecture, not a bug fix). Rather than leaving `<keyword> | <value>`-shaped CSS properties (`z-index`'s `<integer> | auto`, `column-width`'s `<length> | auto`, etc.) as canonicalized strings, this adds real typed union storage so a layout/paint consumer reads a resolved value instead of re-parsing a string — and converts one property (`z-index`) end to end to prove the mechanism before scaling it to the rest in follow-up PRs.

- `CssKeywordOrValue<TEnum,TValue>` (record struct) plus `CssKeywordOrValueParser.FromCssText` mirror `CssProperty<T>`'s existing `FromCssText` factory for the "keyword or typed value" shape.
- `CssProperty<T>` becomes a `record` (was a plain class) so the cascade's copy-on-write comparison (`ComputedStyleAreas.SetPropertyValue`) sees two separate parses of the same authored text as equal instead of always cloning the area. `GridTrackSize`/`GridTemplate` (the other `CssProperty<T>` type argument in active use, for `grid-template-*`) become records too, with `GridTemplate` getting hand-written `Equals`/`GetHashCode` since its list/dictionary-typed members don't get structural equality from the BCL by default.
- The source generator gains a new `keyword-or-value` `cssDataType` shape (`DataTypeKind.KeywordOrValue`), with validation and setter codegen sharing one `KeywordOrValueGrammar` lookup rather than duplicating the value-type switch (and its "unsupported" guard) in two places.
- `z-index` is converted end to end: `css-properties.json`'s entry, `CssBox.ZIndex`'s field type, and every real call site (`DomUtils.IsStackingContextBox`, `StackingOrder.ByLayers`).

## Test plan

- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings, zero errors
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 7842 passed, 0 failed
- [x] `dotnet test PeachPDF.SourceGenerators.Tests/PeachPDF.SourceGenerators.Tests.csproj` — 91 passed, 0 failed (new golden-file + diagnostic tests for the `keyword-or-value` data type, including a PPG011 pass against the real `CssBox.ZIndex`)
- [x] `dotnet test PeachPDF.Cli.Tests/PeachPDF.Cli.Tests.csproj` — 96 passed, 0 failed
- [x] Diff coverage via `diff-cover` against `origin/main` — 100%
- [x] New `CssKeywordOrValueTests.cs` and `GridTrackListGrammarTests.cs` equality theories assert real behavior (resolved union side, equality/hash agreement across independently-parsed instances), not just "did it run"
- [x] `ComputedStyleTests.CascadeDefaultingLoop_OnAFreshBox_OnlyKnownExceptionsAreNotNoOps`'s allowlist shrank from 7 properties to just `FontFamily` (unrelated multi-field-write reason), confirming the new value equality actually closes the reference-equality gap it targets


---
_Generated by [Claude Code](https://claude.ai/code/session_01WsuX3xR9EsNY3x1a5RGQmJ)_