### PR TITLE
Convert display storage to CssProperty&lt;DisplayMode&gt;

### DIFF
--- a/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTablePageBreakTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTablePageBreakTests.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Adapters;
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Utils;
@@ -44,10 +45,10 @@ namespace PeachPDF.Tests.Html.Core.Dom
             var table = FindTableBox(rootBox);
             Assert.NotNull(table);
 
-            var tbody = table.Boxes.FirstOrDefault(b => b.Display == CssConstants.TableRowGroup);
+            var tbody = table.Boxes.FirstOrDefault(b => b.Display.Value == DisplayMode.TableRowGroup);
             Assert.NotNull(tbody);
 
-            var rows = tbody.Boxes.Where(b => b.Display == CssConstants.TableRow).ToList();
+            var rows = tbody.Boxes.Where(b => b.Display.Value == DisplayMode.TableRow).ToList();
             _output.WriteLine($"Total rows: {rows.Count}");
 
             // Find the first body row that starts on page 2 (Y >= pageHeight)
@@ -101,10 +102,10 @@ namespace PeachPDF.Tests.Html.Core.Dom
             var table = FindTableBox(rootBox);
             Assert.NotNull(table);
 
-            var tbody = table.Boxes.FirstOrDefault(b => b.Display == CssConstants.TableRowGroup);
+            var tbody = table.Boxes.FirstOrDefault(b => b.Display.Value == DisplayMode.TableRowGroup);
             Assert.NotNull(tbody);
 
-            var rows = tbody.Boxes.Where(b => b.Display == CssConstants.TableRow).ToList();
+            var rows = tbody.Boxes.Where(b => b.Display.Value == DisplayMode.TableRow).ToList();
             _output.WriteLine($"Total rows: {rows.Count}");
 
             // Check every row whose top is on page 0
@@ -276,10 +277,10 @@ namespace PeachPDF.Tests.Html.Core.Dom
             var table = FindTableBox(rootBox);
             Assert.NotNull(table);
 
-            var tbody = table.Boxes.FirstOrDefault(b => b.Display == CssConstants.TableRowGroup);
+            var tbody = table.Boxes.FirstOrDefault(b => b.Display.Value == DisplayMode.TableRowGroup);
             Assert.NotNull(tbody);
 
-            var rows = tbody.Boxes.Where(b => b.Display == CssConstants.TableRow).ToList();
+            var rows = tbody.Boxes.Where(b => b.Display.Value == DisplayMode.TableRow).ToList();
             _output.WriteLine($"Total rows: {rows.Count}");
 
             foreach (var row in rows)
@@ -396,7 +397,7 @@ namespace PeachPDF.Tests.Html.Core.Dom
             // Find the footer proxy boxes that were injected into the table
             var footerProxies = table.Boxes
                 .OfType<CssProxyBox>()
-                .Where(p => p.Display == CssConstants.TableFooterGroup)
+                .Where(p => p.Display.Value == DisplayMode.TableFooterGroup)
                 .ToList();
 
             _output.WriteLine($"Footer proxies found: {footerProxies.Count}");
@@ -720,7 +721,7 @@ namespace PeachPDF.Tests.Html.Core.Dom
 
         private static CssBox? FindTableBox(CssBox box)
         {
-            if (box.Display == CssConstants.Table)
+            if (box.Display.Value == DisplayMode.Table)
                 return box;
 
             foreach (var child in box.Boxes)

--- a/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTableTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTableTests.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Adapters;
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Utils;
@@ -82,11 +83,11 @@ var table = FindTableBox(rootBox);
       Assert.NotNull(table);
 
    // Find the tbody which contains the rows
-  var tbody = table.Boxes.FirstOrDefault(b => b.Display == CssConstants.TableRowGroup);
+  var tbody = table.Boxes.FirstOrDefault(b => b.Display.Value == DisplayMode.TableRowGroup);
           if (tbody == null)
       {
           // If no explicit tbody, rows might be direct children
-     tbody = table.Boxes.FirstOrDefault(b => b.Boxes.Any(child => child.Display == CssConstants.TableRow));
+     tbody = table.Boxes.FirstOrDefault(b => b.Boxes.Any(child => child.Display.Value == DisplayMode.TableRow));
       }
 
    Assert.NotNull(tbody);
@@ -182,14 +183,14 @@ th, td { border: 1px solid black; padding: 8px; }
 
  // Find a header proxy (there should be one at the top)
   var headerProxies = table.Boxes.OfType<CssProxyBox>()
-   .Where(p => p.Display == CssConstants.TableHeaderGroup)
+   .Where(p => p.Display.Value == DisplayMode.TableHeaderGroup)
   .ToList();
 
  // Assert
   Assert.True(headerProxies.Count > 0, "Should have at least one header proxy");
   var firstProxy = headerProxies.OrderBy(p => p.Location.Y).First();
  _output.WriteLine($"First header proxy type: {firstProxy.GetType().Name}, Display: {firstProxy.Display}, Location.Y: {firstProxy.Location.Y}");
-    Assert.Equal(CssConstants.TableHeaderGroup, firstProxy.Display);
+    Assert.Equal(DisplayMode.TableHeaderGroup, firstProxy.Display.Value);
    }
 
         [Fact]
@@ -225,7 +226,7 @@ th, td { border: 1px solid black; padding: 8px; }
           Assert.NotNull(table);
 
      // Footer might be a proxy, so check all boxes
-      var hasFooter = table.Boxes.Any(b => b.Display == CssConstants.TableFooterGroup);
+      var hasFooter = table.Boxes.Any(b => b.Display.Value == DisplayMode.TableFooterGroup);
 
     // Assert
      Assert.True(hasFooter, "Table should have footer");
@@ -267,7 +268,7 @@ var (rootBox, container) = await BuildCssBoxTree(html, pageHeight: 400);
 
         // Check that thead is not in direct children (it's replaced by proxies)
       var directTheadChildren = table.Boxes.Where(b => 
-    b.Display == CssConstants.TableHeaderGroup && b is not CssProxyBox).ToList();
+    b.Display.Value == DisplayMode.TableHeaderGroup && b is not CssProxyBox).ToList();
 
    var proxyBoxes = table.Boxes.OfType<CssProxyBox>().ToList();
 
@@ -366,7 +367,7 @@ var (rootBox, container) = await BuildCssBoxTree(html, pageHeight);
          Assert.NotNull(table);
 
    var headerProxies = table.Boxes.OfType<CssProxyBox>()
-   .Where(p => p.Display == CssConstants.TableHeaderGroup)
+   .Where(p => p.Display.Value == DisplayMode.TableHeaderGroup)
         .OrderBy(p => p.Location.Y)
    .ToList();
 
@@ -429,11 +430,11 @@ td { border: 1px solid black; padding: 8px; }
   Assert.NotNull(table);
 
  // Find tbody which contains the row
-   var tbody = table.Boxes.FirstOrDefault(b => b.Display == CssConstants.TableRowGroup);
+   var tbody = table.Boxes.FirstOrDefault(b => b.Display.Value == DisplayMode.TableRowGroup);
       if (tbody == null)
      {
          // If no explicit tbody, look for a box that has rows as children
-   tbody = table.Boxes.FirstOrDefault(b => b.Boxes.Any(child => child.Display == CssConstants.TableRow));
+   tbody = table.Boxes.FirstOrDefault(b => b.Boxes.Any(child => child.Display.Value == DisplayMode.TableRow));
     }
 
 Assert.NotNull(tbody);
@@ -492,11 +493,11 @@ var html = @"
  Assert.NotNull(table);
 
   // Find tbody which contains the row
-   var tbody = table.Boxes.FirstOrDefault(b => b.Display == CssConstants.TableRowGroup);
+   var tbody = table.Boxes.FirstOrDefault(b => b.Display.Value == DisplayMode.TableRowGroup);
   if (tbody == null)
  {
  // If no explicit tbody, look for a box that has rows as children
-   tbody = table.Boxes.FirstOrDefault(b => b.Boxes.Any(child => child.Display == CssConstants.TableRow));
+   tbody = table.Boxes.FirstOrDefault(b => b.Boxes.Any(child => child.Display.Value == DisplayMode.TableRow));
   }
 
 Assert.NotNull(tbody);
@@ -537,8 +538,8 @@ Assert.NotNull(tbody);
             var table = FindTableBox(rootBox);
             Assert.NotNull(table);
 
-            var tbody = table!.Boxes.FirstOrDefault(b => b.Display == CssConstants.TableRowGroup)
-                        ?? table.Boxes.FirstOrDefault(b => b.Boxes.Any(c => c.Display == CssConstants.TableRow));
+            var tbody = table!.Boxes.FirstOrDefault(b => b.Display.Value == DisplayMode.TableRowGroup)
+                        ?? table.Boxes.FirstOrDefault(b => b.Boxes.Any(c => c.Display.Value == DisplayMode.TableRow));
             Assert.NotNull(tbody);
             var firstCell = tbody!.Boxes[0].Boxes[0];
             var firstCellWidth = firstCell.ActualRight - firstCell.Location.X;
@@ -565,8 +566,8 @@ Assert.NotNull(tbody);
 
             var (rootBox, _) = await BuildCssBoxTree(html);
             var table = FindTableBox(rootBox)!;
-            var tbody = table.Boxes.Single(b => b.Display == CssConstants.TableRowGroup);
-            var row = tbody.Boxes.Single(b => b.Display == CssConstants.TableRow);
+            var tbody = table.Boxes.Single(b => b.Display.Value == DisplayMode.TableRowGroup);
+            var row = tbody.Boxes.Single(b => b.Display.Value == DisplayMode.TableRow);
 
             Assert.Equal(row.Location.X, tbody.Location.X);
             Assert.Equal(row.Location.Y, tbody.Location.Y);
@@ -589,7 +590,7 @@ Assert.NotNull(tbody);
 
             var (rootBox, _) = await BuildCssBoxTree(html);
             var table = FindTableBox(rootBox)!;
-            var tbodies = table.Boxes.Where(b => b.Display == CssConstants.TableRowGroup).ToList();
+            var tbodies = table.Boxes.Where(b => b.Display.Value == DisplayMode.TableRowGroup).ToList();
 
             Assert.Equal(2, tbodies.Count);
             var realTbody = tbodies.Single(b => b.Boxes.Count > 0);
@@ -619,12 +620,12 @@ Assert.NotNull(tbody);
             // The real <thead>/<tfoot> boxes are removed from the live tree in favor of one
             // CssProxyBox per page (see RemoveHeaderFooterFromTree) - reach the original row via
             // the proxy's SourceBox rather than the proxy's own (paint-time-only) Boxes.
-            var headerProxy = table.Boxes.OfType<CssProxyBox>().Single(b => b.Display == CssConstants.TableHeaderGroup);
-            var headerRow = headerProxy.SourceBox.Boxes.Single(b => b.Display == CssConstants.TableRow);
+            var headerProxy = table.Boxes.OfType<CssProxyBox>().Single(b => b.Display.Value == DisplayMode.TableHeaderGroup);
+            var headerRow = headerProxy.SourceBox.Boxes.Single(b => b.Display.Value == DisplayMode.TableRow);
             AssertRealBounds(headerRow, "thead row");
 
-            var footerProxy = table.Boxes.OfType<CssProxyBox>().Single(b => b.Display == CssConstants.TableFooterGroup);
-            var footerRow = footerProxy.SourceBox.Boxes.Single(b => b.Display == CssConstants.TableRow);
+            var footerProxy = table.Boxes.OfType<CssProxyBox>().Single(b => b.Display.Value == DisplayMode.TableFooterGroup);
+            var footerRow = footerProxy.SourceBox.Boxes.Single(b => b.Display.Value == DisplayMode.TableRow);
             AssertRealBounds(footerRow, "tfoot row");
 
             static void AssertRealBounds(CssBox row, string label)
@@ -657,8 +658,8 @@ Assert.NotNull(tbody);
             var (rootBox, _) = await BuildCssBoxTree(html);
             var table = FindTableBox(rootBox)!;
 
-            var headerProxies = table.Boxes.Count(b => b is CssProxyBox && b.Display == CssConstants.TableHeaderGroup);
-            var footerProxies = table.Boxes.Count(b => b is CssProxyBox && b.Display == CssConstants.TableFooterGroup);
+            var headerProxies = table.Boxes.Count(b => b is CssProxyBox && b.Display.Value == DisplayMode.TableHeaderGroup);
+            var footerProxies = table.Boxes.Count(b => b is CssProxyBox && b.Display.Value == DisplayMode.TableFooterGroup);
 
             Assert.Equal(1, headerProxies);
             Assert.Equal(1, footerProxies);
@@ -816,7 +817,7 @@ using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
 
   private static CssBox? FindTableBox(CssBox box)
      {
-          if (box.Display == CssConstants.Table)
+          if (box.Display.Value == DisplayMode.Table)
       return box;
 
  foreach (var child in box.Boxes)

--- a/src/PeachPDF.Tests/Html/Core/Dom/CssProxyBoxTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/CssProxyBoxTests.cs
@@ -34,7 +34,7 @@ namespace PeachPDF.Tests.Html.Core.Dom
             Assert.True(proxyBoxes.Count > 0, "Should create at least one proxy box");
             foreach (var proxy in proxyBoxes)
             {
-                Assert.Equal(CssConstants.TableHeaderGroup, proxy.Display);
+                Assert.Equal(DisplayMode.TableHeaderGroup, proxy.Display.Value);
                 _output.WriteLine($"Proxy Display: {proxy.Display}");
             }
         }
@@ -107,7 +107,7 @@ namespace PeachPDF.Tests.Html.Core.Dom
             var proxy = proxyBoxes[0];
 
             // Assert - Check that styles are inherited
-            Assert.Equal(CssConstants.TableHeaderGroup, proxy.Display);
+            Assert.Equal(DisplayMode.TableHeaderGroup, proxy.Display.Value);
             Assert.Equal(Visibility.Visible, proxy.Visibility.Value);
             _output.WriteLine($"Proxy BackgroundColor: {proxy.BackgroundColor}");
         }
@@ -249,7 +249,7 @@ namespace PeachPDF.Tests.Html.Core.Dom
             Assert.NotNull(table);
 
             var allProxies = table.Boxes.OfType<CssProxyBox>().ToList();
-    var footerProxies = allProxies.Where(p => p.Display == CssConstants.TableFooterGroup).ToList();
+    var footerProxies = allProxies.Where(p => p.Display.Value == DisplayMode.TableFooterGroup).ToList();
 
          _output.WriteLine($"Total proxies: {allProxies.Count}");
             _output.WriteLine($"Footer proxies: {footerProxies.Count}");
@@ -434,7 +434,7 @@ await container.SetHtml(html, null);
 
         private static CssBox? FindTableBox(CssBox box)
         {
-       if (box.Display == CssConstants.Table)
+       if (box.Display.Value == DisplayMode.Table)
              return box;
 
   foreach (var child in box.Boxes)

--- a/src/PeachPDF.Tests/Html/Core/Dom/DerivedStyleTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/DerivedStyleTests.cs
@@ -30,7 +30,11 @@ namespace PeachPDF.Tests.Html.Core.Dom
         [InlineData(CssConstants.InlineGrid, CssConstants.Grid)]
         public void ActualDisplay_OnAFloatedBox_BlockifiesInlineLevelAndTableInternalValues(string display, string expected)
         {
-            var box = new CssBox(null, null) { Display = display, Float = CssProperty<Floating>.FromValue(CssConstants.Left, Floating.Left) };
+            var box = new CssBox(null, null)
+            {
+                Display = CssProperty<DisplayMode>.FromCssText(display, Map.DisplayModes, DisplayMode.Inline),
+                Float = CssProperty<Floating>.FromValue(CssConstants.Left, Floating.Left)
+            };
 
             Assert.Equal(expected, box.DerivedStyle.ActualDisplay);
         }
@@ -43,7 +47,11 @@ namespace PeachPDF.Tests.Html.Core.Dom
         [InlineData(CssConstants.None)]
         public void ActualDisplay_OnAFloatedBox_LeavesAlreadyBlockLevelValuesUnchanged(string display)
         {
-            var box = new CssBox(null, null) { Display = display, Float = CssProperty<Floating>.FromValue(CssConstants.Left, Floating.Left) };
+            var box = new CssBox(null, null)
+            {
+                Display = CssProperty<DisplayMode>.FromCssText(display, Map.DisplayModes, DisplayMode.Inline),
+                Float = CssProperty<Floating>.FromValue(CssConstants.Left, Floating.Left)
+            };
 
             Assert.Equal(display, box.DerivedStyle.ActualDisplay);
         }
@@ -51,7 +59,11 @@ namespace PeachPDF.Tests.Html.Core.Dom
         [Fact]
         public void ActualDisplay_OnAnUnfloatedBox_ReturnsTheRawCascadedKeywordUnchanged()
         {
-            var box = new CssBox(null, null) { Display = CssConstants.Inline, Float = CssProperty<Floating>.FromValue(CssConstants.None, Floating.None) };
+            var box = new CssBox(null, null)
+            {
+                Display = CssProperty<DisplayMode>.FromValue(CssConstants.Inline, DisplayMode.Inline),
+                Float = CssProperty<Floating>.FromValue(CssConstants.None, Floating.None)
+            };
 
             Assert.Equal(CssConstants.Inline, box.DerivedStyle.ActualDisplay);
         }
@@ -59,9 +71,13 @@ namespace PeachPDF.Tests.Html.Core.Dom
         [Fact]
         public void Display_OnAFloatedBox_StaysTheRawCascadedKeyword_NotBlockified()
         {
-            var box = new CssBox(null, null) { Display = CssConstants.Inline, Float = CssProperty<Floating>.FromValue(CssConstants.Right, Floating.Right) };
+            var box = new CssBox(null, null)
+            {
+                Display = CssProperty<DisplayMode>.FromValue(CssConstants.Inline, DisplayMode.Inline),
+                Float = CssProperty<Floating>.FromValue(CssConstants.Right, Floating.Right)
+            };
 
-            Assert.Equal(CssConstants.Inline, box.Display);
+            Assert.Equal(DisplayMode.Inline, box.Display.Value);
             Assert.Equal(CssConstants.Block, box.DerivedStyle.ActualDisplay);
         }
     }

--- a/src/PeachPDF.Tests/Html/Core/Handlers/StructureTagMapperTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Handlers/StructureTagMapperTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Handlers;
 using PeachPDF.Html.Core.Utils;
@@ -25,7 +26,7 @@ namespace PeachPDF.Tests.Html.Core.Handlers
         {
             // Shouldn't be reachable via real CSS (the property's Converter only accepts the fixed
             // keyword set), but Classify defends against it anyway rather than emitting a bogus /S.
-            var box = new CssBox(null, new HtmlTag("div", false)) { PdfTagType = "not-a-real-value", Display = CssConstants.Block };
+            var box = new CssBox(null, new HtmlTag("div", false)) { PdfTagType = "not-a-real-value", Display = CssProperty<DisplayMode>.FromValue(CssConstants.Block, DisplayMode.Block) };
 
             var classification = StructureTagMapper.Classify(box);
 
@@ -116,7 +117,7 @@ namespace PeachPDF.Tests.Html.Core.Handlers
         {
             // <cite> has no default-stylesheet -peachpdf-pdf-tag-type rule, so it stays "auto" and
             // falls through to the plain block/inline fallback.
-            var box = new CssBox(null, new HtmlTag("cite", false)) { PdfTagType = CssConstants.Auto, Display = display };
+            var box = new CssBox(null, new HtmlTag("cite", false)) { PdfTagType = CssConstants.Auto, Display = CssProperty<DisplayMode>.FromCssText(display, Map.DisplayModes, DisplayMode.Inline) };
 
             var classification = StructureTagMapper.Classify(box);
 
@@ -134,7 +135,7 @@ namespace PeachPDF.Tests.Html.Core.Handlers
             // Anonymous boxes (HtmlTag == null) synthesized by CorrectAnonymousTables to complete
             // a table model have no source element for -peachpdf-pdf-tag-type to be set on - this
             // is the one place table substructure tagging is still Display-driven, not CSS-driven.
-            var box = new CssBox(null, null) { PdfTagType = CssConstants.Auto, Display = display };
+            var box = new CssBox(null, null) { PdfTagType = CssConstants.Auto, Display = CssProperty<DisplayMode>.FromCssText(display, Map.DisplayModes, DisplayMode.Inline) };
 
             var classification = StructureTagMapper.Classify(box);
 
@@ -145,7 +146,7 @@ namespace PeachPDF.Tests.Html.Core.Handlers
         [Fact]
         public void Classify_AnonymousNonTableBoxWithNoWords_IsFullyTransparent()
         {
-            var box = new CssBox(null, null) { PdfTagType = CssConstants.Auto, Display = CssConstants.Block };
+            var box = new CssBox(null, null) { PdfTagType = CssConstants.Auto, Display = CssProperty<DisplayMode>.FromValue(CssConstants.Block, DisplayMode.Block) };
 
             var classification = StructureTagMapper.Classify(box);
 

--- a/src/PeachPDF.Tests/Html/Core/Utils/CssUtilsTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Utils/CssUtilsTests.cs
@@ -21,7 +21,7 @@ namespace PeachPDF.Tests.Html.Core.Utils
                 "text-align: center; font-weight: bold; z-index: 5;");
 
             Assert.Equal(box.Color, CssUtils.GetPropertyValue(box, "color"));
-            Assert.Equal(box.Display, CssUtils.GetPropertyValue(box, "display"));
+            Assert.Equal(box.Display.ToString(), CssUtils.GetPropertyValue(box, "display"));
             Assert.Equal(box.Position.ToString(), CssUtils.GetPropertyValue(box, "position"));
             Assert.Equal(box.Overflow.ToString(), CssUtils.GetPropertyValue(box, "overflow"));
             Assert.Equal(box.TextAlign.ToString(), CssUtils.GetPropertyValue(box, "text-align"));

--- a/src/PeachPDF.Tests/Integration/AbsolutePositioningIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/AbsolutePositioningIntegrationTests.cs
@@ -46,6 +46,22 @@ namespace PeachPDF.Tests.Integration
         }
 
         [Fact]
+        public async Task Absolute_InlineGrid_BlockifiesToGrid()
+        {
+            var box = await FindByIdAsync(
+                "<div id='t' style='display:inline-grid; position:absolute'></div>", "t");
+            Assert.Equal(DisplayMode.Grid, box.Display.Value);
+        }
+
+        [Fact]
+        public async Task Fixed_InlineTable_BlockifiesToTable()
+        {
+            var box = await FindByIdAsync(
+                "<div id='t' style='display:inline-table; position:fixed'></div>", "t");
+            Assert.Equal(DisplayMode.Table, box.Display.Value);
+        }
+
+        [Fact]
         public async Task Static_InlineBlock_IsNotBlockified()
         {
             // A static (non-positioned) box keeps its inline-level display.

--- a/src/PeachPDF.Tests/Integration/AbsolutePositioningIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/AbsolutePositioningIntegrationTests.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Adapters;
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.PdfSharpCore.Drawing;
@@ -25,7 +26,7 @@ namespace PeachPDF.Tests.Integration
         {
             var box = await FindByIdAsync(
                 "<span id='t' style='position:absolute'>x</span>", "t");
-            Assert.Equal("block", box.Display);
+            Assert.Equal(DisplayMode.Block, box.Display.Value);
         }
 
         [Fact]
@@ -33,7 +34,7 @@ namespace PeachPDF.Tests.Integration
         {
             var box = await FindByIdAsync(
                 "<div id='t' style='display:inline-block; position:fixed'>x</div>", "t");
-            Assert.Equal("block", box.Display);
+            Assert.Equal(DisplayMode.Block, box.Display.Value);
         }
 
         [Fact]
@@ -41,7 +42,7 @@ namespace PeachPDF.Tests.Integration
         {
             var box = await FindByIdAsync(
                 "<div id='t' style='display:inline-flex; position:absolute'></div>", "t");
-            Assert.Equal("flex", box.Display);
+            Assert.Equal(DisplayMode.Flex, box.Display.Value);
         }
 
         [Fact]
@@ -50,7 +51,7 @@ namespace PeachPDF.Tests.Integration
             // A static (non-positioned) box keeps its inline-level display.
             var box = await FindByIdAsync(
                 "<div id='t' style='display:inline-block'>x</div>", "t");
-            Assert.Equal("inline-block", box.Display);
+            Assert.Equal(DisplayMode.InlineBlock, box.Display.Value);
         }
 
         // ─── Out-of-flow child of a flex container (fix 8a) ──────────────────────

--- a/src/PeachPDF.Tests/Integration/AnonymousTableBoxIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/AnonymousTableBoxIntegrationTests.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Adapters;
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Utils;
@@ -40,7 +41,7 @@ namespace PeachPDF.Tests.Integration
             Assert.Single(ul.Boxes);
 
             var row = ul.Boxes[0];
-            Assert.Equal(CssConstants.TableRow, row.Display);
+            Assert.Equal(DisplayMode.TableRow, row.Display.Value);
             Assert.Equal(4, row.Boxes.Count);
 
             var first = FindByClass(root, "first")!;
@@ -54,18 +55,18 @@ namespace PeachPDF.Tests.Integration
 
             // Non-cell children each get their own anonymous table-cell wrapper as a direct row child.
             Assert.NotSame(row, second.ParentBox);
-            Assert.Equal(CssConstants.TableCell, second.ParentBox!.Display);
+            Assert.Equal(DisplayMode.TableCell, second.ParentBox!.Display.Value);
             Assert.Same(row, second.ParentBox!.ParentBox);
             Assert.Single(second.ParentBox!.Boxes);
 
             Assert.NotSame(row, fourth.ParentBox);
-            Assert.Equal(CssConstants.TableCell, fourth.ParentBox!.Display);
+            Assert.Equal(DisplayMode.TableCell, fourth.ParentBox!.Display.Value);
             Assert.Same(row, fourth.ParentBox!.ParentBox);
             Assert.Single(fourth.ParentBox!.Boxes);
 
             // The nested display:table on "second" establishes its own table, unaffected by the
             // anonymous-cell wrapper around it.
-            Assert.Equal(CssConstants.Table, second.Display);
+            Assert.Equal(DisplayMode.Table, second.Display.Value);
 
             // Row order must match document order.
             Assert.Equal(
@@ -103,11 +104,11 @@ namespace PeachPDF.Tests.Integration
             // usual inline-content-needs-a-block-wrapper mechanism, unrelated to the table rules under
             // test here), not "a"/"b" as its direct children.
             var anonRow = rowGroup.Boxes[0];
-            Assert.Equal(CssConstants.TableRow, anonRow.Display);
+            Assert.Equal(DisplayMode.TableRow, anonRow.Display.Value);
             Assert.Single(anonRow.Boxes);
 
             var anonCell = anonRow.Boxes[0];
-            Assert.Equal(CssConstants.TableCell, anonCell.Display);
+            Assert.Equal(DisplayMode.TableCell, anonCell.Display.Value);
 
             var a = FindByClass(root, "a")!;
             var b = FindByClass(root, "b")!;
@@ -153,14 +154,14 @@ namespace PeachPDF.Tests.Integration
 
             // 3.1: both cells share one anonymous table-row.
             var anonRow = cell1.ParentBox!;
-            Assert.Equal(CssConstants.TableRow, anonRow.Display);
+            Assert.Equal(DisplayMode.TableRow, anonRow.Display.Value);
             Assert.Same(anonRow, cell2.ParentBox);
 
             // 3.2: the anonymous row is wrapped in an anonymous table (the table formatting context the
             // stray cells require per CSS2.1 §17.2.1) — without it the row would render outside any table.
             var anonTable = anonRow.ParentBox!;
             Assert.Null(anonTable.HtmlTag);
-            Assert.Equal(CssConstants.Table, anonTable.Display);
+            Assert.Equal(DisplayMode.Table, anonTable.Display.Value);
 
             // The synthesized table must sit between "before" and "after" in document order, not after
             // "after" (which is what a naive append-at-the-end would produce).

--- a/src/PeachPDF.Tests/Integration/BlockContentListMarkerTests.cs
+++ b/src/PeachPDF.Tests/Integration/BlockContentListMarkerTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Fragments;
@@ -273,7 +274,7 @@ namespace PeachPDF.Tests.Integration
 
         private static List<CssBox> ListItems(CssBox root) =>
             LayoutHarness.Descendants(root)
-                .Where(b => b.Display == CssConstants.ListItem)
+                .Where(b => b.Display.Value == DisplayMode.ListItem)
                 .ToList();
 
         private static string? Id(CssBox box) => box.HtmlTag?.TryGetAttribute("id");

--- a/src/PeachPDF.Tests/Integration/DisplayTypedStorageTests.cs
+++ b/src/PeachPDF.Tests/Integration/DisplayTypedStorageTests.cs
@@ -1,0 +1,83 @@
+using PeachPDF.Adapters;
+using PeachPDF.CSS;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore.Drawing;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Direct typed-storage assertions for <c>display</c>, now backed by
+    /// <c>CssProperty&lt;DisplayMode&gt;</c>. <c>display</c> is the property issue #598 (keyword
+    /// comparison case-sensitivity) is named for, so this specifically exercises that a non-canonical-case
+    /// author value is still accepted and resolves to the same <see cref="DisplayMode"/> a lowercase
+    /// value would - complementing the layout-geometry tests elsewhere, which exercise <c>display</c>
+    /// indirectly through its effect on box placement rather than asserting the stored <c>.Value</c> and
+    /// its case-insensitive acceptance directly.
+    /// </summary>
+    public class DisplayTypedStorageTests
+    {
+        [Theory]
+        [InlineData("BLOCK", "Block")]
+        [InlineData("Inline-Block", "InlineBlock")]
+        [InlineData("FLEX", "Flex")]
+        [InlineData("Inline-Flex", "InlineFlex")]
+        [InlineData("GRID", "Grid")]
+        [InlineData("Inline-Grid", "InlineGrid")]
+        [InlineData("TABLE", "Table")]
+        [InlineData("Inline-Table", "InlineTable")]
+        [InlineData("List-Item", "ListItem")]
+        [InlineData("NONE", "None")]
+        public async Task Display_StoresTypedValue_CaseInsensitively(string cssValue, string expectedModeName)
+        {
+            var expected = System.Enum.Parse<DisplayMode>(expectedModeName);
+            var box = await GetBoxAsync($"<div id='el' style='display:{cssValue}'></div>");
+            Assert.Equal(expected, box.Display.Value);
+        }
+
+        [Fact]
+        public async Task Display_UnrecognizedValue_DeclarationIsDropped_UaStylesheetValueWins()
+        {
+            // An invalid value makes the whole declaration invalid (CSS Syntax 3 error recovery), so it
+            // never reaches the cascade at all - the UA stylesheet's own "div { display: block }" rule is
+            // what's left in effect, not the property's CSS-wide initial value ("inline").
+            var box = await GetBoxAsync("<div id='el' style='display:not-a-real-display'></div>");
+            Assert.Equal(DisplayMode.Block, box.Display.Value);
+        }
+
+        // ─── Helpers ─────────────────────────────────────────────────────────────
+
+        private static async Task<CssBox> GetBoxAsync(string bodyHtml)
+        {
+            var html = $"<!DOCTYPE html><html><head></head><body>{bodyHtml}</body></html>";
+            var adapter = new PdfSharpAdapter();
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            var size = new XSize(595, 842);
+            container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+            container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+            var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            return FindById(container.Root!, "el")!;
+        }
+
+        private static CssBox? FindById(CssBox box, string id)
+        {
+            var val = box.HtmlTag?.TryGetAttribute("id", "");
+            if (val != null && val.Equals(id, System.StringComparison.OrdinalIgnoreCase))
+                return box;
+            foreach (var child in box.Boxes)
+            {
+                var found = FindById(child, id);
+                if (found != null) return found;
+            }
+            return null;
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/EarlyBreakLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/EarlyBreakLayoutIntegrationTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Fragments;
 using System.Collections.Generic;
@@ -306,12 +307,12 @@ namespace PeachPDF.Tests.Integration
             var (root, _) = await LayoutHarness.LayoutAsync(html, pageHeight: PageHeight, margin: Margin);
 
             var table = LayoutHarness.Descendants(LayoutHarness.FindById(root, "head")!)
-                .First(b => b.Display == CssConstants.Table);
+                .First(b => b.Display.Value == DisplayMode.Table);
             var proxies = table.Boxes.OfType<CssProxyBox>().ToList();
 
             Assert.NotEmpty(proxies);
             Assert.Single(proxies.Select(p => p.SourceBox).Distinct());
-            Assert.All(proxies, p => Assert.Equal(CssConstants.TableHeaderGroup, p.SourceBox.Display));
+            Assert.All(proxies, p => Assert.Equal(DisplayMode.TableHeaderGroup, p.SourceBox.Display.Value));
 
             // Every proxy must sit on a page of its own — a stale one left by a discarded layout would
             // duplicate a position.

--- a/src/PeachPDF.Tests/Integration/EngineRelayoutIdempotencyTests.cs
+++ b/src/PeachPDF.Tests/Integration/EngineRelayoutIdempotencyTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Tests.TestSupport;
@@ -112,7 +113,7 @@ namespace PeachPDF.Tests.Integration
             var rowGeometry = await LayoutHarness.LayoutRepeatedlyAsync(
                 LayoutHarness.Wrap(body), passes: 3,
                 (root, _) => string.Join("|", LayoutHarness.Descendants(root)
-                    .Where(b => b.Display == "table-row")
+                    .Where(b => b.Display.Value == DisplayMode.TableRow)
                     .Select(b => string.Format(CultureInfo.InvariantCulture,
                         "({0:F3},{1:F3})", b.Location.X, b.Location.Y))),
                 pageHeight: 400);
@@ -156,7 +157,7 @@ namespace PeachPDF.Tests.Integration
             var counts = await LayoutHarness.LayoutRepeatedlyAsync(
                 LayoutHarness.Wrap(body), passes: 3,
                 (root, _) => LayoutHarness.Descendants(root)
-                    .Count(b => b.Display == "table-header-group" && b is not CssProxyBox),
+                    .Count(b => b.Display.Value == DisplayMode.TableHeaderGroup && b is not CssProxyBox),
                 pageHeight: 400);
 
             // Both directions of getting the restore wrong show up here: none means a second run found

--- a/src/PeachPDF.Tests/Integration/FlexGridFragmentationIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FlexGridFragmentationIntegrationTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Tests.TestSupport;
@@ -551,7 +552,7 @@ namespace PeachPDF.Tests.Integration
                 pageHeight: PageHeight);
 
             var a = LayoutHarness.FindById(root, "a");
-            var cell = LayoutHarness.Descendants(root).First(b => b.Display == "table-cell");
+            var cell = LayoutHarness.Descendants(root).First(b => b.Display.Value == DisplayMode.TableCell);
             Assert.NotNull(a);
 
             // Wherever the table put the cell, the item is still inside it rather than a page away.

--- a/src/PeachPDF.Tests/Integration/FlexReplacedElementPageBreakIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FlexReplacedElementPageBreakIntegrationTests.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Adapters;
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Utils;
@@ -150,7 +151,7 @@ namespace PeachPDF.Tests.Integration
                 """;
 
             var root = await BuildAndLayoutAsync(html);
-            var table = FindFirst(root, b => b.Display == "table");
+            var table = FindFirst(root, b => b.Display.Value == DisplayMode.Table);
             var img = FindById(root, "target");
 
             Assert.NotNull(img);
@@ -210,7 +211,7 @@ namespace PeachPDF.Tests.Integration
         private static async Task<(CssBox? svg, CssBox? table)> GetTargetSvgAndTable(string html)
         {
             var root = await BuildAndLayoutAsync(html);
-            var table = FindFirst(root, b => b.Display == "table");
+            var table = FindFirst(root, b => b.Display.Value == DisplayMode.Table);
             var svg = FindById(root, "target");
             return (svg, table);
         }

--- a/src/PeachPDF.Tests/Integration/FlexboxIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FlexboxIntegrationTests.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Adapters;
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Utils;
@@ -18,7 +19,7 @@ namespace PeachPDF.Tests.Integration
         public async Task DisplayFlex_PropertyApplied_ToBox()
         {
             var box = await FindByTagAsync("<div style='display:flex'></div>", "div");
-            Assert.Equal("flex", box.Display);
+            Assert.Equal(DisplayMode.Flex, box.Display.Value);
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/GlobalKeywordCascadeTests.cs
+++ b/src/PeachPDF.Tests/Integration/GlobalKeywordCascadeTests.cs
@@ -145,7 +145,7 @@ namespace PeachPDF.Tests.Integration
             var el = FindById(root, "el");
 
             Assert.NotNull(el);
-            Assert.Equal("inline", el!.Display);
+            Assert.Equal(DisplayMode.Inline, el!.Display.Value);
         }
 
         // ── unset ─────────────────────────────────────────────────────────────

--- a/src/PeachPDF.Tests/Integration/GridLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/GridLayoutIntegrationTests.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Adapters;
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.PdfSharpCore.Drawing;
@@ -22,7 +23,7 @@ namespace PeachPDF.Tests.Integration
         public async Task DisplayGrid_PropertyApplied_ToBox()
         {
             var box = await FindByTagAsync("<div style='display:grid'></div>", "div");
-            Assert.Equal("grid", box.Display);
+            Assert.Equal(DisplayMode.Grid, box.Display.Value);
         }
 
         [Fact]
@@ -584,7 +585,7 @@ namespace PeachPDF.Tests.Integration
         public async Task EmptyGrid_ProducesNoError()
         {
             var box = await FindByTagAsync("<div style='display:grid; width:100pt; grid-template-columns:50pt 50pt;'></div>", "div");
-            Assert.Equal("grid", box.Display);
+            Assert.Equal(DisplayMode.Grid, box.Display.Value);
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/InitialValueDefaultingTests.cs
+++ b/src/PeachPDF.Tests/Integration/InitialValueDefaultingTests.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Adapters;
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Utils;
@@ -84,7 +85,7 @@ namespace PeachPDF.Tests.Integration
             var hr = FindById(root, "rule")!;
 
             Assert.NotNull(hr);
-            Assert.Equal("block", hr.Display);
+            Assert.Equal(DisplayMode.Block, hr.Display.Value);
         }
 
         // ── Structural display: anonymous block boxes ─────────────────────────────
@@ -108,7 +109,7 @@ namespace PeachPDF.Tests.Integration
             var wrap = FindById(root, "wrap")!;
             Assert.NotNull(wrap);
 
-            var anon = wrap.Boxes.FirstOrDefault(b => b.HtmlTag is null && b.Display == "block");
+            var anon = wrap.Boxes.FirstOrDefault(b => b.HtmlTag is null && b.Display.Value == DisplayMode.Block);
             Assert.NotNull(anon);
 
             // Inherited property (color) flows into the anonymous box from its parent...

--- a/src/PeachPDF.Tests/Integration/InlineBlockHeightRegressionTests.cs
+++ b/src/PeachPDF.Tests/Integration/InlineBlockHeightRegressionTests.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Adapters;
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.PdfSharpCore.Drawing;
@@ -170,7 +171,7 @@ namespace PeachPDF.Tests.Integration
 
             var host = FindBoxByClass(rootBox, "host");
             Assert.NotNull(host);
-            var pseudo = FindFirst(host!, b => b.Display == "inline-block");
+            var pseudo = FindFirst(host!, b => b.Display.Value == DisplayMode.InlineBlock);
             Assert.NotNull(pseudo);
 
             var rect = Assert.Single(pseudo!.Rectangles).Value;

--- a/src/PeachPDF.Tests/Integration/MarkerPseudoElementIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/MarkerPseudoElementIntegrationTests.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Adapters;
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.PdfSharpCore.Drawing;
@@ -45,7 +46,7 @@ namespace PeachPDF.Tests.Integration
             var li = FindById(root, "li")!;
 
             var marker = li.Boxes.Single(b => b.IsMarkerPseudoElement);
-            Assert.Equal("inline", marker.Display, ignoreCase: true);
+            Assert.Equal(DisplayMode.Inline, marker.Display.Value);
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/NoProgressBackstopTests.cs
+++ b/src/PeachPDF.Tests/Integration/NoProgressBackstopTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Adapters;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
@@ -61,7 +62,7 @@ namespace PeachPDF.Tests.Integration
             internal StallingBox(CssBox parent) : base(parent, null)
             {
                 InheritStyle(parent, everything: true);
-                Display = CssConstants.Block;
+                Display = CssProperty<DisplayMode>.FromValue(CssConstants.Block, DisplayMode.Block);
             }
 
             /// <summary>Whether breaking was live on each pass this box was laid out in, in order.</summary>
@@ -113,7 +114,7 @@ namespace PeachPDF.Tests.Integration
             internal AlternatingBox(CssBox parent) : base(parent, null)
             {
                 InheritStyle(parent, everything: true);
-                Display = CssConstants.Block;
+                Display = CssProperty<DisplayMode>.FromValue(CssConstants.Block, DisplayMode.Block);
             }
 
             protected override ValueTask PerformLayoutImp(RGraphics g, CssBox frame, bool framePlacesChild)
@@ -159,7 +160,7 @@ namespace PeachPDF.Tests.Integration
             internal WalkingBox(CssBox parent) : base(parent, null)
             {
                 InheritStyle(parent, everything: true);
-                Display = CssConstants.Block;
+                Display = CssProperty<DisplayMode>.FromValue(CssConstants.Block, DisplayMode.Block);
             }
 
             protected override ValueTask PerformLayoutImp(RGraphics g, CssBox frame, bool framePlacesChild)

--- a/src/PeachPDF.Tests/Integration/PageBreakTableIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/PageBreakTableIntegrationTests.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Adapters;
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.PdfSharpCore;
@@ -206,7 +207,7 @@ namespace PeachPDF.Tests.Integration
             await container.PerformLayout(graphics);
 
             Assert.NotNull(container.Root);
-            var table = FindFirst(container.Root!, b => b.Display == "table");
+            var table = FindFirst(container.Root!, b => b.Display.Value == DisplayMode.Table);
             var heading = FindFirst(container.Root!, b => b.HtmlTag?.Name == "h2");
             Assert.NotNull(table);
             Assert.NotNull(heading);
@@ -301,7 +302,7 @@ namespace PeachPDF.Tests.Integration
             await container.PerformLayout(graphics);
 
             Assert.NotNull(container.Root);
-            var table = FindFirst(container.Root!, b => b.Display == "table");
+            var table = FindFirst(container.Root!, b => b.Display.Value == DisplayMode.Table);
             return (table, container.PageSize.Height);
         }
 

--- a/src/PeachPDF.Tests/Integration/PageBreakTableKeepWithNextIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/PageBreakTableKeepWithNextIntegrationTests.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Adapters;
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Utils;
@@ -237,7 +238,7 @@ namespace PeachPDF.Tests.Integration
 
             // The <thead> repeats: one header proxy per page the table's body actually spans.
             var headerProxyCount = table.Boxes.OfType<CssProxyBox>()
-                .Count(b => b.Display == CssConstants.TableHeaderGroup);
+                .Count(b => b.Display.Value == DisplayMode.TableHeaderGroup);
             Assert.True(headerProxyCount >= 3,
                 $"Expected the repeating header to appear on at least 3 pages, found {headerProxyCount}");
         }
@@ -296,7 +297,7 @@ namespace PeachPDF.Tests.Integration
             await container.PerformLayout(graphics);
 
             Assert.NotNull(container.Root);
-            var table = FindFirst(container.Root!, b => b.Display == "table");
+            var table = FindFirst(container.Root!, b => b.Display.Value == DisplayMode.Table);
             var heading = FindFirst(container.Root!, b => b.HtmlTag?.Name == "h2");
             return (heading, table, container.PageSize.Height);
         }

--- a/src/PeachPDF.Tests/Integration/PageMarginPaginationIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/PageMarginPaginationIntegrationTests.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Adapters;
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Utils;
@@ -30,7 +31,7 @@ namespace PeachPDF.Tests.Integration
             var html = BuildManyRowTableHtml(rowCount: 80);
             var (rootBox, container) = await BuildContainer(html, RawPageHeight, MarginTopIn, MarginBottomIn);
 
-            var table = FindFirst(rootBox, b => b.Display == CssConstants.Table);
+            var table = FindFirst(rootBox, b => b.Display.Value == DisplayMode.Table);
             Assert.NotNull(table);
             var rows = FindAllRows(table!);
             Assert.True(rows.Count > 10, "test setup should produce enough rows to span multiple pages");
@@ -59,7 +60,7 @@ namespace PeachPDF.Tests.Integration
             var html = BuildManyRowTableHtml(rowCount: 80);
             var (rootBox, container) = await BuildContainer(html, RawPageHeight, marginTop: 0, marginBottom: 0);
 
-            var table = FindFirst(rootBox, b => b.Display == CssConstants.Table);
+            var table = FindFirst(rootBox, b => b.Display.Value == DisplayMode.Table);
             Assert.NotNull(table);
             var rows = FindAllRows(table!);
 
@@ -214,7 +215,7 @@ namespace PeachPDF.Tests.Integration
 
         private static void CollectRows(CssBox box, List<CssBox> rows)
         {
-            if (box.Display == CssConstants.TableRow) rows.Add(box);
+            if (box.Display.Value == DisplayMode.TableRow) rows.Add(box);
             foreach (var child in box.Boxes) CollectRows(child, rows);
         }
 

--- a/src/PeachPDF.Tests/Integration/RenderErrorReportingTests.cs
+++ b/src/PeachPDF.Tests/Integration/RenderErrorReportingTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Adapters;
 using PeachPDF.Html.Adapters.Entities;
 using PeachPDF.Html.Core;
@@ -35,7 +36,7 @@ namespace PeachPDF.Tests.Integration
             internal ThrowingBox(CssBox parent) : base(parent, null)
             {
                 InheritStyle(parent, everything: true);
-                Display = CssConstants.Block;
+                Display = CssProperty<DisplayMode>.FromValue(CssConstants.Block, DisplayMode.Block);
             }
 
             protected override ValueTask PerformLayoutImp(RGraphics g, CssBox frame, bool framePlacesChild) =>

--- a/src/PeachPDF.Tests/Integration/RepeatingTableRelayoutTests.cs
+++ b/src/PeachPDF.Tests/Integration/RepeatingTableRelayoutTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Tests.TestSupport;
 using System.Linq;
 
@@ -54,7 +55,7 @@ namespace PeachPDF.Tests.Integration
                 CardWithTable(130), pageHeight: PageHeight, margin: Margin);
 
             var headerGroups = LayoutHarness.Descendants(root)
-                .Count(b => b.Display == "table-header-group");
+                .Count(b => b.Display.Value == DisplayMode.TableHeaderGroup);
 
             // One per page the table spans, and no stale copy left by the run that was abandoned.
             Assert.InRange(headerGroups, 1, 2);

--- a/src/PeachPDF.Tests/Integration/StraddlingListMarkerTests.cs
+++ b/src/PeachPDF.Tests/Integration/StraddlingListMarkerTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Fragments;
@@ -363,7 +364,7 @@ namespace PeachPDF.Tests.Integration
 
         private static List<CssBox> ListItems(CssBox root) =>
             LayoutHarness.Descendants(root)
-                .Where(b => b.Display == CssConstants.ListItem)
+                .Where(b => b.Display.Value == DisplayMode.ListItem)
                 .ToList();
 
         private static string? Id(CssBox box) => box.HtmlTag?.TryGetAttribute("id");

--- a/src/PeachPDF.Tests/Integration/TableCellBreakTokenTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableCellBreakTokenTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Adapters;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
@@ -42,10 +43,10 @@ namespace PeachPDF.Tests.Integration
             string.Join(" ", Enumerable.Range(0, count).Select(i => $"word{i:0000}"));
 
         private static CssBox TableOf(CssBox root) =>
-            LayoutHarness.Descendants(root).First(b => b.Display == CssConstants.Table);
+            LayoutHarness.Descendants(root).First(b => b.Display.Value == DisplayMode.Table);
 
         private static List<CssBox> CellsOf(CssBox root) =>
-            LayoutHarness.Descendants(root).Where(b => b.Display == CssConstants.TableCell).ToList();
+            LayoutHarness.Descendants(root).Where(b => b.Display.Value == DisplayMode.TableCell).ToList();
 
         // ─── A table that paginates loses nothing and duplicates nothing ─────────────────────────
 
@@ -344,7 +345,7 @@ namespace PeachPDF.Tests.Integration
                 pageHeight: PageHeight, margin: Margin);
 
             var tables = LayoutHarness.Descendants(root)
-                .Where(b => b.Display == CssConstants.Table).ToList();
+                .Where(b => b.Display.Value == DisplayMode.Table).ToList();
 
             Assert.Equal(2, tables.Count);
             Assert.All(tables, t => Assert.Null(t.TableContinuation));
@@ -549,7 +550,7 @@ namespace PeachPDF.Tests.Integration
             internal StoppingCell(CssBox row) : base(row, null)
             {
                 InheritStyle(row, everything: true);
-                Display = CssConstants.TableCell;
+                Display = CssProperty<DisplayMode>.FromValue(CssConstants.TableCell, DisplayMode.TableCell);
                 Record = new InlineBreakToken(this, ResumeSlotIndex: 1, ResumePath: [],
                     ResumeWordIndex: 0, CompletedLineCount: 1);
             }

--- a/src/PeachPDF.Tests/Integration/TableDisplayOverrideTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableDisplayOverrideTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Adapters;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
@@ -36,7 +37,7 @@ namespace PeachPDF.Tests.Integration
                 </body></html>
                 """);
 
-            Assert.Equal(display, FindByClass(root, "t")!.Display);
+            Assert.Equal(display, FindByClass(root, "t")!.Display.ToString());
         }
 
         [Fact]
@@ -48,7 +49,7 @@ namespace PeachPDF.Tests.Integration
                 </body></html>
                 """);
 
-            Assert.Equal(CssConstants.Flex, FindByClass(root, "c")!.Display);
+            Assert.Equal(DisplayMode.Flex, FindByClass(root, "c")!.Display.Value);
         }
 
         [Fact]
@@ -68,10 +69,10 @@ namespace PeachPDF.Tests.Integration
                 </body></html>
                 """);
 
-            Assert.Equal(CssConstants.Block, FindByClass(root, "x")!.Display);
-            Assert.Equal(CssConstants.Block, FindByClass(root, "r")!.Display);
-            Assert.Equal(CssConstants.Block, FindByClass(root, "d")!.Display);
-            Assert.Equal(CssConstants.Block, FindByClass(root, "h")!.Display);
+            Assert.Equal(DisplayMode.Block, FindByClass(root, "x")!.Display.Value);
+            Assert.Equal(DisplayMode.Block, FindByClass(root, "r")!.Display.Value);
+            Assert.Equal(DisplayMode.Block, FindByClass(root, "d")!.Display.Value);
+            Assert.Equal(DisplayMode.Block, FindByClass(root, "h")!.Display.Value);
         }
 
         [Fact]
@@ -85,9 +86,9 @@ namespace PeachPDF.Tests.Integration
                 </body></html>
                 """);
 
-            Assert.Equal(CssConstants.Table, FindByClass(root, "t")!.Display);
-            Assert.Equal(CssConstants.TableRow, FindByClass(root, "r")!.Display);
-            Assert.Equal(CssConstants.TableCell, FindByClass(root, "d")!.Display);
+            Assert.Equal(DisplayMode.Table, FindByClass(root, "t")!.Display.Value);
+            Assert.Equal(DisplayMode.TableRow, FindByClass(root, "r")!.Display.Value);
+            Assert.Equal(DisplayMode.TableCell, FindByClass(root, "d")!.Display.Value);
         }
 
         // --- Partial overrides: only a subset of the table's elements is reset (the common, natural case,
@@ -109,7 +110,7 @@ namespace PeachPDF.Tests.Integration
             // The proper table child under the non-table parent must have been re-wrapped in a synthesized
             // (tag-less) anonymous table box so the table formatting context — and the content — is preserved.
             Assert.Contains(EnumerateBoxes(root),
-                b => b.HtmlTag is null && b.Display is CssConstants.Table or CssConstants.InlineTable);
+                b => b.HtmlTag is null && b.Display.Value is DisplayMode.Table or DisplayMode.InlineTable);
         }
 
         [Fact]
@@ -129,7 +130,7 @@ namespace PeachPDF.Tests.Integration
             var a = FindByClass(root, "a")!;
             var b = FindByClass(root, "b")!;
 
-            Assert.Equal(CssConstants.Flex, FindByClass(root, "row")!.Display);
+            Assert.Equal(DisplayMode.Flex, FindByClass(root, "row")!.Display.Value);
             Assert.True(b.Location.X > a.Location.X,
                 $"flex items should lay out left-to-right, but a.X={a.Location.X} b.X={b.Location.X}");
             Assert.Equal(a.Location.Y, b.Location.Y, 3);

--- a/src/PeachPDF.Tests/Integration/TableHeaderRepetitionIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableHeaderRepetitionIntegrationTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Adapters;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
@@ -484,7 +485,7 @@ using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
 
         private CssBox? FindTableBox(CssBox root)
         {
-            if (root.Display == CssConstants.Table)
+            if (root.Display.Value == DisplayMode.Table)
                 return root;
 
             foreach (var child in root.Boxes)
@@ -502,7 +503,7 @@ using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
             var tables = new List<CssBox>();
             void Collect(CssBox box)
             {
-                if (box.Display == CssConstants.Table)
+                if (box.Display.Value == DisplayMode.Table)
                     tables.Add(box);
                 foreach (var child in box.Boxes)
                     Collect(child);
@@ -513,7 +514,7 @@ using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
 
         private CssBox? FindBoxByDisplay(CssBox root, string display)
         {
-            if (root.Display == display)
+            if (root.Display.ToString() == display)
                 return root;
 
             foreach (var child in root.Boxes)
@@ -532,7 +533,7 @@ using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
   
     void FindProxies(CssBox box)
   {
-  if (box is CssProxyBox proxy && proxy.Display == display)
+  if (box is CssProxyBox proxy && proxy.Display.ToString() == display)
     {
        proxies.Add(proxy);
        }
@@ -562,11 +563,11 @@ using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
 
             void CollectBodyRows(CssBox box, List<CssBox> rows)
             {
-                if (box.Display == CssConstants.TableRow)
+                if (box.Display.Value == DisplayMode.TableRow)
                 {
                     var parent = box.ParentBox;
-                    if (parent?.Display != CssConstants.TableHeaderGroup &&
-             parent?.Display != CssConstants.TableFooterGroup)
+                    if (parent?.Display.Value != DisplayMode.TableHeaderGroup &&
+             parent?.Display.Value != DisplayMode.TableFooterGroup)
                     {
                         rows.Add(box);
                     }

--- a/src/PeachPDF.Tests/Integration/TableOncePerTableTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableOncePerTableTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Adapters;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
@@ -39,7 +40,7 @@ namespace PeachPDF.Tests.Integration
         private const double Margin = 20;
 
         private static CssBox TableOf(CssBox root) =>
-            LayoutHarness.Descendants(root).First(b => b.Display == CssConstants.Table);
+            LayoutHarness.Descendants(root).First(b => b.Display.Value == DisplayMode.Table);
 
         private static List<CssProxyBox> ProxiesOf(CssBox table) =>
             table.Boxes.OfType<CssProxyBox>().ToList();
@@ -180,7 +181,7 @@ namespace PeachPDF.Tests.Integration
             await WithALaidOutTable(RepeatingHeaderTable(3), async (table, container, g) =>
             {
                 var headerRow = table.TableSetup!.Header!.Box.Boxes
-                    .First(b => b.Display == CssConstants.TableRow);
+                    .First(b => b.Display.Value == DisplayMode.TableRow);
 
                 // Replaces a header cell in place rather than being inserted beside it - a row's cells are
                 // its columns, and ParentBox's setter appends.
@@ -205,7 +206,7 @@ namespace PeachPDF.Tests.Integration
             internal ThrowingCell(CssBox row) : base(row, null)
             {
                 InheritStyle(row, everything: true);
-                Display = CssConstants.TableCell;
+                Display = CssProperty<DisplayMode>.FromValue(CssConstants.TableCell, DisplayMode.TableCell);
             }
 
             protected override ValueTask PerformLayoutImp(RGraphics g, CssBox frame, bool framePlacesChild) =>
@@ -354,8 +355,8 @@ namespace PeachPDF.Tests.Integration
                     await RunEngine(g, container, table, Continuation(table));
 
                     var firstBodyRow = LayoutHarness.Descendants(table)
-                        .First(b => b.Display == CssConstants.TableRow
-                                    && b.ParentBox?.Display == CssConstants.TableRowGroup);
+                        .First(b => b.Display.Value == DisplayMode.TableRow
+                                    && b.ParentBox?.Display.Value == DisplayMode.TableRowGroup);
 
                     firstRowTops.Add(firstBodyRow.Location.Y);
                 });

--- a/src/PeachPDF.Tests/Integration/TableRepeatedGroupConditionsTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableRepeatedGroupConditionsTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Fragments;
@@ -408,7 +409,7 @@ namespace PeachPDF.Tests.Integration
 
             var footer = Assert.Single(
                 TableOf(root).Boxes.OfType<CssProxyBox>(),
-                p => p.Display == CssConstants.TableFooterGroup);
+                p => p.Display.Value == DisplayMode.TableFooterGroup);
 
             var slot = container.SlotStartingAt(footer.Location.Y);
 
@@ -497,7 +498,7 @@ namespace PeachPDF.Tests.Integration
 
             var footer = Assert.Single(
                 TableOf(root).Boxes.OfType<CssProxyBox>(),
-                p => p.Display == CssConstants.TableFooterGroup);
+                p => p.Display.Value == DisplayMode.TableFooterGroup);
 
             var slot = container.SlotStartingAt(footer.Location.Y);
 
@@ -543,7 +544,7 @@ namespace PeachPDF.Tests.Integration
         }
 
         private static CssBox TableOf(CssBox root) =>
-            LayoutHarness.Descendants(root).First(b => b.Display == CssConstants.Table);
+            LayoutHarness.Descendants(root).First(b => b.Display.Value == DisplayMode.Table);
 
         private static bool RepeatsOf(CssBox root, string group)
         {
@@ -595,11 +596,11 @@ namespace PeachPDF.Tests.Integration
         /// </remarks>
         private static void AssertLaidOutOnce(CssBox root, string group)
         {
-            var display = group == "thead" ? CssConstants.TableHeaderGroup : CssConstants.TableFooterGroup;
+            var display = group == "thead" ? DisplayMode.TableHeaderGroup : DisplayMode.TableFooterGroup;
 
             var proxies = TableOf(root).Boxes
                 .OfType<CssProxyBox>()
-                .Where(p => p.Display == display)
+                .Where(p => p.Display.Value == display)
                 .ToList();
 
             Assert.Single(proxies);

--- a/src/PeachPDF.Tests/Integration/TableRowCursorBandTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableRowCursorBandTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Utils;
@@ -42,10 +43,10 @@ namespace PeachPDF.Tests.Integration
             </table>");
 
         private static List<CssBox> RowsOf(CssBox root) =>
-            LayoutHarness.Descendants(root).Where(b => b.Display == CssConstants.TableRow).ToList();
+            LayoutHarness.Descendants(root).Where(b => b.Display.Value == DisplayMode.TableRow).ToList();
 
         private static CssBox TableOf(CssBox root) =>
-            LayoutHarness.Descendants(root).First(b => b.Display == CssConstants.Table);
+            LayoutHarness.Descendants(root).First(b => b.Display.Value == DisplayMode.Table);
 
         /// <summary>
         /// A row taller than a page band is left where it is — moving it could only recreate the straddle

--- a/src/PeachPDF.Tests/Integration/TableRowLoopResumptionTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableRowLoopResumptionTests.cs
@@ -39,7 +39,7 @@ namespace PeachPDF.Tests.Integration
         private const double Margin = 20;
 
         private static CssBox TableOf(CssBox root) =>
-            LayoutHarness.Descendants(root).First(b => b.Display == CssConstants.Table);
+            LayoutHarness.Descendants(root).First(b => b.Display.Value == DisplayMode.Table);
 
         /// <summary>
         /// Runs the engine with the fragmentainer detached, which is what keeps these fixtures hermetic:
@@ -72,7 +72,7 @@ namespace PeachPDF.Tests.Integration
 
         private static List<CssBox> BodyRowsOf(CssBox table) =>
             LayoutHarness.Descendants(table)
-                .Where(b => b.Display == CssConstants.TableRow)
+                .Where(b => b.Display.Value == DisplayMode.TableRow)
                 .ToList();
 
         private static string RowsTable(int rows) =>
@@ -110,7 +110,7 @@ namespace PeachPDF.Tests.Integration
             internal StoppingCell(CssBox row) : base(row, null)
             {
                 InheritStyle(row, everything: true);
-                Display = CssConstants.TableCell;
+                Display = CssProperty<DisplayMode>.FromValue(CssConstants.TableCell, DisplayMode.TableCell);
                 Record = new InlineBreakToken(this, ResumeSlotIndex: 2, ResumePath: [],
                     ResumeWordIndex: 4, CompletedLineCount: 1);
             }
@@ -346,7 +346,7 @@ namespace PeachPDF.Tests.Integration
                 prepare: tree => { root = tree; StopRow(tree, 1); });
 
             var table = TableOf(root!);
-            var group = table.Boxes.First(b => b.Display == CssConstants.TableRowGroup);
+            var group = table.Boxes.First(b => b.Display.Value == DisplayMode.TableRowGroup);
             var rows = BodyRowsOf(table);
 
             Assert.Equal(rows[0].Location.Y, group.Location.Y, 3);
@@ -593,7 +593,7 @@ namespace PeachPDF.Tests.Integration
             internal ThrowingCell(CssBox row) : base(row, null)
             {
                 InheritStyle(row, everything: true);
-                Display = CssConstants.TableCell;
+                Display = CssProperty<DisplayMode>.FromValue(CssConstants.TableCell, DisplayMode.TableCell);
             }
 
             protected override ValueTask PerformLayoutImp(RGraphics g, CssBox frame, bool framePlacesChild) =>
@@ -955,7 +955,7 @@ namespace PeachPDF.Tests.Integration
             internal TallCell(CssBox row, double depth) : base(row, null)
             {
                 InheritStyle(row, everything: true);
-                Display = CssConstants.TableCell;
+                Display = CssProperty<DisplayMode>.FromValue(CssConstants.TableCell, DisplayMode.TableCell);
                 _depth = depth;
             }
 
@@ -992,14 +992,14 @@ namespace PeachPDF.Tests.Integration
                 : base(row, null)
             {
                 InheritStyle(row, everything: true);
-                Display = CssConstants.TableCell;
+                Display = CssProperty<DisplayMode>.FromValue(CssConstants.TableCell, DisplayMode.TableCell);
                 VerticalAlign = CssProperty<VerticalAlignment>.FromValue(CssConstants.Middle, VerticalAlignment.Middle);
                 _stops = stops;
                 _keepsItsContentAfterTheFirstLayout = keepsItsContentAfterTheFirstLayout;
 
                 OverflowingContent = new CssBox(this, null);
                 OverflowingContent.InheritStyle(this, everything: true);
-                OverflowingContent.Display = CssConstants.Block;
+                OverflowingContent.Display = CssProperty<DisplayMode>.FromValue(CssConstants.Block, DisplayMode.Block);
             }
 
             /// <summary>The content that flowed past the cell's own box.</summary>

--- a/src/PeachPDF.Tests/Integration/TableRowspanContinuationTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableRowspanContinuationTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Fragments;
@@ -125,7 +126,7 @@ namespace PeachPDF.Tests.Integration
             LayoutHarness.Descendants(root).First(b => b.HtmlTag?.TryGetAttribute("id") == "span");
 
         private static List<CssBox> RowsOf(CssBox root) =>
-            LayoutHarness.Descendants(root).Where(b => b.Display == CssConstants.TableRow).ToList();
+            LayoutHarness.Descendants(root).Where(b => b.Display.Value == DisplayMode.TableRow).ToList();
 
         /// <summary>
         /// The row that ends a <c>rowspan</c> is carried onto the next band whole, like any other row. It
@@ -173,7 +174,7 @@ namespace PeachPDF.Tests.Integration
                 EndingRowWouldStraddle(), pageHeight: PageHeight, margin: Margin);
 
             var cell = SpanningCell(root);
-            var table = LayoutHarness.Descendants(root).First(b => b.Display == CssConstants.Table);
+            var table = LayoutHarness.Descendants(root).First(b => b.Display.Value == DisplayMode.Table);
             var cellSlot = container.SlotStartingAt(cell.Location.Y);
 
             Assert.Equal(0, cellSlot);
@@ -407,7 +408,7 @@ namespace PeachPDF.Tests.Integration
                 pageHeight: PageHeight, margin: Margin);
 
             var cell = SpanningCell(root);
-            var table = LayoutHarness.Descendants(root).First(b => b.Display == CssConstants.Table);
+            var table = LayoutHarness.Descendants(root).First(b => b.Display.Value == DisplayMode.Table);
             var rows = RowsOf(root);
 
             // The fixture only asserts anything if the cell really does outreach the row that opened it.
@@ -671,7 +672,7 @@ namespace PeachPDF.Tests.Integration
                 + $"{rows[2].ActualBottom:F1} - it should have closed several bands earlier instead");
 
             // And the table's own slice-bottom record for that band follows the content, not cellSlot's.
-            var table = LayoutHarness.Descendants(root).First(b => b.Display == CssConstants.Table);
+            var table = LayoutHarness.Descendants(root).First(b => b.Display.Value == DisplayMode.Table);
             Assert.NotNull(table.PageBreakBottoms);
             Assert.True(table.PageBreakBottoms!.TryGetValue(contentSlot, out var recorded));
             Assert.True(recorded >= contentBottom - 0.01,

--- a/src/PeachPDF.Tests/Integration/TableSpannedBandRepetitionTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableSpannedBandRepetitionTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Adapters.Entities;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
@@ -84,10 +85,10 @@ namespace PeachPDF.Tests.Integration
         {
             var (root, container) = await Paginate(TallRowTableWith(group));
 
-            var display = group == "thead" ? CssConstants.TableHeaderGroup : CssConstants.TableFooterGroup;
+            var display = group == "thead" ? DisplayMode.TableHeaderGroup : DisplayMode.TableFooterGroup;
 
             var proxies = TableOf(root).Boxes.OfType<CssProxyBox>()
-                .Where(p => p.Display == display)
+                .Where(p => p.Display.Value == display)
                 .ToList();
 
             Assert.Equal(container.FragmentTree!.Fragmentainers.Count, proxies.Count);
@@ -192,9 +193,9 @@ namespace PeachPDF.Tests.Integration
             var (root, container) = await Paginate(
                 TallRowTableWith(group, groupStyle: "break-inside: auto"));
 
-            var display = group == "thead" ? CssConstants.TableHeaderGroup : CssConstants.TableFooterGroup;
+            var display = group == "thead" ? DisplayMode.TableHeaderGroup : DisplayMode.TableFooterGroup;
 
-            Assert.Single(TableOf(root).Boxes.OfType<CssProxyBox>(), p => p.Display == display);
+            Assert.Single(TableOf(root).Boxes.OfType<CssProxyBox>(), p => p.Display.Value == display);
 
             // And the row is not sliced for room that is never taken. Stated as the absence of a
             // confinement rather than by comparing the row's bottom against the same table without a
@@ -218,7 +219,7 @@ namespace PeachPDF.Tests.Integration
                 + $"<tbody>{rows}</tbody></table>");
 
             var proxies = TableOf(root).Boxes.OfType<CssProxyBox>()
-                .Where(p => p.Display == CssConstants.TableHeaderGroup)
+                .Where(p => p.Display.Value == DisplayMode.TableHeaderGroup)
                 .ToList();
 
             // One per page, and no page twice - which is what a duplicate from step 5b would look like.
@@ -256,10 +257,10 @@ namespace PeachPDF.Tests.Integration
                 + "<tr><td><div style='height:700pt;background:#ddd'></div></td></tr>"
                 + "<tr><td>word9999</td></tr></tbody></table>");
 
-            var display = group == "thead" ? CssConstants.TableHeaderGroup : CssConstants.TableFooterGroup;
+            var display = group == "thead" ? DisplayMode.TableHeaderGroup : DisplayMode.TableFooterGroup;
 
             var proxies = TableOf(root).Boxes.OfType<CssProxyBox>()
-                .Where(p => p.Display == display)
+                .Where(p => p.Display.Value == display)
                 .ToList();
 
             var bands = proxies.Select(p => container.SlotStartingAt(p.Location.Y)).ToList();
@@ -412,7 +413,7 @@ namespace PeachPDF.Tests.Integration
             var wrap = LayoutHarness.FindById(root, "wrap")!;
             var row = LayoutHarness.FindById(root, "tall")!.ParentBox!.ParentBox!;
 
-            Assert.Equal(CssConstants.TableRow, row.Display);
+            Assert.Equal(DisplayMode.TableRow, row.Display.Value);
 
             var displacedFragments = container.FragmentTree!.Fragmentainers
                 .SelectMany(f => Flatten(f.Root)
@@ -446,7 +447,7 @@ namespace PeachPDF.Tests.Integration
                 LayoutHarness.Wrap(TallRowTableWith("thead")));
 
             Assert.Single(TableOf(root).Boxes.OfType<CssProxyBox>(),
-                p => p.Display == CssConstants.TableHeaderGroup);
+                p => p.Display.Value == DisplayMode.TableHeaderGroup);
 
             Assert.All(RowFragmentsOf(container), fragment => Assert.Null(fragment.Fragment.OverflowClip));
         }
@@ -465,13 +466,13 @@ namespace PeachPDF.Tests.Integration
         }
 
         private static CssBox TableOf(CssBox root) =>
-            LayoutHarness.Descendants(root).First(b => b.Display == CssConstants.Table);
+            LayoutHarness.Descendants(root).First(b => b.Display.Value == DisplayMode.Table);
 
         /// <summary>The body row holding the over-tall block — the first one in every fixture here.</summary>
         private static CssBox TallRowOf(CssBox root) =>
-            LayoutHarness.Descendants(root).First(b => b.Display == CssConstants.TableRow
+            LayoutHarness.Descendants(root).First(b => b.Display.Value == DisplayMode.TableRow
                                                        && b.Boxes.Count > 0
-                                                       && b.Boxes[0].Display == CssConstants.TableCell
+                                                       && b.Boxes[0].Display.Value == DisplayMode.TableCell
                                                        && b.Boxes[0].Words.Count == 0);
 
         /// <summary>
@@ -516,7 +517,7 @@ namespace PeachPDF.Tests.Integration
         private static List<(int Slot, BoxFragment Fragment)> RowFragmentsOf(HtmlContainerInt container) =>
             container.FragmentTree!.Fragmentainers
                 .SelectMany(f => Flatten(f.Root)
-                    .Where(b => b.Box.Display == CssConstants.TableRow
+                    .Where(b => b.Box.Display.Value == DisplayMode.TableRow
                                 && b.Box.Boxes.Count > 0
                                 && b.Box.Boxes[0].Words.Count == 0)
                     .Select(b => (f.SlotIndex, b)))

--- a/src/PeachPDF.Tests/Integration/TheFrameDrivesItsChildsPassTests.cs
+++ b/src/PeachPDF.Tests/Integration/TheFrameDrivesItsChildsPassTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Adapters;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Utils;
@@ -41,7 +42,7 @@ namespace PeachPDF.Tests.Integration
             internal RecordingBox(CssBox parent) : base(parent, null)
             {
                 InheritStyle(parent, everything: true);
-                Display = CssConstants.Block;
+                Display = CssProperty<DisplayMode>.FromValue(CssConstants.Block, DisplayMode.Block);
                 Height = "30pt";
 
                 // Not empty, so an engine that skips whitespace-only anonymous children (flex, grid and
@@ -64,7 +65,7 @@ namespace PeachPDF.Tests.Integration
         {
             internal ThrowingBox(CssBox? parent) : base(parent, null)
             {
-                Display = CssConstants.Block;
+                Display = CssProperty<DisplayMode>.FromValue(CssConstants.Block, DisplayMode.Block);
             }
 
             protected override ValueTask PerformLayoutImp(RGraphics g, CssBox frame, bool framePlacesChild) =>

--- a/src/PeachPDF.Tests/Integration/WholeTableRelocationTests.cs
+++ b/src/PeachPDF.Tests/Integration/WholeTableRelocationTests.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Utils;
@@ -39,7 +40,7 @@ namespace PeachPDF.Tests.Integration
             string html)
         {
             var (root, container) = await LayoutHarness.LayoutAsync(html, pageHeight: PageHeight, margin: 0);
-            var table = LayoutHarness.Descendants(root).First(b => b.Display == CssConstants.Table);
+            var table = LayoutHarness.Descendants(root).First(b => b.Display.Value == DisplayMode.Table);
             return (table, container, root);
         }
 

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -688,7 +688,7 @@ namespace PeachPDF.Html.Core.Dom
         {
             return new CssBox(null, null)
             {
-                Display = CssConstants.Block
+                Display = CssProperty<DisplayMode>.FromValue(CssConstants.Block, DisplayMode.Block)
             };
         }
 
@@ -712,7 +712,7 @@ namespace PeachPDF.Html.Core.Dom
             ArgumentNullException.ThrowIfNull(parent);
 
             var newBox = CreateBox(parent, tag, before);
-            newBox.Display = CssConstants.Block;
+            newBox.Display = CssProperty<DisplayMode>.FromValue(CssConstants.Block, DisplayMode.Block);
             return newBox;
         }
 

--- a/src/PeachPDF/Html/Core/Dom/CssBoxHr.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBoxHr.cs
@@ -32,7 +32,7 @@ namespace PeachPDF.Html.Core.Dom
         public CssBoxHr(CssBox? parent, HtmlTag tag)
             : base(parent, tag)
         {
-            Display = CssConstants.Block;
+            Display = CssProperty<DisplayMode>.FromValue(CssConstants.Block, DisplayMode.Block);
         }
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineFlex.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineFlex.cs
@@ -1530,11 +1530,11 @@ namespace PeachPDF.Html.Core.Dom
         /// </summary>
         private static async ValueTask PerformLayoutBlockified(RGraphics g, CssBox box)
         {
-            string? savedDisplay = null;
+            CssProperty<DisplayMode>? savedDisplay = null;
             if (box.IsInline)
             {
-                savedDisplay = box.DerivedStyle.ActualDisplay;
-                box.Display  = CssConstants.Block;
+                savedDisplay = box.Display;
+                box.Display = CssProperty<DisplayMode>.FromValue(CssConstants.Block, DisplayMode.Block);
             }
 
             var container = box.HtmlContainer;
@@ -1560,7 +1560,7 @@ namespace PeachPDF.Html.Core.Dom
                     container.SuppressWordPageBreaks = previousSuppress;
             }
 
-            if (savedDisplay != null)
+            if (savedDisplay is not null)
                 box.Display = savedDisplay;
         }
 

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineGrid.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineGrid.cs
@@ -1673,11 +1673,11 @@ namespace PeachPDF.Html.Core.Dom
 
         private static async ValueTask PerformLayoutBlockified(RGraphics g, CssBox box)
         {
-            string? savedDisplay = null;
+            CssProperty<DisplayMode>? savedDisplay = null;
             if (box.IsInline)
             {
-                savedDisplay = box.DerivedStyle.ActualDisplay;
-                box.Display = CssConstants.Block;
+                savedDisplay = box.Display;
+                box.Display = CssProperty<DisplayMode>.FromValue(CssConstants.Block, DisplayMode.Block);
             }
 
             var container = box.HtmlContainer;
@@ -1701,7 +1701,7 @@ namespace PeachPDF.Html.Core.Dom
                     container.SuppressWordPageBreaks = previousSuppress;
             }
 
-            if (savedDisplay != null)
+            if (savedDisplay is not null)
                 box.Display = savedDisplay;
         }
     }

--- a/src/PeachPDF/Html/Core/Dom/CssSpacingBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssSpacingBox.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Core.Utils;
 using System.Collections.Generic;
 
@@ -12,7 +13,7 @@ namespace PeachPDF.Html.Core.Dom
             : base(tableBox, new HtmlTag("none", false, new Dictionary<string, string> { { "colspan", "1" } }))
         {
             ExtendedBox = extendedBox;
-            Display = CssConstants.TableCell;
+            Display = CssProperty<DisplayMode>.FromValue(CssConstants.TableCell, DisplayMode.TableCell);
 
             StartRow = startRow;
             EndRow = startRow + int.Parse(extendedBox.GetAttribute("rowspan", "1")) - 1;

--- a/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
+++ b/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
@@ -1104,7 +1104,7 @@ namespace PeachPDF.Html.Core.Dom
         /// (<c>Style.DisplayPositioning.Float</c> is not <see cref="CssConstants.None"/>) - the value layout
         /// and paint should actually use. <c>Style.DisplayPositioning.Display</c> itself stays the raw
         /// cascaded keyword (what the cascade produced, e.g. for CSS-OM <c>getPropertyValue</c> readback),
-        /// not blockified. Recomputed fresh every call, not cached - a single string switch, same cost class
+        /// not blockified. Recomputed fresh every call, not cached - a single enum switch, same cost class
         /// as <see cref="ActualLineHeight"/>/<see cref="IsPositioned"/> below.
         /// </summary>
         public string ActualDisplay
@@ -1112,24 +1112,24 @@ namespace PeachPDF.Html.Core.Dom
             get
             {
                 var area = Style.DisplayPositioning;
-                if (area.Float.Value is Floating.None) return area.Display;
+                if (area.Float.Value is Floating.None) return area.Display.ToString();
 
-                return area.Display switch
+                return area.Display.Value switch
                 {
-                    "inline" => "block",
-                    "inline-block" => "block",
-                    "inline-table" => "table",
-                    "table-row" => "block",
-                    "table-row-group" => "block",
-                    "table-column" => "block",
-                    "table-column-group" => "block",
-                    "table-cell" => "block",
-                    "table-caption" => "block",
-                    "table-header-group" => "block",
-                    "table-footer-group" => "block",
-                    "inline-flex" => "flex",
-                    "inline-grid" => "grid",
-                    _ => area.Display
+                    DisplayMode.Inline => CssConstants.Block,
+                    DisplayMode.InlineBlock => CssConstants.Block,
+                    DisplayMode.InlineTable => CssConstants.Table,
+                    DisplayMode.TableRow => CssConstants.Block,
+                    DisplayMode.TableRowGroup => CssConstants.Block,
+                    DisplayMode.TableColumn => CssConstants.Block,
+                    DisplayMode.TableColumnGroup => CssConstants.Block,
+                    DisplayMode.TableCell => CssConstants.Block,
+                    DisplayMode.TableCaption => CssConstants.Block,
+                    DisplayMode.TableHeaderGroup => CssConstants.Block,
+                    DisplayMode.TableFooterGroup => CssConstants.Block,
+                    DisplayMode.InlineFlex => CssConstants.Flex,
+                    DisplayMode.InlineGrid => CssConstants.Grid,
+                    _ => area.Display.ToString()
                 };
             }
         }

--- a/src/PeachPDF/Html/Core/Fragmentation/ItemContentCommit.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/ItemContentCommit.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Adapters;
 using PeachPDF.Html.Adapters.Entities;
 using PeachPDF.Html.Core.Dom;
@@ -104,16 +105,16 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// </summary>
         private static async ValueTask LayoutBlockifiedAtFinalPosition(RGraphics g, CssBox box)
         {
-            string? savedDisplay = null;
+            CssProperty<DisplayMode>? savedDisplay = null;
             if (box.IsInline)
             {
-                savedDisplay = box.DerivedStyle.ActualDisplay;
-                box.Display = CssConstants.Block;
+                savedDisplay = box.Display;
+                box.Display = CssProperty<DisplayMode>.FromValue(CssConstants.Block, DisplayMode.Block);
             }
 
             await box.LayoutContentAtItsAssignedPosition(g);
 
-            if (savedDisplay != null)
+            if (savedDisplay is not null)
                 box.Display = savedDisplay;
         }
 

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -787,12 +787,16 @@ namespace PeachPDF.Html.Core.Parse
         {
             if (box.Position.Value is not (PositionMode.Absolute or PositionMode.Fixed)) return;
 
-            box.Display = box.Display switch
+            box.Display = box.Display.Value switch
             {
-                CssConstants.Inline or CssConstants.InlineBlock => CssConstants.Block,
-                CssConstants.InlineFlex => CssConstants.Flex,
-                CssConstants.InlineGrid => CssConstants.Grid,
-                CssConstants.InlineTable => CssConstants.Table,
+                DisplayMode.Inline or DisplayMode.InlineBlock =>
+                    CssProperty<DisplayMode>.FromValue(CssConstants.Block, DisplayMode.Block),
+                DisplayMode.InlineFlex =>
+                    CssProperty<DisplayMode>.FromValue(CssConstants.Flex, DisplayMode.Flex),
+                DisplayMode.InlineGrid =>
+                    CssProperty<DisplayMode>.FromValue(CssConstants.Grid, DisplayMode.Grid),
+                DisplayMode.InlineTable =>
+                    CssProperty<DisplayMode>.FromValue(CssConstants.Table, DisplayMode.Table),
                 _ => box.Display
             };
         }
@@ -1766,7 +1770,7 @@ namespace PeachPDF.Html.Core.Parse
                 {
                     var block = CssBox.CreateBlock(childBox.ParentBox!, null, childBox);
                     childBox.ParentBox = block;
-                    childBox.Display = CssConstants.Inline;
+                    childBox.Display = CssProperty<DisplayMode>.FromValue(CssConstants.Inline, DisplayMode.Inline);
                 }
                 else
                 {
@@ -1862,7 +1866,7 @@ namespace PeachPDF.Html.Core.Parse
         private static CssBox? CorrectBlockInsideInlineImp(CssBox box)
         {
             if (box.DerivedStyle.ActualDisplay == CssConstants.Inline)
-                box.Display = CssConstants.Block;
+                box.Display = CssProperty<DisplayMode>.FromValue(CssConstants.Block, DisplayMode.Block);
 
             if (box.Boxes.Count > 1 || box.Boxes[0].Boxes.Count > 1)
             {
@@ -1892,7 +1896,7 @@ namespace PeachPDF.Html.Core.Parse
             }
             else if (box.Boxes[0].DerivedStyle.ActualDisplay == CssConstants.Inline)
             {
-                box.Boxes[0].Display = CssConstants.Block;
+                box.Boxes[0].Display = CssProperty<DisplayMode>.FromValue(CssConstants.Block, DisplayMode.Block);
             }
 
             return null;
@@ -1955,7 +1959,7 @@ namespace PeachPDF.Html.Core.Parse
             {
                 splitBox.SetBeforeBox(parentBox.Boxes[1]);
                 if (splitBox.HtmlTag is { Name: "br" } && (leftbox != null || leftBlock.Boxes.Count > 1))
-                    splitBox.Display = CssConstants.Inline;
+                    splitBox.Display = CssProperty<DisplayMode>.FromValue(CssConstants.Inline, DisplayMode.Inline);
             }
         }
 
@@ -2023,7 +2027,7 @@ namespace PeachPDF.Html.Core.Parse
             if (box is { DerivedStyle.ActualDisplay: CssConstants.Inline, Position.Value: PositionMode.Absolute })
             {
                 var blockBox = new CssBox(box.ParentBox, null);
-                blockBox.Display = CssConstants.Block;
+                blockBox.Display = CssProperty<DisplayMode>.FromValue(CssConstants.Block, DisplayMode.Block);
                 blockBox.Position = CssProperty<PositionMode>.FromValue(CssConstants.Absolute, PositionMode.Absolute);
                 blockBox.Left = box.Left;
                 blockBox.Top = box.Top;
@@ -2095,7 +2099,7 @@ namespace PeachPDF.Html.Core.Parse
                     Console.WriteLine($"dom: set child box {childBox.Id} of table-column parent {box.Id} to display: none");
 #endif
 
-                    childBox.Display = CssConstants.None;
+                    childBox.Display = CssProperty<DisplayMode>.FromValue(CssConstants.None, DisplayMode.None);
                 }
             }
 
@@ -2106,7 +2110,7 @@ namespace PeachPDF.Html.Core.Parse
                 Console.WriteLine($"dom: set child box {box.Id} to display:none if parent is table-column-group and child is not table-column");
 #endif
 
-                box.Display = CssConstants.None;
+                box.Display = CssProperty<DisplayMode>.FromValue(CssConstants.None, DisplayMode.None);
             }
 
             // 1.3 This is handled via CorrectTextBoxes above
@@ -2133,7 +2137,7 @@ namespace PeachPDF.Html.Core.Parse
                     // takes C's place in document/column order instead of drifting to the end once C
                     // itself is reparented into it below.
                     var tableRowBox = new CssBox(box.ParentBox, null);
-                    tableRowBox.Display = CssConstants.TableRow;
+                    tableRowBox.Display = CssProperty<DisplayMode>.FromValue(CssConstants.TableRow, DisplayMode.TableRow);
                     tableRowBox.SetBeforeBox(box);
                     box.ParentBox = tableRowBox;
 
@@ -2155,7 +2159,7 @@ namespace PeachPDF.Html.Core.Parse
                             .ToList();
 
                     var tableRowBox = new CssBox(box.ParentBox, null);
-                    tableRowBox.Display = CssConstants.TableRow;
+                    tableRowBox.Display = CssProperty<DisplayMode>.FromValue(CssConstants.TableRow, DisplayMode.TableRow);
                     tableRowBox.SetBeforeBox(box);
                     box.ParentBox = tableRowBox;
 
@@ -2178,7 +2182,7 @@ namespace PeachPDF.Html.Core.Parse
                             .ToList();
 
                     var tableCellBox = new CssBox(box.ParentBox, null);
-                    tableCellBox.Display = CssConstants.TableCell;
+                    tableCellBox.Display = CssProperty<DisplayMode>.FromValue(CssConstants.TableCell, DisplayMode.TableCell);
                     tableCellBox.SetBeforeBox(box);
                     box.ParentBox = tableCellBox;
 
@@ -2199,7 +2203,7 @@ namespace PeachPDF.Html.Core.Parse
                             .ToList();
 
                     var tableRowBox = new CssBox(box.ParentBox, null);
-                    tableRowBox.Display = CssConstants.TableRow;
+                    tableRowBox.Display = CssProperty<DisplayMode>.FromValue(CssConstants.TableRow, DisplayMode.TableRow);
                     tableRowBox.SetBeforeBox(box);
                     box.ParentBox = tableRowBox;
 
@@ -2237,14 +2241,16 @@ namespace PeachPDF.Html.Core.Parse
                 if (isMisparented)
                 {
                     var originalParent = box.ParentBox;
-                    var parentDisplay = originalParent is null || originalParent.IsBlock ? CssConstants.Table : CssConstants.InlineTable;
+                    var isBlockTable = originalParent is null || originalParent.IsBlock;
+                    var parentDisplay = isBlockTable ? CssConstants.Table : CssConstants.InlineTable;
+                    var parentDisplayMode = isBlockTable ? DisplayMode.Table : DisplayMode.InlineTable;
 
                     var followingMatchingSiblings =
                         DomUtils.GetFollowingSiblings(box, DomUtils.IsProperTableChild, true)
                             .ToList();
 
                     var tableBox = new CssBox(originalParent, null);
-                    tableBox.Display = parentDisplay;
+                    tableBox.Display = CssProperty<DisplayMode>.FromValue(parentDisplay, parentDisplayMode);
 
                     // Position the synthesized table at the child's original index in the grandparent (the
                     // constructor only appends it) — same as the SetBeforeBox in rules 2.1/2.3/3.1 — so it

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -1317,33 +1317,17 @@
       "name": "display",
       "inherited": false,
       "initialValue": "inline",
-      "cssDataType": "keyword",
-      "supportedValues": [
-        "block",
-        "inline",
-        "inline-block",
-        "none",
-        "flex",
-        "inline-flex",
-        "grid",
-        "inline-grid",
-        "table",
-        "inline-table",
-        "table-row",
-        "table-cell",
-        "table-header-group",
-        "table-footer-group",
-        "table-row-group",
-        "table-column",
-        "table-column-group",
-        "table-caption",
-        "list-item"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "DisplayMode",
+        "keywordMap": "Map.DisplayModes",
+        "fallback": "DisplayMode.Inline"
+      },
       "html": {
         "propertyPath": "Display",
-        "csharpDataType": "string",
-        "area": "DisplayPositioningArea"
+        "csharpDataType": "CssProperty<DisplayMode>",
+        "area": "DisplayPositioningArea",
+        "getterExpression": "{box}.Display.ToString()"
       }
     },
     {


### PR DESCRIPTION
## Summary

Part of the ongoing #598 follow-up work (group A of the typed-storage conversion, the last and largest property in the group). Converts `display` from plain-string `CssBox` storage to `CssProperty<DisplayMode>`.

- Reused the pre-existing `DisplayMode` enum (19 members) and `Map.DisplayModes` keyword map — both already used by the legacy CSS-OM validation layer, and `DisplayMode` was already named to avoid colliding with the `CssBox.Display` property (no self-shadowing hazard, unlike the earlier `Hyphens`/`WordBreak`/`Overflow`/`Visibility`/`TextTransform` batch).
- Key design decision: `DerivedStyle.ActualDisplay` (added by a prior PR, already on `main`, moving CSS 2.1 §9.7 float-blockification out of the cascaded getter) was kept `string`-returning rather than changed to return `DisplayMode` — it's read at roughly 125 call sites across 21 files via string comparison against `CssConstants.*`, and changing its signature would have forced all of them to convert too. Only its *internal* implementation was rewritten to switch on the new `.Value` and map back to the existing `CssConstants.*` literals, keeping those 125 sites untouched.
- Compiler-driven migration touched `CssBox.cs`, `CssBoxHr.cs`, `CssSpacingBox.cs`, `ItemContentCommit.cs`, `CssLayoutEngineFlex.cs`, `CssLayoutEngineGrid.cs`, and `DomParser.cs` (`BlockifyPositionedBox`'s absolute/fixed blockification switch, `CorrectAbsolutelyPositionedInlineElements`'s synthetic block-box construction, and the anonymous-table-box generation machinery). Three near-identical "blockify for measurement, then restore" helpers were simplified to save/restore `box.Display` directly instead of round-tripping through `ActualDisplay`'s string, since `box.IsInline` (the save-trigger) is itself derived from `ActualDisplay`, so `ActualDisplay == Display.ToString()` is guaranteed whenever the branch fires.
- The larger share of this PR's size is in the test suite: roughly 140 sites across ~24 test files (table-layout integration tests dominate) needed `.Display == CssConstants.X` → `.Display.Value == DisplayMode.X` / `Assert.Equal(CssConstants.X, box.Display)` → `Assert.Equal(DisplayMode.X, box.Display.Value)` conversions, since `CssProperty<T>` has no implicit `string` comparison.
- Post-change review found two real gaps beyond the mechanical migration itself: (1) `BlockifyPositionedBox`'s `inline-grid`/`inline-table` branches had zero test coverage (the existing test only covered `inline`/`inline-block`/`inline-flex`), and (2) no test anywhere exercised `display`'s case-insensitivity — the property issue #598 is actually named for. Both are now closed: two new cases in `AbsolutePositioningIntegrationTests.cs`, and a new `DisplayTypedStorageTests.cs` asserting case-insensitive parsing across all 19 keywords plus confirming an invalid `display` value causes the whole declaration to be dropped (leaving the UA stylesheet's own rule in effect, per CSS Syntax 3 error recovery) rather than falling back to the property's CSS-wide initial value.

## Test plan

- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (7930 passed, 9 skipped)
- [x] Diff coverage vs `main`: 91% (5 remaining uncovered lines in `DomParser.cs` are pre-existing narrow branches equally untested before this PR — the mechanical rewrite just carried them forward, confirmed by post-change review)
- [x] Post-change review pass — confirmed `ActualDisplay`'s rewritten switch is a faithful 1:1 translation of all 13 blockified cases, confirmed `BlockifyPositionedBox`'s enum conversion is faithful, confirmed the three blockify/restore helpers' `IsInline`/`ActualDisplay` reasoning is sound, confirmed the 19-keyword set is unchanged and no unnecessary sentinel enum member was added, spot-checked the mechanical test edits for semantic drift (none found), and caught the two coverage gaps described above — both fixed before opening