### PR TITLE
Convert column-count to CssProperty&lt;CssKeywordOrValue&lt;AutoKeyword, int&gt;&gt;

### DIFF
--- a/src/PeachPDF.SourceGenerators.Tests/GeneratorGoldenFileTests.cs
+++ b/src/PeachPDF.SourceGenerators.Tests/GeneratorGoldenFileTests.cs
@@ -282,6 +282,34 @@ namespace PeachPDF.SourceGenerators.Tests
         }
 
         [Fact]
+        public void Emits_KeywordOrValue_Validation_Narrowed_By_Min_For_An_Integer_Or_Auto_Property()
+        {
+            var json = """
+                {
+                  "properties": [
+                    { "name": "column-count", "inherited": false, "initialValue": "auto",
+                      "cssDataType": { "type": "keyword-or-value", "enumType": "AutoKeyword", "keywordMap": "Map.AutoKeywords",
+                        "fallback": "AutoKeyword.Auto", "valueType": "integer", "min": 1 },
+                      "html": { "propertyPath": "Transform", "csharpDataType": "string", "area": "VisualEffectsArea" } }
+                  ]
+                }
+                """;
+
+            var result = GeneratorTestHost.Run(json, StubSources.MinimalCssBoxAndSvgElement);
+
+            var generated = result.Results.Single().GeneratedSources
+                .Single(s => s.HintName == "CssPropertyRegistry.g.cs").SourceText.ToString();
+
+            Assert.Contains(
+                "private static bool Validate_ColumnCount(CssValueParser parser, string value) => " +
+                "Map.AutoKeywords.ContainsKey(value) || int.TryParse(value, out var parsedInt) && parsedInt >= 1;",
+                generated);
+            Assert.Contains(
+                "box.Transform = global::PeachPDF.CSS.CssKeywordOrValueParser.FromCssText<AutoKeyword, int>(value, Map.AutoKeywords, int.TryParse, AutoKeyword.Auto);",
+                generated);
+        }
+
+        [Fact]
         public void Emits_False_For_An_Unsupported_Property()
         {
             var json = """

--- a/src/PeachPDF.SourceGenerators/Emit/KeywordOrValueGrammar.cs
+++ b/src/PeachPDF.SourceGenerators/Emit/KeywordOrValueGrammar.cs
@@ -8,7 +8,12 @@ namespace PeachPDF.SourceGenerators.Emit
     /// maps to real C# — the value-side validation clause, the storage type, and the <c>TryParse</c>-shaped
     /// parser to hand to <see cref="global::PeachPDF.CSS.CssKeywordOrValueParser.FromCssText{TEnum,TValue}"/>.
     /// <see cref="ValidatorExpressionBuilder"/> and <see cref="RegistryEmitter"/> both consult this rather
-    /// than each declaring (and separately guarding) their own copy of the valueType switch.
+    /// than each declaring (and separately guarding) their own copy of the valueType switch. An entry's
+    /// optional <see cref="DataTypeSpec.Min"/>/<see cref="DataTypeSpec.Max"/> — the same JSON <c>min</c>/
+    /// <c>max</c> fields the plain "integer" DataTypeKind uses — narrow the "integer" value clause the
+    /// same way that DataTypeKind's own min/max do. Only the validation clause is narrowed, since
+    /// <c>Set_X</c> always runs <c>Validate_X</c> first, so the stored value is already known in range by
+    /// the time <c>CssKeywordOrValueParser.FromCssText</c> itself parses it.
     /// </summary>
     internal static class KeywordOrValueGrammar
     {
@@ -28,7 +33,7 @@ namespace PeachPDF.SourceGenerators.Emit
 
         public static Resolved Resolve(PropertyEntry entry, DataTypeSpec dt) => dt.ValueType switch
         {
-            "integer" => new Resolved("int.TryParse(value, out _)", "int", "int.TryParse"),
+            "integer" => new Resolved(BuildIntegerValueClause(dt), "int", "int.TryParse"),
             "length" => new Resolved(
                 "global::PeachPDF.Html.Core.Parse.CssValueParser.IsValidLength(value)",
                 "global::PeachPDF.CSS.Length", "global::PeachPDF.CSS.Length.TryParse"),
@@ -36,5 +41,18 @@ namespace PeachPDF.SourceGenerators.Emit
                 $"\"{entry.Name}\" declares a keyword-or-value cssDataType with valueType \"{dt.ValueType}\", " +
                 "which KeywordOrValueGrammar does not yet implement."),
         };
+
+        // Mirrors ValidatorExpressionBuilder.BuildIntegerClause (the plain "integer" DataTypeKind's own
+        // min/max clause) exactly, so a keyword-or-value entry's min/max behaves identically to a plain
+        // "integer" entry's min/max rather than a second, independently-derived narrowing rule.
+        private static string BuildIntegerValueClause(DataTypeSpec dt)
+        {
+            if (dt.Min is null && dt.Max is null) return "int.TryParse(value, out _)";
+
+            var clause = "int.TryParse(value, out var parsedInt)";
+            if (dt.Min.HasValue) clause += $" && parsedInt >= {(int)dt.Min.Value}";
+            if (dt.Max.HasValue) clause += $" && parsedInt <= {(int)dt.Max.Value}";
+            return clause;
+        }
     }
 }

--- a/src/PeachPDF.SourceGenerators/Model/PropertyModelParser.cs
+++ b/src/PeachPDF.SourceGenerators/Model/PropertyModelParser.cs
@@ -372,7 +372,10 @@ namespace PeachPDF.SourceGenerators.Model
                         json.TryGetProperty("keywordMap", out var korvKeywordMapValue);
                         json.TryGetProperty("fallback", out var korvFallbackValue);
                         json.TryGetProperty("valueType", out var korvValueTypeValue);
+                        double? korvMin = json.TryGetProperty("min", out var korvMinValue) && korvMinValue.Kind == JsonValueKind.Number ? korvMinValue.NumberValue : null;
+                        double? korvMax = json.TryGetProperty("max", out var korvMaxValue) && korvMaxValue.Kind == JsonValueKind.Number ? korvMaxValue.NumberValue : null;
                         return new DataTypeSpec(DataTypeKind.KeywordOrValue,
+                            min: korvMin, max: korvMax,
                             enumType: korvEnumTypeValue.StringValue, keywordMap: korvKeywordMapValue.StringValue,
                             fallback: korvFallbackValue.StringValue, valueType: korvValueTypeValue.StringValue);
 

--- a/src/PeachPDF.Tests/Integration/ColumnCountTypedStorageTests.cs
+++ b/src/PeachPDF.Tests/Integration/ColumnCountTypedStorageTests.cs
@@ -1,0 +1,83 @@
+using PeachPDF.CSS;
+using PeachPDF.Tests.TestSupport;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Direct typed-storage assertions for <c>column-count</c>, now backed by
+    /// <c>CssProperty&lt;CssKeywordOrValue&lt;AutoKeyword, int&gt;&gt;</c> - the second property (after the
+    /// <c>z-index</c> pilot) through this "group B" keyword-or-value conversion mechanism. Also exercises
+    /// the new generator-level <c>min</c> support on a <c>keyword-or-value</c> entry (CSS Multi-column
+    /// Layout 1 requires <c>column-count</c>'s <c>&lt;integer&gt;</c> to be &gt;= 1), complementing
+    /// <c>MulticolLayoutIntegrationTests</c>, which exercises <c>column-count</c> indirectly through its
+    /// effect on column geometry rather than asserting the stored <c>.Value</c> directly.
+    /// </summary>
+    public class ColumnCountTypedStorageTests
+    {
+        [Fact]
+        public async Task Auto_StoresTheAutoKeyword_CaseInsensitively()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='column-count:AUTO'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.ColumnCount.Value is { IsKeyword: true, Keyword: AutoKeyword.Auto });
+        }
+
+        [Fact]
+        public async Task PositiveInteger_StoresTheParsedCount()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='column-count:3'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.Equal("3", box!.ColumnCount.ToString());
+            Assert.True(box.ColumnCount.Value is { IsValue: true, Value: 3 });
+        }
+
+        [Fact]
+        public async Task MinimumLegalCount_One_IsAccepted()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='column-count:1'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.ColumnCount.Value is { IsValue: true, Value: 1 });
+        }
+
+        [Fact]
+        public async Task Zero_IsRejected_InitialAutoValueIsKept()
+        {
+            // CSS Multi-column Layout 1: column-count's <integer> must be >= 1. An out-of-range
+            // declaration is invalid at the box-application layer, so the whole declaration is dropped
+            // and the property keeps its initial value (auto) rather than storing 0.
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='column-count:0'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.ColumnCount.Value is { IsKeyword: true, Keyword: AutoKeyword.Auto });
+        }
+
+        [Fact]
+        public async Task Negative_IsRejected_InitialAutoValueIsKept()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='column-count:-2'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.ColumnCount.Value is { IsKeyword: true, Keyword: AutoKeyword.Auto });
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineColumns.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineColumns.cs
@@ -1089,6 +1089,8 @@ namespace PeachPDF.Html.Core.Dom
             if (hasCount && hasWidth)
             {
                 // Both given: column-count is a maximum — never more columns than fit at >= column-width.
+                // Validate_ColumnCount already guarantees parsedCount >= 1, so the Math.Max(1, ...) here
+                // only guards maxByWidth's own computation, not parsedCount itself.
                 var maxByWidth = specifiedWidth > 0 ? Math.Max(1, (int)((containerWidth + gap) / (specifiedWidth + gap))) : parsedCount;
                 var count = Math.Max(1, Math.Min(parsedCount, maxByWidth));
                 return (count, Math.Max(0, (containerWidth - gap * (count - 1)) / count));
@@ -1096,6 +1098,8 @@ namespace PeachPDF.Html.Core.Dom
 
             if (hasCount)
             {
+                // parsedCount is already >= 1 here (Validate_ColumnCount enforces it) - Math.Max(1, ...) is
+                // defensive, not load-bearing.
                 var count = Math.Max(1, parsedCount);
                 return (count, Math.Max(0, (containerWidth - gap * (count - 1)) / count));
             }

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineColumns.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineColumns.cs
@@ -1079,8 +1079,9 @@ namespace PeachPDF.Html.Core.Dom
         /// </summary>
         private static (int Count, double Width) ResolveColumns(CssBox columnsBox, double containerWidth, double gap)
         {
-            var parsedCount = 0;
-            var hasCount = columnsBox.ColumnCount != CssConstants.Auto && int.TryParse(columnsBox.ColumnCount, out parsedCount);
+            var columnCount = columnsBox.ColumnCount.Value;
+            var hasCount = columnCount.IsValue;
+            var parsedCount = columnCount.Value.GetValueOrDefault();
             var hasWidth = columnsBox.ColumnWidth != CssConstants.Auto && CssValueParser.IsValidLength(columnsBox.ColumnWidth);
 
             var specifiedWidth = hasWidth ? CssValueParser.ParseLength(columnsBox.ColumnWidth, containerWidth, columnsBox) : 0;

--- a/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
+++ b/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
@@ -1146,7 +1146,7 @@ namespace PeachPDF.Html.Core.Dom
         /// is not <c>auto</c>, or <c>column-count</c> is not <c>auto</c>.
         /// </summary>
         public bool EstablishesMultiColumnContext =>
-            (!string.IsNullOrEmpty(Style.MultiColumn.ColumnCount) && Style.MultiColumn.ColumnCount != CssConstants.Auto) ||
+            Style.MultiColumn.ColumnCount.Value is { IsValue: true } ||
             (!string.IsNullOrEmpty(Style.MultiColumn.ColumnWidth) && Style.MultiColumn.ColumnWidth != CssConstants.Auto);
 
         #endregion

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -2335,23 +2335,22 @@
     },
     {
       "name": "column-count",
+      "comment": "CssKeywordOrValue<AutoKeyword, int>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText. Unlike z-index (this mechanism's pilot, whose <integer> is unconstrained), column-count's <integer> must be >= 1 (CSS Multi-column Layout 1 - 0/negative is invalid); min narrows the keyword-or-value grammar's integer clause the same way plain \"integer\" entries' own min does (see KeywordOrValueGrammar).",
       "inherited": false,
       "initialValue": "auto",
-      "cssDataType": [
-        "keyword",
-        {
-          "type": "integer",
-          "min": 1
-        }
-      ],
-      "supportedValues": [
-        "auto"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "keyword-or-value",
+        "enumType": "AutoKeyword",
+        "keywordMap": "Map.AutoKeywords",
+        "fallback": "AutoKeyword.Auto",
+        "valueType": "integer",
+        "min": 1
+      },
       "html": {
         "propertyPath": "ColumnCount",
-        "csharpDataType": "string",
-        "area": "MultiColumnArea"
+        "csharpDataType": "CssProperty<CssKeywordOrValue<AutoKeyword, int>>",
+        "area": "MultiColumnArea",
+        "getterExpression": "{box}.ColumnCount.ToString()"
       }
     },
     {

--- a/src/PeachPDF/css-properties.schema.json
+++ b/src/PeachPDF/css-properties.schema.json
@@ -138,7 +138,9 @@
             "enumType": { "type": "string" },
             "keywordMap": { "type": "string" },
             "fallback": { "type": "string" },
-            "valueType": { "type": "string", "enum": ["integer", "length"], "description": "The non-keyword side's grammar and TValue — must match a TryParse-shaped parser (int.TryParse, Length.TryParse) RegistryEmitter knows how to call." }
+            "valueType": { "type": "string", "enum": ["integer", "length"], "description": "The non-keyword side's grammar and TValue — must match a TryParse-shaped parser (int.TryParse, Length.TryParse) RegistryEmitter knows how to call." },
+            "min": { "type": "number", "description": "Narrows an \"integer\" valueType's validation clause — same field/meaning as the plain \"integer\" DataTypeKind's own \"min\" (e.g. column-count's <integer> must be >= 1) — see KeywordOrValueGrammar." },
+            "max": { "type": "number", "description": "Narrows an \"integer\" valueType's validation clause — same field/meaning as the plain \"integer\" DataTypeKind's own \"max\" — see KeywordOrValueGrammar." }
           }
         }
       ]


### PR DESCRIPTION
## Summary

Part of the ongoing #598 follow-up work — the first property of "group B" (keyword-or-value conversions), following the `z-index` pilot. Converts `column-count` (`<integer> | auto`) from plain-string `CssBox` storage to `CssProperty<CssKeywordOrValue<AutoKeyword, int>>`.

- Reused the existing `AutoKeyword`/`Map.AutoKeywords` (already shared by `z-index`) — no new enum needed.
- Extended the generator itself: the `keyword-or-value` `cssDataType` shape previously had no min/max plumbing for its `valueType: "integer"` side, but `column-count`'s `<integer>` must be `>= 1` per CSS Multi-column Layout Module Level 1. Added `min`/`max` fields to the `keyword-or-value` JSON shape — deliberately reusing the exact same field names the plain `"integer"` `cssDataType` already uses (not `minValue`/`maxValue`) — wired through `PropertyModelParser.cs` into the existing shared `DataTypeSpec.Min`/`Max` fields, and `KeywordOrValueGrammar.BuildIntegerValueClause` mirrors `ValidatorExpressionBuilder.BuildIntegerClause` (the plain `"integer"` kind's own min/max clause) line-for-line so a keyword-or-value entry's `min`/`max` behaves identically to a plain `"integer"` entry's, rather than a second, independently-derived narrowing rule. The unconstrained case (no `min`/`max`, e.g. `z-index`) is provably unchanged — confirmed the existing z-index golden-file test still passes untouched. A new golden-file test covers the min-narrowed clause.
- Compiler-driven migration touched `CssLayoutEngineColumns.cs`'s `ResolveColumns` and `DerivedStyle.cs`'s `EstablishesMultiColumnContext`.
- New `ColumnCountTypedStorageTests.cs`: case-insensitive `auto`, a positive integer, the `1` boundary, and `0`/`-2` rejection (falls back to `auto` rather than storing the invalid value, since an out-of-range declaration is invalid at the box-application layer).
- Post-change review found no correctness defects in either the generator extension or the call-site conversions; it flagged one purely cosmetic idiom nit (addressed — see the follow-up commit noting `ResolveColumns`'s `Math.Max(1, ...)` clamps are now defensive-only, since `Validate_ColumnCount` already guarantees a stored count is `>= 1`).

## Test plan

- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (7935 passed, 9 skipped)
- [x] `dotnet test PeachPDF.SourceGenerators.Tests/PeachPDF.SourceGenerators.Tests.csproj` — 108 passed (new golden-file test for the min-narrowed keyword-or-value clause)
- [x] Diff coverage vs `main`: 100%
- [x] Post-change review pass — independently traced the generator's new min/max clause-building against its plain-`"integer"` counterpart, confirmed the unconstrained (z-index) case is byte-for-byte unchanged, confirmed the CSS Multi-column Layout 1 `>= 1` constraint against the actual spec text, confirmed no new PPG0xx diagnostic was needed, and confirmed both call-site conversions are faithful translations