### PR TITLE
Move display blockification out of CssBox.Display into DerivedStyle.ActualDisplay

### DIFF
--- a/src/PeachPDF.Tests/Html/Core/Dom/DerivedStyleTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/DerivedStyleTests.cs
@@ -1,0 +1,67 @@
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Utils;
+
+namespace PeachPDF.Tests.Html.Core.Dom
+{
+    /// <summary>
+    /// Coverage for <see cref="DerivedStyle.ActualDisplay"/> - the CSS 2.1 §9.7 blockification a floated
+    /// box's <c>display</c> undergoes, moved here from <see cref="CssBox"/>'s <c>Display</c> getter so that
+    /// property stays a plain, mechanical read of the raw cascaded keyword. These tests exist because the
+    /// move itself doesn't change behavior (every prior reader of <c>Display</c> got the blockified value;
+    /// they now read <c>ActualDisplay</c> instead), so the blockification mapping needs its own direct
+    /// coverage independent of whichever layout/paint call site happens to exercise it.
+    /// </summary>
+    public class DerivedStyleTests
+    {
+        [Theory]
+        [InlineData(CssConstants.Inline, CssConstants.Block)]
+        [InlineData(CssConstants.InlineBlock, CssConstants.Block)]
+        [InlineData(CssConstants.InlineTable, CssConstants.Table)]
+        [InlineData(CssConstants.TableRow, CssConstants.Block)]
+        [InlineData(CssConstants.TableRowGroup, CssConstants.Block)]
+        [InlineData(CssConstants.TableColumn, CssConstants.Block)]
+        [InlineData(CssConstants.TableColumnGroup, CssConstants.Block)]
+        [InlineData(CssConstants.TableCell, CssConstants.Block)]
+        [InlineData(CssConstants.TableCaption, CssConstants.Block)]
+        [InlineData(CssConstants.TableHeaderGroup, CssConstants.Block)]
+        [InlineData(CssConstants.TableFooterGroup, CssConstants.Block)]
+        [InlineData(CssConstants.InlineFlex, CssConstants.Flex)]
+        [InlineData(CssConstants.InlineGrid, CssConstants.Grid)]
+        public void ActualDisplay_OnAFloatedBox_BlockifiesInlineLevelAndTableInternalValues(string display, string expected)
+        {
+            var box = new CssBox(null, null) { Display = display, Float = CssConstants.Left };
+
+            Assert.Equal(expected, box.DerivedStyle.ActualDisplay);
+        }
+
+        [Theory]
+        [InlineData(CssConstants.Block)]
+        [InlineData(CssConstants.Flex)]
+        [InlineData(CssConstants.Grid)]
+        [InlineData(CssConstants.Table)]
+        [InlineData(CssConstants.None)]
+        public void ActualDisplay_OnAFloatedBox_LeavesAlreadyBlockLevelValuesUnchanged(string display)
+        {
+            var box = new CssBox(null, null) { Display = display, Float = CssConstants.Left };
+
+            Assert.Equal(display, box.DerivedStyle.ActualDisplay);
+        }
+
+        [Fact]
+        public void ActualDisplay_OnAnUnfloatedBox_ReturnsTheRawCascadedKeywordUnchanged()
+        {
+            var box = new CssBox(null, null) { Display = CssConstants.Inline, Float = CssConstants.None };
+
+            Assert.Equal(CssConstants.Inline, box.DerivedStyle.ActualDisplay);
+        }
+
+        [Fact]
+        public void Display_OnAFloatedBox_StaysTheRawCascadedKeyword_NotBlockified()
+        {
+            var box = new CssBox(null, null) { Display = CssConstants.Inline, Float = CssConstants.Right };
+
+            Assert.Equal(CssConstants.Inline, box.Display);
+            Assert.Equal(CssConstants.Block, box.DerivedStyle.ActualDisplay);
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/BaselineAlignment.cs
+++ b/src/PeachPDF/Html/Core/Dom/BaselineAlignment.cs
@@ -21,7 +21,7 @@ namespace PeachPDF.Html.Core.Dom
 
             foreach (var child in box.Boxes)
             {
-                if (child.Display == CssConstants.None || child.IsOutOfFlow) continue;
+                if (child.DerivedStyle.ActualDisplay == CssConstants.None || child.IsOutOfFlow) continue;
 
                 var found = FindFirstLineBox(child);
                 if (found != null) return found;

--- a/src/PeachPDF/Html/Core/Dom/ComputedStyleAreas.cs
+++ b/src/PeachPDF/Html/Core/Dom/ComputedStyleAreas.cs
@@ -229,8 +229,9 @@ namespace PeachPDF.Html.Core.Dom
 
     /// <summary>
     /// CSS Display + Positioned Layout + Overflow properties. Kept together (rather than split further
-    /// by literal spec module) since <c>Display</c>'s used-value getter already reads <c>Float</c>
-    /// directly for CSS2.1 §9.7 blockification. None inherited.
+    /// by literal spec module) since <c>Display</c> and <c>Float</c> are read together for CSS 2.1 §9.7
+    /// blockification (see <see cref="Dom.DerivedStyle.ActualDisplay"/>, which reads both from this area -
+    /// the plain <c>Display</c> field here stays the raw, un-blockified cascaded keyword). None inherited.
     /// </summary>
     internal sealed record DisplayPositioningArea
     {

--- a/src/PeachPDF/Html/Core/Dom/CssBidiParagraphResolver.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBidiParagraphResolver.cs
@@ -50,10 +50,10 @@ namespace PeachPDF.Html.Core.Dom
         }
 
         private static bool EstablishesOwnParagraph(CssBox box) =>
-            box.IsRoot || box.Display != CssConstants.Inline || box is CssBoxMarker;
+            box.IsRoot || box.DerivedStyle.ActualDisplay != CssConstants.Inline || box is CssBoxMarker;
 
         private static bool ParticipatesInParentParagraph(CssBox box) =>
-            box.Display == CssConstants.Inline && box is not (CssBoxImage or CssBoxSvg or CssBoxMarker);
+            box.DerivedStyle.ActualDisplay == CssConstants.Inline && box is not (CssBoxImage or CssBoxSvg or CssBoxMarker);
 
         private static void ResolveParagraph(CssBox paragraphRoot)
         {

--- a/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
@@ -891,34 +891,14 @@ namespace PeachPDF.Html.Core.Dom
             }
         }
 
+        /// <summary>
+        /// The raw cascaded <c>display</c> keyword - not blockified. Layout/paint code that needs the
+        /// used value (CSS 2.1 §9.7 blockification when floated) reads <see cref="DerivedStyle.ActualDisplay"/>
+        /// instead.
+        /// </summary>
         public string Display
         {
-            get
-            {
-                var area = _computedStyle.DisplayPositioning;
-                if (area.Float is not CssConstants.None)
-                {
-                    return area.Display switch
-                    {
-                        "inline" => "block",
-                        "inline-block" => "block",
-                        "inline-table" => "table",
-                        "table-row" => "block",
-                        "table-row-group" => "block",
-                        "table-column" => "block",
-                        "table-column-group" => "block",
-                        "table-cell" => "block",
-                        "table-caption" => "block",
-                        "table-header-group" => "block",
-                        "table-footer-group" => "block",
-                        "inline-flex" => "flex",
-                        "inline-grid" => "grid",
-                        _ => area.Display
-                    };
-                }
-
-                return area.Display;
-            }
+            get => _computedStyle.DisplayPositioning.Display;
             set
             {
                 var area = _computedStyle.DisplayPositioning;

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -292,12 +292,12 @@ namespace PeachPDF.Html.Core.Dom
         /// <summary>
         /// is the box "Display" is "Inline", is this is an inline box and not block.
         /// </summary>
-        public bool IsInline => Display is CssConstants.Inline or CssConstants.InlineBlock or CssConstants.InlineTable or CssConstants.InlineFlex or CssConstants.InlineGrid;
+        public bool IsInline => DerivedStyle.ActualDisplay is CssConstants.Inline or CssConstants.InlineBlock or CssConstants.InlineTable or CssConstants.InlineFlex or CssConstants.InlineGrid;
 
         /// <summary>
         /// is the box "Display" is "Block", is this is a block box and not inline.
         /// </summary>
-        public bool IsBlock => Display == CssConstants.Block;
+        public bool IsBlock => DerivedStyle.ActualDisplay == CssConstants.Block;
 
         public bool IsFloated => Float is CssConstants.Left or CssConstants.Right;
 
@@ -343,7 +343,7 @@ namespace PeachPDF.Html.Core.Dom
             }
         }
 
-        public virtual bool IsTableRowGroupBox => Display is CssConstants.TableRowGroup or CssConstants.TableHeaderGroup or CssConstants.TableFooterGroup;
+        public virtual bool IsTableRowGroupBox => DerivedStyle.ActualDisplay is CssConstants.TableRowGroup or CssConstants.TableHeaderGroup or CssConstants.TableFooterGroup;
 
         /// <summary>
         /// Maps page number → last row bottom Y on that page. Set by CssLayoutEngineTable when rows break across pages.
@@ -401,7 +401,7 @@ namespace PeachPDF.Html.Core.Dom
         /// </summary>
         internal List<(double X, double Top, double Bottom)>? ColumnRuleSegments { get; set; }
 
-        public virtual bool IsTableCell => Display is CssConstants.TableCell;
+        public virtual bool IsTableCell => DerivedStyle.ActualDisplay is CssConstants.TableCell;
 
         /// <summary>
         /// Gets the containing block-box of this box. (The nearest parent box with display=block)
@@ -417,11 +417,11 @@ namespace PeachPDF.Html.Core.Dom
 
                 var box = ParentBox;
                 while (!box.IsBlock &&
-                       box.Display != CssConstants.ListItem &&
-                       box.Display != CssConstants.Table &&
-                       box.Display != CssConstants.TableCell &&
-                       box.Display != CssConstants.Flex &&
-                       box.Display != CssConstants.InlineFlex &&
+                       box.DerivedStyle.ActualDisplay != CssConstants.ListItem &&
+                       box.DerivedStyle.ActualDisplay != CssConstants.Table &&
+                       box.DerivedStyle.ActualDisplay != CssConstants.TableCell &&
+                       box.DerivedStyle.ActualDisplay != CssConstants.Flex &&
+                       box.DerivedStyle.ActualDisplay != CssConstants.InlineFlex &&
                        box.ParentBox != null)
                 {
                     box = box.ParentBox;
@@ -1849,7 +1849,7 @@ namespace PeachPDF.Html.Core.Dom
         {
             foreach (var childBox in Boxes)
             {
-                if (childBox.IsOutOfFlow && childBox.Display != CssConstants.None)
+                if (childBox.IsOutOfFlow && childBox.DerivedStyle.ActualDisplay != CssConstants.None)
                 {
                     await LayoutBlockChild(g, childBox);
                 }
@@ -2143,7 +2143,7 @@ namespace PeachPDF.Html.Core.Dom
         /// </remarks>
         private void TakeBackTheMarkerOfAnItemThisPassKeptNothingOf()
         {
-            if (Display != CssConstants.ListItem) return;
+            if (DerivedStyle.ActualDisplay != CssConstants.ListItem) return;
 
             if (OutsideMarkerChild is not { } marker) return;
 
@@ -2197,7 +2197,7 @@ namespace PeachPDF.Html.Core.Dom
             foreach (var childBox in box.Boxes)
             {
                 if (ReferenceEquals(childBox, excluded)) continue;
-                if (childBox.Display == CssConstants.None || childBox.IsOutOfFlow) continue;
+                if (childBox.DerivedStyle.ActualDisplay == CssConstants.None || childBox.IsOutOfFlow) continue;
 
                 if (childBox.PlacesItselfAsBlockBox && childBox.ActualBottom > childBox.Location.Y) return true;
 
@@ -2227,7 +2227,7 @@ namespace PeachPDF.Html.Core.Dom
         /// </remarks>
         private async ValueTask LayoutOutsideMarker(RGraphics g)
         {
-            if (Display != CssConstants.ListItem) return;
+            if (DerivedStyle.ActualDisplay != CssConstants.ListItem) return;
 
             foreach (var childBox in Boxes)
             {
@@ -2372,7 +2372,7 @@ namespace PeachPDF.Html.Core.Dom
         /// </remarks>
         private async ValueTask PerformLayoutPrologue(RGraphics g)
         {
-            if (Display != CssConstants.None)
+            if (DerivedStyle.ActualDisplay != CssConstants.None)
             {
                 RectanglesReset();
                 await MeasureWordsSize(g);
@@ -2504,7 +2504,7 @@ namespace PeachPDF.Html.Core.Dom
         /// </remarks>
         internal bool PlacesItselfAsBlockBox =>
             IsBlock
-            || Display is CssConstants.ListItem or CssConstants.Table or CssConstants.InlineTable
+            || DerivedStyle.ActualDisplay is CssConstants.ListItem or CssConstants.Table or CssConstants.InlineTable
                        or CssConstants.TableCell or CssConstants.Flex or CssConstants.InlineFlex
                        or CssConstants.Grid or CssConstants.InlineGrid;
 
@@ -2519,7 +2519,7 @@ namespace PeachPDF.Html.Core.Dom
             {
                 // The engines MonolithicContent.RunsAnEngineOfItsOwn names, in the same order; this branch
                 // needs to know *which* one, which is why it cannot ask the combined predicate.
-                if (Display is CssConstants.Flex or CssConstants.InlineFlex)
+                if (DerivedStyle.ActualDisplay is CssConstants.Flex or CssConstants.InlineFlex)
                 {
                     // The record travels into the engine so a resumed pass can re-enter exactly the items
                     // that did not finish their own content last time (CssLayoutEngineFlex's commit pass),
@@ -2528,7 +2528,7 @@ namespace PeachPDF.Html.Core.Dom
 
                     if (PendingBreakToken is not null) return;
                 }
-                else if (Display is CssConstants.Grid or CssConstants.InlineGrid)
+                else if (DerivedStyle.ActualDisplay is CssConstants.Grid or CssConstants.InlineGrid)
                 {
                     // The record travels into the engine so a resumed pass can re-enter exactly the row
                     // (and that row's items) that did not finish their own content last time
@@ -2538,7 +2538,7 @@ namespace PeachPDF.Html.Core.Dom
 
                     if (PendingBreakToken is not null) return;
                 }
-                else if (Display is CssConstants.Table or CssConstants.InlineTable)
+                else if (DerivedStyle.ActualDisplay is CssConstants.Table or CssConstants.InlineTable)
                 {
                     // The record travels into the engine so it can tell a resumed pass from a fresh layout
                     // of the same box - the once-per-table half of its work is destructive when repeated
@@ -2680,7 +2680,7 @@ namespace PeachPDF.Html.Core.Dom
         /// </remarks>
         private bool PaginatedItsOwnContentWithoutBreaking() =>
             !IsOutOfFlow
-            && Display is CssConstants.Table or CssConstants.InlineTable
+            && DerivedStyle.ActualDisplay is CssConstants.Table or CssConstants.InlineTable
             && HtmlContainer is { IsFragmenting: true }
             && PageBreakBottoms is not { Count: > 0 };
 
@@ -3118,7 +3118,7 @@ namespace PeachPDF.Html.Core.Dom
                     if (i > start
                         && childBox.PlacesItselfAsBlockBox
                         && !childBox.IsOutOfFlow
-                        && childBox.Display != CssConstants.None
+                        && childBox.DerivedStyle.ActualDisplay != CssConstants.None
                         && HtmlContainer is { IsFragmenting: true }
                         && HtmlContainer.CurrentFragmentainer is { HasOwnBand: true } columnBand
                         && childBox.ActualBottom > columnBand.BandBottom)
@@ -3160,7 +3160,7 @@ namespace PeachPDF.Html.Core.Dom
                     // (no break of its own to take, but a bottom past the page it started on) leaving the
                     // cursor stale for whatever follows it.
                     if (!childBox.IsOutOfFlow
-                        && childBox.Display != CssConstants.None
+                        && childBox.DerivedStyle.ActualDisplay != CssConstants.None
                         && HtmlContainer?.CurrentFragmentainer is { HasOwnBand: false })
                     {
                         HtmlContainer.CurrentFragmentainer.StepOverTo(HtmlContainer.SlotEndingAt(childBox.ActualBottom));
@@ -3572,7 +3572,7 @@ namespace PeachPDF.Html.Core.Dom
         private void ResumeInTheNextFragmentainer()
         {
             if (HtmlContainer?.CurrentFragmentainer is not { HasOwnBand: true } fragmentainer) return;
-            if (Display is CssConstants.TableCell || Position is not (CssConstants.Static or CssConstants.Relative))
+            if (DerivedStyle.ActualDisplay is CssConstants.TableCell || Position is not (CssConstants.Static or CssConstants.Relative))
                 return;
 
             // Moving Location is the whole translation: ActualRight and ActualBottom are derived from it
@@ -3713,7 +3713,7 @@ namespace PeachPDF.Html.Core.Dom
         private async ValueTask ResolveOwnInlineSize(RGraphics g, double blockTop)
         {
             // Because their width and height are set by CssTable, CssLayoutEngineFlex or CssLayoutEngineGrid
-            if (Display != CssConstants.TableCell && Display != CssConstants.Table && Display != CssConstants.Flex && Display != CssConstants.InlineFlex && Display != CssConstants.Grid && Display != CssConstants.InlineGrid)
+            if (DerivedStyle.ActualDisplay != CssConstants.TableCell && DerivedStyle.ActualDisplay != CssConstants.Table && DerivedStyle.ActualDisplay != CssConstants.Flex && DerivedStyle.ActualDisplay != CssConstants.InlineFlex && DerivedStyle.ActualDisplay != CssConstants.Grid && DerivedStyle.ActualDisplay != CssConstants.InlineGrid)
             {
                 var width = await CssLayoutEngine.GetBoxWidth(g, this, blockTop);
                 ActualRight = Location.X + width + ActualBoxSizeIncludedWidth;
@@ -3924,7 +3924,7 @@ namespace PeachPDF.Html.Core.Dom
         /// </remarks>
         private BlockChildOffset? ResolveBlockChildOffset(CssBox child)
         {
-            if (child.Display != CssConstants.TableCell)
+            if (child.DerivedStyle.ActualDisplay != CssConstants.TableCell)
             {
                 if (child.Position is CssConstants.Static or CssConstants.Relative)
                 {
@@ -4197,7 +4197,7 @@ namespace PeachPDF.Html.Core.Dom
         /// </remarks>
         private void CommitBlockChildOffset(CssBox child, BlockChildOffset offset)
         {
-            if (child.Display != CssConstants.TableCell)
+            if (child.DerivedStyle.ActualDisplay != CssConstants.TableCell)
             {
                 if (offset.PositionedInBlockFlow)
                 {
@@ -4954,7 +4954,7 @@ namespace PeachPDF.Html.Core.Dom
             {
                 foreach (CssBox childBox in box.Boxes)
                 {
-                    if (childBox.Display == CssConstants.None) continue;
+                    if (childBox.DerivedStyle.ActualDisplay == CssConstants.None) continue;
                     GetMinimumWidth_LongestWord(childBox, ref maxWidth, ref maxWidthWord);
                 }
             }
@@ -5048,7 +5048,7 @@ namespace PeachPDF.Html.Core.Dom
             double? oldPaddingSum = null;
 
             // not inline (block) boxes start a new line so we need to reset the max sum
-            if (box.Display != CssConstants.Inline && box.Display != CssConstants.TableCell && box.WhiteSpace != CssConstants.NoWrap)
+            if (box.DerivedStyle.ActualDisplay != CssConstants.Inline && box.DerivedStyle.ActualDisplay != CssConstants.TableCell && box.WhiteSpace != CssConstants.NoWrap)
             {
                 oldSum = maxSum;
                 maxSum = marginSum;
@@ -5061,7 +5061,7 @@ namespace PeachPDF.Html.Core.Dom
 
 
             // for tables the padding also contains the spacing between cells
-            if (box.Display == CssConstants.Table)
+            if (box.DerivedStyle.ActualDisplay == CssConstants.Table)
                 paddingSum += CssLayoutEngineTable.GetTableSpacing(box);
 
             if (box.Words.Count > 0)
@@ -5082,7 +5082,7 @@ namespace PeachPDF.Html.Core.Dom
                 // recursively on all the child boxes
                 foreach (var childBox in box.Boxes)
                 {
-                    if (childBox.Display == CssConstants.None) continue;
+                    if (childBox.DerivedStyle.ActualDisplay == CssConstants.None) continue;
 
                     marginSum += childBox.ActualMarginLeft + childBox.ActualMarginRight;
 
@@ -5126,11 +5126,11 @@ namespace PeachPDF.Html.Core.Dom
                     // explicit 10em/90pt) summed to 308 (128+90+90) instead of correctly taking the
                     // widest single line (~128).
                     if (CssValueParser.IsValidLength(childBox.Width) && !childBox.Width.EndsWith('%')
-                        && !(childBox.Display == CssConstants.Inline && childBox.Words.Count == 0))
+                        && !(childBox.DerivedStyle.ActualDisplay == CssConstants.Inline && childBox.Words.Count == 0))
                     {
                         var explicitContentWidth = CssValueParser.ParseLength(childBox.Width, 0, childBox);
-                        var childStartsNewLine = childBox.Display != CssConstants.Inline
-                            && childBox.Display != CssConstants.TableCell && childBox.WhiteSpace != CssConstants.NoWrap;
+                        var childStartsNewLine = childBox.DerivedStyle.ActualDisplay != CssConstants.Inline
+                            && childBox.DerivedStyle.ActualDisplay != CssConstants.TableCell && childBox.WhiteSpace != CssConstants.NoWrap;
                         maxSum = childStartsNewLine
                             ? Math.Max(maxSum, explicitContentWidth)
                             : Math.Max(maxSum, maxSumBeforeChild + explicitContentWidth);
@@ -5367,7 +5367,7 @@ namespace PeachPDF.Html.Core.Dom
             while (chainMembers.Count < 1000 && current.Overflow == CssConstants.Visible &&
                    current.ActualBorderTopWidth < 0.1 && current.ActualPaddingTop < 0.1)
             {
-                var firstInFlowChild = current.Boxes.FirstOrDefault(b => !b.IsOutOfFlow && b.Display != CssConstants.None);
+                var firstInFlowChild = current.Boxes.FirstOrDefault(b => !b.IsOutOfFlow && b.DerivedStyle.ActualDisplay != CssConstants.None);
                 if (firstInFlowChild == null || firstInFlowChild.Clear != CssConstants.None || firstInFlowChild == current) break;
 
                 margins.Fold(firstInFlowChild.ActualMarginTop);
@@ -5461,7 +5461,7 @@ namespace PeachPDF.Html.Core.Dom
 
             foreach (var childBox in Boxes)
             {
-                if (childBox.IsOutOfFlow || childBox.Display == CssConstants.None) continue;
+                if (childBox.IsOutOfFlow || childBox.DerivedStyle.ActualDisplay == CssConstants.None) continue;
                 childBox.FoldSelfCollapsingMargins(ref margins, depth + 1);
             }
         }
@@ -5478,7 +5478,7 @@ namespace PeachPDF.Html.Core.Dom
             // Capped defensively (real documents never nest this deep) so a malformed/cyclic box tree
             // degrades to "not self-collapsing" instead of a stack overflow.
             if (depth > 500) return false;
-            if (Display == CssConstants.None) return false;
+            if (DerivedStyle.ActualDisplay == CssConstants.None) return false;
             if (IsOutOfFlow) return false;
             // A percentage height against an indefinite (not-yet-height-calculated) containing block
             // resolves to auto (CSS2.1 §10.5, the same rule ApplyHeight already applies) - Acid2's own
@@ -5499,7 +5499,7 @@ namespace PeachPDF.Html.Core.Dom
                  CssValueParser.ParseLength(MinHeight, ContainingBlock.Size.Height, this) <= 0);
             if (!minHeightZero) return false;
 
-            var inFlowChildren = Boxes.Where(b => !b.IsOutOfFlow && b.Display != CssConstants.None && b != this).ToList();
+            var inFlowChildren = Boxes.Where(b => !b.IsOutOfFlow && b.DerivedStyle.ActualDisplay != CssConstants.None && b != this).ToList();
             return inFlowChildren.Count == 0 || inFlowChildren.All(b => b.IsMarginCollapseThrough(depth + 1));
         }
 
@@ -5969,13 +5969,13 @@ namespace PeachPDF.Html.Core.Dom
             {
                 return $"{(ParentBox == null ? "Root: " : string.Empty)}{tag} Block {FontSize}, Children:{Boxes.Count}";
             }
-            else if (Display == CssConstants.None)
+            else if (DerivedStyle.ActualDisplay == CssConstants.None)
             {
                 return $"{(ParentBox == null ? "Root: " : string.Empty)}{tag} None";
             }
             else
             {
-                return $"{(ParentBox == null ? "Root: " : string.Empty)}{tag} {Display}: {Text}";
+                return $"{(ParentBox == null ? "Root: " : string.Empty)}{tag} {DerivedStyle.ActualDisplay}: {Text}";
             }
         }
 

--- a/src/PeachPDF/Html/Core/Dom/CssBoxHr.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBoxHr.cs
@@ -71,7 +71,7 @@ namespace PeachPDF.Html.Core.Dom
         /// </remarks>
         protected override ValueTask PerformLayoutImp(RGraphics g, CssBox frame, bool framePlacesChild)
         {
-            if (Display == CssConstants.None)
+            if (DerivedStyle.ActualDisplay == CssConstants.None)
                 return ValueTask.CompletedTask;
 
             // The rule has no content to resume into, so the only pass state it carries is a break-before

--- a/src/PeachPDF/Html/Core/Dom/CssCounterEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssCounterEngine.cs
@@ -209,7 +209,7 @@ namespace PeachPDF.Html.Core.Dom
             // selector (selectors can't match on a computed Display value), so it's applied here
             // directly. An author's own explicit counter-increment targeting list-item on the same
             // element still wins (already captured above, so it's not overwritten below).
-            if (box.Display == CssConstants.ListItem && !incrementValues.ContainsKey(CssConstants.ListItem))
+            if (box.DerivedStyle.ActualDisplay == CssConstants.ListItem && !incrementValues.ContainsKey(CssConstants.ListItem))
             {
                 var currentListItemCounter = box.Counters.GetValueOrDefault(CssConstants.ListItem);
                 incrementValues[CssConstants.ListItem] = currentListItemCounter is { IsReversed: true } ? -1 : 1;
@@ -247,7 +247,7 @@ namespace PeachPDF.Html.Core.Dom
         private static bool WouldIncrementCounter(CssBox box, string counterName)
         {
             if (CounterNameAppears(box.CounterIncrement, counterName)) return true;
-            return counterName == CssConstants.ListItem && box.Display == CssConstants.ListItem;
+            return counterName == CssConstants.ListItem && box.DerivedStyle.ActualDisplay == CssConstants.ListItem;
         }
 
         private static bool CounterNameAppears(string counterPropertyValue, string counterName)
@@ -457,12 +457,12 @@ namespace PeachPDF.Html.Core.Dom
             var diff = 1;
             var sib = b.ParentBox.Boxes[index - diff];
 
-            while (sib.Display == CssConstants.None && index - diff - 1 >= 0)
+            while (sib.DerivedStyle.ActualDisplay == CssConstants.None && index - diff - 1 >= 0)
             {
                 sib = b.ParentBox.Boxes[index - ++diff];
             }
 
-            sib = sib.Display == CssConstants.None ? null : sib;
+            sib = sib.DerivedStyle.ActualDisplay == CssConstants.None ? null : sib;
 
             return sib;
         }

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -522,13 +522,13 @@ namespace PeachPDF.Html.Core.Dom
 
             if (box.MarginRight is not CssConstants.Auto) return 0;
 
-            if (box.Display.StartsWith("table-") && box.Display != CssConstants.TableCaption)
+            if (box.DerivedStyle.ActualDisplay.StartsWith("table-") && box.DerivedStyle.ActualDisplay != CssConstants.TableCaption)
             {
                 return 0;
             }
 
             // This will be used by the table layout engine later with boxWidth provided
-            if (box.Display is CssConstants.Table && boxWidth is null)
+            if (box.DerivedStyle.ActualDisplay is CssConstants.Table && boxWidth is null)
             {
                 return 0;
             }
@@ -552,13 +552,13 @@ namespace PeachPDF.Html.Core.Dom
 
             if (box.MarginLeft is not CssConstants.Auto) return 0;
 
-            if (box.Display.StartsWith("table-") && box.Display != CssConstants.TableCaption)
+            if (box.DerivedStyle.ActualDisplay.StartsWith("table-") && box.DerivedStyle.ActualDisplay != CssConstants.TableCaption)
             {
                 return 0;
             }
 
             // This will be used by the table layout engine later with boxWidth provided
-            if (box.Display is CssConstants.Table && boxWidth is null)
+            if (box.DerivedStyle.ActualDisplay is CssConstants.Table && boxWidth is null)
             {
                 return 0;
             }
@@ -627,7 +627,7 @@ namespace PeachPDF.Html.Core.Dom
         {
             foreach (var childBox in box.Boxes)
             {
-                if (childBox.Display == CssConstants.None) continue;
+                if (childBox.DerivedStyle.ActualDisplay == CssConstants.None) continue;
 
                 await childBox.MeasureWordsSize(g);
                 await MeasureWords(childBox, g);
@@ -764,7 +764,7 @@ namespace PeachPDF.Html.Core.Dom
             // for position:absolute shrink-to-fit, e.g. ".eyes") wrongly folded 7.5em into the
             // ancestor's width, inflating it well past its real content.
             if (box.Width != CssConstants.Auto && !string.IsNullOrEmpty(box.Width)
-                && !(box.Display == CssConstants.Inline && box.Words.Count == 0))
+                && !(box.DerivedStyle.ActualDisplay == CssConstants.Inline && box.Words.Count == 0))
             {
                 // Absolute boxes resolve a percentage width against their nearest positioned ancestor
                 // (CSS 2.1 §10.1), consistent with GetBoxHeight and the left/top positioning code.
@@ -990,7 +990,7 @@ namespace PeachPDF.Html.Core.Dom
                 // pass afterward) would recompute the cell's height from its own explicit `height`
                 // alone, discarding that stretch - exactly what made ".third-part" (Acid2's own
                 // "gets stretched to fit row" test case) end up 4.5pt short of its row.
-                if (childBox.Display is CssConstants.TableCell or CssConstants.TableRow
+                if (childBox.DerivedStyle.ActualDisplay is CssConstants.TableCell or CssConstants.TableRow
                     or CssConstants.TableRowGroup or CssConstants.TableHeaderGroup or CssConstants.TableFooterGroup)
                 {
                     continue;
@@ -1623,7 +1623,7 @@ namespace PeachPDF.Html.Core.Dom
                         ApplyAtomicInlineVerticalInsets(b, box, coordinates);
                     }
                 }
-                else if (b.Display == CssConstants.InlineFlex)
+                else if (b.DerivedStyle.ActualDisplay == CssConstants.InlineFlex)
                 {
                     // Nothing at all for a box a resumed pass is only walking through. An inline-flex
                     // contributes no word ordinals, so nothing else here would notice that it belongs to
@@ -1735,7 +1735,7 @@ namespace PeachPDF.Html.Core.Dom
             // box's whole height, so it only means anything for a box this pass both opened and
             // finished. For one it merely walked through the deficit is the box's entire height, which
             // it would then add to the flow all over again.
-            if (opensHere && box.Display is not CssConstants.Inline && coordinates.MaxBottom - startY < box.ActualHeight)
+            if (opensHere && box.DerivedStyle.ActualDisplay is not CssConstants.Inline && coordinates.MaxBottom - startY < box.ActualHeight)
             {
                 coordinates.MaxBottom = startY + box.ActualHeight;
             }
@@ -1876,7 +1876,7 @@ namespace PeachPDF.Html.Core.Dom
         /// <param name="coordinates">the current line coordinates</param>
         private static void ApplyAtomicInlineVerticalInsets(CssBox b, CssBox flowContext, CssLineBoxCoordinates coordinates)
         {
-            if (b.Display is not CssConstants.InlineBlock)
+            if (b.DerivedStyle.ActualDisplay is not CssConstants.InlineBlock)
                 return;
 
             var topInset = b.ActualBorderTopWidth + b.ActualPaddingTop;

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineColumns.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineColumns.cs
@@ -72,7 +72,7 @@ namespace PeachPDF.Html.Core.Dom
             columnsBox.ActualRight = columnsBox.Location.X + containerWidth + columnsBox.ActualBoxSizeIncludedWidth;
 
             var children = columnsBox.Boxes
-                .Where(b => b.Display != CssConstants.None && !b.IsOutOfFlow
+                .Where(b => b.DerivedStyle.ActualDisplay != CssConstants.None && !b.IsOutOfFlow
                             && (b.HtmlTag != null || !b.IsSpaceOrEmpty))
                 .ToList();
 

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineFlex.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineFlex.cs
@@ -104,7 +104,7 @@ namespace PeachPDF.Html.Core.Dom
             // Phase 1: collect and order flex items.
             // Anonymous whitespace-only boxes between flex items must be discarded per CSS spec.
             var rawItems = _flexBox.Boxes
-                .Where(b => b.Display != CssConstants.None && !b.IsOutOfFlow
+                .Where(b => b.DerivedStyle.ActualDisplay != CssConstants.None && !b.IsOutOfFlow
                             && (b.HtmlTag != null || !b.IsSpaceOrEmpty))
                 .OrderBy(ParseOrder)
                 .ThenBy(b => _flexBox.Boxes.IndexOf(b))
@@ -270,7 +270,7 @@ namespace PeachPDF.Html.Core.Dom
             // Phase 10b: inline-flex shrinks to content in the main axis (like inline-block).
             // For row direction with auto width, update ActualRight to the actual content extent.
             bool hasExplicitWidth = CssValueParser.IsValidLength(_flexBox.Width);
-            if (_flexBox.Display == CssConstants.InlineFlex && _isRow && !hasExplicitWidth && lines.Count > 0)
+            if (_flexBox.DerivedStyle.ActualDisplay == CssConstants.InlineFlex && _isRow && !hasExplicitWidth && lines.Count > 0)
             {
                 double contentMainEnd = lines.Max(l =>
                     l.Items.Count > 0
@@ -950,7 +950,7 @@ namespace PeachPDF.Html.Core.Dom
             // is the line it is on to decide.
             if (container is null || !container.HasRealPageGrid || lines.Count == 0
                 || !container.IsFragmenting
-                || _flexBox.Display == CssConstants.InlineFlex)
+                || _flexBox.DerivedStyle.ActualDisplay == CssConstants.InlineFlex)
             {
                 return;
             }
@@ -1053,7 +1053,7 @@ namespace PeachPDF.Html.Core.Dom
             // The same liveness gate RelocateLinesAcrossFragmentainers uses, for the same reason: outside
             // it this container's own coordinates are provisional, belonging to whatever is measuring it.
             if (container is null || !container.HasRealPageGrid || !container.IsFragmenting
-                || _flexBox.Display == CssConstants.InlineFlex)
+                || _flexBox.DerivedStyle.ActualDisplay == CssConstants.InlineFlex)
             {
                 return;
             }
@@ -1217,7 +1217,7 @@ namespace PeachPDF.Html.Core.Dom
             // The same liveness gate RelocateLinesAcrossFragmentainers uses, for the same reason: outside
             // it this container's own coordinates are provisional, belonging to whatever is measuring it.
             if (container is null || !container.HasRealPageGrid || !container.IsFragmenting
-                || _flexBox.Display == CssConstants.InlineFlex)
+                || _flexBox.DerivedStyle.ActualDisplay == CssConstants.InlineFlex)
             {
                 return;
             }
@@ -1532,7 +1532,7 @@ namespace PeachPDF.Html.Core.Dom
             string? savedDisplay = null;
             if (box.IsInline)
             {
-                savedDisplay = box.Display;
+                savedDisplay = box.DerivedStyle.ActualDisplay;
                 box.Display  = CssConstants.Block;
             }
 

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineGrid.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineGrid.cs
@@ -126,7 +126,7 @@ namespace PeachPDF.Html.Core.Dom
             }
 
             var items = _gridBox.Boxes
-                .Where(b => b.Display != CssConstants.None && !b.IsOutOfFlow
+                .Where(b => b.DerivedStyle.ActualDisplay != CssConstants.None && !b.IsOutOfFlow
                             && (b.HtmlTag != null || !b.IsSpaceOrEmpty))
                 .ToList();
 
@@ -355,7 +355,7 @@ namespace PeachPDF.Html.Core.Dom
                 subgridContexts, placementOrigin: _gridBox.Location);
 
             // Inline-grid shrinks to the content extent in the inline axis (like inline-block).
-            if (_gridBox.Display == CssConstants.InlineGrid && !CssValueParser.IsValidLength(_gridBox.Width) && columns.Length > 0)
+            if (_gridBox.DerivedStyle.ActualDisplay == CssConstants.InlineGrid && !CssValueParser.IsValidLength(_gridBox.Width) && columns.Length > 0)
             {
                 var contentRight = columns[^1].Position + columns[^1].Size;
                 _gridBox.ActualRight = contentRight + _gridBox.ActualPaddingRight + _gridBox.ActualBorderRightWidth;
@@ -382,7 +382,7 @@ namespace PeachPDF.Html.Core.Dom
 
             if (container is null || !container.HasRealPageGrid || placements.Count == 0
                 || !container.IsFragmenting
-                || _gridBox.Display == CssConstants.InlineGrid)
+                || _gridBox.DerivedStyle.ActualDisplay == CssConstants.InlineGrid)
             {
                 return;
             }
@@ -499,7 +499,7 @@ namespace PeachPDF.Html.Core.Dom
             // The same liveness gate RelocateRowsAcrossFragmentainers uses, for the same reason: outside
             // it this container's own coordinates are provisional, belonging to whatever is measuring it.
             if (container is null || !container.HasRealPageGrid || !container.IsFragmenting
-                || _gridBox.Display == CssConstants.InlineGrid)
+                || _gridBox.DerivedStyle.ActualDisplay == CssConstants.InlineGrid)
             {
                 return;
             }
@@ -1410,7 +1410,7 @@ namespace PeachPDF.Html.Core.Dom
         /// <summary>Whether a grid item is a subgrid on at least one axis — a nested grid whose
         /// <c>grid-template-columns</c> and/or <c>grid-template-rows</c> is <c>subgrid</c>.</summary>
         private static bool IsSubgridItem(CssBox box) =>
-            (box.Display == CssConstants.Grid || box.Display == CssConstants.InlineGrid)
+            (box.DerivedStyle.ActualDisplay == CssConstants.Grid || box.DerivedStyle.ActualDisplay == CssConstants.InlineGrid)
             && (ChildColSubgrid(box) || ChildRowSubgrid(box));
 
         private static bool ChildColSubgrid(CssBox box) => box.GridTemplateColumns.Value?.IsSubgrid == true;
@@ -1676,7 +1676,7 @@ namespace PeachPDF.Html.Core.Dom
             string? savedDisplay = null;
             if (box.IsInline)
             {
-                savedDisplay = box.Display;
+                savedDisplay = box.DerivedStyle.ActualDisplay;
                 box.Display = CssConstants.Block;
             }
 

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
@@ -85,13 +85,13 @@ namespace PeachPDF.Html.Core.Dom
         /// pre-check — which is gated on the *absence* of both groups, so reading repetition here would
         /// send a non-repeating table down a relocation path a table with a <c>&lt;thead&gt;</c> never takes.
         /// </remarks>
-        private bool HeaderIsDetached => _headerBox != null && _headerBox.Display == CssConstants.TableHeaderGroup;
+        private bool HeaderIsDetached => _headerBox != null && _headerBox.DerivedStyle.ActualDisplay == CssConstants.TableHeaderGroup;
 
         /// <summary>
         /// Whether the table has a <c>&lt;tfoot&gt;</c> this engine took out of the child list. See
         /// <see cref="HeaderIsDetached"/>; <see cref="_footerRepeats"/> is the other question.
         /// </summary>
-        private bool FooterIsDetached => _footerBox != null && _footerBox.Display == CssConstants.TableFooterGroup;
+        private bool FooterIsDetached => _footerBox != null && _footerBox.DerivedStyle.ActualDisplay == CssConstants.TableFooterGroup;
 
         /// <summary>
         /// Whether css-tables-3 §6.2 lets the detached <c>&lt;thead&gt;</c> be repeated on every band the
@@ -231,7 +231,7 @@ namespace PeachPDF.Html.Core.Dom
 
             foreach (var box in tableBox.Boxes)
             {
-                switch (box.Display)
+                switch (box.DerivedStyle.ActualDisplay)
                 {
                     case CssConstants.TableColumn:
                         columns += GetSpan(box);
@@ -241,7 +241,7 @@ namespace PeachPDF.Html.Core.Dom
                             foreach (var cr in tableBox.Boxes)
                             {
                                 count++;
-                                if (cr.Display == CssConstants.TableRow)
+                                if (cr.DerivedStyle.ActualDisplay == CssConstants.TableRow)
                                     columns = Math.Max(columns, cr.Boxes.Count);
                             }
 
@@ -388,7 +388,7 @@ namespace PeachPDF.Html.Core.Dom
                 // as a row throws on an empty sequence (issue #353, from the other direction).
                 if (box is CssProxyBox) continue;
 
-                switch (box.Display)
+                switch (box.DerivedStyle.ActualDisplay)
                 {
                     case CssConstants.TableCaption:
                         break;
@@ -397,7 +397,7 @@ namespace PeachPDF.Html.Core.Dom
                         break;
                     case CssConstants.TableRowGroup:
                         foreach (CssBox childBox in box.Boxes)
-                            if (childBox.Display == CssConstants.TableRow)
+                            if (childBox.DerivedStyle.ActualDisplay == CssConstants.TableRow)
                                 _bodyRows.Add(childBox);
                         break;
                     case CssConstants.TableHeaderGroup:
@@ -549,7 +549,7 @@ namespace PeachPDF.Html.Core.Dom
                     {
                         if (i >= 20 && !double.IsNaN(_columnWidths[i])) continue; // limit column width check
 
-                        if (i >= row.Boxes.Count || row.Boxes[i].Display != CssConstants.TableCell) continue;
+                        if (i >= row.Boxes.Count || row.Boxes[i].DerivedStyle.ActualDisplay != CssConstants.TableCell) continue;
 
                         var len = CssValueParser.ParseLength(row.Boxes[i].Width, availCellSpace, row.Boxes[i]);
 
@@ -1107,7 +1107,7 @@ namespace PeachPDF.Html.Core.Dom
 
                 foreach (var row in _headerBox.Boxes)
                 {
-                    if (row.Display != CssConstants.TableRow)
+                    if (row.DerivedStyle.ActualDisplay != CssConstants.TableRow)
                         continue;
 
                     headerCursor.CurrentY = headerRowsLayoutY;
@@ -1144,7 +1144,7 @@ namespace PeachPDF.Html.Core.Dom
 
                 foreach (var row in _footerBox.Boxes)
                 {
-                    if (row.Display != CssConstants.TableRow)
+                    if (row.DerivedStyle.ActualDisplay != CssConstants.TableRow)
                         continue;
 
                     footerCursor.CurrentY = footerRowsLayoutY;
@@ -1649,10 +1649,10 @@ namespace PeachPDF.Html.Core.Dom
 
             foreach (var box in _tableBox.Boxes)
             {
-                if (box.Display != CssConstants.TableRowGroup)
+                if (box.DerivedStyle.ActualDisplay != CssConstants.TableRowGroup)
                     continue;
 
-                var rows = box.Boxes.Where(b => b.Display == CssConstants.TableRow && placed.Contains(b))
+                var rows = box.Boxes.Where(b => b.DerivedStyle.ActualDisplay == CssConstants.TableRow && placed.Contains(b))
                     .ToList();
                 if (rows.Count == 0)
                     continue;
@@ -2063,8 +2063,8 @@ namespace PeachPDF.Html.Core.Dom
             {
                 var slot = container.SlotStartingAt(proxy.Location.Y);
 
-                if (proxy.Display == CssConstants.TableHeaderGroup) headerBands.Add(slot);
-                else if (proxy.Display == CssConstants.TableFooterGroup) footerBands.Add(slot);
+                if (proxy.DerivedStyle.ActualDisplay == CssConstants.TableHeaderGroup) headerBands.Add(slot);
+                else if (proxy.DerivedStyle.ActualDisplay == CssConstants.TableFooterGroup) footerBands.Add(slot);
             }
 
             foreach (var slot in _bandsARowOverflowedInto.Order())
@@ -2844,7 +2844,7 @@ namespace PeachPDF.Html.Core.Dom
         {
             foreach (var childBox in box.Boxes)
             {
-                if (childBox.Display == CssConstants.None) continue;
+                if (childBox.DerivedStyle.ActualDisplay == CssConstants.None) continue;
 
                 await childBox.MeasureWordsSize(g);
                 await MeasureWords(childBox, g);

--- a/src/PeachPDF/Html/Core/Dom/CssProxyBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssProxyBox.cs
@@ -94,7 +94,7 @@ namespace PeachPDF.Html.Core.Dom
             _awaitingRefill = false;
 
 #if DEBUG
-            System.Console.WriteLine($"CssProxyBox.PerformLayoutImp: START - Location={Location}, Display={Display}");
+            System.Console.WriteLine($"CssProxyBox.PerformLayoutImp: START - Location={Location}, Display={DerivedStyle.ActualDisplay}");
             System.Console.WriteLine($"  Source already laid out: Location={_sourceBox.Location}, ActualBottom={_sourceBox.ActualBottom}, ActualRight={_sourceBox.ActualRight}");
 #endif
 

--- a/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
+++ b/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
@@ -1071,6 +1071,45 @@ namespace PeachPDF.Html.Core.Dom
 
         #endregion
 
+        #region Display
+
+        /// <summary>
+        /// This box's <c>display</c>, blockified per CSS 2.1 §9.7 when <see cref="Owner"/> is floated
+        /// (<c>Style.DisplayPositioning.Float</c> is not <see cref="CssConstants.None"/>) - the value layout
+        /// and paint should actually use. <c>Style.DisplayPositioning.Display</c> itself stays the raw
+        /// cascaded keyword (what the cascade produced, e.g. for CSS-OM <c>getPropertyValue</c> readback),
+        /// not blockified. Recomputed fresh every call, not cached - a single string switch, same cost class
+        /// as <see cref="ActualLineHeight"/>/<see cref="IsPositioned"/> below.
+        /// </summary>
+        public string ActualDisplay
+        {
+            get
+            {
+                var area = Style.DisplayPositioning;
+                if (area.Float is CssConstants.None) return area.Display;
+
+                return area.Display switch
+                {
+                    "inline" => "block",
+                    "inline-block" => "block",
+                    "inline-table" => "table",
+                    "table-row" => "block",
+                    "table-row-group" => "block",
+                    "table-column" => "block",
+                    "table-column-group" => "block",
+                    "table-cell" => "block",
+                    "table-caption" => "block",
+                    "table-header-group" => "block",
+                    "table-footer-group" => "block",
+                    "inline-flex" => "flex",
+                    "inline-grid" => "grid",
+                    _ => area.Display
+                };
+            }
+        }
+
+        #endregion
+
         #region Position, multi-column
 
         /// <summary>True for a positioned element: <c>position</c> of relative, absolute, fixed, or sticky.</summary>

--- a/src/PeachPDF/Html/Core/Fragmentation/BreakPropagation.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/BreakPropagation.cs
@@ -186,7 +186,7 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// fragmentainer.
         /// </remarks>
         private static bool IsInFlow(CssBox box) =>
-            box.Display != CssConstants.None
+            box.DerivedStyle.ActualDisplay != CssConstants.None
             && box.Position is not (CssConstants.Absolute or CssConstants.Fixed)
             && !box.IsFloated
             && !CssBox.IsOutsideMarker(box);

--- a/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
@@ -1546,7 +1546,7 @@ namespace PeachPDF.Html.Core.Fragmentation
             (CssBox Root, double Shift, RRect Band)? displacement = null)
         {
             // A display:none subtree paints nothing at all, so it produces no fragments either.
-            if (box.Display == CssConstants.None) return null;
+            if (box.DerivedStyle.ActualDisplay == CssConstants.None) return null;
 
             // Fixed-position content ignores the page origin and repeats identically on every page, so
             // its fragments carry raw document coordinates (CSS Position 3: a fixed box's containing

--- a/src/PeachPDF/Html/Core/Fragmentation/ItemContentCommit.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/ItemContentCommit.cs
@@ -107,7 +107,7 @@ namespace PeachPDF.Html.Core.Fragmentation
             string? savedDisplay = null;
             if (box.IsInline)
             {
-                savedDisplay = box.Display;
+                savedDisplay = box.DerivedStyle.ActualDisplay;
                 box.Display = CssConstants.Block;
             }
 

--- a/src/PeachPDF/Html/Core/Fragmentation/MonolithicContent.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/MonolithicContent.cs
@@ -124,7 +124,7 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// </remarks>
         /// <seealso cref="RunsAnEngineOfItsOwn"/>
         internal static bool PaginatesItsOwnContent(CssBox box) =>
-            RunsAnEngineOfItsOwn(box.Display) || box.EstablishesMultiColumnContext;
+            RunsAnEngineOfItsOwn(box.DerivedStyle.ActualDisplay) || box.EstablishesMultiColumnContext;
 
         /// <summary>
         /// The display-value half of <see cref="PaginatesItsOwnContent"/>, which

--- a/src/PeachPDF/Html/Core/Fragmentation/TableRowCursor.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/TableRowCursor.cs
@@ -151,8 +151,8 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// <c>CssBox.PerformLayoutImp</c> treats as "did not finish". That is safe today for a reason
         /// worth naming exactly, because it is not the obvious one: <c>CssBox.PlaceBlockChild</c> wraps
         /// its whole body — both <c>RequestBreakBefore</c> call sites included — in
-        /// <c>if (child.Display != CssConstants.TableCell)</c>, so a cell cannot carry that request at
-        /// all. It is not that the row loop's per-row break check covers it; that check is a different
+        /// <c>if (child.DerivedStyle.ActualDisplay != CssConstants.TableCell)</c>, so a cell cannot carry
+        /// that request at all. It is not that the row loop's per-row break check covers it; that check is a different
         /// decision, taken from <c>EstimateRowHeight</c> before the row is laid out. A change that gives
         /// a cell its own break-before has to add the second channel here.
         /// </para>

--- a/src/PeachPDF/Html/Core/Handlers/StructureTagMapper.cs
+++ b/src/PeachPDF/Html/Core/Handlers/StructureTagMapper.cs
@@ -116,7 +116,7 @@ namespace PeachPDF.Html.Core.Handlers
 
         static StructureTagClassification ClassifyAnonymous(CssBox box)
         {
-            var tableStructureType = box.Display switch
+            var tableStructureType = box.DerivedStyle.ActualDisplay switch
             {
                 CssConstants.TableRow => "TR",
                 // Anonymous table cells can't be distinguished into header (/TH) vs data (/TD) -

--- a/src/PeachPDF/Html/Core/HtmlContainerInt.cs
+++ b/src/PeachPDF/Html/Core/HtmlContainerInt.cs
@@ -1008,7 +1008,7 @@ namespace PeachPDF.Html.Core
             {
                 var child = box.Boxes[i];
 
-                if (child.Display == CssConstants.None
+                if (child.DerivedStyle.ActualDisplay == CssConstants.None
                     || child.Position is CssConstants.Absolute or CssConstants.Fixed
                     || child.IsFloated)
                 {

--- a/src/PeachPDF/Html/Core/Paint/FragmentPainter.cs
+++ b/src/PeachPDF/Html/Core/Paint/FragmentPainter.cs
@@ -76,7 +76,7 @@ namespace PeachPDF.Html.Core.Paint
 
             try
             {
-                if (box.Display == CssConstants.None || box.Visibility != CssConstants.Visible) return;
+                if (box.DerivedStyle.ActualDisplay == CssConstants.None || box.Visibility != CssConstants.Visible) return;
 
                 // use initial clip to draw blocks with Position = fixed. I.e. ignore page margins
                 if (box.Position == CssConstants.Fixed)
@@ -336,8 +336,8 @@ namespace PeachPDF.Html.Core.Paint
         {
             var box = fragment.Box;
 
-            if (box.Display == CssConstants.None ||
-                (box.Display == CssConstants.TableCell && box.EmptyCells == CssConstants.Hide && box.IsSpaceOrEmpty)) return;
+            if (box.DerivedStyle.ActualDisplay == CssConstants.None ||
+                (box.DerivedStyle.ActualDisplay == CssConstants.TableCell && box.EmptyCells == CssConstants.Hide && box.IsSpaceOrEmpty)) return;
 
             var clipped = RenderUtils.ClipGraphicsByOverflow(g, fragment.OverflowClip);
 
@@ -385,7 +385,7 @@ namespace PeachPDF.Html.Core.Paint
                 // intermediate pages (instead of at the rectangle's bottom, which is off-page).
                 // The page clip already constrains the side-border top to MarginTop.
                 var rectForBorders = geometry.DecorationRect;
-                if ((box.Display == CssConstants.Table || box.Display == CssConstants.InlineTable)
+                if ((box.DerivedStyle.ActualDisplay == CssConstants.Table || box.DerivedStyle.ActualDisplay == CssConstants.InlineTable)
                     && box.PageBreakBottoms != null && box.HtmlContainer != null)
                 {
                     // PageBreakBottoms is keyed by pagination slot, which is exactly what the fragment

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -855,7 +855,7 @@ namespace PeachPDF.Html.Core.Parse
         /// </summary>
         private static void EnsureListItemMarkers(CssValueParser valueParser, CssBox box, CssData cssData, MediaQueryContext media, ContainerQuerySizes? containerSizes = null)
         {
-            if (box.Display == CssConstants.ListItem && !box.Boxes.Any(b => b.IsMarkerPseudoElement))
+            if (box.DerivedStyle.ActualDisplay == CssConstants.ListItem && !box.Boxes.Any(b => b.IsMarkerPseudoElement))
             {
                 var markerBox = new CssBoxMarker(box);
                 box.Boxes.Remove(markerBox);
@@ -946,7 +946,7 @@ namespace PeachPDF.Html.Core.Parse
         }
 
         private static bool IsFirstLetterScopeBoundary(CssBox box) =>
-            box.Display is CssConstants.Block or CssConstants.Table or CssConstants.TableRow
+            box.DerivedStyle.ActualDisplay is CssConstants.Block or CssConstants.Table or CssConstants.TableRow
                 or CssConstants.TableRowGroup or CssConstants.TableCell or CssConstants.ListItem
                 or CssConstants.Flex or CssConstants.InlineBlock or CssConstants.InlineTable
                 or CssConstants.InlineFlex or CssConstants.Grid or CssConstants.InlineGrid;
@@ -1757,7 +1757,7 @@ namespace PeachPDF.Html.Core.Parse
             for (int i = box.Boxes.Count - 1; i >= 0; i--)
             {
                 var childBox = box.Boxes[i];
-                if (childBox is CssBoxImage or CssBoxSvg && childBox.Display == CssConstants.Block)
+                if (childBox is CssBoxImage or CssBoxSvg && childBox.DerivedStyle.ActualDisplay == CssConstants.Block)
                 {
                     var block = CssBox.CreateBlock(childBox.ParentBox!, null, childBox);
                     childBox.ParentBox = block;
@@ -1856,7 +1856,7 @@ namespace PeachPDF.Html.Core.Parse
         /// <param name="box">the box that has the problem</param>
         private static CssBox? CorrectBlockInsideInlineImp(CssBox box)
         {
-            if (box.Display == CssConstants.Inline)
+            if (box.DerivedStyle.ActualDisplay == CssConstants.Inline)
                 box.Display = CssConstants.Block;
 
             if (box.Boxes.Count > 1 || box.Boxes[0].Boxes.Count > 1)
@@ -1885,7 +1885,7 @@ namespace PeachPDF.Html.Core.Parse
 
                 return tempRightBox;
             }
-            else if (box.Boxes[0].Display == CssConstants.Inline)
+            else if (box.Boxes[0].DerivedStyle.ActualDisplay == CssConstants.Inline)
             {
                 box.Boxes[0].Display = CssConstants.Block;
             }
@@ -2015,7 +2015,7 @@ namespace PeachPDF.Html.Core.Parse
             // and are never laid out as HTML boxes, so HTML box-tree normalization must not descend into
             // (and restructure) them. See CssBoxSvg / issue #159.
             if (box is CssBoxSvg) return;
-            if (box is { Display: CssConstants.Inline, Position: CssConstants.Absolute })
+            if (box is { DerivedStyle.ActualDisplay: CssConstants.Inline, Position: CssConstants.Absolute })
             {
                 var blockBox = new CssBox(box.ParentBox, null);
                 blockBox.Display = CssConstants.Block;
@@ -2082,7 +2082,7 @@ namespace PeachPDF.Html.Core.Parse
         private static void CorrectAnonymousTablesRemoveIrrelevantBoxes(CssBox box)
         {
             // 1.1 All child boxes of a 'table-column' parent are treated as if they had 'display: none'
-            if (box.Display is CssConstants.TableColumn)
+            if (box.DerivedStyle.ActualDisplay is CssConstants.TableColumn)
             {
                 foreach (var childBox in box.Boxes)
                 {
@@ -2095,7 +2095,7 @@ namespace PeachPDF.Html.Core.Parse
             }
 
             // 1.2 If a child C of a 'table-column-group' parent is not a 'table-column' box, then it is treated as if it had 'display: none'.
-            if (box.ParentBox?.Display is CssConstants.TableColumnGroup && box.Display is not CssConstants.TableColumn)
+            if (box.ParentBox?.DerivedStyle.ActualDisplay is CssConstants.TableColumnGroup && box.DerivedStyle.ActualDisplay is not CssConstants.TableColumn)
             {
 #if DEBUG
                 Console.WriteLine($"dom: set child box {box.Id} to display:none if parent is table-column-group and child is not table-column");
@@ -2111,7 +2111,7 @@ namespace PeachPDF.Html.Core.Parse
         private static void CorrectAnonymousTablesGenerateMissingChildWrappers(CssBox box)
         {
             // 2.1 If a child C of a 'table' or 'inline-table' box is not a proper table child, then generate an anonymous 'table-row' box around C and all consecutive siblings of C that are not proper table children.
-            if (box.ParentBox?.Display is CssConstants.Table)
+            if (box.ParentBox?.DerivedStyle.ActualDisplay is CssConstants.Table)
             {
                 if (!DomUtils.IsProperTableChild(box))
                 {
@@ -2139,14 +2139,14 @@ namespace PeachPDF.Html.Core.Parse
             // 2.2 If a child C of a row group box is not a 'table-row' box, then generate an anonymous 'table-row' box around C and all consecutive siblings of C that are not 'table-row' boxes.
             if (box.ParentBox?.IsTableRowGroupBox ?? false)
             {
-                if (box.Display is not CssConstants.TableRow)
+                if (box.DerivedStyle.ActualDisplay is not CssConstants.TableRow)
                 {
 #if DEBUG
                     Console.WriteLine($"dom: if box {box.Id} is not a table row and parent is a table row group box, then generate table-row around element");
 #endif
 
                     var followingMatchingSiblings =
-                        DomUtils.GetFollowingSiblings(box, sibling => sibling.Display is not CssConstants.TableRow, true)
+                        DomUtils.GetFollowingSiblings(box, sibling => sibling.DerivedStyle.ActualDisplay is not CssConstants.TableRow, true)
                             .ToList();
 
                     var tableRowBox = new CssBox(box.ParentBox, null);
@@ -2159,9 +2159,9 @@ namespace PeachPDF.Html.Core.Parse
             }
 
             // 2.3 If a child C of a 'table-row' box is not a 'table-cell', then generate an anonymous 'table-cell' box around C and all consecutive siblings of C that are not 'table-cell' boxes.
-            if (box.ParentBox?.Display is CssConstants.TableRow)
+            if (box.ParentBox?.DerivedStyle.ActualDisplay is CssConstants.TableRow)
             {
-                if (box.Display is not CssConstants.TableCell)
+                if (box.DerivedStyle.ActualDisplay is not CssConstants.TableCell)
                 {
 
 #if DEBUG
@@ -2169,7 +2169,7 @@ namespace PeachPDF.Html.Core.Parse
 #endif
 
                     var followingMatchingSiblings =
-                        DomUtils.GetFollowingSiblings(box, sibling => sibling.Display is not CssConstants.TableCell, true)
+                        DomUtils.GetFollowingSiblings(box, sibling => sibling.DerivedStyle.ActualDisplay is not CssConstants.TableCell, true)
                             .ToList();
 
                     var tableCellBox = new CssBox(box.ParentBox, null);
@@ -2185,12 +2185,12 @@ namespace PeachPDF.Html.Core.Parse
         private static void CorrectAnonymousTablesGenerateMissingParents(CssBox box)
         {
             // 3.1 For each 'table-cell' box C in a sequence of consecutive internal table and 'table-caption' siblings, if C's parent is not a 'table-row' then generate an anonymous 'table-row' box around C and all consecutive siblings of C that are 'table-cell' boxes.
-            if (box.Display is CssConstants.TableCell)
+            if (box.DerivedStyle.ActualDisplay is CssConstants.TableCell)
             {
-                if (box.ParentBox?.Display is not CssConstants.TableRow)
+                if (box.ParentBox?.DerivedStyle.ActualDisplay is not CssConstants.TableRow)
                 {
                     var followingMatchingSiblings =
-                        DomUtils.GetFollowingSiblings(box, sibling => sibling.Display is CssConstants.TableCell, true)
+                        DomUtils.GetFollowingSiblings(box, sibling => sibling.DerivedStyle.ActualDisplay is CssConstants.TableCell, true)
                             .ToList();
 
                     var tableRowBox = new CssBox(box.ParentBox, null);
@@ -2220,12 +2220,12 @@ namespace PeachPDF.Html.Core.Parse
                 // around cells under a `display:block` `<tr>`, lost their table box and silently dropped all
                 // content. That case only became reachable once author `display` could override table tags.)
                 var parent = box.ParentBox;
-                var parentIsTable = parent?.Display is CssConstants.Table or CssConstants.InlineTable;
+                var parentIsTable = parent?.DerivedStyle.ActualDisplay is CssConstants.Table or CssConstants.InlineTable;
 
-                var isMisparented = parent is null || box.Display switch
+                var isMisparented = parent is null || box.DerivedStyle.ActualDisplay switch
                 {
                     CssConstants.TableRow => !parentIsTable && !parent.IsTableRowGroupBox,
-                    CssConstants.TableColumn => !parentIsTable && parent.Display is not CssConstants.TableColumnGroup,
+                    CssConstants.TableColumn => !parentIsTable && parent.DerivedStyle.ActualDisplay is not CssConstants.TableColumnGroup,
                     _ => !parentIsTable // row group, table-column-group, or table-caption
                 };
 
@@ -2308,7 +2308,7 @@ namespace PeachPDF.Html.Core.Parse
         /// <param name="box">the box to check</param>
         /// <returns>true - an atomic inline-level box with a layout path of its own, false - otherwise</returns>
         private static bool IsAtomicInlineLevel(CssBox box) =>
-            box.Display is CssConstants.InlineFlex;
+            box.DerivedStyle.ActualDisplay is CssConstants.InlineFlex;
 
         /// <summary>
         /// Check if the given box contains inline and block child boxes.

--- a/src/PeachPDF/Html/Core/Utils/DomUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/DomUtils.cs
@@ -116,12 +116,12 @@ namespace PeachPDF.Html.Core.Utils
             var diff = 1;
             var sib = b.ParentBox.Boxes[index - diff];
 
-            while ((sib.Display == CssConstants.None || sib.Position == CssConstants.Absolute || sib.Position == CssConstants.Fixed || (!includeFloats && sib.IsFloated) || CssBox.IsOutsideMarker(sib)) && index - diff - 1 >= 0)
+            while ((sib.DerivedStyle.ActualDisplay == CssConstants.None || sib.Position == CssConstants.Absolute || sib.Position == CssConstants.Fixed || (!includeFloats && sib.IsFloated) || CssBox.IsOutsideMarker(sib)) && index - diff - 1 >= 0)
             {
                 sib = b.ParentBox.Boxes[index - ++diff];
             }
 
-            sib = sib.Display == CssConstants.None || sib.Position == CssConstants.Fixed || (!includeFloats && sib.IsFloated) || CssBox.IsOutsideMarker(sib) ? null : sib;
+            sib = sib.DerivedStyle.ActualDisplay == CssConstants.None || sib.Position == CssConstants.Fixed || (!includeFloats && sib.IsFloated) || CssBox.IsOutsideMarker(sib) ? null : sib;
 
             return sib;
         }
@@ -245,7 +245,7 @@ namespace PeachPDF.Html.Core.Utils
         {
             var conBlock = b;
             var index = conBlock.ParentBox!.Boxes.IndexOf(conBlock);
-            while (conBlock.ParentBox != null && index < 1 && conBlock.Display != CssConstants.Block && conBlock.Display != CssConstants.Table && conBlock.Display != CssConstants.TableCell && conBlock.Display != CssConstants.ListItem)
+            while (conBlock.ParentBox != null && index < 1 && conBlock.DerivedStyle.ActualDisplay != CssConstants.Block && conBlock.DerivedStyle.ActualDisplay != CssConstants.Table && conBlock.DerivedStyle.ActualDisplay != CssConstants.TableCell && conBlock.DerivedStyle.ActualDisplay != CssConstants.ListItem)
             {
                 conBlock = conBlock.ParentBox;
                 index = conBlock.ParentBox != null ? conBlock.ParentBox.Boxes.IndexOf(conBlock) : -1;
@@ -256,12 +256,12 @@ namespace PeachPDF.Html.Core.Utils
             var diff = 1;
             var sib = conBlock.Boxes[index - diff];
 
-            while ((sib.Display == CssConstants.None || sib.Position == CssConstants.Absolute || sib.Position == CssConstants.Fixed) && index - diff - 1 >= 0)
+            while ((sib.DerivedStyle.ActualDisplay == CssConstants.None || sib.Position == CssConstants.Absolute || sib.Position == CssConstants.Fixed) && index - diff - 1 >= 0)
             {
                 sib = conBlock.Boxes[index - ++diff];
             }
 
-            return sib.Display == CssConstants.None ? null : sib;
+            return sib.DerivedStyle.ActualDisplay == CssConstants.None ? null : sib;
         }
 
         /// <summary>
@@ -919,7 +919,7 @@ namespace PeachPDF.Html.Core.Utils
             // `position` value of its own (CSS Flexible Box Layout §z-order), unlike a plain block/
             // inline child, which needs position:relative/absolute for z-index to have any effect at all.
             if (box.ZIndex.Value is { IsValue: true } &&
-                box.ParentBox?.Display is CssConstants.Flex or CssConstants.InlineFlex)
+                box.ParentBox?.DerivedStyle.ActualDisplay is CssConstants.Flex or CssConstants.InlineFlex)
             {
                 return true;
             }
@@ -943,9 +943,9 @@ namespace PeachPDF.Html.Core.Utils
 
         public static bool IsProperTableChild(CssBox box)
         {
-            return box.IsTableRowGroupBox || box.Display is CssConstants.TableRow ||
-                   box.Display is CssConstants.TableColumn || box.Display is CssConstants.TableColumnGroup ||
-                   box.Display is CssConstants.TableCaption;
+            return box.IsTableRowGroupBox || box.DerivedStyle.ActualDisplay is CssConstants.TableRow ||
+                   box.DerivedStyle.ActualDisplay is CssConstants.TableColumn || box.DerivedStyle.ActualDisplay is CssConstants.TableColumnGroup ||
+                   box.DerivedStyle.ActualDisplay is CssConstants.TableCaption;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Part of the ongoing #598 follow-up work (typed/mechanical box storage). `CssBox.Display`'s getter used to blockify the value inline (CSS 2.1 §9.7: a floated `inline`/`inline-block` computes to `block`, `inline-table` to `table`, several table-internal values to `block`, `inline-flex`/`inline-grid` to `flex`/`grid`). This conflated "the raw cascaded keyword" with "the used value after blockification" in a single property — a problem for the planned source-generated storage layer, since a mechanically-generated property can only be a plain field read, not custom logic.

- `Display` now returns the raw cascaded keyword — a plain field read.
- The blockification logic moved to a new `DerivedStyle.ActualDisplay`, alongside the class's existing `Actual*` family of values computed from `ComputedStyle` (`ActualBorderTopWidth`, `ActualFont`, etc.).
- Every production call site that relied on `Display` being blockified (layout engines, paint, fragmentation, DOM structural fixups) was migrated to read `.DerivedStyle.ActualDisplay` instead.
- Call sites that genuinely want the raw value were left reading `Display`: `CssProxyBox`'s constructor-time copy, `InheritStyle`'s structural-duplicate area copy, the CSS-OM style declaration, and `DomParser`'s separate position-based blockification (`BlockifyPositionedBox`).

This is a pure refactor — no behavior change. Full test suite passing with the same pass count confirms this.

## Test plan

- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (7868 passed, 9 skipped)
- [x] Diff coverage vs `main`: 98%
- [x] New `DerivedStyleTests.cs` covering every blockification mapping, the non-floated passthrough, and confirming `Display` itself stays raw
- [x] Post-change review pass against the diff (migration completeness, C# conventions, CSS spec compliance) — one stale doc comment found and fixed


---
_Generated by [Claude Code](https://claude.ai/code/session_01WsuX3xR9EsNY3x1a5RGQmJ)_