### PR TITLE
Convert border-style/column-rule-style storage to CssProperty&lt;LineStyle&gt;

### DIFF
--- a/src/PeachPDF.Tests/Integration/BorderStylePaintIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/BorderStylePaintIntegrationTests.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Adapters;
+using PeachPDF.CSS;
 using PeachPDF.Html.Adapters.Entities;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
@@ -217,10 +218,10 @@ namespace PeachPDF.Tests.Integration
                 "<div id='b' style='width:40px; height:40px; border-width:4px; border-color:rgb(51,51,51); border-style: none solid'>x</div>"));
             var div = FindById(root, "b")!;
 
-            Assert.Equal(CssConstants.None, div.BorderTopStyle);
-            Assert.Equal(CssConstants.Solid, div.BorderRightStyle);
-            Assert.Equal(CssConstants.None, div.BorderBottomStyle);
-            Assert.Equal(CssConstants.Solid, div.BorderLeftStyle);
+            Assert.Equal(LineStyle.None, div.BorderTopStyle.Value);
+            Assert.Equal(LineStyle.Solid, div.BorderRightStyle.Value);
+            Assert.Equal(LineStyle.None, div.BorderBottomStyle.Value);
+            Assert.Equal(LineStyle.Solid, div.BorderLeftStyle.Value);
 
             var g = new TestRecordingGraphics();
             FragmentPaintHarness.PaintBox(container, div, g);
@@ -280,6 +281,28 @@ namespace PeachPDF.Tests.Integration
             Assert.Equal("1em", div.BorderRightWidth);
             Assert.Equal("1em", div.BorderBottomWidth);
             Assert.Equal("1em", div.BorderLeftWidth);
+        }
+
+        // ─── deprecated presentational `border` HTML attribute always resolves solid ──
+        // DomParser.CascadeApplyStyles' HtmlConstants.Border case: a non-zero `border` attribute forces
+        // every side's style to solid (CssProperty<LineStyle>.FromValue(CssConstants.Solid, LineStyle.Solid)
+        // / the shared SolidBorderStyle constant). Only the plain-element path is covered here -
+        // ApplyTableBorder's TD-cascading path (SetForAllCells) was found, while writing this test, to
+        // already not actually reach the cells regardless of this PR's changes (the same pre-existing gap
+        // affects cellpadding/ApplyTablePadding, which uses the identical SetForAllCells mechanism) - a
+        // pre-existing issue unrelated to the border-style/LineStyle conversion, out of scope here and
+        // tracked separately (issue #636).
+
+        [Fact]
+        public async Task PresentationalBorderAttribute_OnAPlainElement_ForcesSolidOnAllSides()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<div id='b' border='1'>x</div>"));
+            var div = FindById(root, "b")!;
+
+            Assert.Equal(LineStyle.Solid, div.BorderTopStyle.Value);
+            Assert.Equal(LineStyle.Solid, div.BorderRightStyle.Value);
+            Assert.Equal(LineStyle.Solid, div.BorderBottomStyle.Value);
+            Assert.Equal(LineStyle.Solid, div.BorderLeftStyle.Value);
         }
 
         // ─── Helpers ─────────────────────────────────────────────────────────────

--- a/src/PeachPDF/Html/Core/Dom/CssBox.LogicalProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.LogicalProperties.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Core.Utils;
 
 namespace PeachPDF.Html.Core.Dom
@@ -152,12 +153,13 @@ namespace PeachPDF.Html.Core.Dom
 
         private void ApplyBorderStyle(PhysicalSide side, string value)
         {
+            var parsed = CssProperty<LineStyle>.FromCssText(value, Map.LineStyles, LineStyle.None);
             switch (side)
             {
-                case PhysicalSide.Top: BorderTopStyle = value; break;
-                case PhysicalSide.Right: BorderRightStyle = value; break;
-                case PhysicalSide.Bottom: BorderBottomStyle = value; break;
-                default: BorderLeftStyle = value; break;
+                case PhysicalSide.Top: BorderTopStyle = parsed; break;
+                case PhysicalSide.Right: BorderRightStyle = parsed; break;
+                case PhysicalSide.Bottom: BorderBottomStyle = parsed; break;
+                default: BorderLeftStyle = parsed; break;
             }
         }
 

--- a/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
@@ -389,7 +389,8 @@ namespace PeachPDF.Html.Core.Dom
         protected void SetAllBorders(string? style = null, string? width = null, string? color = null)
         {
             if (style != null)
-                BorderLeftStyle = BorderTopStyle = BorderRightStyle = BorderBottomStyle = style;
+                BorderLeftStyle = BorderTopStyle = BorderRightStyle = BorderBottomStyle =
+                    CssProperty<LineStyle>.FromCssText(style, Map.LineStyles, LineStyle.None);
             if (width != null)
                 BorderLeftWidth = BorderTopWidth = BorderRightWidth = BorderBottomWidth = width;
             if (color != null)

--- a/src/PeachPDF/Html/Core/Dom/CssBoxHr.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBoxHr.cs
@@ -10,6 +10,7 @@
 // - Sun Tsu,
 // "The Art of War"
 
+using PeachPDF.CSS;
 using PeachPDF.Html.Adapters;
 using PeachPDF.Html.Adapters.Entities;
 using PeachPDF.Html.Core.Parse;
@@ -124,7 +125,7 @@ namespace PeachPDF.Html.Core.Dom
             }
             if (height <= 2 && ActualBorderTopWidth < 1 && ActualBorderBottomWidth < 1)
             {
-                BorderTopStyle = BorderBottomStyle = CssConstants.Solid;
+                BorderTopStyle = BorderBottomStyle = CssProperty<LineStyle>.FromValue(CssConstants.Solid, LineStyle.Solid);
                 BorderTopWidth = "1px";
                 BorderBottomWidth = "1px";
             }

--- a/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
+++ b/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
@@ -47,7 +47,7 @@ namespace PeachPDF.Html.Core.Dom
                 if (!double.IsNaN(_actualBorderTopWidth)) return _actualBorderTopWidth;
 
                 _actualBorderTopWidth = CssValueParser.GetActualBorderWidth(Style.Border.BorderTopWidth, Owner);
-                if (string.IsNullOrEmpty(Style.Border.BorderTopStyle) || Style.Border.BorderTopStyle == CssConstants.None)
+                if (Style.Border.BorderTopStyle.Value == LineStyle.None)
                     _actualBorderTopWidth = 0f;
 
                 return _actualBorderTopWidth;
@@ -61,7 +61,7 @@ namespace PeachPDF.Html.Core.Dom
                 if (!double.IsNaN(_actualBorderRightWidth)) return _actualBorderRightWidth;
 
                 _actualBorderRightWidth = CssValueParser.GetActualBorderWidth(Style.Border.BorderRightWidth, Owner);
-                if (string.IsNullOrEmpty(Style.Border.BorderRightStyle) || Style.Border.BorderRightStyle == CssConstants.None)
+                if (Style.Border.BorderRightStyle.Value == LineStyle.None)
                     _actualBorderRightWidth = 0f;
 
                 return _actualBorderRightWidth;
@@ -75,7 +75,7 @@ namespace PeachPDF.Html.Core.Dom
                 if (!double.IsNaN(_actualBorderBottomWidth)) return _actualBorderBottomWidth;
 
                 _actualBorderBottomWidth = CssValueParser.GetActualBorderWidth(Style.Border.BorderBottomWidth, Owner);
-                if (string.IsNullOrEmpty(Style.Border.BorderBottomStyle) || Style.Border.BorderBottomStyle == CssConstants.None)
+                if (Style.Border.BorderBottomStyle.Value == LineStyle.None)
                     _actualBorderBottomWidth = 0f;
 
                 return _actualBorderBottomWidth;
@@ -89,7 +89,7 @@ namespace PeachPDF.Html.Core.Dom
                 if (!double.IsNaN(_actualBorderLeftWidth)) return _actualBorderLeftWidth;
 
                 _actualBorderLeftWidth = CssValueParser.GetActualBorderWidth(Style.Border.BorderLeftWidth, Owner);
-                if (string.IsNullOrEmpty(Style.Border.BorderLeftStyle) || Style.Border.BorderLeftStyle == CssConstants.None)
+                if (Style.Border.BorderLeftStyle.Value == LineStyle.None)
                     _actualBorderLeftWidth = 0f;
 
                 return _actualBorderLeftWidth;
@@ -104,7 +104,7 @@ namespace PeachPDF.Html.Core.Dom
                 if (!double.IsNaN(_actualColumnRuleWidth)) return _actualColumnRuleWidth;
 
                 _actualColumnRuleWidth = CssValueParser.GetActualBorderWidth(Style.MultiColumn.ColumnRuleWidth, Owner);
-                if (string.IsNullOrEmpty(Style.MultiColumn.ColumnRuleStyle) || Style.MultiColumn.ColumnRuleStyle == CssConstants.None)
+                if (Style.MultiColumn.ColumnRuleStyle.Value == LineStyle.None)
                     _actualColumnRuleWidth = 0f;
 
                 return _actualColumnRuleWidth;

--- a/src/PeachPDF/Html/Core/Handlers/BordersDrawHandler.cs
+++ b/src/PeachPDF/Html/Core/Handlers/BordersDrawHandler.cs
@@ -10,6 +10,7 @@
 // - Sun Tsu,
 // "The Art of War"
 
+using PeachPDF.CSS;
 using PeachPDF.Html.Adapters;
 using PeachPDF.Html.Adapters.Entities;
 using PeachPDF.Html.Core.Dom;
@@ -58,19 +59,19 @@ namespace PeachPDF.Html.Core.Handlers
         {
             if (rect is not { Width: > 0, Height: > 0 }) return;
 
-            if (hasTopEdge && !(string.IsNullOrEmpty(box.BorderTopStyle) || box.BorderTopStyle == CssConstants.None || box.BorderTopStyle == CssConstants.Hidden) && box.ActualBorderTopWidth > 0)
+            if (hasTopEdge && box.BorderTopStyle.Value is not (LineStyle.None or LineStyle.Hidden) && box.ActualBorderTopWidth > 0)
             {
                 DrawBorder(Border.Top, box, g, rect, hasLeftEdge, hasRightEdge, true, hasBottomEdge);
             }
-            if (hasLeftEdge && !(string.IsNullOrEmpty(box.BorderLeftStyle) || box.BorderLeftStyle == CssConstants.None || box.BorderLeftStyle == CssConstants.Hidden) && box.ActualBorderLeftWidth > 0)
+            if (hasLeftEdge && box.BorderLeftStyle.Value is not (LineStyle.None or LineStyle.Hidden) && box.ActualBorderLeftWidth > 0)
             {
                 DrawBorder(Border.Left, box, g, rect, true, hasRightEdge, hasTopEdge, hasBottomEdge);
             }
-            if (hasBottomEdge && !(string.IsNullOrEmpty(box.BorderBottomStyle) || box.BorderBottomStyle == CssConstants.None || box.BorderBottomStyle == CssConstants.Hidden) && box.ActualBorderBottomWidth > 0)
+            if (hasBottomEdge && box.BorderBottomStyle.Value is not (LineStyle.None or LineStyle.Hidden) && box.ActualBorderBottomWidth > 0)
             {
                 DrawBorder(Border.Bottom, box, g, rect, hasLeftEdge, hasRightEdge, hasTopEdge, true);
             }
-            if (hasRightEdge && !(string.IsNullOrEmpty(box.BorderRightStyle) || box.BorderRightStyle == CssConstants.None || box.BorderRightStyle == CssConstants.Hidden) && box.ActualBorderRightWidth > 0)
+            if (hasRightEdge && box.BorderRightStyle.Value is not (LineStyle.None or LineStyle.Hidden) && box.ActualBorderRightWidth > 0)
             {
                 DrawBorder(Border.Right, box, g, rect, hasLeftEdge, true, hasTopEdge, hasBottomEdge);
             }
@@ -129,7 +130,7 @@ namespace PeachPDF.Html.Core.Handlers
             else
             {
                 // non rounded border
-                if (style is CssConstants.Inset or CssConstants.Outset or CssConstants.Solid)
+                if (style is LineStyle.Inset or LineStyle.Outset or LineStyle.Solid)
                 {
                     // Solid (like inset/outset) needs the mitered trapezoid, not a thick straight line
                     // spanning the box's full width/height: CSS2.1 8.5.3 draws each border edge as a
@@ -147,7 +148,7 @@ namespace PeachPDF.Html.Core.Handlers
                     SetInOutsetRectanglePoints(border, box, rect, isLineStart, isLineEnd, isBlockStart, isBlockEnd);
                     g.DrawPolygon(g.GetSolidBrush(color), _borderPts);
                 }
-                else if (style is CssConstants.Double or CssConstants.Groove or CssConstants.Ridge)
+                else if (style is LineStyle.Double or LineStyle.Groove or LineStyle.Ridge)
                 {
                     DrawDoubleOrGrooveRidgeBorder(border, box, g, rect, style, color);
                 }
@@ -244,7 +245,7 @@ namespace PeachPDF.Html.Core.Handlers
         /// (groove/ridge), so this paints the two stripes directly with their own pens instead of
         /// going through <see cref="GetPen"/>.
         /// </summary>
-        private static void DrawDoubleOrGrooveRidgeBorder(Border border, CssBox box, RGraphics g, RRect rect, string style, RColor color)
+        private static void DrawDoubleOrGrooveRidgeBorder(Border border, CssBox box, RGraphics g, RRect rect, LineStyle style, RColor color)
         {
             var width = GetWidth(border, box);
 
@@ -253,7 +254,7 @@ namespace PeachPDF.Html.Core.Handlers
             RColor outerColor;
             RColor innerColor;
 
-            if (style == CssConstants.Double)
+            if (style == LineStyle.Double)
             {
                 outerWidth = innerWidth = Math.Max(1, Math.Floor(width / 3));
                 outerColor = innerColor = color;
@@ -265,8 +266,8 @@ namespace PeachPDF.Html.Core.Handlers
                 // UA-defined - the only spec-relevant property is that groove/ridge are visually
                 // distinct from each other and from solid/double/inset/outset.
                 outerWidth = innerWidth = width / 2;
-                outerColor = style == CssConstants.Groove ? Darken(color) : color;
-                innerColor = style == CssConstants.Groove ? color : Darken(color);
+                outerColor = style == LineStyle.Groove ? Darken(color) : color;
+                innerColor = style == LineStyle.Groove ? color : Darken(color);
             }
 
             var outerPen = g.GetPen(outerColor);
@@ -344,8 +345,8 @@ namespace PeachPDF.Html.Core.Handlers
                     if (rad.TRX > 0 || rad.TRY > 0 || rad.BRX > 0 || rad.BRY > 0)
                     {
                         path = g.GetGraphicsPath();
-                        bool noTop = b.BorderTopStyle == CssConstants.None || b.BorderTopStyle == CssConstants.Hidden;
-                        bool noBottom = b.BorderBottomStyle == CssConstants.None || b.BorderBottomStyle == CssConstants.Hidden;
+                        bool noTop = b.BorderTopStyle.Value is LineStyle.None or LineStyle.Hidden;
+                        bool noBottom = b.BorderBottomStyle.Value is LineStyle.None or LineStyle.Hidden;
                         path.Start(r.Right - b.ActualBorderRightWidth / 2 - (noTop ? rad.TRX : 0), r.Top + b.ActualBorderTopWidth / 2 + (noTop ? 0 : rad.TRY));
                         if ((rad.TRX > 0 || rad.TRY > 0) && noTop)
                             path.ArcTo(r.Right - b.ActualBorderLeftWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + rad.TRY, rad.TRX, rad.TRY, RGraphicsPath.Corner.TopRight);
@@ -358,8 +359,8 @@ namespace PeachPDF.Html.Core.Handlers
                     if (rad.TLX > 0 || rad.TLY > 0 || rad.BLX > 0 || rad.BLY > 0)
                     {
                         path = g.GetGraphicsPath();
-                        bool noTop = b.BorderTopStyle == CssConstants.None || b.BorderTopStyle == CssConstants.Hidden;
-                        bool noBottom = b.BorderBottomStyle == CssConstants.None || b.BorderBottomStyle == CssConstants.Hidden;
+                        bool noTop = b.BorderTopStyle.Value is LineStyle.None or LineStyle.Hidden;
+                        bool noBottom = b.BorderBottomStyle.Value is LineStyle.None or LineStyle.Hidden;
                         path.Start(r.Left + b.ActualBorderLeftWidth / 2 + (noBottom ? rad.BLX : 0), r.Bottom - b.ActualBorderBottomWidth / 2 - (noBottom ? 0 : rad.BLY));
                         if ((rad.BLX > 0 || rad.BLY > 0) && noBottom)
                             path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - rad.BLY, rad.BLX, rad.BLY, RGraphicsPath.Corner.BottomLeft);
@@ -376,15 +377,15 @@ namespace PeachPDF.Html.Core.Handlers
         /// <summary>
         /// Get pen to be used for border draw respecting its style.
         /// </summary>
-        private static RPen GetPen(RGraphics g, string style, RColor color, double width)
+        private static RPen GetPen(RGraphics g, LineStyle style, RColor color, double width)
         {
             var p = g.GetPen(color);
             p.Width = width;
             p.DashStyle = style switch
             {
-                "solid" => RDashStyle.Solid,
-                "dotted" => RDashStyle.Dot,
-                "dashed" => RDashStyle.Dash,
+                LineStyle.Solid => RDashStyle.Solid,
+                LineStyle.Dotted => RDashStyle.Dot,
+                LineStyle.Dashed => RDashStyle.Dash,
                 // double/groove/ridge are handled by DrawDoubleOrGrooveRidgeBorder and never reach
                 // here for non-rounded borders; a rounded border with one of these styles falls back
                 // to a single solid-colored stroke here (GetRoundedBorderPath has no double/groove/
@@ -399,18 +400,18 @@ namespace PeachPDF.Html.Core.Handlers
         /// <summary>
         /// Get the border color for the given box border.
         /// </summary>
-        private static RColor GetColor(Border border, CssBox box, string style)
+        private static RColor GetColor(Border border, CssBox box, LineStyle style)
         {
             return border switch
             {
-                Border.Top => style == CssConstants.Inset ? Darken(box.ActualBorderTopColor) : box.ActualBorderTopColor,
-                Border.Right => style == CssConstants.Outset
+                Border.Top => style == LineStyle.Inset ? Darken(box.ActualBorderTopColor) : box.ActualBorderTopColor,
+                Border.Right => style == LineStyle.Outset
                     ? Darken(box.ActualBorderRightColor)
                     : box.ActualBorderRightColor,
-                Border.Bottom => style == CssConstants.Outset
+                Border.Bottom => style == LineStyle.Outset
                     ? Darken(box.ActualBorderBottomColor)
                     : box.ActualBorderBottomColor,
-                Border.Left => style == CssConstants.Inset
+                Border.Left => style == LineStyle.Inset
                     ? Darken(box.ActualBorderLeftColor)
                     : box.ActualBorderLeftColor,
                 _ => throw new ArgumentOutOfRangeException(nameof(border))
@@ -435,14 +436,14 @@ namespace PeachPDF.Html.Core.Handlers
         /// <summary>
         /// Get the border style for the given box border.
         /// </summary>
-        private static string GetStyle(Border border, CssBox box)
+        private static LineStyle GetStyle(Border border, CssBox box)
         {
             return border switch
             {
-                Border.Top => box.BorderTopStyle,
-                Border.Right => box.BorderRightStyle,
-                Border.Bottom => box.BorderBottomStyle,
-                Border.Left => box.BorderLeftStyle,
+                Border.Top => box.BorderTopStyle.Value,
+                Border.Right => box.BorderRightStyle.Value,
+                Border.Bottom => box.BorderBottomStyle.Value,
+                Border.Left => box.BorderLeftStyle.Value,
                 _ => throw new ArgumentOutOfRangeException(nameof(border))
             };
         }

--- a/src/PeachPDF/Html/Core/Paint/FragmentPainter.Decorations.cs
+++ b/src/PeachPDF/Html/Core/Paint/FragmentPainter.Decorations.cs
@@ -568,10 +568,10 @@ namespace PeachPDF.Html.Core.Paint
         {
             var pen = g.GetPen(box.ActualColumnRuleColor);
             pen.Width = box.ActualColumnRuleWidth;
-            pen.DashStyle = box.ColumnRuleStyle switch
+            pen.DashStyle = box.ColumnRuleStyle.Value switch
             {
-                CssConstants.Dashed => RDashStyle.Dash,
-                CssConstants.Dotted => RDashStyle.Dot,
+                LineStyle.Dashed => RDashStyle.Dash,
+                LineStyle.Dotted => RDashStyle.Dot,
                 _ => RDashStyle.Solid,
             };
 

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -35,6 +35,11 @@ namespace PeachPDF.Html.Core.Parse
     /// </summary>
     internal sealed class DomParser
     {
+        /// <summary>The deprecated presentational <c>border</c> HTML attribute always resolves to a solid
+        /// border style - shared to avoid re-parsing the literal at each call site.</summary>
+        private static readonly CssProperty<LineStyle> SolidBorderStyle =
+            CssProperty<LineStyle>.FromValue(CssConstants.Solid, LineStyle.Solid);
+
         /// <summary>
         /// Parser for CSS
         /// </summary>
@@ -1441,7 +1446,7 @@ namespace PeachPDF.Html.Core.Parse
                         break;
                     case HtmlConstants.Border:
                         if (!string.IsNullOrEmpty(value) && value != "0")
-                            box.BorderLeftStyle = box.BorderTopStyle = box.BorderRightStyle = box.BorderBottomStyle = CssConstants.Solid;
+                            box.BorderLeftStyle = box.BorderTopStyle = box.BorderRightStyle = box.BorderBottomStyle = SolidBorderStyle;
                         box.BorderLeftWidth = box.BorderTopWidth = box.BorderRightWidth = box.BorderBottomWidth = TranslateLength(value);
 
                         if (tag.Name.Equals(HtmlConstants.Table, StringComparison.OrdinalIgnoreCase))
@@ -1451,7 +1456,7 @@ namespace PeachPDF.Html.Core.Parse
                         }
                         else
                         {
-                            box.BorderTopStyle = box.BorderLeftStyle = box.BorderRightStyle = box.BorderBottomStyle = CssConstants.Solid;
+                            box.BorderTopStyle = box.BorderLeftStyle = box.BorderRightStyle = box.BorderBottomStyle = SolidBorderStyle;
                         }
                         break;
                     case HtmlConstants.Bordercolor:
@@ -1609,7 +1614,7 @@ namespace PeachPDF.Html.Core.Parse
         {
             SetForAllCells(table, cell =>
             {
-                cell.BorderLeftStyle = cell.BorderTopStyle = cell.BorderRightStyle = cell.BorderBottomStyle = CssConstants.Solid;
+                cell.BorderLeftStyle = cell.BorderTopStyle = cell.BorderRightStyle = cell.BorderBottomStyle = SolidBorderStyle;
                 cell.BorderLeftWidth = cell.BorderTopWidth = cell.BorderRightWidth = cell.BorderBottomWidth = border;
             });
         }

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -372,96 +372,68 @@
       "name": "border-bottom-style",
       "inherited": false,
       "initialValue": "none",
-      "cssDataType": "keyword",
-      "supportedValues": [
-        "none",
-        "solid",
-        "hidden",
-        "dotted",
-        "dashed",
-        "double",
-        "groove",
-        "ridge",
-        "inset",
-        "outset"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "LineStyle",
+        "keywordMap": "Map.LineStyles",
+        "fallback": "LineStyle.None"
+      },
       "html": {
         "propertyPath": "BorderBottomStyle",
-        "csharpDataType": "string",
-        "area": "BorderArea"
+        "csharpDataType": "CssProperty<LineStyle>",
+        "area": "BorderArea",
+        "getterExpression": "{box}.BorderBottomStyle.ToString()"
       }
     },
     {
       "name": "border-left-style",
       "inherited": false,
       "initialValue": "none",
-      "cssDataType": "keyword",
-      "supportedValues": [
-        "none",
-        "solid",
-        "hidden",
-        "dotted",
-        "dashed",
-        "double",
-        "groove",
-        "ridge",
-        "inset",
-        "outset"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "LineStyle",
+        "keywordMap": "Map.LineStyles",
+        "fallback": "LineStyle.None"
+      },
       "html": {
         "propertyPath": "BorderLeftStyle",
-        "csharpDataType": "string",
-        "area": "BorderArea"
+        "csharpDataType": "CssProperty<LineStyle>",
+        "area": "BorderArea",
+        "getterExpression": "{box}.BorderLeftStyle.ToString()"
       }
     },
     {
       "name": "border-right-style",
       "inherited": false,
       "initialValue": "none",
-      "cssDataType": "keyword",
-      "supportedValues": [
-        "none",
-        "solid",
-        "hidden",
-        "dotted",
-        "dashed",
-        "double",
-        "groove",
-        "ridge",
-        "inset",
-        "outset"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "LineStyle",
+        "keywordMap": "Map.LineStyles",
+        "fallback": "LineStyle.None"
+      },
       "html": {
         "propertyPath": "BorderRightStyle",
-        "csharpDataType": "string",
-        "area": "BorderArea"
+        "csharpDataType": "CssProperty<LineStyle>",
+        "area": "BorderArea",
+        "getterExpression": "{box}.BorderRightStyle.ToString()"
       }
     },
     {
       "name": "border-top-style",
       "inherited": false,
       "initialValue": "none",
-      "cssDataType": "keyword",
-      "supportedValues": [
-        "none",
-        "solid",
-        "hidden",
-        "dotted",
-        "dashed",
-        "double",
-        "groove",
-        "ridge",
-        "inset",
-        "outset"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "LineStyle",
+        "keywordMap": "Map.LineStyles",
+        "fallback": "LineStyle.None"
+      },
       "html": {
         "propertyPath": "BorderTopStyle",
-        "csharpDataType": "string",
-        "area": "BorderArea"
+        "csharpDataType": "CssProperty<LineStyle>",
+        "area": "BorderArea",
+        "getterExpression": "{box}.BorderTopStyle.ToString()"
       }
     },
     {
@@ -2222,8 +2194,13 @@
       "name": "row-gap",
       "inherited": false,
       "initialValue": "normal",
-      "cssDataType": ["length", "keyword"],
-      "supportedValues": ["normal"],
+      "cssDataType": [
+        "length",
+        "keyword"
+      ],
+      "supportedValues": [
+        "normal"
+      ],
       "keywordComparison": "ordinal-ignore-case",
       "html": {
         "propertyPath": "FlexRowGap",
@@ -2235,8 +2212,13 @@
       "name": "column-gap",
       "inherited": false,
       "initialValue": "normal",
-      "cssDataType": ["length", "keyword"],
-      "supportedValues": ["normal"],
+      "cssDataType": [
+        "length",
+        "keyword"
+      ],
+      "supportedValues": [
+        "normal"
+      ],
       "keywordComparison": "ordinal-ignore-case",
       "html": {
         "propertyPath": "FlexColumnGap",
@@ -2502,24 +2484,17 @@
       "name": "column-rule-style",
       "inherited": false,
       "initialValue": "none",
-      "cssDataType": "keyword",
-      "supportedValues": [
-        "none",
-        "solid",
-        "hidden",
-        "dotted",
-        "dashed",
-        "double",
-        "groove",
-        "ridge",
-        "inset",
-        "outset"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "LineStyle",
+        "keywordMap": "Map.LineStyles",
+        "fallback": "LineStyle.None"
+      },
       "html": {
         "propertyPath": "ColumnRuleStyle",
-        "csharpDataType": "string",
-        "area": "MultiColumnArea"
+        "csharpDataType": "CssProperty<LineStyle>",
+        "area": "MultiColumnArea",
+        "getterExpression": "{box}.ColumnRuleStyle.ToString()"
       }
     },
     {


### PR DESCRIPTION
## Summary

Stacked on #635 (still open) — this PR is scoped against that branch, not `main`, and should merge after it.

Part of the ongoing #598 follow-up work (group A of the typed-storage conversion). Converts `border-top-style`, `border-right-style`, `border-bottom-style`, `border-left-style`, and `column-rule-style` from plain-string `CssBox` storage to typed `CssProperty<LineStyle>`, reusing the pre-existing `LineStyle` enum and `Map.LineStyles` keyword map (already used by the CSS-OM validation pipeline) rather than introducing a new enum — the JSON-schema side goes through the storage generator built in #635, so no hand-written registry/storage code is needed for the properties themselves.

- `css-properties.json`: the 5 properties switch from plain `"keyword"` to `"enum-keyword"` (`LineStyle`/`Map.LineStyles`), matching the `box-sizing`/`direction` precedent.
- Compiler-driven migration of every C# call site that read these properties as strings:
  - `DerivedStyle.cs`: `ActualBorder*Width`/`ActualColumnRuleWidth`'s none/hidden zeroing now compares against `LineStyle.None` directly (the `string.IsNullOrEmpty` check is gone since a typed `CssProperty<LineStyle>` seeded from the cascade default is never null).
  - `BordersDrawHandler.cs`: `GetStyle`/`GetPen`/`GetColor`/`DrawDoubleOrGrooveRidgeBorder`/`DrawBoxBorders`/`GetRoundedBorderPath` all thread `LineStyle` instead of comparing against `CssConstants.*` string literals.
  - `FragmentPainter.Decorations.cs`: the column-rule dash-style switch.
  - `CssBox.LogicalProperties.cs`: `ApplyBorderStyle` (the logical→physical border-style bridge) now parses via `CssProperty<LineStyle>.FromCssText`.
  - `CssBox.StyleProperties.cs`'s `SetAllBorders`, `CssBoxHr.cs`, and `DomParser.cs`'s deprecated presentational `border=` HTML attribute handling now construct `CssProperty<LineStyle>` values directly (`FromValue`/a shared `SolidBorderStyle` constant) instead of assigning string literals.
- `BorderStylePaintIntegrationTests.cs`: updated the two-value-shorthand test's assertions to the enum, and added a test for the presentational `border=` attribute path.

While adding that last test, found (but did not fix, filed as #636 — pre-existing, unrelated to this conversion) that `DomParser`'s `ApplyTableBorder`/`ApplyTablePadding` table→cell attribute cascading (`SetForAllCells`) is dead code that never actually reaches `<td>` cells, confirmed independently via the unrelated `cellpadding` attribute hitting the identical failure.

## Test plan

- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (7879 passed, 9 skipped)
- [x] `dotnet test PeachPDF.SourceGenerators.Tests/PeachPDF.SourceGenerators.Tests.csproj` — 107 passed (JSON-only change, generator itself untouched by this PR)
- [x] Diff coverage vs #635's branch tip: 97% (the one uncovered line is the pre-existing `SetForAllCells` dead code noted above, tracked as #636)
- [x] Post-change review pass — confirmed no leftover string comparisons against the 5 converted properties anywhere in the tree, confirmed the dropped `IsNullOrEmpty` checks are safe, confirmed `GetPen`/`GetColor`'s enum rewrite is behaviorally identical to the string original, confirmed case-insensitivity is preserved via `Map.LineStyles`'s `StringComparer.OrdinalIgnoreCase`


---
_Generated by [Claude Code](https://claude.ai/code/session_01WsuX3xR9EsNY3x1a5RGQmJ)_