### PR TITLE
Remove unused IsAnsi1252Char from AnsiEncoding

### DIFF
--- a/src/PeachPDF/PdfSharpCore/Pdf.Internal/AnsiEncoding.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf.Internal/AnsiEncoding.cs
@@ -98,53 +98,6 @@ namespace PeachPDF.PdfSharpCore.Pdf.Internal
         }
 
         /// <summary>
-        /// Indicates whether the specified Unicode character is available in the ANSI code page 1252.
-        /// </summary>
-        public static bool IsAnsi1252Char(char ch)
-        {
-            if (ch < '\u0080' || (ch >= '\u00A0' && ch <= '\u00FF'))
-                return true;
-
-            switch (ch)
-            {
-                case '\u20AC':
-                case '\u0081':
-                case '\u201A':
-                case '\u0192':
-                case '\u201E':
-                case '\u2026':
-                case '\u2020':
-                case '\u2021':
-                case '\u02C6':
-                case '\u2030':
-                case '\u0160':
-                case '\u2039':
-                case '\u0152':
-                case '\u008D':
-                case '\u017D':
-                case '\u008F':
-                case '\u0090':
-                case '\u2018':
-                case '\u2019':
-                case '\u201C':
-                case '\u201D':
-                case '\u2022':
-                case '\u2013':
-                case '\u2014':
-                case '\u02DC':
-                case '\u2122':
-                case '\u0161':
-                case '\u203A':
-                case '\u0153':
-                case '\u009D':
-                case '\u017E':
-                case '\u0178':
-                    return true;
-            }
-            return false;
-        }
-
-        /// <summary>
         /// Maps Unicode to ANSI code page 1252.
         /// </summary>
         public static char UnicodeToAnsi(char ch)


### PR DESCRIPTION
## Summary
- `IsAnsi1252Char` in `AnsiEncoding` had no callers anywhere in the repo (library, tests, CLI, TestHarness) — a repo-wide search only found its own declaration.
- `UnicodeToAnsi` already performs the equivalent membership check as a side effect of its mapping (same range check + switch), so the method was redundant dead code with a high cyclomatic complexity / zero coverage crap score.
- Deleted the method; left `UnicodeToAnsi`, `AnsiToUnicode`, and the rest of `AnsiEncoding` untouched since they're actively used.

## Test plan
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings, 0 errors
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~Encoding"` — 14/14 passed
- [x] Confirmed no remaining references to `IsAnsi1252Char` in the repo

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3sUZrhnp1RAy3i3LLvLwh)_