### PR TITLE
Convert box-sizing, box-decoration-break, column-fill, column-span to enum-keyword storage

### DIFF
--- a/src/PeachPDF.Tests/CSS/CssPropertyTests.cs
+++ b/src/PeachPDF.Tests/CSS/CssPropertyTests.cs
@@ -50,6 +50,28 @@ namespace PeachPDF.Tests.CSS
         }
 
         [Theory]
+        [InlineData("ltr", "ltr")]
+        [InlineData("LTR", "ltr")]     // issue #598: matched case-insensitively, stored canonicalized
+        [InlineData("Rtl", "rtl")]
+        public void FromCssText_KeywordMatch_StoresCanonicalCasing(string authored, string expectedText)
+        {
+            var p = CssProperty<DirectionMode>.FromCssText(authored, Map.DirectionModes, DirectionMode.Ltr);
+
+            Assert.False(p.IsGlobalValue);
+            Assert.False(p.IsUnresolved);
+            Assert.Equal(expectedText, p.ToString());
+        }
+
+        [Fact]
+        public void FromCssText_UnrecognizedKeyword_FallsBackAndKeepsRawText()
+        {
+            var p = CssProperty<DirectionMode>.FromCssText("sideways", Map.DirectionModes, DirectionMode.Ltr);
+
+            Assert.Equal(DirectionMode.Ltr, p.Value);
+            Assert.Equal("sideways", p.ToString());
+        }
+
+        [Theory]
         [InlineData("inherit")]
         [InlineData("INITIAL")]      // case-insensitive
         [InlineData("revert-layer")]

--- a/src/PeachPDF.Tests/Html/Core/Dom/ComputedStyleTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/ComputedStyleTests.cs
@@ -172,13 +172,17 @@ namespace PeachPDF.Tests.Html.Core.Dom
         {
             // box-sizing was deliberately made non-inherited (CSS Box Sizing 3 §3) - BoxModel (which now
             // holds BoxSizing) must therefore never be among the areas InheritStyle adopts by reference.
-            var parent = new CssBox(null, null) { BoxSizing = "border-box", Width = "100px" };
+            var parent = new CssBox(null, null)
+            {
+                BoxSizing = CssProperty<BoxSizingMode>.FromCssText("border-box", Map.BoxSizingModes, BoxSizingMode.ContentBox),
+                Width = "100px"
+            };
             var child = new CssBox(parent, null);
 
             child.InheritStyle();
 
             Assert.NotSame(parent.ComputedStyle.BoxModel, child.ComputedStyle.BoxModel);
-            Assert.Equal("content-box", child.BoxSizing);
+            Assert.Equal("content-box", child.BoxSizing.ToString());
             Assert.Equal("auto", child.Width);
         }
 
@@ -212,12 +216,15 @@ namespace PeachPDF.Tests.Html.Core.Dom
             // BoxDecorationBreak/the break properties/PdfTagType. Without this, a border-box element split
             // across an inline/block boundary would have its continuation fragment silently revert to the
             // CSS initial content-box.
-            var source = new CssBox(null, null) { BoxSizing = "border-box" };
+            var source = new CssBox(null, null)
+            {
+                BoxSizing = CssProperty<BoxSizingMode>.FromCssText("border-box", Map.BoxSizingModes, BoxSizingMode.ContentBox)
+            };
             var clone = new CssBox(null, null);
 
             clone.InheritStyle(source, everything: true);
 
-            Assert.Equal("border-box", clone.BoxSizing);
+            Assert.Equal("border-box", clone.BoxSizing.ToString());
         }
 
         [Fact]
@@ -297,7 +304,8 @@ namespace PeachPDF.Tests.Html.Core.Dom
         /// <para>
         /// Every <see cref="CSS.CssProperty{T}"/>-backed property (<c>direction</c>/<c>unicode-bidi</c>/
         /// <c>writing-mode</c>/<c>container-type</c>/<c>z-index</c>/<c>grid-template-columns</c>/
-        /// <c>-rows</c>) is exempt from needing an exception here: <see cref="CSS.CssProperty{T}"/> is a
+        /// <c>-rows</c>/<c>box-sizing</c>/<c>box-decoration-break</c>/<c>column-fill</c>/<c>column-span</c>)
+        /// is exempt from needing an exception here: <see cref="CSS.CssProperty{T}"/> is a
         /// record, and every T it's instantiated with (an enum, <see cref="CSS.CssKeywordOrValue{TEnum,TValue}"/>,
         /// or <see cref="CSS.GridTemplate"/> — the latter two records too, with <see cref="CSS.GridTemplate"/>
         /// giving its list/dictionary-typed members explicit content equality since the BCL collection

--- a/src/PeachPDF.Tests/Html/Core/Utils/CssUtilsTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Utils/CssUtilsTests.cs
@@ -109,10 +109,12 @@ namespace PeachPDF.Tests.Html.Core.Utils
             var (box, parser) = await FindDivBoxAndParser("");
 
             CssUtils.SetPropertyValue(parser, box, "column-fill", "balance");
-            Assert.Equal("balance", box.ColumnFill);
+            Assert.Equal("balance", box.ColumnFill.ToString());
+            Assert.Equal(ColumnFillMode.Balance, box.ColumnFill.Value);
 
             CssUtils.SetPropertyValue(parser, box, "column-fill", "auto");
-            Assert.Equal("auto", box.ColumnFill);
+            Assert.Equal("auto", box.ColumnFill.ToString());
+            Assert.Equal(ColumnFillMode.Auto, box.ColumnFill.Value);
         }
 
         [Fact]
@@ -121,10 +123,12 @@ namespace PeachPDF.Tests.Html.Core.Utils
             var (box, parser) = await FindDivBoxAndParser("");
 
             CssUtils.SetPropertyValue(parser, box, "column-span", "all");
-            Assert.Equal("all", box.ColumnSpan);
+            Assert.Equal("all", box.ColumnSpan.ToString());
+            Assert.Equal(ColumnSpanMode.All, box.ColumnSpan.Value);
 
             CssUtils.SetPropertyValue(parser, box, "column-span", "none");
-            Assert.Equal("none", box.ColumnSpan);
+            Assert.Equal("none", box.ColumnSpan.ToString());
+            Assert.Equal(ColumnSpanMode.None, box.ColumnSpan.Value);
         }
 
         [Theory]
@@ -197,7 +201,7 @@ namespace PeachPDF.Tests.Html.Core.Utils
 
             CssUtils.SetPropertyValue(parser, box, "box-sizing", "not-a-real-value");
 
-            Assert.Equal("border-box", box.BoxSizing);
+            Assert.Equal("border-box", box.BoxSizing.ToString());
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/BoxDecorationBreakCascadeTests.cs
+++ b/src/PeachPDF.Tests/Integration/BoxDecorationBreakCascadeTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Utils;
 using PeachPDF.Tests.TestSupport;
@@ -32,7 +33,7 @@ namespace PeachPDF.Tests.Integration
         {
             var box = await FindTargetBox($"box-decoration-break: {authored}");
 
-            Assert.Equal(expected, box.BoxDecorationBreak);
+            Assert.Equal(expected, box.BoxDecorationBreak.ToString());
         }
 
         [Fact]
@@ -40,7 +41,7 @@ namespace PeachPDF.Tests.Integration
         {
             var box = await FindTargetBox("");
 
-            Assert.Equal(CssConstants.Slice, box.BoxDecorationBreak);
+            Assert.Equal(BoxDecorationBreakMode.Slice, box.BoxDecorationBreak.Value);
         }
 
         // ── the CSS-wide keywords ──────────────────────────────────────────────
@@ -58,7 +59,7 @@ namespace PeachPDF.Tests.Integration
         {
             var box = await FindTargetBox($"box-decoration-break: {keyword}", lowerPriorityCss: "box-decoration-break: clone");
 
-            Assert.Equal(CssConstants.Slice, box.BoxDecorationBreak);
+            Assert.Equal(BoxDecorationBreakMode.Slice, box.BoxDecorationBreak.Value);
         }
 
         // The companion direction: the lower-priority "clone" really is what the keyword rolls back, so the
@@ -68,7 +69,7 @@ namespace PeachPDF.Tests.Integration
         {
             var box = await FindTargetBox("", lowerPriorityCss: "box-decoration-break: clone");
 
-            Assert.Equal(CssConstants.Clone, box.BoxDecorationBreak);
+            Assert.Equal(BoxDecorationBreakMode.Clone, box.BoxDecorationBreak.Value);
         }
 
         // What distinguishes the _knownPropertyNames entry from the initial-value entry: revert-layer rolls
@@ -89,7 +90,7 @@ namespace PeachPDF.Tests.Integration
 
             var box = await FindById(html, "target");
 
-            Assert.Equal(CssConstants.Clone, box.BoxDecorationBreak);
+            Assert.Equal(BoxDecorationBreakMode.Clone, box.BoxDecorationBreak.Value);
         }
 
         // box-decoration-break is not inherited, so an explicit "inherit" is the only way a child picks up
@@ -105,7 +106,7 @@ namespace PeachPDF.Tests.Integration
 
             var child = await FindById(html, "child");
 
-            Assert.Equal(CssConstants.Clone, child.BoxDecorationBreak);
+            Assert.Equal(BoxDecorationBreakMode.Clone, child.BoxDecorationBreak.Value);
         }
 
         // ...and without one it stays at the initial value, however the parent is styled.
@@ -120,7 +121,7 @@ namespace PeachPDF.Tests.Integration
 
             var child = await FindById(html, "child");
 
-            Assert.Equal(CssConstants.Slice, child.BoxDecorationBreak);
+            Assert.Equal(BoxDecorationBreakMode.Slice, child.BoxDecorationBreak.Value);
         }
 
         // ── the two structural-clone call sites ────────────────────────────────
@@ -152,7 +153,7 @@ namespace PeachPDF.Tests.Integration
 
             var proxies = table!.Boxes.OfType<CssProxyBox>().ToList();
             Assert.NotEmpty(proxies);
-            Assert.All(proxies, proxy => Assert.Equal(CssConstants.Clone, proxy.BoxDecorationBreak));
+            Assert.All(proxies, proxy => Assert.Equal(BoxDecorationBreakMode.Clone, proxy.BoxDecorationBreak.Value));
         }
 
         // DomParser's block-in-inline correction splits one element's box into several. Every resulting
@@ -169,7 +170,7 @@ namespace PeachPDF.Tests.Integration
 
             // The correction really did split the span, rather than leaving a single box.
             Assert.True(spanBoxes.Count > 1, $"expected the span to be split, found {spanBoxes.Count} box(es)");
-            Assert.All(spanBoxes, b => Assert.Equal(CssConstants.Clone, b.BoxDecorationBreak));
+            Assert.All(spanBoxes, b => Assert.Equal(BoxDecorationBreakMode.Clone, b.BoxDecorationBreak.Value));
         }
 
         // ── helpers ───────────────────────────────────────────────────────────

--- a/src/PeachPDF.Tests/Integration/BoxSizingConstraintsIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/BoxSizingConstraintsIntegrationTests.cs
@@ -207,6 +207,61 @@ namespace PeachPDF.Tests.Integration
                 $"Cell 'a' should be widened to at least its min-width:200px: {a.ActualBoxSizingWidth}");
         }
 
+        // ─── Shrink-to-fit width (CssBox.CalculateActualRight) ─────────────────────
+        //
+        // CalculateActualRight only does real work (rather than early-returning the already-resolved
+        // ActualRight most boxes have by the time it runs - a placed child's own frame resolves it via
+        // ResolveOwnInlineSize, and the root box is sized directly by HtmlContainerInt) for a box whose
+        // width genuinely hasn't been settled yet. Rather than chase the exact real-markup shape that
+        // leaves a box in that state, build a normal box tree through real layout (so ContainingBlock,
+        // paddings, and margins are all genuinely resolved) and then invoke the method directly with
+        // ActualRight forced back to its "unresolved" sentinel - exercising its actual box-sizing-aware
+        // max-right-edge walk against real per-box geometry, not hand-constructed internals.
+
+        [Fact]
+        public async Task CalculateActualRight_BorderBoxSelfAndChild_AddsChildsOwnMarginOnBothSides()
+        {
+            var html = Wrap(@"
+                <div id='item' style='box-sizing:border-box; padding:5px; border:2px solid black;'>
+                    <div id='kid' style='box-sizing:border-box; width:100px; padding:10px; border:3px solid black; margin-right:7px;'></div>
+                </div>");
+            var (root, _) = await BuildAndLayout(html);
+            var item = FindById(root, "item")!;
+            var kid = FindById(root, "kid")!;
+
+            item.ActualRight = 1_000_000;
+            var actualRight = item.CalculateActualRight();
+
+            // BoxSizingMode.BorderBox on both self and child: the child's own margin-right is added on
+            // top of its (already padding/border-inclusive) border-box right edge, then the parent's own
+            // border-box padding+border is added on top of that.
+            var expected = kid.ActualRight - kid.RelativeOffsetX + kid.ActualMarginRight
+                           + item.ActualPaddingRight + item.ActualMarginRight + item.ActualBorderRightWidth;
+            Assert.Equal(expected, actualRight, 3);
+        }
+
+        [Fact]
+        public async Task CalculateActualRight_ContentBoxSelfAndChild_DoesNotDoubleCountEitherMargin()
+        {
+            var html = Wrap(@"
+                <div id='item' style='box-sizing:content-box; padding:5px; border:2px solid black;'>
+                    <div id='kid' style='box-sizing:content-box; width:100px; margin-right:7px;'></div>
+                </div>");
+            var (root, _) = await BuildAndLayout(html);
+            var item = FindById(root, "item")!;
+            var kid = FindById(root, "kid")!;
+
+            item.ActualRight = 1_000_000;
+            var actualRight = item.CalculateActualRight();
+
+            // BoxSizingMode.ContentBox on both self and child: neither side's own margin is added a
+            // second time (additionalMarginRight is 0 for content-box), so this is just the child's
+            // already-margin-inclusive right edge plus the parent's own content-box padding+border.
+            var expected = kid.ActualRight - kid.RelativeOffsetX
+                           + item.ActualPaddingRight + item.ActualBorderRightWidth;
+            Assert.Equal(expected, actualRight, 3);
+        }
+
         // ─── Helpers ─────────────────────────────────────────────────────────────
 
         private static string Wrap(string body) =>

--- a/src/PeachPDF.Tests/Integration/GlobalKeywordCascadeTests.cs
+++ b/src/PeachPDF.Tests/Integration/GlobalKeywordCascadeTests.cs
@@ -522,7 +522,7 @@ namespace PeachPDF.Tests.Integration
             var child = FindById(root, "child");
 
             Assert.NotNull(child);
-            Assert.Equal("content-box", child!.BoxSizing);
+            Assert.Equal("content-box", child!.BoxSizing.ToString());
         }
 
         [Fact]
@@ -542,7 +542,7 @@ namespace PeachPDF.Tests.Integration
             var child = FindById(root, "child");
 
             Assert.NotNull(child);
-            Assert.Equal("border-box", child!.BoxSizing);
+            Assert.Equal("border-box", child!.BoxSizing.ToString());
         }
 
         // ── regression: vertical-align is spec-correctly not inherited (issue #530) ──

--- a/src/PeachPDF/CSS/CssProperty.cs
+++ b/src/PeachPDF/CSS/CssProperty.cs
@@ -96,7 +96,16 @@ namespace PeachPDF.CSS
                 return Global(keyword);
             if (value.Contains("var(", StringComparison.OrdinalIgnoreCase))
                 return Unresolved(value);
-            return FromValue(value, keywordMap.TryGetValue(value.Trim(), out var parsed) ? parsed : fallback);
+
+            var trimmed = value.Trim();
+            if (!keywordMap.TryGetValue(trimmed, out var parsed))
+                return FromValue(value, fallback);
+
+            // The matched keyword is stored canonicalized (lowercase — every keyword this codebase's
+            // Map.* dictionaries recognize is authored in lowercase ASCII), not the raw input, so
+            // ToString() round-trips to the canonical spelling regardless of how it was cased (issue
+            // #598) — a case-insensitively-matched "LTR" must not silently become "LTR" again on readback.
+            return FromValue(trimmed.ToLowerInvariant(), parsed);
         }
 
         public override string ToString() => _cssText;

--- a/src/PeachPDF/CSS/Enumerations/BoxDecorationBreakMode.cs
+++ b/src/PeachPDF/CSS/Enumerations/BoxDecorationBreakMode.cs
@@ -1,0 +1,8 @@
+namespace PeachPDF.CSS
+{
+    internal enum BoxDecorationBreakMode
+    {
+        Slice,
+        Clone
+    }
+}

--- a/src/PeachPDF/CSS/Enumerations/BoxSizingMode.cs
+++ b/src/PeachPDF/CSS/Enumerations/BoxSizingMode.cs
@@ -1,0 +1,8 @@
+namespace PeachPDF.CSS
+{
+    internal enum BoxSizingMode
+    {
+        ContentBox,
+        BorderBox
+    }
+}

--- a/src/PeachPDF/CSS/Enumerations/ColumnFillMode.cs
+++ b/src/PeachPDF/CSS/Enumerations/ColumnFillMode.cs
@@ -1,0 +1,8 @@
+namespace PeachPDF.CSS
+{
+    internal enum ColumnFillMode
+    {
+        Balance,
+        Auto
+    }
+}

--- a/src/PeachPDF/CSS/Enumerations/ColumnSpanMode.cs
+++ b/src/PeachPDF/CSS/Enumerations/ColumnSpanMode.cs
@@ -1,0 +1,8 @@
+namespace PeachPDF.CSS
+{
+    internal enum ColumnSpanMode
+    {
+        None,
+        All
+    }
+}

--- a/src/PeachPDF/CSS/Model/Map.cs
+++ b/src/PeachPDF/CSS/Model/Map.cs
@@ -272,6 +272,30 @@ namespace PeachPDF.CSS
             {
                 {Keywords.Auto, AutoKeyword.Auto}
             }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        public static readonly FrozenDictionary<string, BoxSizingMode> BoxSizingModes =
+            new Dictionary<string, BoxSizingMode>(StringComparer.OrdinalIgnoreCase)
+            {
+                {Keywords.BorderBox, BoxSizingMode.BorderBox},
+                {Keywords.ContentBox, BoxSizingMode.ContentBox}
+            }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        public static readonly FrozenDictionary<string, BoxDecorationBreakMode> BoxDecorationBreakModes =
+            new Dictionary<string, BoxDecorationBreakMode>(StringComparer.OrdinalIgnoreCase)
+            {
+                {Keywords.Slice, BoxDecorationBreakMode.Slice},
+                {Keywords.Clone, BoxDecorationBreakMode.Clone}
+            }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        public static readonly FrozenDictionary<string, ColumnFillMode> ColumnFillModes =
+            new Dictionary<string, ColumnFillMode>(StringComparer.OrdinalIgnoreCase)
+            {
+                {Keywords.Auto, ColumnFillMode.Auto},
+                {Keywords.Balance, ColumnFillMode.Balance}
+            }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        public static readonly FrozenDictionary<string, ColumnSpanMode> ColumnSpanModes =
+            new Dictionary<string, ColumnSpanMode>(StringComparer.OrdinalIgnoreCase)
+            {
+                {Keywords.None, ColumnSpanMode.None},
+                {Keywords.All, ColumnSpanMode.All}
+            }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
         public static readonly FrozenDictionary<string, WritingMode> WritingModes =
             new Dictionary<string, WritingMode>(StringComparer.OrdinalIgnoreCase)
             {

--- a/src/PeachPDF/Html/Core/Dom/ComputedStyleAreas.cs
+++ b/src/PeachPDF/Html/Core/Dom/ComputedStyleAreas.cs
@@ -161,7 +161,8 @@ namespace PeachPDF.Html.Core.Dom
         public string MaxHeight { get; init; } = CssDefaults.GetInitialValue(PropertyNames.MaxHeight)!;
         public string MinHeight { get; init; } = CssDefaults.GetInitialValue(PropertyNames.MinHeight)!;
 
-        public string BoxSizing { get; init; } = CssDefaults.GetInitialValue(PropertyNames.BoxSizing)!;
+        public CssProperty<BoxSizingMode> BoxSizing { get; init; } =
+            CssProperty<BoxSizingMode>.FromCssText(CssDefaults.GetInitialValue(PropertyNames.BoxSizing)!, Map.BoxSizingModes, BoxSizingMode.ContentBox);
     }
 
     #endregion
@@ -179,7 +180,8 @@ namespace PeachPDF.Html.Core.Dom
         public string BreakBefore { get; init; } = CssDefaults.GetInitialValue(PropertyNames.BreakBefore)!;
         public string BreakInside { get; init; } = CssDefaults.GetInitialValue(PropertyNames.BreakInside)!;
         public string BreakAfter { get; init; } = CssDefaults.GetInitialValue(PropertyNames.BreakAfter)!;
-        public string BoxDecorationBreak { get; init; } = CssDefaults.GetInitialValue(PropertyNames.BoxDecorationBreak)!;
+        public CssProperty<BoxDecorationBreakMode> BoxDecorationBreak { get; init; } =
+            CssProperty<BoxDecorationBreakMode>.FromCssText(CssDefaults.GetInitialValue(PropertyNames.BoxDecorationBreak)!, Map.BoxDecorationBreakModes, BoxDecorationBreakMode.Slice);
     }
 
     #endregion
@@ -451,8 +453,10 @@ namespace PeachPDF.Html.Core.Dom
 
         public string ColumnCount { get; init; } = CssDefaults.GetInitialValue(PropertyNames.ColumnCount)!;
         public string ColumnWidth { get; init; } = CssDefaults.GetInitialValue(PropertyNames.ColumnWidth)!;
-        public string ColumnFill { get; init; } = CssDefaults.GetInitialValue(PropertyNames.ColumnFill)!;
-        public string ColumnSpan { get; init; } = CssDefaults.GetInitialValue(PropertyNames.ColumnSpan)!;
+        public CssProperty<ColumnFillMode> ColumnFill { get; init; } =
+            CssProperty<ColumnFillMode>.FromCssText(CssDefaults.GetInitialValue(PropertyNames.ColumnFill)!, Map.ColumnFillModes, ColumnFillMode.Balance);
+        public CssProperty<ColumnSpanMode> ColumnSpan { get; init; } =
+            CssProperty<ColumnSpanMode>.FromCssText(CssDefaults.GetInitialValue(PropertyNames.ColumnSpan)!, Map.ColumnSpanModes, ColumnSpanMode.None);
         public string ColumnRuleWidth { get; init; } = CssDefaults.GetInitialValue(PropertyNames.ColumnRuleWidth)!;
         public string ColumnRuleStyle { get; init; } = CssDefaults.GetInitialValue(PropertyNames.ColumnRuleStyle)!;
         public string ColumnRuleColor { get; init; } = CssDefaults.GetInitialValue(PropertyNames.ColumnRuleColor)!;

--- a/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
@@ -360,7 +360,7 @@ namespace PeachPDF.Html.Core.Dom
             }
         }
 
-        public string BoxSizing
+        public CssProperty<BoxSizingMode> BoxSizing
         {
             get => _computedStyle.BoxModel.BoxSizing;
             set
@@ -596,7 +596,7 @@ namespace PeachPDF.Html.Core.Dom
         // (Html/Core/Fragments/SliceGeometry) - deliberately not against BoxFragment's
         // IsFirstFragment/IsLastFragment, whose span includes descendants. Layout also reserves room for
         // cloned decorations, so a cloned border at a break pushes content rather than overlapping it.
-        public string BoxDecorationBreak
+        public CssProperty<BoxDecorationBreakMode> BoxDecorationBreak
         {
             get => _computedStyle.Break.BoxDecorationBreak;
             set
@@ -1751,7 +1751,7 @@ namespace PeachPDF.Html.Core.Dom
             }
         }
 
-        public string ColumnFill
+        public CssProperty<ColumnFillMode> ColumnFill
         {
             get => _computedStyle.MultiColumn.ColumnFill;
             set
@@ -1762,7 +1762,7 @@ namespace PeachPDF.Html.Core.Dom
             }
         }
 
-        public string ColumnSpan
+        public CssProperty<ColumnSpanMode> ColumnSpan
         {
             get => _computedStyle.MultiColumn.ColumnSpan;
             set
@@ -2070,10 +2070,10 @@ namespace PeachPDF.Html.Core.Dom
         {
             get
             {
-                return BoxSizing switch
+                return BoxSizing.Value switch
                 {
-                    CssConstants.ContentBox => ActualPaddingLeft + ActualPaddingRight + ActualBorderLeftWidth + ActualBorderRightWidth,
-                    CssConstants.BorderBox => 0,
+                    BoxSizingMode.ContentBox => ActualPaddingLeft + ActualPaddingRight + ActualBorderLeftWidth + ActualBorderRightWidth,
+                    BoxSizingMode.BorderBox => 0,
                     _ => throw new HtmlRenderException("Unknown box sizing", HtmlRenderErrorType.Layout)
                 };
             }
@@ -2085,10 +2085,10 @@ namespace PeachPDF.Html.Core.Dom
         {
             get
             {
-                return BoxSizing switch
+                return BoxSizing.Value switch
                 {
-                    CssConstants.ContentBox => ActualPaddingTop + ActualPaddingBottom + ActualBorderTopWidth + ActualBorderBottomWidth,
-                    CssConstants.BorderBox => 0,
+                    BoxSizingMode.ContentBox => ActualPaddingTop + ActualPaddingBottom + ActualBorderTopWidth + ActualBorderBottomWidth,
+                    BoxSizingMode.BorderBox => 0,
                     _ => throw new HtmlRenderException("Unknown box sizing", HtmlRenderErrorType.Layout)
                 };
             }

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -2973,7 +2973,7 @@ namespace PeachPDF.Html.Core.Dom
                         && HtmlContainer is { IsFragmenting: true }
                         && HtmlContainer.CurrentFragmentainer is { HasOwnBand: true } spanContext
                         && ReferenceEquals(this, spanContext.ContextRoot)
-                        && childBox.ColumnSpan == CssConstants.All)
+                        && childBox.ColumnSpan.Value == ColumnSpanMode.All)
                     {
                         PendingBreakToken = new BlockBreakToken(
                             this, spanContext.SlotIndex, i, null, IsBreakBefore: true, null,
@@ -3011,7 +3011,7 @@ namespace PeachPDF.Html.Core.Dom
                     if (i == start
                         && i + 1 < Boxes.Count
                         && EstablishesMultiColumnContext
-                        && childBox.ColumnSpan == CssConstants.All
+                        && childBox.ColumnSpan.Value == ColumnSpanMode.All
                         && childBox.PendingBreakToken is null
                         && HtmlContainer is { IsFragmenting: true }
                         && HtmlContainer.CurrentFragmentainer is { HasOwnBand: true } afterSpanContext
@@ -5538,10 +5538,10 @@ namespace PeachPDF.Html.Core.Dom
 
             foreach (var box in Boxes)
             {
-                additionalMarginRight = box.BoxSizing switch
+                additionalMarginRight = box.BoxSizing.Value switch
                 {
-                    CssConstants.ContentBox => 0,
-                    CssConstants.BorderBox => box.ActualMarginRight,
+                    BoxSizingMode.ContentBox => 0,
+                    BoxSizingMode.BorderBox => box.ActualMarginRight,
                     _ => throw new HtmlRenderException("Unknown BoxSizing", HtmlRenderErrorType.Layout)
                 };
 
@@ -5551,10 +5551,10 @@ namespace PeachPDF.Html.Core.Dom
                 maxRight = Math.Max(maxRight, box.ActualRight - box.RelativeOffsetX + additionalMarginRight);
             }
 
-            additionalMarginRight = BoxSizing switch
+            additionalMarginRight = BoxSizing.Value switch
             {
-                CssConstants.ContentBox => 0,
-                CssConstants.BorderBox => ActualMarginRight,
+                BoxSizingMode.ContentBox => 0,
+                BoxSizingMode.BorderBox => ActualMarginRight,
                 _ => throw new HtmlRenderException("Unknown BoxSizing", HtmlRenderErrorType.Layout)
             };
 

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -1360,7 +1360,7 @@ namespace PeachPDF.Html.Core.Dom
                 {
                     coordinates.CurrentX += leftSpacing;
                 }
-                else if (b.BoxDecorationBreak == CssConstants.Clone)
+                else if (b.BoxDecorationBreak.Value == BoxDecorationBreakMode.Clone)
                 {
                     childClonedResumeStart += leftSpacing;
                 }
@@ -1368,7 +1368,7 @@ namespace PeachPDF.Html.Core.Dom
                 // What the guard above actually put on the cursor. The float branches below re-establish
                 // the line start from scratch rather than adjusting it, so they have to re-apply the same
                 // amount - re-applying the raw `leftSpacing` would put back exactly what `slice` suppresses.
-                var appliedLeftSpacing = childOpensHere || b.BoxDecorationBreak == CssConstants.Clone ? leftSpacing : 0;
+                var appliedLeftSpacing = childOpensHere || b.BoxDecorationBreak.Value == BoxDecorationBreakMode.Clone ? leftSpacing : 0;
 
                 var lastLeftIntersectingFloatBox = DomUtils.GetLastLeftIntersectingFloatBox(box, coordinates);
 

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineColumns.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineColumns.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Adapters;
 using PeachPDF.Html.Core.Entities;
 using PeachPDF.Html.Core.Parse;
@@ -310,7 +311,7 @@ namespace PeachPDF.Html.Core.Dom
 
             foreach (var child in children)
             {
-                if (child.ColumnSpan == CssConstants.All)
+                if (child.ColumnSpan.Value == ColumnSpanMode.All)
                 {
                     if (run.Count > 0)
                     {
@@ -413,7 +414,7 @@ namespace PeachPDF.Html.Core.Dom
             // it, so the first fragment starts from the estimate (its measurement pass has just said how
             // tall everything is) and a continuation starts from the full budget and is re-balanced below
             // once the fill has shown that the remainder ends here.
-            var balances = columnsBox.ColumnFill != CssConstants.Auto;
+            var balances = columnsBox.ColumnFill.Value != ColumnFillMode.Auto;
 
             var target = balances && resume is null
                 ? EstimateBalancedColumnHeight(children, 0, columnCount, pageBudget)

--- a/src/PeachPDF/Html/Core/Dom/CssLineBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLineBox.cs
@@ -10,6 +10,7 @@
 // - Sun Tsu,
 // "The Art of War"
 
+using PeachPDF.CSS;
 using PeachPDF.Html.Adapters.Entities;
 using PeachPDF.Html.Core.Utils;
 using System;
@@ -170,7 +171,7 @@ namespace PeachPDF.Html.Core.Dom
             // rectangle covers its own leading and trailing border and padding rather than only the ones at
             // the box's true ends (css-break-3 §6.2). CssLayoutEngine.FlowBox reserves the matching room, so
             // the rectangle and the content inside it agree.
-            var clonesDecorations = box.BoxDecorationBreak == CssConstants.Clone;
+            var clonesDecorations = box.BoxDecorationBreak.Value == BoxDecorationBreakMode.Clone;
 
             if (clonesDecorations || (box.FirstHostingLineBox != null && box.FirstHostingLineBox.Equals(this)) || box.IsImage)
                 x -= leftSpacing;

--- a/src/PeachPDF/Html/Core/Paint/BoxDecorationGeometry.cs
+++ b/src/PeachPDF/Html/Core/Paint/BoxDecorationGeometry.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Adapters.Entities;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Fragments;
@@ -78,7 +79,7 @@ namespace PeachPDF.Html.Core.Paint
         {
             var slice = line.Slice;
 
-            if (box.BoxDecorationBreak == CssConstants.Clone)
+            if (box.BoxDecorationBreak.Value == BoxDecorationBreakMode.Clone)
             {
                 // Each fragment is wrapped independently, so its own band-cut box IS its decoration area
                 // and every edge of it is a real edge - a box crossing a page boundary gets a closed

--- a/src/PeachPDF/Html/Core/Utils/DomUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/DomUtils.cs
@@ -10,6 +10,7 @@
 // - Sun Tsu,
 // "The Art of War"
 
+using PeachPDF.CSS;
 using PeachPDF.Html.Adapters.Entities;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Entities;
@@ -740,7 +741,7 @@ namespace PeachPDF.Html.Core.Utils
         /// </summary>
         internal static bool AnyBoxClonesDecorations(CssBox box)
         {
-            if (box.BoxDecorationBreak == CssConstants.Clone) return true;
+            if (box.BoxDecorationBreak.Value == BoxDecorationBreakMode.Clone) return true;
 
             foreach (var child in box.Boxes)
             {
@@ -811,7 +812,7 @@ namespace PeachPDF.Html.Core.Utils
                     break;
                 }
 
-                if (current.BoxDecorationBreak == CssConstants.Clone)
+                if (current.BoxDecorationBreak.Value == BoxDecorationBreakMode.Clone)
                     total += current.ActualBorderTopWidth + current.ActualPaddingTop;
             }
 
@@ -851,7 +852,7 @@ namespace PeachPDF.Html.Core.Utils
         /// content it holds — each level of a nested cloning stack closes inside its ancestors' own close.
         /// </remarks>
         internal static double OwnClonedBlockEnd(CssBox box) =>
-            box.BoxDecorationBreak == CssConstants.Clone
+            box.BoxDecorationBreak.Value == BoxDecorationBreakMode.Clone
                 ? box.ActualBorderBottomWidth + box.ActualPaddingBottom
                 : 0;
 
@@ -873,7 +874,7 @@ namespace PeachPDF.Html.Core.Utils
 
             for (var current = from; current is not null && !ReferenceEquals(current, stopAt); current = current.ParentBox)
             {
-                if (current.BoxDecorationBreak == CssConstants.Clone)
+                if (current.BoxDecorationBreak.Value == BoxDecorationBreakMode.Clone)
                     total += current.ActualMarginLeft + current.ActualBorderLeftWidth + current.ActualPaddingLeft;
             }
 
@@ -890,7 +891,7 @@ namespace PeachPDF.Html.Core.Utils
 
             for (var current = from; current is not null && !ReferenceEquals(current, stopAt); current = current.ParentBox)
             {
-                if (current.BoxDecorationBreak == CssConstants.Clone)
+                if (current.BoxDecorationBreak.Value == BoxDecorationBreakMode.Clone)
                     total += current.ActualMarginRight + current.ActualBorderRightWidth + current.ActualPaddingRight;
             }
 

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -36,19 +36,20 @@
     },
     {
       "name": "box-sizing",
-      "comment": "Replaces the old CssUtils.IsValidBoxSizing helper.",
+      "comment": "Replaces the old CssUtils.IsValidBoxSizing helper. CssProperty<BoxSizingMode>-backed (issue #598's follow-up: typed enum storage instead of a raw string).",
       "inherited": false,
       "initialValue": "content-box",
-      "cssDataType": "keyword",
-      "supportedValues": [
-        "border-box",
-        "content-box"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "BoxSizingMode",
+        "keywordMap": "Map.BoxSizingModes",
+        "fallback": "BoxSizingMode.ContentBox"
+      },
       "html": {
         "propertyPath": "BoxSizing",
-        "csharpDataType": "string",
-        "area": "BoxModelArea"
+        "csharpDataType": "CssProperty<BoxSizingMode>",
+        "area": "BoxModelArea",
+        "getterExpression": "{box}.BoxSizing.ToString()"
       }
     },
     {
@@ -1131,18 +1132,20 @@
     },
     {
       "name": "box-decoration-break",
+      "comment": "CssProperty<BoxDecorationBreakMode>-backed (issue #598's follow-up: typed enum storage instead of a raw string).",
       "inherited": false,
       "initialValue": "slice",
-      "cssDataType": "keyword",
-      "supportedValues": [
-        "slice",
-        "clone"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "BoxDecorationBreakMode",
+        "keywordMap": "Map.BoxDecorationBreakModes",
+        "fallback": "BoxDecorationBreakMode.Slice"
+      },
       "html": {
         "propertyPath": "BoxDecorationBreak",
-        "csharpDataType": "string",
-        "area": "BreakArea"
+        "csharpDataType": "CssProperty<BoxDecorationBreakMode>",
+        "area": "BreakArea",
+        "getterExpression": "{box}.BoxDecorationBreak.ToString()"
       }
     },
     {
@@ -2418,34 +2421,38 @@
     },
     {
       "name": "column-fill",
+      "comment": "CssProperty<ColumnFillMode>-backed (issue #598's follow-up: typed enum storage instead of a raw string).",
       "inherited": false,
       "initialValue": "balance",
-      "cssDataType": "keyword",
-      "supportedValues": [
-        "auto",
-        "balance"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "ColumnFillMode",
+        "keywordMap": "Map.ColumnFillModes",
+        "fallback": "ColumnFillMode.Balance"
+      },
       "html": {
         "propertyPath": "ColumnFill",
-        "csharpDataType": "string",
-        "area": "MultiColumnArea"
+        "csharpDataType": "CssProperty<ColumnFillMode>",
+        "area": "MultiColumnArea",
+        "getterExpression": "{box}.ColumnFill.ToString()"
       }
     },
     {
       "name": "column-span",
+      "comment": "CssProperty<ColumnSpanMode>-backed (issue #598's follow-up: typed enum storage instead of a raw string).",
       "inherited": false,
       "initialValue": "none",
-      "cssDataType": "keyword",
-      "supportedValues": [
-        "none",
-        "all"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "ColumnSpanMode",
+        "keywordMap": "Map.ColumnSpanModes",
+        "fallback": "ColumnSpanMode.None"
+      },
       "html": {
         "propertyPath": "ColumnSpan",
-        "csharpDataType": "string",
-        "area": "MultiColumnArea"
+        "csharpDataType": "CssProperty<ColumnSpanMode>",
+        "area": "MultiColumnArea",
+        "getterExpression": "{box}.ColumnSpan.ToString()"
       }
     },
     {


### PR DESCRIPTION
## Summary

Continues the #598 follow-up work (typed box storage for keyword-valued CSS properties, building on the `CssKeywordOrValue`/`CssProperty<T>` infrastructure landed in the prior PR). This batch converts the four smallest pure-enum properties from raw string storage to `CssProperty<TMode>`:

- `box-sizing` → `CssProperty<BoxSizingMode>`
- `box-decoration-break` → `CssProperty<BoxDecorationBreakMode>`
- `column-fill` → `CssProperty<ColumnFillMode>`
- `column-span` → `CssProperty<ColumnSpanMode>`

Each property's `css-properties.json` entry moved to the `enum-keyword` cssDataType shape (matching the existing `direction`/`writing-mode`/`z-index` pattern), with a new enum + case-insensitive `Map.*` keyword dictionary for each. All call sites across layout (`CssBox.cs`, `CssLayoutEngine*.cs`), paint (`BoxDecorationGeometry.cs`), and `DomUtils.cs` were migrated from string comparisons to enum comparisons via compiler-driven fixups.

Also fixes `CssProperty<T>.FromCssText` to canonicalize a case-insensitively-matched keyword to its canonical (lowercase) spelling before storing it, rather than storing the raw as-authored casing — the same canonicalization bug already fixed for the plain-`"keyword"` codegen path in the #598 fix, but this generic helper (used by every `enum-keyword`-backed property) had the same gap.

Since `CssProperty<T>` is now a record with real value equality (landed in the prior PR), these four properties don't need special-casing in `ComputedStyleTests.cs`'s cascade-defaulting-loop no-op exception list — only `font-family` remains there, for an unrelated reason (multi-field setter).

## Test plan

- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (7848 passed, 9 skipped)
- [x] `dotnet test PeachPDF.SourceGenerators.Tests/PeachPDF.SourceGenerators.Tests.csproj` — green
- [x] Diff coverage vs `main`: 100%
- [x] Post-change review pass against the diff (C# conventions, current APIs, CSS spec compliance) — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01WsuX3xR9EsNY3x1a5RGQmJ)_