### PR TITLE
Fix font-size relative resolution: unit-conversion bug and cross-generation compounding

### DIFF
--- a/src/PeachPDF.Tests/Integration/Acid2FeatureVerificationTests.cs
+++ b/src/PeachPDF.Tests/Integration/Acid2FeatureVerificationTests.cs
@@ -1018,9 +1018,10 @@ namespace PeachPDF.Tests.Integration
             var box = FindById(root, "t")!;
 
             // "2em" font-size is eagerly converted to points against the parent's actual font size (see
-            // CssBoxProperties.FontSize); "24px" line-height is a plain length and stays as declared.
+            // CssBox.StyleProperties.cs's FontSize setter); "24px" line-height is a plain length and stays
+            // as declared.
             var expectedPt = 2 * parent.ActualFont.Size;
-            Assert.Equal($"{expectedPt:0.0}pt", box.FontSize);
+            Assert.Equal($"{expectedPt.ToString(System.Globalization.NumberFormatInfo.InvariantInfo)}pt", box.FontSize);
             Assert.Equal("24px", box.LineHeight);
         }
 

--- a/src/PeachPDF.Tests/Integration/CalcIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/CalcIntegrationTests.cs
@@ -83,14 +83,15 @@ namespace PeachPDF.Tests.Integration
 
             Assert.NotNull(parent);
             Assert.NotNull(child);
-            // CssBoxProperties.ActualFont.Size is the resolved font size further divided by
-            // PixelsPerPoint (a pre-existing, calc()-unrelated font-metric convention), and that same
-            // already-divided parent.ActualFont.Size is exactly what calc()'s "em" unit multiplies
-            // against here - matching plain (non-calc) em resolution's own emFactor at this call site.
-            // Deriving the expected value from the actually-measured parent size (rather than a
-            // hardcoded constant) keeps this test correct regardless of that convention, while still
-            // proving both the em and px terms resolve correctly.
-            var expected = (parent!.ActualFont.Size + 4 * (72.0 / 96.0)) / 72.0;
+            // CssBox.ActualFont.Size is the resolved font size further divided by PixelsPerPoint (a
+            // pre-existing, calc()-unrelated font-metric convention) - undo that once to get parent's font
+            // size in true CSS points (what calc()'s "em" unit multiplies against), add the 4px term
+            // (converted to points), then redivide by PixelsPerPoint to land in the same space
+            // child.ActualFont.Size reports in. Deriving the expected value from the actually-measured
+            // parent size (rather than a hardcoded constant) keeps this test correct regardless of that
+            // convention, while still proving both the em and px terms resolve correctly.
+            var parentSizePt = parent!.ActualFont.Size * 72.0;
+            var expected = (parentSizePt + 4 * (72.0 / 96.0)) / 72.0;
             Assert.Equal(expected, child!.ActualFont.Size, 8);
         }
 
@@ -108,8 +109,10 @@ namespace PeachPDF.Tests.Integration
 
             Assert.NotNull(child);
             // GetRemHeight() walks up to the outermost box (the container's root, not <html>) and reads
-            // its ActualFont.Size - that's what calc()'s "rem" unit multiplies against.
-            var expected = (root.ActualFont.Size + 4 * (72.0 / 96.0)) / 72.0;
+            // its ActualFont.Size - that's what calc()'s "rem" unit multiplies against, in true CSS points
+            // (undoing the same PixelsPerPoint division the em test above undoes for parent.ActualFont.Size).
+            var rootSizePt = root.ActualFont.Size * 72.0;
+            var expected = (rootSizePt + 4 * (72.0 / 96.0)) / 72.0;
             Assert.Equal(expected, child!.ActualFont.Size, 8);
         }
 

--- a/src/PeachPDF.Tests/Integration/FontSizeInheritanceIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FontSizeInheritanceIntegrationTests.cs
@@ -1,0 +1,259 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore.Drawing;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Coverage for two bugs found while investigating a suspected <c>font-size</c> inheritance issue,
+    /// both in how a parent-relative <c>font-size</c> (<c>em</c>, a percentage, or the <c>smaller</c>/
+    /// <c>larger</c> keywords) resolves against its parent's already-resolved size:
+    /// <list type="bullet">
+    /// <item>
+    /// <b>Magnitude</b>: <see cref="DerivedStyle.ActualFont"/>'s <c>parentSize</c>/<c>remSize</c> inputs
+    /// (read from <c>parentBox.ActualFont.Size</c>/<c>GetRemHeight()</c>) are in the adapter's
+    /// device-scaled font-measurement space, not true CSS points - <c>PdfSharpAdapter.CreateFontInt</c>
+    /// divides a requested size by <c>PixelsPerPoint</c> once to get there. Feeding that already-divided
+    /// value back in as a relative-resolution reference, whose own result is then divided by
+    /// <c>PixelsPerPoint</c> *again* when its font is created, produces a font roughly
+    /// <c>PixelsPerPoint</c> times too small - invisible only because most of this suite (and the
+    /// library's own default <see cref="PeachPDF.PdfGenerateConfig"/>) happens to use a
+    /// <c>PixelsPerPoint</c> of <c>1.0</c>. These tests deliberately build through a bare
+    /// <see cref="PdfSharpAdapter"/> (default <c>PixelsPerPoint</c> of 72) to actually exercise the
+    /// scaling.
+    /// </item>
+    /// <item>
+    /// <b>Compounding across non-overriding descendants</b>: <c>CssBox</c>'s <c>Font</c> area is inherited
+    /// by reference (<c>InheritStyle</c> adopts the whole area from parent to child), so whatever string
+    /// sits in <c>FontSize</c> at that moment is what every non-overriding descendant, at any depth, ends
+    /// up with. A relative value left as raw text for lazy resolution is indistinguishable from a value
+    /// merely copied down unchanged, so a box several generations below the one that actually declared,
+    /// say, <c>150%</c> would re-resolve that same raw text against its own immediate parent, compounding
+    /// the multiplier once per generation instead of applying it once.
+    /// </item>
+    /// </list>
+    /// Both are fixed together: every parent-relative form is eagerly resolved to an absolute point value
+    /// in the <c>FontSize</c> setter (<c>CssBox.StyleProperties.cs</c>), using the parent's actual size
+    /// with the device-scaling undone.
+    /// </summary>
+    public class FontSizeInheritanceIntegrationTests
+    {
+        [Fact]
+        public async Task FontSize_PlainEm_ResolvesToTheCorrectAbsoluteMagnitude()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="parent" style="font-size: 20pt">
+                  <div id="child" style="font-size: 1.2em"></div>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var parent = FindById(root, "parent");
+            var child = FindById(root, "child");
+
+            Assert.NotNull(parent);
+            Assert.NotNull(child);
+            Assert.Equal(parent!.ActualFont.Size * 1.2, child!.ActualFont.Size, 6);
+        }
+
+        [Fact]
+        public async Task FontSize_PlainEx_ResolvesToTheCorrectAbsoluteMagnitude()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="parent" style="font-size: 20pt">
+                  <div id="child" style="font-size: 4ex"></div>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var parent = FindById(root, "parent");
+            var child = FindById(root, "child");
+
+            Assert.NotNull(parent);
+            Assert.NotNull(child);
+            // Length.ToPixels resolves ex as emFactor / 2 * value - "4ex" against parent's font size is
+            // 4 * (parent / 2) = 2 * parent.
+            Assert.Equal(parent!.ActualFont.Size * 2, child!.ActualFont.Size, 6);
+        }
+
+        [Fact]
+        public async Task FontSize_ExThreeLevelsDeep_DoesNotCompoundAcrossNonOverridingDescendants()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="grandparent" style="font-size: 20pt">
+                  <div id="middle" style="font-size: 4ex">
+                    <div id="leaf"></div>
+                  </div>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var grandparent = FindById(root, "grandparent");
+            var middle = FindById(root, "middle");
+            var leaf = FindById(root, "leaf");
+
+            Assert.NotNull(grandparent);
+            Assert.NotNull(middle);
+            Assert.NotNull(leaf);
+            Assert.Equal(grandparent!.ActualFont.Size * 2, middle!.ActualFont.Size, 6);
+            Assert.Equal(middle.ActualFont.Size, leaf!.ActualFont.Size, 6);
+        }
+
+        [Fact]
+        public async Task ActualFontSize_MirrorsActualFontSizeValue()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="parent" style="font-size: 20pt">
+                  <div id="child" style="font-size: 1.2em"></div>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var child = FindById(root, "child");
+
+            Assert.NotNull(child);
+            Assert.Equal(child!.ActualFont.Size, child.DerivedStyle.ActualFontSize);
+        }
+
+        [Fact]
+        public async Task FontSize_PlainPercentage_ResolvesToTheCorrectAbsoluteMagnitude()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="parent" style="font-size: 20pt">
+                  <div id="child" style="font-size: 150%"></div>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var parent = FindById(root, "parent");
+            var child = FindById(root, "child");
+
+            Assert.NotNull(parent);
+            Assert.NotNull(child);
+            Assert.Equal(parent!.ActualFont.Size * 1.5, child!.ActualFont.Size, 6);
+        }
+
+        [Fact]
+        public async Task FontSize_PercentageThreeLevelsDeep_DoesNotCompoundAcrossNonOverridingDescendants()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="grandparent" style="font-size: 20pt">
+                  <div id="middle" style="font-size: 150%">
+                    <div id="leaf"></div>
+                  </div>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var grandparent = FindById(root, "grandparent");
+            var middle = FindById(root, "middle");
+            var leaf = FindById(root, "leaf");
+
+            Assert.NotNull(grandparent);
+            Assert.NotNull(middle);
+            Assert.NotNull(leaf);
+            // middle actually resolves 150% of grandparent - not just "whatever leaf also ends up with".
+            Assert.Equal(grandparent!.ActualFont.Size * 1.5, middle!.ActualFont.Size, 6);
+            // The leaf never declares its own font-size, so its computed font-size must equal the
+            // middle's (the nearest ancestor that actually specified one) - not middle's size scaled by
+            // another 150%.
+            Assert.Equal(middle.ActualFont.Size, leaf!.ActualFont.Size, 6);
+        }
+
+        [Fact]
+        public async Task FontSize_SmallerKeywordThreeLevelsDeep_DoesNotCompoundAcrossNonOverridingDescendants()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="grandparent" style="font-size: 20pt">
+                  <div id="middle" style="font-size: smaller">
+                    <div id="leaf"></div>
+                  </div>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var grandparent = FindById(root, "grandparent");
+            var middle = FindById(root, "middle");
+            var leaf = FindById(root, "leaf");
+
+            Assert.NotNull(grandparent);
+            Assert.NotNull(middle);
+            Assert.NotNull(leaf);
+            Assert.True(middle!.ActualFont.Size < grandparent!.ActualFont.Size);
+            Assert.Equal(middle.ActualFont.Size, leaf!.ActualFont.Size, 6);
+        }
+
+        [Fact]
+        public async Task FontSize_LargerKeywordThreeLevelsDeep_DoesNotCompoundAcrossNonOverridingDescendants()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="grandparent" style="font-size: 20pt">
+                  <div id="middle" style="font-size: larger">
+                    <div id="leaf"></div>
+                  </div>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var grandparent = FindById(root, "grandparent");
+            var middle = FindById(root, "middle");
+            var leaf = FindById(root, "leaf");
+
+            Assert.NotNull(grandparent);
+            Assert.NotNull(middle);
+            Assert.NotNull(leaf);
+            Assert.True(middle!.ActualFont.Size > grandparent!.ActualFont.Size);
+            Assert.Equal(middle.ActualFont.Size, leaf!.ActualFont.Size, 6);
+        }
+
+        private static async Task<CssBox> BuildBoxTree(string html)
+        {
+            var adapter = new PdfSharpAdapter();
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            var size = new XSize(595, 842);
+            container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+            container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+            var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            return container.Root!;
+        }
+
+        private static CssBox? FindById(CssBox box, string id)
+        {
+            if (box.HtmlTag?.Attributes?.TryGetValue("id", out var boxId) == true
+                && string.Equals(boxId, id, StringComparison.OrdinalIgnoreCase))
+                return box;
+
+            foreach (var child in box.Boxes)
+            {
+                var found = FindById(child, id);
+                if (found is not null) return found;
+            }
+            return null;
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/GlobalKeywordCascadeTests.cs
+++ b/src/PeachPDF.Tests/Integration/GlobalKeywordCascadeTests.cs
@@ -231,9 +231,10 @@ namespace PeachPDF.Tests.Integration
         public async Task Revert_H1FontSizeInAuthorRule_RevertsToUaFontSize()
         {
             // Author sets h1 font-size to 50px, then a later author rule reverts it.
-            // The UA stylesheet defines h1 { font-size: 2em }; PeachPDF eagerly converts em
-            // to points at cascade time (using the parent's ActualFont.Size), so revert restores
-            // the already-converted pt value rather than the original "2em" string.
+            // The UA stylesheet defines h1 { font-size: 2em }; PeachPDF eagerly converts em to points at
+            // cascade time (using the parent's ActualFont.Size, in true CSS points), so revert restores
+            // the already-converted pt value rather than the original "2em" string - 2 * the 11pt "medium"
+            // default the parent resolves to.
             var html = """
                 <!DOCTYPE html><html><head><style>
                   h1 { font-size: 50px; }
@@ -247,7 +248,7 @@ namespace PeachPDF.Tests.Integration
             var el = FindById(root, "el");
 
             Assert.NotNull(el);
-            Assert.Equal("0.3pt", el!.FontSize);
+            Assert.Equal("22pt", el!.FontSize);
         }
 
         [Fact]
@@ -806,8 +807,9 @@ namespace PeachPDF.Tests.Integration
         [Fact]
         public async Task Regression_UaStylesheetSetsH1FontSize()
         {
-            // The UA stylesheet defines h1 { font-size: 2em }. PeachPDF eagerly converts em
-            // values to points at cascade time, so the stored value is the converted pt string.
+            // The UA stylesheet defines h1 { font-size: 2em }. PeachPDF eagerly converts em values to
+            // points at cascade time, so the stored value is the converted pt string - 2 * the 11pt
+            // "medium" default the parent resolves to.
             var html = """
                 <!DOCTYPE html><html><body>
                 <h1 id="el">heading</h1>
@@ -818,7 +820,7 @@ namespace PeachPDF.Tests.Integration
             var el = FindById(root, "el");
 
             Assert.NotNull(el);
-            Assert.Equal("0.3pt", el!.FontSize);
+            Assert.Equal("22pt", el!.FontSize);
         }
 
         [Fact]

--- a/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
@@ -1,3 +1,4 @@
+using PeachPDF.Adapters;
 using PeachPDF.CSS;
 using PeachPDF.Html.Adapters;
 using PeachPDF.Html.Adapters.Entities;
@@ -5,6 +6,7 @@ using PeachPDF.Html.Core.Entities;
 using PeachPDF.Html.Core.Parse;
 using PeachPDF.Html.Core.Utils;
 using PeachPDF.Text;
+using System;
 using System.Collections.Generic;
 using PeachPDF;
 
@@ -1239,18 +1241,41 @@ namespace PeachPDF.Html.Core.Dom
             set
             {
                 // calc()-family text is resolved directly by ActualFont's own ParseLength call later
-                // (including any em/rem terms it contains) - leave it untouched here. A plain "Nem" is
-                // the only case needing eager conversion at this point (to points, using the parent's
-                // already-resolved font size); everything else - keywords like "medium"/"larger", or any
-                // other single-unit length - is left as-is for ActualFont's own resolution later.
+                // (including any em/rem terms it contains) - leave it untouched here; rem is likewise left
+                // lazy, since it resolves against a single, non-chained reference (the root's font size) and
+                // so can't compound across generations the way a parent-relative value can. Every other
+                // parent-relative form - a plain "Nem"/"Nex", a plain percentage, or the smaller/larger
+                // keywords - needs eager conversion to an absolute point value here, using the parent's
+                // already-resolved font size: InheritStyle adopts the whole Font area from parent to child
+                // *by reference*, so whatever sits in FontSize at that moment is what every non-overriding
+                // descendant, at any depth, ends up with. Eager resolution is what makes that safe - by the
+                // time a value is inherited, it's already absolute, so copying it down any number of
+                // generations is idempotent. Left lazy (as raw text, for ActualFont's own resolution later),
+                // a parent-relative value would be indistinguishable from a value merely copied down
+                // unchanged, and both would resolve against their own immediate parent - compounding the
+                // multiplier once per non-overriding generation instead of applying it once. Absolute-size
+                // keywords (medium/small/large/x-small/...) and any other single-unit absolute length are
+                // left as-is too: they don't depend on the parent at all, so there's nothing to compound.
                 string resolved;
-                if (!CssValueParser.IsCalcFunction(value) &&
-                    CssValueParser.GetCssTokens(value) is [UnitToken unitToken] &&
-                    Length.GetUnit(unitToken.Unit) == Length.Unit.Em &&
-                    ParentBox is { } parent)
+                var trimmed = value.Trim();
+                if (!CssValueParser.IsCalcFunction(value) && ParentBox is { } parent &&
+                    (CssValueParser.GetCssTokens(value) is [UnitToken unitToken] &&
+                        Length.GetUnit(unitToken.Unit) is Length.Unit.Em or Length.Unit.Ex or Length.Unit.Percent
+                     || trimmed.Equals(CssConstants.Smaller, StringComparison.OrdinalIgnoreCase)
+                     || trimmed.Equals(CssConstants.Larger, StringComparison.OrdinalIgnoreCase)))
                 {
-                    var points = unitToken.Value * parent.ActualFont.Size;
-                    resolved = $"{points.ToString("0.0", System.Globalization.NumberFormatInfo.InvariantInfo)}pt";
+                    // parent.ActualFont.Size is in the adapter's device-scaled font-measurement space
+                    // (CreateFontInt divides a requested size by PixelsPerPoint once to get there) - undo
+                    // that scaling before using it as a true-CSS-points reference, the same correction
+                    // DerivedStyle.ActualFont's own parentSize/remSize inputs need and for the same reason
+                    // (see its doc comment). PixelsPerPoint is usually 1.0 (so this was invisible) but a
+                    // non-default PixelsPerInch, or ShrinkToFit/ScaleToPageSize, both legitimately move it
+                    // away from 1.0.
+                    var pixelsPerPoint = (HtmlContainer?.Adapter as PdfSharpAdapter)?.PixelsPerPoint ?? 1.0;
+                    var parentSizePt = parent.ActualFont.Size * pixelsPerPoint;
+
+                    var points = FontSizeResolver.Resolve(trimmed, parentSizePt, parentSizePt);
+                    resolved = $"{points.ToString(System.Globalization.NumberFormatInfo.InvariantInfo)}pt";
                 }
                 else
                 {

--- a/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
+++ b/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
@@ -1,3 +1,4 @@
+using PeachPDF.Adapters;
 using PeachPDF.CSS;
 using PeachPDF.Html.Adapters;
 using PeachPDF.Html.Adapters.Entities;
@@ -890,8 +891,23 @@ namespace PeachPDF.Html.Core.Dom
 
                 if (parentBox is not null)
                 {
-                    parentSize = parentBox.ActualFont.Size;
-                    remSize = GetRemHeight();
+                    // parentBox.ActualFont.Size (like GetRemHeight()'s own ActualFont.Size read below) is
+                    // in the adapter's device-scaled font-measurement space - CreateFontInt divides a
+                    // requested size by PixelsPerPoint once to get there. FontSizeResolver.Resolve expects
+                    // its parentSize/remSize inputs in true CSS points (the same space Style.Font.FontSize
+                    // itself is authored in), so the device scaling has to be undone here before handing
+                    // it in - otherwise a relative font-size (em/%/smaller/larger) resolves against a
+                    // reference that's already off by PixelsPerPoint, then gets divided by PixelsPerPoint
+                    // again when its own font is created, compounding into a value that's wrong by roughly
+                    // PixelsPerPoint² instead of exactly right. PixelsPerPoint is usually 1.0 (so this was
+                    // invisible) but a non-default PixelsPerInch, or ShrinkToFit/ScaleToPageSize, both
+                    // legitimately move it away from 1.0 - verified directly by generating PDFs at a
+                    // non-default PixelsPerInch and confirming the stored/computed font size lands on the
+                    // spec-correct value (see FontSizeInheritanceIntegrationTests.cs, and this fix's own
+                    // commit message for the reasoning).
+                    var pixelsPerPoint = (Owner.HtmlContainer?.Adapter as PdfSharpAdapter)?.PixelsPerPoint ?? 1.0;
+                    parentSize = parentBox.ActualFont.Size * pixelsPerPoint;
+                    remSize = GetRemHeight() * pixelsPerPoint;
                 }
                 else
                 {
@@ -918,6 +934,16 @@ namespace PeachPDF.Html.Core.Dom
                 return _actualFont!;
             }
         }
+
+        /// <summary>
+        /// This box's resolved <c>font-size</c>, in the same units as <see cref="ActualFont"/>'s own
+        /// <c>Size</c> - a thin accessor kept alongside it for symmetry with the rest of this class's
+        /// naming, not an independent computation. <see cref="CssBox.FontSize"/> is safe to read as a plain
+        /// cascaded value everywhere else (the CSS-OM, tests asserting the authored value) because every
+        /// parent-relative form is eagerly resolved to an absolute point value in its setter - see that
+        /// setter's own doc comment.
+        /// </summary>
+        public double ActualFontSize => ActualFont.Size;
 
         private int? _actualNumericWeight;
 


### PR DESCRIPTION
## Summary

Part of the ongoing #598 follow-up work. Investigating a suspected multi-generation compounding bug in relative `font-size` inheritance turned up two related, real bugs:

1. **Unit-conversion/magnitude bug**: `DerivedStyle.ActualFont` resolved a relative `font-size` (`em`, `ex`, `%`, `smaller`/`larger`) using `parentBox.ActualFont.Size` as the reference point. But `ActualFont.Size` is already divided by the adapter's `PixelsPerPoint` (`PdfSharpAdapter.CreateFontInt`: `size / PixelsPerPoint`) — it's device-scaled, not true CSS points. The freshly-resolved relative size was then divided by `PixelsPerPoint` *again* when its own font was created, so any relative font-size came out roughly `PixelsPerPoint` times too small. Invisible under the library's own default `PdfGenerateConfig` (`PixelsPerInch` defaults to 72, giving `PixelsPerPoint = 1.0`) and under most of the existing test suite (which explicitly hardcodes `PixelsPerPoint = 1.0`), but real under a non-default `PixelsPerInch` or the `ShrinkToFit`/`ScaleToPageSize` features. Verified with actual PDF generation at a non-default `PixelsPerInch`.

2. **Cross-generation compounding**: `CssBox`'s `Font` area is inherited by reference, so whatever string sits in `FontSize` at cascade time is what every non-overriding descendant, at any depth, ends up with. Only a plain `em` was eagerly resolved to an absolute value at cascade time; percentages, `ex`, and `smaller`/`larger` were left as raw text for lazy resolution, so a box several generations below the one that declared a relative size would re-resolve that raw text against its own immediate parent, compounding the multiplier once per generation.

## Fix

- `DerivedStyle.ActualFont`: undoes the device-scaling (`* PixelsPerPoint`) before using `parentBox.ActualFont.Size`/`GetRemHeight()` as `FontSizeResolver.Resolve`'s inputs — fixes bug 1 for everything that still resolves lazily (`calc()`, `rem`).
- `CssBox.StyleProperties.cs`'s `FontSize` setter: generalized the existing plain-`em`-only eager-resolution special case to also cover `ex`, a plain percentage, and the `smaller`/`larger` keywords (`calc()` and `rem` stay lazy — `calc()` needs real layout-time info not available at cascade time, `rem` resolves against a single non-chained reference so it can't compound). Also fixes a latent precision-loss bug (the old code forced a single decimal place, silently rounding e.g. `0.333...` to `0.3`).
- Added `DerivedStyle.ActualFontSize` as a thin accessor for symmetry with the class's other `Actual*` members.
- Updated tests whose hardcoded expected values baked in the old buggy magnitude/format, and added `FontSizeInheritanceIntegrationTests.cs` with direct magnitude and non-compounding assertions for every case (`em`, `ex`, `%`, `smaller`, `larger`).

Filed #631 to track the same device-scaling confusion found (but not fixed here, different call sites/properties, out of scope) in `@page` margin em/rem resolution and in `text-indent`/`word-spacing`/`letter-spacing`'s own em resolution.

## Test plan

- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (7876 passed, 9 skipped)
- [x] Diff coverage vs `main`: 100%
- [x] Post-change review pass — verified fix correctness by generating actual PDFs at non-default `PixelsPerInch`, found and fixed a real gap (`ex` unit) plus a misleading comment before finalizing


---
_Generated by [Claude Code](https://claude.ai/code/session_01WsuX3xR9EsNY3x1a5RGQmJ)_