### PR TITLE
Convert float/clear/overflow/visibility/text-transform/text-align/white-space/word-break/hyphens to typed CssProperty storage

### DIFF
--- a/.claude/accepted-gaps/text-transform-full-width-no-effect.md
+++ b/.claude/accepted-gaps/text-transform-full-width-no-effect.md
@@ -1,0 +1,20 @@
+# `text-transform: full-width` has no rendering effect
+
+Tracking issue: [#638](https://github.com/jhaygood86/PeachPDF/issues/638).
+
+Per [CSS Text Module Level 3 §2.1](https://www.w3.org/TR/css-text-3/#text-transform-property),
+`full-width` should convert characters to their full-width form (used mainly for CJK typesetting
+alongside Latin characters) — a transform distinct from `uppercase`/`lowercase`/`capitalize`.
+`CssBox.cs`'s `ApplyTextTransform` only implements those three; `full-width` falls through to the
+switch's `default: return text;` case and is a silent no-op.
+
+`css-properties.json`'s `text-transform` entry reuses the pre-existing `Map.TextTransforms` keyword
+map (already used by SVG's own text-transform handling), which includes `full-width` mapped to
+`TextTransform.FullWidth` — so the value parses, cascades, and round-trips through
+`getPropertyValue`/`@supports` correctly, it just doesn't change the rendered text.
+
+`full-size-kana` (the spec's other CJK-related keyword) is not implemented at all - it isn't in the
+`TextTransform` enum or `Map.TextTransforms` - so it's rejected outright and unaffected by this gap.
+
+**Deliberately out of scope.** Fixing this means adding half-width-to-full-width Unicode form mapping
+to `ApplyTextTransform` - a real text-transform behavior addition, not a doc-accuracy fix.

--- a/.claude/accepted-gaps/visibility-collapse-no-table-collapse-layout.md
+++ b/.claude/accepted-gaps/visibility-collapse-no-table-collapse-layout.md
@@ -1,0 +1,18 @@
+# `visibility: collapse` renders identically to `hidden` (no table row/column collapse layout)
+
+Tracking issue: [#639](https://github.com/jhaygood86/PeachPDF/issues/639).
+
+Per [CSS 2.1 §17.6.1](https://www.w3.org/TR/CSS21/tables.html#dynamic-effects), `visibility: collapse`
+on a table row/row-group/column/column-group should remove it from the table's geometry entirely
+(other rows/columns shift to fill the gap) - behavior distinct from `visibility: hidden`, which
+reserves the element's layout space and merely omits painting it.
+
+PeachPDF has no table row/column collapse layout implementation. As of the typed-storage conversion
+that reused the pre-existing `Map.Visibilities` keyword map (which already included `collapse` for use
+elsewhere in the CSS-OM pipeline - see `.claude/migration-notes/2026-08-04-visibility-collapse-now-accepted.md`),
+`collapse` is validated and stored like any other `visibility` value, but every downstream layout/paint
+check only distinguishes `Visibility.Visible` from "anything else" - so `collapse` currently renders
+exactly like `hidden` (space reserved, nothing painted) on every element, not just table rows/columns.
+
+**Deliberately out of scope.** Fixing this means real table layout changes - removing collapsed
+rows/columns from track sizing and shifting subsequent ones - not a doc-accuracy fix.

--- a/.claude/migration-notes/2026-08-04-visibility-collapse-now-accepted.md
+++ b/.claude/migration-notes/2026-08-04-visibility-collapse-now-accepted.md
@@ -1,0 +1,16 @@
+# `visibility: collapse` is now accepted
+
+**Landed:** 2026-08-04 — Convert word-break/hyphens/clear/visibility/text-transform/text-align/white-space/overflow/float to typed storage (#598 follow-up)
+**Doc section:** docs/html-css-support.md § [visibility row](../../docs/html-css-support.md)
+
+`visibility`'s accepted keyword set was previously `visible`/`hidden` only — an authored
+`visibility: collapse` failed validation and had no effect, leaving the element at its previous or
+inherited visibility. Converting `visibility` to typed `CssProperty<Visibility>` storage reused the
+existing `Visibility` enum and `Map.Visibilities` keyword map, which already included `collapse` (used
+elsewhere in the CSS-OM parsing pipeline) — so `collapse` is now a valid, stored value.
+
+PeachPDF does not implement CSS 2.1 §17.6.1's table row/column collapse layout (removing the row/column
+from table geometry entirely), so `visibility: collapse` renders identically to `visibility: hidden`
+everywhere (every downstream check only distinguishes `visible` from "anything else"). A document that
+declared `visibility: collapse` expecting it to be silently ignored (falling back to the previous or
+inherited value) will now see the element hidden instead.

--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -374,7 +374,7 @@ Remaining boundaries: fallback walks the declared `font-family` stack (plus the 
 | `text-decoration-line` | [text-decoration-line](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line) | `none`, `underline`, `overline`, `line-through`, and any space-separated combination of them (e.g. `underline overline` draws both lines) |
 | `text-decoration-style` | [text-decoration-style](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style) | `solid`, `dashed`, `dotted`, `double`, `wavy` |
 | `text-indent` | [text-indent](https://developer.mozilla.org/en-US/docs/Web/CSS/text-indent) | Full support, including the `hanging` and `each-line` keywords (CSS Text 3) |
-| `text-transform` | [text-transform](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform) | `none`, `uppercase`, `lowercase`, `capitalize`; `full-width`/`full-size-kana` not supported |
+| `text-transform` | [text-transform](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform) | `none`, `uppercase`, `lowercase`, `capitalize`. `full-width` is parsed and accepted but has no distinct effect; `full-size-kana` is not supported |
 | `white-space` | [white-space](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space) | `normal`, `nowrap`, `pre`, `pre-wrap`, `pre-line` |
 | `word-break` | [word-break](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break) | `normal`, `break-all`. `keep-all` is parsed and accepted but has no distinct effect — CJK text still breaks between characters the way `normal` does |
 | `word-spacing` | [word-spacing](https://developer.mozilla.org/en-US/docs/Web/CSS/word-spacing) | Full support |

--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -424,7 +424,7 @@ Regenerating the pattern set (`tools/Update-HyphenationPatterns.ps1`) re-checks 
 | `float` | [float](https://developer.mozilla.org/en-US/docs/Web/CSS/float) | `left`, `right`, `none` |
 | `clear` | [clear](https://developer.mozilla.org/en-US/docs/Web/CSS/clear) | `left`, `right`, `both`, `none` |
 | `overflow` | [overflow](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow) | Affects clipping regions; there is no interactive scrolling in PDF output |
-| `visibility` | [visibility](https://developer.mozilla.org/en-US/docs/Web/CSS/visibility) | `visible`, `hidden` |
+| `visibility` | [visibility](https://developer.mozilla.org/en-US/docs/Web/CSS/visibility) | `visible`, `hidden`, `collapse` (table row/column collapse layout isn't implemented, so `collapse` renders identically to `hidden`) |
 | `z-index` | [z-index](https://developer.mozilla.org/en-US/docs/Web/CSS/z-index) | Full support for positioned elements |
 
 #### Atomic inline-level layout is approximated, not fully atomic

--- a/src/PeachPDF.Tests/CSS/Supports.cs
+++ b/src/PeachPDF.Tests/CSS/Supports.cs
@@ -222,6 +222,19 @@ namespace PeachPDF.Tests.CSS
             Assert.False(supports.Condition.Check());
         }
 
+        // text-transform's cssDataType includes 'full-width' (Map.TextTransforms parses and stores it),
+        // but its supportsDataType override excludes it - CssBox.cs's ApplyTextTransform only implements
+        // uppercase/lowercase/capitalize, so 'full-width' has no distinct effect and @supports must say
+        // no. Same shape as word-break's keep-all above.
+        [Fact]
+        public void SupportsTextTransformFullWidthRule_NotGenuinelyEnforced()
+        {
+            var source = @"@supports (text-transform: full-width) { }";
+            var sheet = ParseStyleSheet(source);
+            var supports = (SupportsRule)sheet.Rules[0];
+            Assert.False(supports.Condition.Check());
+        }
+
         [Fact]
         public void SupportsWordBreakAllRule()
         {

--- a/src/PeachPDF.Tests/Html/Core/Dom/CssProxyBoxTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/CssProxyBoxTests.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Adapters;
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Utils;
@@ -107,7 +108,7 @@ namespace PeachPDF.Tests.Html.Core.Dom
 
             // Assert - Check that styles are inherited
             Assert.Equal(CssConstants.TableHeaderGroup, proxy.Display);
-            Assert.Equal("visible", proxy.Visibility);
+            Assert.Equal(Visibility.Visible, proxy.Visibility.Value);
             _output.WriteLine($"Proxy BackgroundColor: {proxy.BackgroundColor}");
         }
 

--- a/src/PeachPDF.Tests/Html/Core/Dom/DerivedStyleTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/DerivedStyleTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Utils;
 
@@ -29,7 +30,7 @@ namespace PeachPDF.Tests.Html.Core.Dom
         [InlineData(CssConstants.InlineGrid, CssConstants.Grid)]
         public void ActualDisplay_OnAFloatedBox_BlockifiesInlineLevelAndTableInternalValues(string display, string expected)
         {
-            var box = new CssBox(null, null) { Display = display, Float = CssConstants.Left };
+            var box = new CssBox(null, null) { Display = display, Float = CssProperty<Floating>.FromValue(CssConstants.Left, Floating.Left) };
 
             Assert.Equal(expected, box.DerivedStyle.ActualDisplay);
         }
@@ -42,7 +43,7 @@ namespace PeachPDF.Tests.Html.Core.Dom
         [InlineData(CssConstants.None)]
         public void ActualDisplay_OnAFloatedBox_LeavesAlreadyBlockLevelValuesUnchanged(string display)
         {
-            var box = new CssBox(null, null) { Display = display, Float = CssConstants.Left };
+            var box = new CssBox(null, null) { Display = display, Float = CssProperty<Floating>.FromValue(CssConstants.Left, Floating.Left) };
 
             Assert.Equal(display, box.DerivedStyle.ActualDisplay);
         }
@@ -50,7 +51,7 @@ namespace PeachPDF.Tests.Html.Core.Dom
         [Fact]
         public void ActualDisplay_OnAnUnfloatedBox_ReturnsTheRawCascadedKeywordUnchanged()
         {
-            var box = new CssBox(null, null) { Display = CssConstants.Inline, Float = CssConstants.None };
+            var box = new CssBox(null, null) { Display = CssConstants.Inline, Float = CssProperty<Floating>.FromValue(CssConstants.None, Floating.None) };
 
             Assert.Equal(CssConstants.Inline, box.DerivedStyle.ActualDisplay);
         }
@@ -58,7 +59,7 @@ namespace PeachPDF.Tests.Html.Core.Dom
         [Fact]
         public void Display_OnAFloatedBox_StaysTheRawCascadedKeyword_NotBlockified()
         {
-            var box = new CssBox(null, null) { Display = CssConstants.Inline, Float = CssConstants.Right };
+            var box = new CssBox(null, null) { Display = CssConstants.Inline, Float = CssProperty<Floating>.FromValue(CssConstants.Right, Floating.Right) };
 
             Assert.Equal(CssConstants.Inline, box.Display);
             Assert.Equal(CssConstants.Block, box.DerivedStyle.ActualDisplay);

--- a/src/PeachPDF.Tests/Html/Core/Fragmentation/MonolithicContentTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Fragmentation/MonolithicContentTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Fragmentation;
 using PeachPDF.Html.Core.Utils;
@@ -75,7 +76,7 @@ namespace PeachPDF.Tests.Html.Core.Fragmentation
         {
             var box = await BoxOfTag($"{tag} {{ overflow: hidden }}", tag);
 
-            Assert.Equal(CssConstants.Hidden, box.Overflow);
+            Assert.Equal(Overflow.Hidden, box.Overflow.Value);
             Assert.False(MonolithicContent.IsScrollContainer(box));
             Assert.False(MonolithicContent.IsMonolithic(box));
         }

--- a/src/PeachPDF.Tests/Html/Core/Utils/CssUtilsTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Utils/CssUtilsTests.cs
@@ -23,8 +23,8 @@ namespace PeachPDF.Tests.Html.Core.Utils
             Assert.Equal(box.Color, CssUtils.GetPropertyValue(box, "color"));
             Assert.Equal(box.Display, CssUtils.GetPropertyValue(box, "display"));
             Assert.Equal(box.Position, CssUtils.GetPropertyValue(box, "position"));
-            Assert.Equal(box.Overflow, CssUtils.GetPropertyValue(box, "overflow"));
-            Assert.Equal(box.TextAlign, CssUtils.GetPropertyValue(box, "text-align"));
+            Assert.Equal(box.Overflow.ToString(), CssUtils.GetPropertyValue(box, "overflow"));
+            Assert.Equal(box.TextAlign.ToString(), CssUtils.GetPropertyValue(box, "text-align"));
             Assert.Equal(box.FontWeight, CssUtils.GetPropertyValue(box, "font-weight"));
             Assert.Equal(box.ZIndex.ToString(), CssUtils.GetPropertyValue(box, "z-index"));
         }

--- a/src/PeachPDF.Tests/Html/Core/Utils/DomUtilsTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Utils/DomUtilsTests.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Adapters;
+using PeachPDF.Html.Adapters.Entities;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.PdfSharpCore.Drawing;
@@ -160,6 +161,72 @@ namespace PeachPDF.Tests.Html.Core.Utils
             DomUtils.GetAllLinkBoxes(root, links);
 
             Assert.Contains(links, b => b.HtmlTag?.Name == "a");
+        }
+
+        [Fact]
+        public async Task GetCssBox_LocationInsideBounds_ReturnsABox()
+        {
+            var root = await Render("<div id='outer' style='width:100px;height:50px'><span id='inner'>Text</span></div>");
+            var outer = DomUtils.GetBoxById(root, "outer")!;
+            var point = new RPoint(outer.Bounds.X + 1, outer.Bounds.Y + 1);
+
+            var found = DomUtils.GetCssBox(root, point);
+
+            Assert.NotNull(found);
+        }
+
+        [Fact]
+        public async Task GetCssBox_InvisibleBox_ReturnsNull()
+        {
+            var root = await Render("<div id='hidden' style='visibility:hidden;height:20px'>x</div>");
+            var hidden = DomUtils.GetBoxById(root, "hidden")!;
+            var point = new RPoint(hidden.Bounds.X + 1, hidden.Bounds.Y + 1);
+
+            Assert.Null(DomUtils.GetCssBox(hidden, point));
+        }
+
+        [Fact]
+        public async Task GetLinkBox_LocationOnClickableVisibleLink_ReturnsIt()
+        {
+            var root = await Render("<a id='link' href='#'>Click</a>");
+            var link = DomUtils.GetBoxById(root, "link")!;
+            var word = FindFirstWord(link)!;
+            var point = new RPoint(word.Rectangle.X + word.Rectangle.Width / 2, word.Rectangle.Y + word.Rectangle.Height / 2);
+
+            var found = DomUtils.GetLinkBox(root, point);
+
+            Assert.NotNull(found);
+            Assert.Equal("a", found!.HtmlTag!.Name);
+        }
+
+        [Fact]
+        public async Task GetLinkBox_LocationAwayFromAnyLink_ReturnsNull()
+        {
+            var root = await Render("<a id='link' href='#'>Click</a>");
+
+            Assert.Null(DomUtils.GetLinkBox(root, new RPoint(-1000, -1000)));
+        }
+
+        [Fact]
+        public async Task GetCssBoxWord_LocationOnVisibleWord_ReturnsWord()
+        {
+            var root = await Render("<p id='p'>Hello</p>");
+            var p = DomUtils.GetBoxById(root, "p")!;
+            var word = FindFirstWord(p)!;
+            var point = new RPoint(word.Rectangle.X + word.Rectangle.Width / 2, word.Rectangle.Y + word.Rectangle.Height / 2);
+
+            Assert.NotNull(DomUtils.GetCssBoxWord(root, point));
+        }
+
+        [Fact]
+        public async Task GetCssBoxWord_InvisibleBox_ReturnsNull()
+        {
+            var root = await Render("<p id='p' style='visibility:hidden'>Hello</p>");
+            var p = DomUtils.GetBoxById(root, "p")!;
+            var word = FindFirstWord(p)!;
+            var point = new RPoint(word.Rectangle.X + word.Rectangle.Width / 2, word.Rectangle.Y + word.Rectangle.Height / 2);
+
+            Assert.Null(DomUtils.GetCssBoxWord(p, point));
         }
 
         [Fact]
@@ -349,6 +416,17 @@ namespace PeachPDF.Tests.Html.Core.Utils
         }
 
         // --- Helper ---
+
+        private static CssRect? FindFirstWord(CssBox box)
+        {
+            if (box.Words.Count > 0) return box.Words[0];
+            foreach (var child in box.Boxes)
+            {
+                var found = FindFirstWord(child);
+                if (found is not null) return found;
+            }
+            return null;
+        }
 
         private static async Task<CssBox> Render(string bodyHtml)
         {

--- a/src/PeachPDF.Tests/Integration/Acid2FeatureVerificationTests.cs
+++ b/src/PeachPDF.Tests/Integration/Acid2FeatureVerificationTests.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Adapters;
+using PeachPDF.CSS;
 using PeachPDF.Html.Adapters.Entities;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
@@ -1187,7 +1188,7 @@ namespace PeachPDF.Tests.Integration
             var (root, container) = await BuildAndLayout(html);
             var box = FindById(root, "t")!;
 
-            Assert.Equal("left", box.Float);
+            Assert.Equal(Floating.Left, box.Float.Value);
         }
 
         // ─── overflow: hidden on the root <html> in a multi-page document ──────────

--- a/src/PeachPDF.Tests/Integration/FloatLayoutRegressionTests.cs
+++ b/src/PeachPDF.Tests/Integration/FloatLayoutRegressionTests.cs
@@ -220,6 +220,89 @@ namespace PeachPDF.Tests.Integration
             Assert.True(document.PageCount > 1, $"expected the document to span pages, got {document.PageCount}");
         }
 
+        [Fact]
+        public async Task FloatLeft_WrapsBelowAFullWidthFloatRightSibling()
+        {
+            // A float:left box that would overlap a previously-placed, full-width float:right sibling
+            // must wrap below it rather than overlapping - exercises FloatBoxLeft's handling of an
+            // *opposite-direction* intersecting float (CssLayoutEngine.FloatBoxLeft's Floating.Right
+            // branch), not just same-direction float avoidance.
+            var html = Wrap(@"
+                <div style='width:200pt;'>
+                    <div id='r' style='float:right; width:200pt; height:50pt;'></div>
+                    <div id='l' style='float:left; width:100pt; height:30pt;'></div>
+                </div>");
+
+            var (root, _) = await BuildAndLayout(html);
+            var r = FindById(root, "r")!;
+            var l = FindById(root, "l")!;
+
+            Assert.True(l.Location.Y >= r.ActualBottom,
+                $"float:left box should wrap below the full-width float:right sibling it can't fit beside " +
+                $"(l.Y={l.Location.Y}, r.ActualBottom={r.ActualBottom})");
+        }
+
+        [Fact]
+        public async Task FloatRight_InNarrowerNestedBlock_AvoidsAWiderAncestorFloatRightSibling()
+        {
+            // A float:right box placed inside a narrower, non-floated nested block still avoids an
+            // ancestor float:right sibling that sits past the nested block's own right edge - the search
+            // climbs past the immediate containing block to find it (DomUtils.FindIntersectingFloatBox's
+            // ancestor walk), which is what exercises DomUtils.IsFloatIntersecting's Floating.Right branch
+            // and FloatBoxRight's matching switch case: neither is reachable when the intersecting float
+            // and the box being placed share the same containing block, since a same-container float
+            // can never start past that container's own right edge.
+            var html = Wrap(@"
+                <div style='width:500pt;'>
+                    <div id='outerR' style='float:right; width:50pt; height:80pt;'></div>
+                    <div style='width:200pt;'>
+                        <div id='r' style='float:right; width:100pt; height:30pt;'></div>
+                    </div>
+                </div>");
+
+            var (root, _) = await BuildAndLayout(html);
+            var outerR = FindById(root, "outerR")!;
+            var r = FindById(root, "r")!;
+
+            Assert.Equal(outerR.Location.X - outerR.ActualMarginLeft, r.ActualRight, 1);
+        }
+
+        [Fact]
+        public async Task ClearLeft_IgnoresAPrecedingFloatRightSibling()
+        {
+            // clear:left only clears past float:left siblings - a float:right sibling must not push it
+            // down (CssLayoutEngine.ClearBox's "Floating.Right when Clear.Left: continue" skip).
+            var html = Wrap(@"
+                <div style='width:200pt;'>
+                    <div id='r' style='float:right; width:50pt; height:80pt;'></div>
+                    <div id='cleared' style='clear:left; margin:0;'>text</div>
+                </div>");
+
+            var (root, _) = await BuildAndLayout(html);
+            var cleared = FindById(root, "cleared")!;
+
+            Assert.True(cleared.Location.Y < 80,
+                $"clear:left must not clear past a float:right sibling, was pushed to Y={cleared.Location.Y}");
+        }
+
+        [Fact]
+        public async Task ClearRight_IgnoresAPrecedingFloatLeftSibling()
+        {
+            // Symmetric case: clear:right ignoring a float:left sibling (ClearBox's
+            // "Floating.Left when Clear.Right: continue" skip).
+            var html = Wrap(@"
+                <div style='width:200pt;'>
+                    <div id='l' style='float:left; width:50pt; height:80pt;'></div>
+                    <div id='cleared' style='clear:right; margin:0;'>text</div>
+                </div>");
+
+            var (root, _) = await BuildAndLayout(html);
+            var cleared = FindById(root, "cleared")!;
+
+            Assert.True(cleared.Location.Y < 80,
+                $"clear:right must not clear past a float:left sibling, was pushed to Y={cleared.Location.Y}");
+        }
+
         // ── Helpers ────────────────────────────────────────────────────────────
 
         private static string Wrap(string body) =>

--- a/src/PeachPDF.Tests/Integration/FragmentPaintIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FragmentPaintIntegrationTests.cs
@@ -181,6 +181,35 @@ namespace PeachPDF.Tests.Integration
             Assert.Contains(recording.DrawStringCalls, c => c.Text.Contains("Visible"));
         }
 
+        [Fact]
+        public async Task VisibilityCollapse_ReservesLayoutSpace_ButPaintsNothing_VisibleSiblingStillPaints()
+        {
+            // PeachPDF doesn't implement table row/column collapse layout (CSS 2.1 §17.6.1), so
+            // visibility:collapse renders identically to visibility:hidden - see
+            // .claude/migration-notes/2026-08-04-visibility-collapse-now-accepted.md.
+            var (root, container) = await LayoutHarness.LayoutAsync(
+                LayoutHarness.Wrap(
+                    "<div id='collapsed' style='visibility:collapse;height:50pt;background:rgb(10,20,30)'>Collapsed</div>"
+                    + "<div id='visible' style='height:50pt;background:rgb(40,50,60)'>Visible</div>"),
+                pageHeight: 300, margin: 0);
+
+            var collapsed = LayoutHarness.FindById(root, "collapsed")!;
+            var visible = LayoutHarness.FindById(root, "visible")!;
+
+            Assert.Equal(collapsed.ActualBottom, visible.Location.Y, 1);
+
+            var recording = new TestRecordingGraphics();
+            FragmentPaintHarness.PaintPage(container, recording, 0);
+
+            Assert.DoesNotContain(recording.Log.OfType<TestRecordingGraphics.DrawRectCall>(),
+                r => r.Color == RColorOf(10, 20, 30));
+            Assert.DoesNotContain(recording.DrawStringCalls, c => c.Text.Contains("Collapsed"));
+
+            Assert.Contains(recording.Log.OfType<TestRecordingGraphics.DrawRectCall>(),
+                r => r.Color == RColorOf(40, 50, 60));
+            Assert.Contains(recording.DrawStringCalls, c => c.Text.Contains("Visible"));
+        }
+
         private static RColor RColorOf(int r, int g, int b) =>
             RColor.FromArgb(r, g, b);
 

--- a/src/PeachPDF.Tests/Integration/HyphensIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/HyphensIntegrationTests.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Adapters;
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.PdfSharpCore.Drawing;
@@ -13,21 +14,21 @@ namespace PeachPDF.Tests.Integration
         public async Task Hyphens_DefaultsToManual()
         {
             var box = await FindByIdAsync("<p id='p'>text</p>");
-            Assert.Equal("manual", box.Hyphens);
+            Assert.Equal(Hyphens.Manual, box.Hyphens.Value);
         }
 
         [Fact]
         public async Task Hyphens_ParsesNone()
         {
             var box = await FindByIdAsync("<p id='p' style='hyphens:none'>text</p>");
-            Assert.Equal("none", box.Hyphens);
+            Assert.Equal(Hyphens.None, box.Hyphens.Value);
         }
 
         [Fact]
         public async Task Hyphens_ParsesAuto()
         {
             var box = await FindByIdAsync("<p id='p' style='hyphens:auto'>text</p>");
-            Assert.Equal("auto", box.Hyphens);
+            Assert.Equal(Hyphens.Auto, box.Hyphens.Value);
         }
 
         [Fact]
@@ -36,7 +37,7 @@ namespace PeachPDF.Tests.Integration
             var html = Wrap("<div style='hyphens:none'><p id='p'>text</p></div>");
             var (root, _) = await BuildAndLayout(html);
             var box = FindById(root, "p")!;
-            Assert.Equal("none", box.Hyphens);
+            Assert.Equal(Hyphens.None, box.Hyphens.Value);
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/OverflowClipIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/OverflowClipIntegrationTests.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Adapters;
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.PdfSharpCore;
@@ -34,7 +35,7 @@ body { margin: 0; }
 </style></head><body><div class='outer'><div class='inner'></div></div></body></html>";
 
             var root = await GetRootBox(html);
-            var outer = FindFirst(root, b => b.HtmlTag?.Name == "div" && b.Overflow == "hidden");
+            var outer = FindFirst(root, b => b.HtmlTag?.Name == "div" && b.Overflow.Value == Overflow.Hidden);
             var inner = FindFirst(outer!, b => b.HtmlTag?.Name == "div" && b != outer);
 
             Assert.NotNull(outer);
@@ -70,7 +71,7 @@ td { padding: 3px; }
             Assert.NotNull(div);
 
             // td has overflow:hidden from the PeachPDF default stylesheet
-            Assert.Equal("hidden", td!.Overflow);
+            Assert.Equal(Overflow.Hidden, td!.Overflow.Value);
 
             var paddingBoxRight = td.ClientRight + td.ActualPaddingRight;
 
@@ -116,7 +117,7 @@ body { margin: 0; }
 </style></head><body><div class='outer'><div class='inner'></div></div></body></html>";
 
             var root = await GetRootBox(html);
-            var outer = FindFirst(root, b => b.HtmlTag?.Name == "div" && b.Overflow == "hidden");
+            var outer = FindFirst(root, b => b.HtmlTag?.Name == "div" && b.Overflow.Value == Overflow.Hidden);
             var inner = FindFirst(outer!, b => b.HtmlTag?.Name == "div" && b != outer);
 
             Assert.NotNull(outer);

--- a/src/PeachPDF.Tests/Integration/PresentationalAttributeIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/PresentationalAttributeIntegrationTests.cs
@@ -1,0 +1,118 @@
+using PeachPDF.Adapters;
+using PeachPDF.CSS;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore.Drawing;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Deprecated presentational HTML attributes (<c>align</c>, <c>nowrap</c>) that <c>DomParser</c>
+    /// translates directly into typed <c>CssProperty</c> values rather than going through the CSS
+    /// cascade. See <see cref="BorderStylePaintIntegrationTests"/> for the sibling <c>border</c>
+    /// attribute coverage.
+    /// </summary>
+    public class PresentationalAttributeIntegrationTests
+    {
+        [Fact]
+        public async Task ImgAlignLeft_SetsFloatLeft()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<img id='i' align='left' src='x.png' width='10' height='10'>"));
+            var img = FindById(root, "i")!;
+
+            Assert.Equal(Floating.Left, img.Float.Value);
+        }
+
+        [Fact]
+        public async Task ImgAlignRight_SetsFloatRight()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<img id='i' align='right' src='x.png' width='10' height='10'>"));
+            var img = FindById(root, "i")!;
+
+            Assert.Equal(Floating.Right, img.Float.Value);
+        }
+
+        [Fact]
+        public async Task AlignAttributeLeft_OnNonImgElement_SetsTextAlignLeft()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<div id='d' align='left'>x</div>"));
+            var div = FindById(root, "d")!;
+
+            Assert.Equal(HorizontalAlignment.Left, div.TextAlign.Value);
+        }
+
+        [Fact]
+        public async Task AlignAttributeCenter_OnNonImgElement_SetsTextAlignCenter()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<div id='d' align='center'>x</div>"));
+            var div = FindById(root, "d")!;
+
+            Assert.Equal(HorizontalAlignment.Center, div.TextAlign.Value);
+        }
+
+        [Fact]
+        public async Task AlignAttributeRight_OnNonImgElement_SetsTextAlignRight()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<div id='d' align='right'>x</div>"));
+            var div = FindById(root, "d")!;
+
+            Assert.Equal(HorizontalAlignment.Right, div.TextAlign.Value);
+        }
+
+        [Fact]
+        public async Task AlignAttributeJustify_OnNonImgElement_SetsTextAlignJustify()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<div id='d' align='justify'>x</div>"));
+            var div = FindById(root, "d")!;
+
+            Assert.Equal(HorizontalAlignment.Justify, div.TextAlign.Value);
+        }
+
+        [Fact]
+        public async Task NowrapAttribute_SetsWhiteSpaceNoWrap()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<td id='d' nowrap='nowrap'>x</td>"));
+            var td = FindById(root, "d")!;
+
+            Assert.Equal(Whitespace.NoWrap, td.WhiteSpace.Value);
+        }
+
+        // ─── Helpers ─────────────────────────────────────────────────────────────
+
+        private static string Wrap(string body) =>
+            $"<!DOCTYPE html><html><head></head><body>{body}</body></html>";
+
+        private static async Task<(CssBox root, HtmlContainerInt container)> BuildAndLayout(string html)
+        {
+            var adapter = new PdfSharpAdapter();
+            adapter.PixelsPerPoint = 1.0;
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            var size = new XSize(595, 842);
+            container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+            container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+            var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            return (container.Root!, container);
+        }
+
+        private static CssBox? FindById(CssBox box, string id)
+        {
+            var val = box.HtmlTag?.TryGetAttribute("id", "");
+            if (val != null && val.Equals(id, System.StringComparison.OrdinalIgnoreCase))
+                return box;
+            foreach (var child in box.Boxes)
+            {
+                var found = FindById(child, id);
+                if (found != null) return found;
+            }
+            return null;
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/TextTransformTests.cs
+++ b/src/PeachPDF.Tests/Integration/TextTransformTests.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Adapters;
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.PdfSharpCore.Drawing;
@@ -147,7 +148,7 @@ namespace PeachPDF.Tests.Integration
             var child = FindById(root, "child");
 
             Assert.NotNull(child);
-            Assert.Equal("uppercase", child!.TextTransform);
+            Assert.Equal(TextTransform.Uppercase, child!.TextTransform.Value);
         }
 
         [Fact]
@@ -165,7 +166,7 @@ namespace PeachPDF.Tests.Integration
             var child = FindById(root, "child");
 
             Assert.NotNull(child);
-            Assert.Equal("none", child!.TextTransform);
+            Assert.Equal(TextTransform.None, child!.TextTransform.Value);
         }
 
         [Fact]
@@ -184,7 +185,7 @@ namespace PeachPDF.Tests.Integration
             var child = FindById(root, "child");
 
             Assert.NotNull(child);
-            Assert.Equal("uppercase", child!.TextTransform);
+            Assert.Equal(TextTransform.Uppercase, child!.TextTransform.Value);
         }
 
         // ── helpers ───────────────────────────────────────────────────────────

--- a/src/PeachPDF.Tests/Integration/TextTransformTests.cs
+++ b/src/PeachPDF.Tests/Integration/TextTransformTests.cs
@@ -188,6 +188,26 @@ namespace PeachPDF.Tests.Integration
             Assert.Equal(TextTransform.Uppercase, child!.TextTransform.Value);
         }
 
+        [Fact]
+        public async Task FullWidth_ParsesAndStores_ButLeavesTextUnchanged()
+        {
+            // See .claude/accepted-gaps/text-transform-full-width-no-effect.md: full-width is a valid,
+            // stored keyword (Map.TextTransforms includes it) but CssBox.ApplyTextTransform doesn't
+            // implement the half-width-to-full-width mapping, so it's currently a rendering no-op.
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div id="el" style="text-transform: full-width">Hello World</div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal(TextTransform.FullWidth, el!.TextTransform.Value);
+            Assert.Equal("Hello", FindFirstWord(el)!.Text);
+        }
+
         // ── helpers ───────────────────────────────────────────────────────────
 
         private static async Task<CssBox> BuildBoxTree(string html)

--- a/src/PeachPDF/CSS/Enumerations/Hyphens.cs
+++ b/src/PeachPDF/CSS/Enumerations/Hyphens.cs
@@ -1,0 +1,9 @@
+namespace PeachPDF.CSS
+{
+    internal enum Hyphens : byte
+    {
+        None,
+        Manual,
+        Auto
+    }
+}

--- a/src/PeachPDF/CSS/Model/Map.cs
+++ b/src/PeachPDF/CSS/Model/Map.cs
@@ -195,6 +195,13 @@ namespace PeachPDF.CSS
                 {Keywords.Hidden, Visibility.Hidden},
                 {Keywords.Collapse, Visibility.Collapse}
             }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        public static readonly FrozenDictionary<string, Hyphens> HyphensModes =
+            new Dictionary<string, Hyphens>(StringComparer.OrdinalIgnoreCase)
+            {
+                {Keywords.None, Hyphens.None},
+                {Keywords.Manual, Hyphens.Manual},
+                {Keywords.Auto, Hyphens.Auto}
+            }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
         public static readonly FrozenDictionary<string, PlayState> PlayStates =
             new Dictionary<string, PlayState>(StringComparer.OrdinalIgnoreCase)
             {

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -299,7 +299,7 @@ namespace PeachPDF.Html.Core.Dom
         /// </summary>
         public bool IsBlock => DerivedStyle.ActualDisplay == CssConstants.Block;
 
-        public bool IsFloated => Float is CssConstants.Left or CssConstants.Right;
+        public bool IsFloated => Float.Value is Floating.Left or Floating.Right;
 
         public bool IsOutOfFlow => IsFloated || Position is CssConstants.Absolute or CssConstants.Fixed;
 
@@ -766,8 +766,8 @@ namespace PeachPDF.Html.Core.Dom
 
             var text = ApplyTextTransform(_text!, TextTransform);
             var startIdx = 0;
-            var preserveSpaces = WhiteSpace is CssConstants.Pre or CssConstants.PreWrap;
-            var respectNewLines = preserveSpaces || WhiteSpace == CssConstants.PreLine || IsBrElement;
+            var preserveSpaces = WhiteSpace.Value is Whitespace.Pre or Whitespace.PreWrap;
+            var respectNewLines = preserveSpaces || WhiteSpace.Value == Whitespace.PreLine || IsBrElement;
 
             // Only ever null for text set after CssBidiParagraphResolver.AssignBidiLevels already ran
             // (e.g. DomParser.CorrectLineBreaksBlocks' synthetic "\n" for a standalone <br>) - one level
@@ -808,7 +808,7 @@ namespace PeachPDF.Html.Core.Dom
                         // with a known document language, HyphenationEngine's own suggested positions)
                         // is instead recorded as a candidate on the whole word and consulted only when
                         // CssLayoutEngine.FlowBox actually needs to break the line - see AddWord.
-                        var honorSoftHyphen = Hyphens != CssConstants.None;
+                        var honorSoftHyphen = Hyphens.Value != PeachPDF.CSS.Hyphens.None;
 
                         // Scan by whole codepoint (Rune), not UTF-16 code unit, so an astral character (an
                         // emoji, a CJK Extension-B ideograph, etc.) is never split across its surrogate pair -
@@ -819,7 +819,7 @@ namespace PeachPDF.Html.Core.Dom
                         {
                             Rune.DecodeFromUtf16(text.AsSpan(endIdx), out var rune, out var runeLength);
                             if (HtmlUtils.IsCollapsibleWhitespace(text[endIdx]) || text[endIdx] == '-'
-                                || WordBreak == CssConstants.BreakAll || CommonUtils.IsAsianCharacter(rune))
+                                || WordBreak.Value == PeachPDF.CSS.WordBreak.BreakAll || CommonUtils.IsAsianCharacter(rune))
                                 break;
                             endIdx += runeLength;
                         }
@@ -827,7 +827,7 @@ namespace PeachPDF.Html.Core.Dom
                         if (endIdx < text.Length)
                         {
                             Rune.DecodeFromUtf16(text.AsSpan(endIdx), out var rune, out var runeLength);
-                            if (text[endIdx] == '-' || WordBreak == CssConstants.BreakAll || CommonUtils.IsAsianCharacter(rune))
+                            if (text[endIdx] == '-' || WordBreak.Value == PeachPDF.CSS.WordBreak.BreakAll || CommonUtils.IsAsianCharacter(rune))
                                 endIdx += runeLength;
                         }
 
@@ -874,7 +874,7 @@ namespace PeachPDF.Html.Core.Dom
                                 cleanWord = rawWord;
                                 cleanOriginalWord = rawOriginalWord;
 
-                                if (Hyphens == CssConstants.Auto)
+                                if (Hyphens.Value == PeachPDF.CSS.Hyphens.Auto)
                                 {
                                     var language = HtmlContainer?.DocumentLanguage;
                                     if (!string.IsNullOrEmpty(language))
@@ -1171,28 +1171,28 @@ namespace PeachPDF.Html.Core.Dom
         /// input - callers rely on word/whitespace boundary indices computed against the transformed
         /// text remaining valid.
         /// </summary>
-        private static string ApplyTextTransform(string text, string transform)
+        private static string ApplyTextTransform(string text, CssProperty<TextTransform> transform)
         {
             if (string.IsNullOrEmpty(text))
                 return text;
 
-            switch (transform)
+            switch (transform.Value)
             {
-                case CssConstants.Uppercase:
+                case PeachPDF.CSS.TextTransform.Uppercase:
                 {
                     var chars = text.ToCharArray();
                     for (var i = 0; i < chars.Length; i++)
                         chars[i] = char.ToUpperInvariant(chars[i]);
                     return new string(chars);
                 }
-                case CssConstants.Lowercase:
+                case PeachPDF.CSS.TextTransform.Lowercase:
                 {
                     var chars = text.ToCharArray();
                     for (var i = 0; i < chars.Length; i++)
                         chars[i] = char.ToLowerInvariant(chars[i]);
                     return new string(chars);
                 }
-                case CssConstants.Capitalize:
+                case PeachPDF.CSS.TextTransform.Capitalize:
                 {
                     var chars = text.ToCharArray();
                     var atWordStart = true;
@@ -5048,7 +5048,7 @@ namespace PeachPDF.Html.Core.Dom
             double? oldPaddingSum = null;
 
             // not inline (block) boxes start a new line so we need to reset the max sum
-            if (box.DerivedStyle.ActualDisplay != CssConstants.Inline && box.DerivedStyle.ActualDisplay != CssConstants.TableCell && box.WhiteSpace != CssConstants.NoWrap)
+            if (box.DerivedStyle.ActualDisplay != CssConstants.Inline && box.DerivedStyle.ActualDisplay != CssConstants.TableCell && box.WhiteSpace.Value != Whitespace.NoWrap)
             {
                 oldSum = maxSum;
                 maxSum = marginSum;
@@ -5130,7 +5130,7 @@ namespace PeachPDF.Html.Core.Dom
                     {
                         var explicitContentWidth = CssValueParser.ParseLength(childBox.Width, 0, childBox);
                         var childStartsNewLine = childBox.DerivedStyle.ActualDisplay != CssConstants.Inline
-                            && childBox.DerivedStyle.ActualDisplay != CssConstants.TableCell && childBox.WhiteSpace != CssConstants.NoWrap;
+                            && childBox.DerivedStyle.ActualDisplay != CssConstants.TableCell && childBox.WhiteSpace.Value != Whitespace.NoWrap;
                         maxSum = childStartsNewLine
                             ? Math.Max(maxSum, explicitContentWidth)
                             : Math.Max(maxSum, maxSumBeforeChild + explicitContentWidth);
@@ -5364,11 +5364,11 @@ namespace PeachPDF.Html.Core.Dom
             var current = this;
             // Capped defensively (real documents never nest this deep) so a malformed/cyclic box tree
             // degrades to "stop extending the group" instead of hanging or overflowing the stack.
-            while (chainMembers.Count < 1000 && current.Overflow == CssConstants.Visible &&
+            while (chainMembers.Count < 1000 && current.Overflow.Value == PeachPDF.CSS.Overflow.Visible &&
                    current.ActualBorderTopWidth < 0.1 && current.ActualPaddingTop < 0.1)
             {
                 var firstInFlowChild = current.Boxes.FirstOrDefault(b => !b.IsOutOfFlow && b.DerivedStyle.ActualDisplay != CssConstants.None);
-                if (firstInFlowChild == null || firstInFlowChild.Clear != CssConstants.None || firstInFlowChild == current) break;
+                if (firstInFlowChild == null || firstInFlowChild.Clear.Value != ClearMode.None || firstInFlowChild == current) break;
 
                 margins.Fold(firstInFlowChild.ActualMarginTop);
                 chainMembers.Add(firstInFlowChild);
@@ -5487,7 +5487,7 @@ namespace PeachPDF.Html.Core.Dom
             var heightIsAuto = Height == CssConstants.Auto ||
                 (Height.EndsWith('%') && !ContainingBlock.IsHeightCalculated);
             if (!heightIsAuto) return false;
-            if (Overflow != CssConstants.Visible) return false;
+            if (Overflow.Value != PeachPDF.CSS.Overflow.Visible) return false;
             if (!(ActualPaddingTop < 0.1) || !(ActualPaddingBottom < 0.1)) return false;
             if (!(ActualBorderTopWidth < 0.1) || !(ActualBorderBottomWidth < 0.1)) return false;
             // A box with real text content (e.g. an anonymous text-node box) is not empty even when it
@@ -5601,7 +5601,7 @@ namespace PeachPDF.Html.Core.Dom
             if (ParentBox == null || ParentBox.Boxes.IndexOf(this) != ParentBox.Boxes.Count - 1 ||
                 !(_parentBox!.ActualMarginBottom < 0.1) ||
                 !(ActualPaddingBottom < 0.1) || !(ActualBorderBottomWidth < 0.1) ||
-                Overflow != CssConstants.Visible)
+                Overflow.Value != PeachPDF.CSS.Overflow.Visible)
                 return Math.Max(ActualBottom,
                     lastNonFloatingBox.StaticBottom + margin + ActualPaddingBottom + ActualBorderBottomWidth);
 

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -400,7 +400,7 @@ namespace PeachPDF.Html.Core.Dom
             blockBox.ActualBottom = coordinates.MaxBottom + blockBox.ActualPaddingBottom + blockBox.ActualBorderBottomWidth;
 
             // handle limiting block height when overflow is hidden
-            if (blockBox.Height != CssConstants.Auto && blockBox.Overflow == CssConstants.Hidden && blockBox.ActualBottom - blockBox.Location.Y > blockBox.ActualHeight)
+            if (blockBox.Height != CssConstants.Auto && blockBox.Overflow.Value == Overflow.Hidden && blockBox.ActualBottom - blockBox.Location.Y > blockBox.ActualHeight)
             {
                 blockBox.ActualBottom = blockBox.Location.Y + blockBox.ActualHeight + blockBox.ActualPaddingBottom + blockBox.ActualPaddingTop;
             }
@@ -482,7 +482,7 @@ namespace PeachPDF.Html.Core.Dom
 
         public static void FloatBox(CssBox box)
         {
-            if (box is { Float: CssConstants.None, Clear: CssConstants.None })
+            if (box is { Float.Value: Floating.None, Clear.Value: ClearMode.None })
             {
                 return;
             }
@@ -497,17 +497,17 @@ namespace PeachPDF.Html.Core.Dom
 
             var currentBoxIdx = containingBox.Boxes.IndexOf(box);
 
-            switch (box.Float)
+            switch (box.Float.Value)
             {
-                case CssConstants.Left:
+                case Floating.Left:
                     FloatBoxLeft(box, startX, startY, limitRight);
                     break;
-                case CssConstants.Right:
+                case Floating.Right:
                     FloatBoxRight(box, startX, startY, limitRight);
                     break;
             }
 
-            if (box.Clear is not CssConstants.None)
+            if (box.Clear.Value is not ClearMode.None)
             {
                 ClearBox(box, currentBoxIdx, containingBox);
             }
@@ -1081,14 +1081,14 @@ namespace PeachPDF.Html.Core.Dom
             {
                 var siblingBox = containingBox.Boxes[i];
 
-                clearance = Math.Max(clearance, GetClearance(siblingBox, box.Clear));
+                clearance = Math.Max(clearance, GetClearance(siblingBox, box.Clear.Value));
 
                 if (!siblingBox.IsFloated) continue;
 
-                switch (siblingBox.Float)
+                switch (siblingBox.Float.Value)
                 {
-                    case CssConstants.Left when box.Clear is CssConstants.Right:
-                    case CssConstants.Right when box.Clear is CssConstants.Left:
+                    case Floating.Left when box.Clear.Value is ClearMode.Right:
+                    case Floating.Right when box.Clear.Value is ClearMode.Left:
                         continue;
                 }
 
@@ -1104,7 +1104,7 @@ namespace PeachPDF.Html.Core.Dom
             box.Location = new RPoint(box.ClientLeft, clearance);
         }
 
-        private static double GetClearance(CssBox box, string clearPropValue)
+        private static double GetClearance(CssBox box, ClearMode clearPropValue)
         {
             var clearance = 0d;
 
@@ -1123,10 +1123,10 @@ namespace PeachPDF.Html.Core.Dom
                 // clearPropValue (the CLEARING box's own `clear` value, passed down through the
                 // recursion) - not box.Clear, which is the container being searched and is usually
                 // "none", never filtering anything.
-                switch (childBox.Float)
+                switch (childBox.Float.Value)
                 {
-                    case CssConstants.Left when clearPropValue is CssConstants.Right:
-                    case CssConstants.Right when clearPropValue is CssConstants.Left:
+                    case Floating.Left when clearPropValue is ClearMode.Right:
+                    case Floating.Right when clearPropValue is ClearMode.Left:
                         continue;
                 }
 
@@ -1153,16 +1153,16 @@ namespace PeachPDF.Html.Core.Dom
 
             do
             {
-                var intersectingFloat = DomUtils.GetFirstIntersectingFloatBox(box, coordinates, box.Float);
+                var intersectingFloat = DomUtils.GetFirstIntersectingFloatBox(box, coordinates, box.Float.Value);
 
                 if (intersectingFloat is null) break;
 
-                switch (intersectingFloat.Float)
+                switch (intersectingFloat.Float.Value)
                 {
-                    case CssConstants.Left:
+                    case Floating.Left:
                         coordinates.Left = intersectingFloat.ActualRight + intersectingFloat.ActualMarginRight + box.ActualMarginLeft;
                         break;
-                    case CssConstants.Right:
+                    case Floating.Right:
                         coordinates.Right = intersectingFloat.Location.X - intersectingFloat.ActualMarginLeft;
                         break;
                 }
@@ -1198,16 +1198,16 @@ namespace PeachPDF.Html.Core.Dom
 
             do
             {
-                var intersectingFloat = DomUtils.GetFirstIntersectingFloatBox(box, coordinates, box.Float);
+                var intersectingFloat = DomUtils.GetFirstIntersectingFloatBox(box, coordinates, box.Float.Value);
 
                 if (intersectingFloat is null) break;
 
-                switch (intersectingFloat.Float)
+                switch (intersectingFloat.Float.Value)
                 {
-                    case CssConstants.Left:
+                    case Floating.Left:
                         coordinates.Left = intersectingFloat.ActualRight;
                         break;
-                    case CssConstants.Right:
+                    case Floating.Right:
                         coordinates.Right = intersectingFloat.Location.X;
                         break;
                 }
@@ -1381,7 +1381,7 @@ namespace PeachPDF.Html.Core.Dom
                 {
                     var wrapNoWrapBox = false;
 
-                    if (b.WhiteSpace == CssConstants.NoWrap && coordinates.CurrentX > lineStartX)
+                    if (b.WhiteSpace.Value == Whitespace.NoWrap && coordinates.CurrentX > lineStartX)
                     {
                         var boxRight = coordinates.CurrentX;
 
@@ -1431,9 +1431,9 @@ namespace PeachPDF.Html.Core.Dom
                                 coordinates.Line.Equals(blockBox.LineBoxes[0]), coordinates.Line.FollowsForcedBreak);
                         }
 
-                        var overflows = b.WhiteSpace != CssConstants.NoWrap && b.WhiteSpace != CssConstants.Pre
+                        var overflows = b.WhiteSpace.Value != Whitespace.NoWrap && b.WhiteSpace.Value != Whitespace.Pre
                                          && coordinates.CurrentX + word.Width + rightSpacing + clonedTrailing > actualLimitRight
-                                         && (b.WhiteSpace != CssConstants.PreWrap || !word.IsSpaces);
+                                         && (b.WhiteSpace.Value != Whitespace.PreWrap || !word.IsSpaces);
 
                         // hyphens:auto/manual: before giving up and wrapping the whole word, see if a
                         // cached candidate break point (from ParseToWords - either an explicit soft
@@ -1992,22 +1992,22 @@ namespace PeachPDF.Html.Core.Dom
             // owning box's own direction - the CSS-OM-visible value (box.TextAlign) stays exactly as
             // authored/defaulted; only this *used*-value resolution is direction-aware.
             var isRtl = lineBox.OwnerBox.Direction.Value == DirectionMode.Rtl;
-            var textAlign = lineBox.OwnerBox.TextAlign switch
+            var textAlign = lineBox.OwnerBox.TextAlign.Value switch
             {
-                CssConstants.Start => isRtl ? CssConstants.Right : CssConstants.Left,
-                CssConstants.End => isRtl ? CssConstants.Left : CssConstants.Right,
+                HorizontalAlignment.Start => isRtl ? HorizontalAlignment.Right : HorizontalAlignment.Left,
+                HorizontalAlignment.End => isRtl ? HorizontalAlignment.Left : HorizontalAlignment.Right,
                 var other => other
             };
 
             switch (textAlign)
             {
-                case CssConstants.Right:
+                case HorizontalAlignment.Right:
                     ApplyRightAlignment(lineBox);
                     break;
-                case CssConstants.Center:
+                case HorizontalAlignment.Center:
                     ApplyCenterAlignment(lineBox);
                     break;
-                case CssConstants.Justify:
+                case HorizontalAlignment.Justify:
                     ApplyJustifyAlignment(lineBox, blockFinished);
                     break;
             }

--- a/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
+++ b/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
@@ -1112,7 +1112,7 @@ namespace PeachPDF.Html.Core.Dom
             get
             {
                 var area = Style.DisplayPositioning;
-                if (area.Float is CssConstants.None) return area.Display;
+                if (area.Float.Value is Floating.None) return area.Display;
 
                 return area.Display switch
                 {

--- a/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
@@ -1359,7 +1359,7 @@ namespace PeachPDF.Html.Core.Fragmentation
 
             while (true)
             {
-                if (containingBlock.Overflow == CssConstants.Hidden)
+                if (containingBlock.Overflow.Value == Overflow.Hidden)
                     return IsSelfOrAncestor(root, containingBlock);
 
                 var next = containingBlock.ContainingBlock;
@@ -1861,7 +1861,7 @@ namespace PeachPDF.Html.Core.Fragmentation
 
             while (true)
             {
-                if (containingBlock.Overflow == CssConstants.Hidden)
+                if (containingBlock.Overflow.Value == Overflow.Hidden)
                     return Localize(PaddingEdgeOf(containingBlock, snapshot), originY);
 
                 var next = containingBlock.ContainingBlock;

--- a/src/PeachPDF/Html/Core/Fragmentation/MonolithicContent.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/MonolithicContent.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Utils;
 using System;
@@ -80,7 +81,7 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// </para>
         /// </remarks>
         internal static bool IsScrollContainer(CssBox box) =>
-            box.Overflow != CssConstants.Visible && !IsViewportPropagationSource(box);
+            box.Overflow.Value != Overflow.Visible && !IsViewportPropagationSource(box);
 
         private static bool IsViewportPropagationSource(CssBox box)
         {
@@ -91,7 +92,7 @@ namespace PeachPDF.Html.Core.Fragmentation
             if (!IsNamed(box, "body") || box.ParentBox is not { } parent || !IsRootElement(parent))
                 return false;
 
-            return parent.Overflow == CssConstants.Visible;
+            return parent.Overflow.Value == Overflow.Visible;
         }
 
         private static bool IsRootElement(CssBox box) => box.IsRoot || IsNamed(box, "html");

--- a/src/PeachPDF/Html/Core/Paint/FragmentPainter.cs
+++ b/src/PeachPDF/Html/Core/Paint/FragmentPainter.cs
@@ -76,7 +76,7 @@ namespace PeachPDF.Html.Core.Paint
 
             try
             {
-                if (box.DerivedStyle.ActualDisplay == CssConstants.None || box.Visibility != CssConstants.Visible) return;
+                if (box.DerivedStyle.ActualDisplay == CssConstants.None || box.Visibility.Value != Visibility.Visible) return;
 
                 // use initial clip to draw blocks with Position = fixed. I.e. ignore page margins
                 if (box.Position == CssConstants.Fixed)

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -1411,11 +1411,11 @@ namespace PeachPDF.Html.Core.Parse
                             {
                                 case HtmlConstants.Left:
                                     box.VerticalAlign = CssConstants.Top;
-                                    box.Float = CssConstants.Left;
+                                    box.Float = CssProperty<Floating>.FromValue(CssConstants.Left, Floating.Left);
                                     break;
                                 case HtmlConstants.Right:
                                     box.VerticalAlign = CssConstants.Top;
-                                    box.Float = CssConstants.Right;
+                                    box.Float = CssProperty<Floating>.FromValue(CssConstants.Right, Floating.Right);
                                     break;
                                 case HtmlConstants.Bottom:
                                     box.VerticalAlign = CssConstants.Baseline;
@@ -1431,7 +1431,7 @@ namespace PeachPDF.Html.Core.Parse
                         else
                         {
                             if (value is HtmlConstants.Left or HtmlConstants.Center or HtmlConstants.Right or HtmlConstants.Justify)
-                                box.TextAlign = value.ToLower();
+                                box.TextAlign = CssProperty<HorizontalAlignment>.FromCssText(value.ToLower(), Map.HorizontalAlignments, HorizontalAlignment.Start);
                             else
                                 box.VerticalAlign = value.ToLower();
 
@@ -1481,7 +1481,7 @@ namespace PeachPDF.Html.Core.Parse
                         box.MarginRight = box.MarginLeft = TranslateLength(value);
                         break;
                     case HtmlConstants.Nowrap:
-                        box.WhiteSpace = CssConstants.NoWrap;
+                        box.WhiteSpace = CssProperty<Whitespace>.FromValue(CssConstants.NoWrap, Whitespace.NoWrap);
                         break;
                     case HtmlConstants.Size:
                         if (tag.Name.Equals(HtmlConstants.Hr, StringComparison.OrdinalIgnoreCase))
@@ -1716,7 +1716,7 @@ namespace PeachPDF.Html.Core.Parse
                     keepBox = keepBox || childBox.IsBrElement;
 
                     // is the box is pre-formatted
-                    keepBox = keepBox || childBox.WhiteSpace == CssConstants.Pre || childBox.WhiteSpace == CssConstants.PreWrap;
+                    keepBox = keepBox || childBox.WhiteSpace.Value == Whitespace.Pre || childBox.WhiteSpace.Value == Whitespace.PreWrap;
 
                     // is the box is only one in the parent
                     keepBox = keepBox || box.Boxes.Count == 1;

--- a/src/PeachPDF/Html/Core/Utils/DomUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/DomUtils.cs
@@ -289,7 +289,7 @@ namespace PeachPDF.Html.Core.Utils
         {
             if (box == null) return null;
 
-            if ((visible && box.Visibility != CssConstants.Visible) ||
+            if ((visible && box.Visibility.Value != Visibility.Visible) ||
                 (!box.Bounds.IsEmpty && !box.Bounds.Contains(location))) return null;
 
             foreach (var childBox in box.Boxes)
@@ -314,7 +314,7 @@ namespace PeachPDF.Html.Core.Utils
             {
                 case null:
                     return;
-                case { IsClickable: true, Visibility: CssConstants.Visible }:
+                case { IsClickable: true, Visibility.Value: Visibility.Visible }:
                     linkBoxes.Add(box);
                     break;
             }
@@ -370,7 +370,7 @@ namespace PeachPDF.Html.Core.Utils
             {
                 case null:
                     return null;
-                case { IsClickable: true, Visibility: CssConstants.Visible } when IsInBox(box, location):
+                case { IsClickable: true, Visibility.Value: Visibility.Visible } when IsInBox(box, location):
                     return box;
             }
 
@@ -488,7 +488,7 @@ namespace PeachPDF.Html.Core.Utils
         /// <returns>css word box if exists or null</returns>
         public static CssRect? GetCssBoxWord(CssBox? box, RPoint location)
         {
-            if (box is not { Visibility: CssConstants.Visible }) return null;
+            if (box is not { Visibility.Value: Visibility.Visible }) return null;
 
             if (box.LineBoxes.Count > 0)
             {
@@ -577,7 +577,7 @@ namespace PeachPDF.Html.Core.Utils
             return false;
         }
 
-        public static CssBox? GetFirstIntersectingFloatBox(CssBox reference, CssFloatCoordinates coordinates, string floatProp)
+        public static CssBox? GetFirstIntersectingFloatBox(CssBox reference, CssFloatCoordinates coordinates, Floating floatProp)
         {
             var container = reference.HtmlContainer;
 
@@ -607,7 +607,7 @@ namespace PeachPDF.Html.Core.Utils
         /// <param name="coordinates">The area a float has to intersect to be returned.</param>
         /// <param name="floatProp">Which side's floats to look for.</param>
         /// <param name="boxesVisited">Accumulator, not an input: every box the walk examines is added to it.</param>
-        private static CssBox? FindIntersectingFloatBox(CssBox reference, CssFloatCoordinates coordinates, string floatProp, ref int boxesVisited)
+        private static CssBox? FindIntersectingFloatBox(CssBox reference, CssFloatCoordinates coordinates, Floating floatProp, ref int boxesVisited)
         {
             while (true)
             {
@@ -658,7 +658,7 @@ namespace PeachPDF.Html.Core.Utils
                     Right = coordinates.MaxRight
                 };
 
-                var intersectingFloat = GetFirstIntersectingFloatBox(box, floatCoordinates, CssConstants.Left);
+                var intersectingFloat = GetFirstIntersectingFloatBox(box, floatCoordinates, Floating.Left);
 
                 if (intersectingFloat is null)
                 {
@@ -692,7 +692,7 @@ namespace PeachPDF.Html.Core.Utils
                     Right = left + referenceWidth
                 };
 
-                var intersectingFloat = GetFirstIntersectingFloatBox(box, floatCoordinates, CssConstants.Left);
+                var intersectingFloat = GetFirstIntersectingFloatBox(box, floatCoordinates, Floating.Left);
 
                 if (intersectingFloat is null)
                 {
@@ -981,7 +981,7 @@ namespace PeachPDF.Html.Core.Utils
             return false;
         }
 
-        private static CssBox? GetNextIntersectingFloatBox(CssBox box, CssFloatCoordinates coordinates, string floatProp, ref int boxesVisited)
+        private static CssBox? GetNextIntersectingFloatBox(CssBox box, CssFloatCoordinates coordinates, Floating floatProp, ref int boxesVisited)
         {
             boxesVisited++;
 
@@ -1002,7 +1002,7 @@ namespace PeachPDF.Html.Core.Utils
             return null;
         }
 
-        private static bool IsFloatIntersecting(CssFloatCoordinates coordinates, string floatProp, CssBox targetBox)
+        private static bool IsFloatIntersecting(CssFloatCoordinates coordinates, Floating floatProp, CssBox targetBox)
         {
             if (!targetBox.IsFloated) return false;
 
@@ -1016,8 +1016,8 @@ namespace PeachPDF.Html.Core.Utils
 
             switch (floatProp)
             {
-                case CssConstants.Left when targetRight > currentLeft && targetLeft <= currentLeft:
-                case CssConstants.Right when targetLeft > coordinates.FloatRightStartX + coordinates.MarginLeft + coordinates.ReferenceWidth + coordinates.MarginRight:
+                case Floating.Left when targetRight > currentLeft && targetLeft <= currentLeft:
+                case Floating.Right when targetLeft > coordinates.FloatRightStartX + coordinates.MarginLeft + coordinates.ReferenceWidth + coordinates.MarginRight:
                     return true;
                 default:
                     return false;

--- a/src/PeachPDF/Html/Core/Utils/RenderUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/RenderUtils.cs
@@ -10,6 +10,7 @@
 // - Sun Tsu,
 // "The Art of War"
 
+using PeachPDF.CSS;
 using PeachPDF.Html.Adapters;
 using PeachPDF.Html.Adapters.Entities;
 using PeachPDF.Html.Core.Dom;
@@ -62,7 +63,7 @@ namespace PeachPDF.Html.Core.Utils
         /// </summary>
         private static bool TryPushOverflowClip(RGraphics g, CssBox overflowBox, double originY)
         {
-            if (overflowBox.Overflow != CssConstants.Hidden) return false;
+            if (overflowBox.Overflow.Value != Overflow.Hidden) return false;
 
             var prevClip = g.GetClip();
             var rect = PaddingEdgeOf(overflowBox, overflowBox.Bounds);

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -1582,6 +1582,7 @@
     },
     {
       "name": "text-transform",
+      "comment": "cssDataType's own Map.TextTransforms includes full-width because it's already used elsewhere in the CSS-OM pipeline, even though CssBox.cs's ApplyTextTransform only implements uppercase/lowercase/capitalize - full-width parses and stores but has no distinct effect (see .claude/accepted-gaps/text-transform-full-width-no-effect.md). supportsDataType is the stricter, @supports-only list excluding full-width for exactly that reason, same shape as word-break's keep-all split.",
       "inherited": true,
       "initialValue": "none",
       "cssDataType": {
@@ -1590,6 +1591,13 @@
         "keywordMap": "Map.TextTransforms",
         "fallback": "TextTransform.None"
       },
+      "supportsDataType": "keyword",
+      "supportsSupportedValues": [
+        "none",
+        "capitalize",
+        "uppercase",
+        "lowercase"
+      ],
       "html": {
         "propertyPath": "TextTransform",
         "csharpDataType": "CssProperty<TextTransform>",

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -1380,35 +1380,34 @@
       "name": "float",
       "inherited": false,
       "initialValue": "none",
-      "cssDataType": "keyword",
-      "supportedValues": [
-        "left",
-        "right",
-        "none"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "Floating",
+        "keywordMap": "Map.FloatingModes",
+        "fallback": "Floating.None"
+      },
       "html": {
         "propertyPath": "Float",
-        "csharpDataType": "string",
-        "area": "DisplayPositioningArea"
+        "csharpDataType": "CssProperty<Floating>",
+        "area": "DisplayPositioningArea",
+        "getterExpression": "{box}.Float.ToString()"
       }
     },
     {
       "name": "clear",
       "inherited": false,
       "initialValue": "none",
-      "cssDataType": "keyword",
-      "supportedValues": [
-        "left",
-        "right",
-        "both",
-        "none"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "ClearMode",
+        "keywordMap": "Map.ClearModes",
+        "fallback": "ClearMode.None"
+      },
       "html": {
         "propertyPath": "Clear",
-        "csharpDataType": "string",
-        "area": "DisplayPositioningArea"
+        "csharpDataType": "CssProperty<ClearMode>",
+        "area": "DisplayPositioningArea",
+        "getterExpression": "{box}.Clear.ToString()"
       }
     },
     {
@@ -1435,18 +1434,17 @@
       "comment": "'clip' is intentionally excluded - CssUtilsTests/MonolithicContentTests confirm it isn't (and wasn't, pre-migration) an accepted value, so it never overrides the inherited/initial 'visible' and MonolithicContent.IsScrollContainer sees 'visible', not a stored 'clip'. 'auto'/'scroll' are genuinely used by MonolithicContent.IsScrollContainer (a non-visible overflow makes a box a scroll container, treated as monolithic/unbreakable across pages) even though they don't distinguish real interactive scrolling from 'hidden' - both are meaningful CSS Overflow 3 values for a non-interactive, paginated renderer.",
       "inherited": false,
       "initialValue": "visible",
-      "cssDataType": "keyword",
-      "supportedValues": [
-        "visible",
-        "hidden",
-        "scroll",
-        "auto"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "Overflow",
+        "keywordMap": "Map.OverflowModes",
+        "fallback": "Overflow.Visible"
+      },
       "html": {
         "propertyPath": "Overflow",
-        "csharpDataType": "string",
-        "area": "DisplayPositioningArea"
+        "csharpDataType": "CssProperty<Overflow>",
+        "area": "DisplayPositioningArea",
+        "getterExpression": "{box}.Overflow.ToString()"
       }
     },
     {
@@ -1569,71 +1567,64 @@
       "name": "text-align",
       "inherited": true,
       "initialValue": "start",
-      "cssDataType": "keyword",
-      "supportedValues": [
-        "left",
-        "right",
-        "center",
-        "justify",
-        "start",
-        "end"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "HorizontalAlignment",
+        "keywordMap": "Map.HorizontalAlignments",
+        "fallback": "HorizontalAlignment.Start"
+      },
       "html": {
         "propertyPath": "TextAlign",
-        "csharpDataType": "string",
-        "area": "TextArea"
+        "csharpDataType": "CssProperty<HorizontalAlignment>",
+        "area": "TextArea",
+        "getterExpression": "{box}.TextAlign.ToString()"
       }
     },
     {
       "name": "text-transform",
       "inherited": true,
       "initialValue": "none",
-      "cssDataType": "keyword",
-      "supportedValues": [
-        "none",
-        "uppercase",
-        "lowercase",
-        "capitalize"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "TextTransform",
+        "keywordMap": "Map.TextTransforms",
+        "fallback": "TextTransform.None"
+      },
       "html": {
         "propertyPath": "TextTransform",
-        "csharpDataType": "string",
-        "area": "TextArea"
+        "csharpDataType": "CssProperty<TextTransform>",
+        "area": "TextArea",
+        "getterExpression": "{box}.TextTransform.ToString()"
       }
     },
     {
       "name": "white-space",
       "inherited": true,
       "initialValue": "normal",
-      "cssDataType": "keyword",
-      "supportedValues": [
-        "normal",
-        "nowrap",
-        "pre",
-        "pre-wrap",
-        "pre-line"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "Whitespace",
+        "keywordMap": "Map.WhitespaceModes",
+        "fallback": "Whitespace.Normal"
+      },
       "html": {
         "propertyPath": "WhiteSpace",
-        "csharpDataType": "string",
-        "area": "TextArea"
+        "csharpDataType": "CssProperty<Whitespace>",
+        "area": "TextArea",
+        "getterExpression": "{box}.WhiteSpace.ToString()"
       }
     },
     {
       "name": "word-break",
-      "comment": "cssDataType's own supportedValues includes keep-all because Layer A's own WordBreakConverter/Map.WordBreaks parses and stores it as valid CSS (WordBreak.KeepAll), even though CssBox.cs's line-breaking logic only special-cases break-all - keep-all has no distinct effect (see .claude/accepted-gaps/word-break-keep-all-no-effect.md). supportsDataType is the stricter, @supports-only list excluding keep-all for exactly that reason, same shape as break-before's region/avoid-region split.",
+      "comment": "cssDataType's own Map.WordBreaks includes keep-all because Layer A's own WordBreakConverter/Map.WordBreaks parses and stores it as valid CSS (WordBreak.KeepAll), even though CssBox.cs's line-breaking logic only special-cases break-all - keep-all has no distinct effect (see .claude/accepted-gaps/word-break-keep-all-no-effect.md). supportsDataType is the stricter, @supports-only list excluding keep-all for exactly that reason, same shape as break-before's region/avoid-region split.",
       "inherited": true,
       "initialValue": "normal",
-      "cssDataType": "keyword",
-      "supportedValues": [
-        "normal",
-        "break-all",
-        "keep-all"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "WordBreak",
+        "keywordMap": "Map.WordBreaks",
+        "fallback": "WordBreak.Normal"
+      },
       "supportsDataType": "keyword",
       "supportsSupportedValues": [
         "normal",
@@ -1641,24 +1632,26 @@
       ],
       "html": {
         "propertyPath": "WordBreak",
-        "csharpDataType": "string",
-        "area": "TextArea"
+        "csharpDataType": "CssProperty<WordBreak>",
+        "area": "TextArea",
+        "getterExpression": "{box}.WordBreak.ToString()"
       }
     },
     {
       "name": "visibility",
       "inherited": true,
       "initialValue": "visible",
-      "cssDataType": "keyword",
-      "supportedValues": [
-        "visible",
-        "hidden"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "Visibility",
+        "keywordMap": "Map.Visibilities",
+        "fallback": "Visibility.Visible"
+      },
       "html": {
         "propertyPath": "Visibility",
-        "csharpDataType": "string",
-        "area": "TextArea"
+        "csharpDataType": "CssProperty<Visibility>",
+        "area": "TextArea",
+        "getterExpression": "{box}.Visibility.ToString()"
       }
     },
     {
@@ -1737,17 +1730,17 @@
       "name": "hyphens",
       "inherited": true,
       "initialValue": "manual",
-      "cssDataType": "keyword",
-      "supportedValues": [
-        "none",
-        "manual",
-        "auto"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "Hyphens",
+        "keywordMap": "Map.HyphensModes",
+        "fallback": "Hyphens.Manual"
+      },
       "html": {
         "propertyPath": "Hyphens",
-        "csharpDataType": "string",
-        "area": "TextArea"
+        "csharpDataType": "CssProperty<Hyphens>",
+        "area": "TextArea",
+        "getterExpression": "{box}.Hyphens.ToString()"
       }
     },
     {


### PR DESCRIPTION
## Summary

Part of the ongoing #598 follow-up work (group A of the typed-storage conversion). Converts nine properties — `float`, `clear`, `overflow`, `visibility`, `text-transform`, `text-align`, `white-space`, `word-break`, and `hyphens` — from plain-string `CssBox` storage to typed `CssProperty<TEnum>`, reusing existing enums/`Map.*` keyword maps where they already existed (`Floating`, `ClearMode`, `Overflow`, `Visibility`, `TextTransform`, `HorizontalAlignment`, `Whitespace`, `WordBreak`) and adding one new pair (`Hyphens`/`Map.HyphensModes`) for the one property that had none. The JSON-schema side goes through the storage generator built in #635, so no hand-written registry/storage code was needed for the properties themselves.

- `css-properties.json`: the 9 properties switch from plain `"keyword"` to `"enum-keyword"`.
- Compiler-driven migration of every C# call site that read these properties as strings, across `CssBox.cs`, `CssLayoutEngine.cs`, `DerivedStyle.cs`, `FragmentEmitter.cs`, `MonolithicContent.cs`, `FragmentPainter.cs`, `DomParser.cs`, `DomUtils.cs`, `RenderUtils.cs`.
- Several of these properties share their exact name with their backing enum type (`Hyphens`, `WordBreak`, `Overflow`, `Visibility`, `TextTransform`) — inside `CssBox.cs`'s own method bodies, an unqualified reference like `Hyphens.None` resolves to the class's own property, not the type, so those call sites fully qualify the enum (`PeachPDF.CSS.Hyphens.None`, etc.).
- `visibility` now accepts `collapse` (previously silently rejected/no-op), since the `enum-keyword` schema validates purely off the reused `Map.Visibilities` keyword map, which already includes it elsewhere in the CSS-OM pipeline. PeachPDF has no table row/column collapse layout, so `collapse` currently renders identically to `hidden` — documented via a migration note, a `docs/html-css-support.md` update, and a new accepted-gap file with tracking issue #639.
- The post-change review also caught that `text-transform` reusing `Map.TextTransforms` similarly widened accepted values to include `full-width` (a rendering no-op, since `CssBox.ApplyTextTransform` only implements `uppercase`/`lowercase`/`capitalize`) — fixed via the same `supportsDataType`/`supportsSupportedValues` restriction `word-break` already uses for `keep-all`, with its own accepted-gap file and tracking issue #638.
- Added coverage for float/clear direction interplay (a float wrapping below an opposite-direction full-width float sibling, `clear:left`/`clear:right` correctly ignoring an opposite-direction float), the deprecated legacy HTML presentational attributes (`align`, `nowrap`) `DomParser` translates into these typed properties, and the previously-untested `DomUtils` hit-testing helpers (`GetCssBox`/`GetLinkBox`/`GetCssBoxWord`).

## Test plan

- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (7899 passed, 9 skipped)
- [x] `dotnet test PeachPDF.SourceGenerators.Tests/PeachPDF.SourceGenerators.Tests.csproj` — 107 passed (JSON-only change, generator itself untouched)
- [x] Diff coverage vs `main`: 100%
- [x] Post-change review pass — confirmed the self-shadowing qualifications are correct and consistently applied, confirmed every `.Value` comparison is a semantically identical translation of the original string comparison, and caught the `text-transform: full-width` widening (fixed as described above)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WsuX3xR9EsNY3x1a5RGQmJ)_