### PR TITLE
Convert word-spacing, letter-spacing, row-gap, column-gap to typed keyword-or-value storage

### DIFF
--- a/src/PeachPDF.SourceGenerators.Tests/GeneratorGoldenFileTests.cs
+++ b/src/PeachPDF.SourceGenerators.Tests/GeneratorGoldenFileTests.cs
@@ -274,10 +274,10 @@ namespace PeachPDF.SourceGenerators.Tests
 
             Assert.Contains(
                 "private static bool Validate_ColumnWidth(CssValueParser parser, string value) => " +
-                "Map.AutoKeywords.ContainsKey(value) || global::PeachPDF.CSS.Length.TryParse(value, out _);",
+                "Map.AutoKeywords.ContainsKey(value) || global::PeachPDF.Html.Core.Parse.CssValueParser.TryParseLengthOrCalc(value, out _);",
                 generated);
             Assert.Contains(
-                "box.Transform = global::PeachPDF.CSS.CssKeywordOrValueParser.FromCssText<AutoKeyword, global::PeachPDF.CSS.Length>(value, Map.AutoKeywords, global::PeachPDF.CSS.Length.TryParse, AutoKeyword.Auto);",
+                "box.Transform = global::PeachPDF.CSS.CssKeywordOrValueParser.FromCssText<AutoKeyword, global::PeachPDF.CSS.LengthOrCalc>(value, Map.AutoKeywords, global::PeachPDF.Html.Core.Parse.CssValueParser.TryParseLengthOrCalc, AutoKeyword.Auto);",
                 generated);
         }
 
@@ -700,7 +700,7 @@ namespace PeachPDF.SourceGenerators.Tests
                     { "name": "word-spacing", "inherited": true, "initialValue": "normal",
                       "cssDataType": { "type": "keyword-or-value", "enumType": "NormalKeyword", "keywordMap": "Map.NormalKeywords",
                         "fallback": "NormalKeyword.Normal", "valueType": "length" },
-                      "html": { "propertyPath": "WordSpacing", "csharpDataType": "CssProperty<CssKeywordOrValue<NormalKeyword, Length>>",
+                      "html": { "propertyPath": "WordSpacing", "csharpDataType": "CssProperty<CssKeywordOrValue<NormalKeyword, LengthOrCalc>>",
                         "area": "TextArea", "valueComputation": "no-ems" } }
                   ]
                 }
@@ -714,8 +714,8 @@ namespace PeachPDF.SourceGenerators.Tests
                 .Single(s => s.HintName == "CssBox.StyleProperties.g.cs").SourceText.ToString();
 
             Assert.Contains(
-                "box.WordSpacing = global::PeachPDF.CSS.CssKeywordOrValueParser.FromCssText<NormalKeyword, global::PeachPDF.CSS.Length>" +
-                "(box.NoEms(value), Map.NormalKeywords, global::PeachPDF.CSS.Length.TryParse, NormalKeyword.Normal);",
+                "box.WordSpacing = global::PeachPDF.CSS.CssKeywordOrValueParser.FromCssText<NormalKeyword, global::PeachPDF.CSS.LengthOrCalc>" +
+                "(box.NoEms(value), Map.NormalKeywords, global::PeachPDF.Html.Core.Parse.CssValueParser.TryParseLengthOrCalc, NormalKeyword.Normal);",
                 registry);
 
             Assert.DoesNotContain("NoEms(value)", styleProperties);

--- a/src/PeachPDF.SourceGenerators.Tests/GeneratorGoldenFileTests.cs
+++ b/src/PeachPDF.SourceGenerators.Tests/GeneratorGoldenFileTests.cs
@@ -274,7 +274,7 @@ namespace PeachPDF.SourceGenerators.Tests
 
             Assert.Contains(
                 "private static bool Validate_ColumnWidth(CssValueParser parser, string value) => " +
-                "Map.AutoKeywords.ContainsKey(value) || global::PeachPDF.Html.Core.Parse.CssValueParser.IsValidLength(value);",
+                "Map.AutoKeywords.ContainsKey(value) || global::PeachPDF.CSS.Length.TryParse(value, out _);",
                 generated);
             Assert.Contains(
                 "box.Transform = global::PeachPDF.CSS.CssKeywordOrValueParser.FromCssText<AutoKeyword, global::PeachPDF.CSS.Length>(value, Map.AutoKeywords, global::PeachPDF.CSS.Length.TryParse, AutoKeyword.Auto);",
@@ -685,6 +685,43 @@ namespace PeachPDF.SourceGenerators.Tests
             Assert.Contains(
                 "var newArea = area.SetPropertyValue(area.WordSpacing, resolved, static (a, v) => a with { WordSpacing = v });",
                 generated);
+        }
+
+        [Fact]
+        public void Emits_NoEms_InTheRegistry_NotTheBoxSetter_ForAKeywordOrValueProperty()
+        {
+            // word-spacing/letter-spacing's real shape post-#598-conversion: a keyword-or-value property
+            // that also declares valueComputation "no-ems". The box's own generated setter no longer has a
+            // raw string to run NoEms against (its parameter is the already-parsed typed union), so the
+            // resolution has to happen in the registry's Set_X, against the raw text, before parsing.
+            var json = """
+                {
+                  "properties": [
+                    { "name": "word-spacing", "inherited": true, "initialValue": "normal",
+                      "cssDataType": { "type": "keyword-or-value", "enumType": "NormalKeyword", "keywordMap": "Map.NormalKeywords",
+                        "fallback": "NormalKeyword.Normal", "valueType": "length" },
+                      "html": { "propertyPath": "WordSpacing", "csharpDataType": "CssProperty<CssKeywordOrValue<NormalKeyword, Length>>",
+                        "area": "TextArea", "valueComputation": "no-ems" } }
+                  ]
+                }
+                """;
+
+            var result = GeneratorTestHost.Run(json, StubSources.MinimalCssBoxAndSvgElement);
+
+            var registry = result.Results.Single().GeneratedSources
+                .Single(s => s.HintName == "CssPropertyRegistry.g.cs").SourceText.ToString();
+            var styleProperties = result.Results.Single().GeneratedSources
+                .Single(s => s.HintName == "CssBox.StyleProperties.g.cs").SourceText.ToString();
+
+            Assert.Contains(
+                "box.WordSpacing = global::PeachPDF.CSS.CssKeywordOrValueParser.FromCssText<NormalKeyword, global::PeachPDF.CSS.Length>" +
+                "(box.NoEms(value), Map.NormalKeywords, global::PeachPDF.CSS.Length.TryParse, NormalKeyword.Normal);",
+                registry);
+
+            Assert.DoesNotContain("NoEms(value)", styleProperties);
+            Assert.Contains(
+                "var newArea = area.SetPropertyValue(area.WordSpacing, value, static (a, v) => a with { WordSpacing = v });",
+                styleProperties);
         }
 
         [Fact]

--- a/src/PeachPDF.SourceGenerators/Emit/KeywordOrValueGrammar.cs
+++ b/src/PeachPDF.SourceGenerators/Emit/KeywordOrValueGrammar.cs
@@ -34,8 +34,20 @@ namespace PeachPDF.SourceGenerators.Emit
         public static Resolved Resolve(PropertyEntry entry, DataTypeSpec dt) => dt.ValueType switch
         {
             "integer" => new Resolved(BuildIntegerValueClause(dt), "int", "int.TryParse"),
+            // Deliberately validates via Length.TryParse itself, NOT the broader
+            // CssValueParser.IsValidLength (which also accepts calc()) - Length.TryParse can't parse a
+            // calc() expression needing layout-time context (mixed em/rem/% units; a pure-absolute
+            // calc() has already folded to a literal length by the time Layer A hands this text down, so
+            // it still passes), and CssKeywordOrValueParser.FromCssText has no third "unresolved, retry
+            // at layout time" state the way plain CssProperty<T> has for var() - the value side of this
+            // union is only ever Keyword or a concrete TValue. Validating with the broader clause would
+            // let an unparseable relative calc() pass validation and then silently fall back to the
+            // keyword side in FromCssText (the wrong value, not what was authored) instead of being
+            // correctly rejected as an invalid declaration (CSS Syntax 3 error recovery - the previous/
+            // inherited/initial value stays in effect, same as any other invalid value already handled
+            // by this generator).
             "length" => new Resolved(
-                "global::PeachPDF.Html.Core.Parse.CssValueParser.IsValidLength(value)",
+                "global::PeachPDF.CSS.Length.TryParse(value, out _)",
                 "global::PeachPDF.CSS.Length", "global::PeachPDF.CSS.Length.TryParse"),
             _ => throw new NotSupportedException(
                 $"\"{entry.Name}\" declares a keyword-or-value cssDataType with valueType \"{dt.ValueType}\", " +

--- a/src/PeachPDF.SourceGenerators/Emit/KeywordOrValueGrammar.cs
+++ b/src/PeachPDF.SourceGenerators/Emit/KeywordOrValueGrammar.cs
@@ -34,21 +34,19 @@ namespace PeachPDF.SourceGenerators.Emit
         public static Resolved Resolve(PropertyEntry entry, DataTypeSpec dt) => dt.ValueType switch
         {
             "integer" => new Resolved(BuildIntegerValueClause(dt), "int", "int.TryParse"),
-            // Deliberately validates via Length.TryParse itself, NOT the broader
-            // CssValueParser.IsValidLength (which also accepts calc()) - Length.TryParse can't parse a
-            // calc() expression needing layout-time context (mixed em/rem/% units; a pure-absolute
-            // calc() has already folded to a literal length by the time Layer A hands this text down, so
-            // it still passes), and CssKeywordOrValueParser.FromCssText has no third "unresolved, retry
-            // at layout time" state the way plain CssProperty<T> has for var() - the value side of this
-            // union is only ever Keyword or a concrete TValue. Validating with the broader clause would
-            // let an unparseable relative calc() pass validation and then silently fall back to the
-            // keyword side in FromCssText (the wrong value, not what was authored) instead of being
-            // correctly rejected as an invalid declaration (CSS Syntax 3 error recovery - the previous/
-            // inherited/initial value stays in effect, same as any other invalid value already handled
-            // by this generator).
+            // LengthOrCalc.TryParse (via CssValueParser.TryParseLengthOrCalc), not the plain
+            // Length.TryParse - a keyword-or-value property's "length" side must accept calc() too (CSS
+            // Values and Units 4 §10.9 - calc() is valid anywhere <length> is), including a calc()
+            // mixing relative units that can't fold to a literal Length at cascade time (a pure-absolute
+            // calc() already has, by Layer A's CalcSerializer, before this ever runs). LengthOrCalc keeps
+            // that text for Layer B's own ParseLength to evaluate lazily against real box context at
+            // consumption time - see LengthOrCalc's doc comment. Validating with the same TryParse that
+            // storage uses keeps the two in lockstep (unlike a broader validator that accepts more than
+            // storage can actually represent, which would let a value pass validation and then silently
+            // fall back to the wrong keyword-side value in FromCssText).
             "length" => new Resolved(
-                "global::PeachPDF.CSS.Length.TryParse(value, out _)",
-                "global::PeachPDF.CSS.Length", "global::PeachPDF.CSS.Length.TryParse"),
+                "global::PeachPDF.Html.Core.Parse.CssValueParser.TryParseLengthOrCalc(value, out _)",
+                "global::PeachPDF.CSS.LengthOrCalc", "global::PeachPDF.Html.Core.Parse.CssValueParser.TryParseLengthOrCalc"),
             _ => throw new NotSupportedException(
                 $"\"{entry.Name}\" declares a keyword-or-value cssDataType with valueType \"{dt.ValueType}\", " +
                 "which KeywordOrValueGrammar does not yet implement."),

--- a/src/PeachPDF.SourceGenerators/Emit/RegistryEmitter.cs
+++ b/src/PeachPDF.SourceGenerators/Emit/RegistryEmitter.cs
@@ -145,10 +145,23 @@ namespace PeachPDF.SourceGenerators.Emit
             {
                 var dt = entry.CssDataTypes[0];
                 var resolved = KeywordOrValueGrammar.Resolve(entry, dt);
+                // A keyword-or-value property's html.valueComputation (e.g. word-spacing/letter-spacing's
+                // "no-ems") must run on the raw authored text *before* FromCssText parses it - the box's
+                // own generated property setter (StylePropertiesEmitter) no longer sees a string to run it
+                // against once the property is typed, so this is the one place left with both the raw
+                // string and a CssBox in scope. See StylePropertiesEmitter's doc comment.
+                var rawValueExpr = html.ValueComputation switch
+                {
+                    null => "value",
+                    "no-ems" => "box.NoEms(value)",
+                    _ => throw new NotSupportedException(
+                        $"\"{entry.Name}\" declares a keyword-or-value cssDataType with html.valueComputation " +
+                        $"\"{html.ValueComputation}\", which RegistryEmitter does not implement."),
+                };
                 // Explicit type arguments: a method-group argument (int.TryParse) doesn't drive generic
                 // inference for TValue the way a concrete delegate instance would.
                 return $"box.{html.PropertyPath} = global::PeachPDF.CSS.CssKeywordOrValueParser.FromCssText<{dt.EnumType}, {resolved.CSharpType}>" +
-                       $"(value, {dt.KeywordMap}, {resolved.TryParseMethod}, {dt.Fallback});";
+                       $"({rawValueExpr}, {dt.KeywordMap}, {resolved.TryParseMethod}, {dt.Fallback});";
             }
 
             // A case-insensitively-matched keyword (plain "keyword", or the keyword side of a union like

--- a/src/PeachPDF.SourceGenerators/Emit/StylePropertiesEmitter.cs
+++ b/src/PeachPDF.SourceGenerators/Emit/StylePropertiesEmitter.cs
@@ -21,6 +21,11 @@ namespace PeachPDF.SourceGenerators.Emit
     /// parent-relative length to points; <c>word-spacing</c>/<c>letter-spacing</c> ("no-ems") and
     /// <c>text-indent</c> ("text-indent") eagerly resolve a plain <c>em</c> length the same way, via the
     /// hand-written <c>NoEms</c>/<c>NoEmsTextIndent</c> helpers this class still keeps on <c>CssBox</c>.
+    /// A <c>keyword-or-value</c>-shaped property declaring <c>valueComputation</c> is the one exception:
+    /// this setter's parameter is already a parsed typed union by the time it runs (there is no raw
+    /// string left for <c>NoEms</c> to act on), so <see cref="RegistryEmitter.BuildHtmlAssignment"/> runs
+    /// the computation itself against the raw authored text, before parsing, and this emitter skips its
+    /// own <c>EmitValueComputation</c> call for that shape entirely (see <see cref="EmitProperty"/>).
     /// </summary>
     internal static class StylePropertiesEmitter
     {
@@ -81,8 +86,15 @@ namespace PeachPDF.SourceGenerators.Emit
             if (invalidates is { Count: > 0 })
                 sb.AppendLine("                var previousStyle = _computedStyle;");
 
+            // A keyword-or-value property (e.g. word-spacing/letter-spacing) is already fully resolved -
+            // its html.valueComputation ran in RegistryEmitter.BuildHtmlAssignment against the raw
+            // authored string, before CssKeywordOrValueParser.FromCssText parsed it into the typed union
+            // this setter actually receives, since a typed union has no string for this class's own
+            // NoEms/NoEmsTextIndent helpers to run against. See RegistryEmitter's matching comment.
+            var isKeywordOrValue = entry.CssDataTypes.Count == 1 && entry.CssDataTypes[0].Kind == DataTypeKind.KeywordOrValue;
+
             var valueExpr = "value";
-            if (html.ValueComputation is not null)
+            if (html.ValueComputation is not null && !isKeywordOrValue)
             {
                 valueExpr = "resolved";
                 EmitValueComputation(sb, html.ValueComputation, entry);

--- a/src/PeachPDF.Tests/Html/Core/Utils/CssUtilsTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Utils/CssUtilsTests.cs
@@ -144,18 +144,18 @@ namespace PeachPDF.Tests.Html.Core.Utils
         {
             var (box, parser) = await FindDivBoxAndParser("");
 
-            Assert.Equal("normal", box.FlexColumnGap);
-            Assert.Equal("normal", box.FlexRowGap);
+            Assert.Equal("normal", box.FlexColumnGap.ToString());
+            Assert.Equal("normal", box.FlexRowGap.ToString());
 
             CssUtils.SetPropertyValue(parser, box, "column-gap", "10px");
             CssUtils.SetPropertyValue(parser, box, "row-gap", "1em");
-            Assert.Equal("10px", box.FlexColumnGap);
-            Assert.Equal("1em", box.FlexRowGap);
+            Assert.Equal("10px", box.FlexColumnGap.ToString());
+            Assert.Equal("1em", box.FlexRowGap.ToString());
 
             CssUtils.SetPropertyValue(parser, box, "column-gap", "normal");
             CssUtils.SetPropertyValue(parser, box, "row-gap", "normal");
-            Assert.Equal("normal", box.FlexColumnGap);
-            Assert.Equal("normal", box.FlexRowGap);
+            Assert.Equal("normal", box.FlexColumnGap.ToString());
+            Assert.Equal("normal", box.FlexRowGap.ToString());
         }
 
         [Fact]
@@ -166,8 +166,8 @@ namespace PeachPDF.Tests.Html.Core.Utils
             CssUtils.SetPropertyValue(parser, box, "column-gap", "banana");
             CssUtils.SetPropertyValue(parser, box, "row-gap", "banana");
 
-            Assert.Equal("10px", box.FlexColumnGap);
-            Assert.Equal("10px", box.FlexRowGap);
+            Assert.Equal("10px", box.FlexColumnGap.ToString());
+            Assert.Equal("10px", box.FlexRowGap.ToString());
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/CalcIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/CalcIntegrationTests.cs
@@ -3,6 +3,7 @@ using PeachPDF.Html.Adapters;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.PdfSharpCore.Drawing;
+using PeachPDF.Tests.TestSupport;
 
 namespace PeachPDF.Tests.Integration
 {
@@ -208,32 +209,28 @@ namespace PeachPDF.Tests.Integration
         }
 
         [Fact]
-        public async Task WordSpacing_MixedUnitCalc_DeclarationIsRejected_InheritsParentsValue()
+        public async Task WordSpacing_MixedUnitCalc_EvaluatesAgainstTheBoxsOwnFontSize()
         {
-            // word-spacing is CssKeywordOrValue<NormalKeyword, Length>-backed: the value side can only
-            // ever be a concrete, already-resolved Length, not "text to evaluate once layout context is
-            // known." A calc() expression built entirely from absolute units still folds to a literal
-            // length before it ever reaches here (see the sibling test above), but one mixing em/rem/%
-            // with other units can't fold at cascade time - Length.TryParse can't parse "calc(...)" text
-            // at all, so the property's own validator (Length.TryParse-based, not the broader
-            // CssValueParser.IsValidLength used elsewhere) correctly rejects it as an invalid declaration
-            // (CSS Syntax 3 error recovery) rather than silently substituting the wrong value. Confirmed
-            // via a real cascade: the child inherits the parent's word-spacing exactly like any other
-            // invalid declaration on an inherited property would.
-            var html = """
-                <!DOCTYPE html><html><body>
-                <div style="word-spacing: 5px">
-                <div id="el" style="word-spacing: calc(1em + 2px)">hello world</div>
-                </div>
-                </body></html>
-                """;
+            // word-spacing is CssKeywordOrValue<NormalKeyword, LengthOrCalc>-backed: an absolute-only
+            // calc() (see the sibling test above) still folds to a literal length before it ever reaches
+            // the property registry, but one mixing em/rem/%/cq* units can't fold without layout context
+            // - Length.TryParse alone can't represent that. LengthOrCalc keeps the calc()'s own text for
+            // exactly this case (mirroring GridTrackSize's identical trick for grid track sizes), and
+            // CssValueParser.ParseLength evaluates it lazily at consumption time against the box's real
+            // em/rem/container context - so a relative-unit calc() here resolves exactly like it did
+            // before this property was converted to typed storage, not silently to "normal".
+            var (calcRoot, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='el' style='font-size:20px; word-spacing: calc(1em + 2px)'>hello world</div>"));
+            var (absoluteRoot, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='el' style='font-size:20px; word-spacing: 22px'>hello world</div>"));
 
-            var root = await BuildBoxTree(html);
-            var el = FindById(root, "el");
+            var calcEl = LayoutHarness.FindById(calcRoot, "el");
+            var absoluteEl = LayoutHarness.FindById(absoluteRoot, "el");
 
-            Assert.NotNull(el);
-            Assert.Equal("5px", el!.WordSpacing.ToString());
-            Assert.True(el.WordSpacing.Value is { IsValue: true, Value.Value: 5f });
+            Assert.NotNull(calcEl);
+            Assert.NotNull(absoluteEl);
+            Assert.True(calcEl!.WordSpacing.Value is { IsValue: true, Value: { IsCalc: true } });
+            Assert.Equal(absoluteEl!.ActualWordSpacing, calcEl.ActualWordSpacing, 2);
         }
 
         [Fact]
@@ -366,6 +363,33 @@ namespace PeachPDF.Tests.Integration
             Assert.NotNull(el);
             Assert.Equal("15px", el!.FlexRowGap.ToString());
             Assert.Equal("20px", el.FlexColumnGap.ToString());
+        }
+
+        [Fact]
+        public async Task ColumnGap_MixedUnitCalc_LaysOutIdenticallyToTheEquivalentAbsoluteLength()
+        {
+            // Same LengthOrCalc deferred-evaluation path as word-spacing's sibling test above, exercised
+            // for row-gap/column-gap: a relative-unit calc() can't fold to a literal Length at cascade
+            // time, so it's kept as text and evaluated lazily by CssLayoutEngineGrid.ParseGap against the
+            // grid box's own real context - proven here by laying out two equal-width tracks either side
+            // of the gap and confirming the second track starts at the same X as it would with the
+            // equivalent absolute gap.
+            var (calcRoot, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='el' style='display:grid; grid-template-columns:50pt 50pt; font-size:20px; column-gap: calc(1em + 2px)'>" +
+                "<div id='a'></div><div id='b'></div></div>"));
+            var (absoluteRoot, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='el' style='display:grid; grid-template-columns:50pt 50pt; font-size:20px; column-gap: 22px'>" +
+                "<div id='a'></div><div id='b'></div></div>"));
+
+            var calcEl = LayoutHarness.FindById(calcRoot, "el");
+            var calcB = LayoutHarness.FindById(calcRoot, "b");
+            var absoluteB = LayoutHarness.FindById(absoluteRoot, "b");
+
+            Assert.NotNull(calcEl);
+            Assert.NotNull(calcB);
+            Assert.NotNull(absoluteB);
+            Assert.True(calcEl!.FlexColumnGap.Value is { IsValue: true, Value: { IsCalc: true } });
+            Assert.Equal(absoluteB!.Location.X, calcB!.Location.X, 2);
         }
 
         // ── helpers ───────────────────────────────────────────────────────────

--- a/src/PeachPDF.Tests/Integration/CalcIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/CalcIntegrationTests.cs
@@ -208,6 +208,35 @@ namespace PeachPDF.Tests.Integration
         }
 
         [Fact]
+        public async Task WordSpacing_MixedUnitCalc_DeclarationIsRejected_InheritsParentsValue()
+        {
+            // word-spacing is CssKeywordOrValue<NormalKeyword, Length>-backed: the value side can only
+            // ever be a concrete, already-resolved Length, not "text to evaluate once layout context is
+            // known." A calc() expression built entirely from absolute units still folds to a literal
+            // length before it ever reaches here (see the sibling test above), but one mixing em/rem/%
+            // with other units can't fold at cascade time - Length.TryParse can't parse "calc(...)" text
+            // at all, so the property's own validator (Length.TryParse-based, not the broader
+            // CssValueParser.IsValidLength used elsewhere) correctly rejects it as an invalid declaration
+            // (CSS Syntax 3 error recovery) rather than silently substituting the wrong value. Confirmed
+            // via a real cascade: the child inherits the parent's word-spacing exactly like any other
+            // invalid declaration on an inherited property would.
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div style="word-spacing: 5px">
+                <div id="el" style="word-spacing: calc(1em + 2px)">hello world</div>
+                </div>
+                </body></html>
+                """;
+
+            var root = await BuildBoxTree(html);
+            var el = FindById(root, "el");
+
+            Assert.NotNull(el);
+            Assert.Equal("5px", el!.WordSpacing.ToString());
+            Assert.True(el.WordSpacing.Value is { IsValue: true, Value.Value: 5f });
+        }
+
+        [Fact]
         public async Task Width_Min_PicksSmaller()
         {
             var root = await BuildBoxTree(WidthHtml("min(150pt, 100pt)"));
@@ -335,8 +364,8 @@ namespace PeachPDF.Tests.Integration
             var el = FindById(root, "el");
 
             Assert.NotNull(el);
-            Assert.Equal("15px", el!.FlexRowGap);
-            Assert.Equal("20px", el.FlexColumnGap);
+            Assert.Equal("15px", el!.FlexRowGap.ToString());
+            Assert.Equal("20px", el.FlexColumnGap.ToString());
         }
 
         // ── helpers ───────────────────────────────────────────────────────────

--- a/src/PeachPDF.Tests/Integration/GlobalKeywordCascadeTests.cs
+++ b/src/PeachPDF.Tests/Integration/GlobalKeywordCascadeTests.cs
@@ -632,7 +632,7 @@ namespace PeachPDF.Tests.Integration
             var child = FindById(root, "child");
 
             Assert.NotNull(child);
-            Assert.Equal("2px", child!.LetterSpacing);
+            Assert.Equal("2px", child!.LetterSpacing.ToString());
         }
 
         [Fact]
@@ -650,7 +650,7 @@ namespace PeachPDF.Tests.Integration
             var child = FindById(root, "child");
 
             Assert.NotNull(child);
-            Assert.Equal("3px", child!.WordSpacing);
+            Assert.Equal("3px", child!.WordSpacing.ToString());
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/NormalLengthGroupTypedStorageTests.cs
+++ b/src/PeachPDF.Tests/Integration/NormalLengthGroupTypedStorageTests.cs
@@ -8,8 +8,9 @@ namespace PeachPDF.Tests.Integration
     /// <summary>
     /// Direct typed-storage assertions for the "normal | length" group (<c>word-spacing</c>,
     /// <c>letter-spacing</c>, <c>row-gap</c>, <c>column-gap</c>) - each now backed by
-    /// <c>CssProperty&lt;CssKeywordOrValue&lt;NormalKeyword, Length&gt;&gt;</c>, the second grammar shape
-    /// through the keyword-or-value mechanism after <c>z-index</c>/<c>column-count</c>'s integer-or-auto.
+    /// <c>CssProperty&lt;CssKeywordOrValue&lt;NormalKeyword, LengthOrCalc&gt;&gt;</c>, the second grammar
+    /// shape through the keyword-or-value mechanism after <c>z-index</c>/<c>column-count</c>'s
+    /// integer-or-auto.
     /// Complements the existing layout-geometry tests (<c>LetterWordSpacingLayoutIntegrationTests</c>,
     /// <c>FlexboxIntegrationTests</c>, <c>GridLayoutIntegrationTests</c>, <c>MulticolLayoutIntegrationTests</c>),
     /// which exercise these properties indirectly through their effect on measured/laid-out positions
@@ -28,7 +29,7 @@ namespace PeachPDF.Tests.Integration
         public async Task WordSpacing_LengthValue_StoresParsedLength()
         {
             var box = await GetBoxAsync("<div id='el' style='word-spacing:4px'></div>");
-            Assert.True(box.WordSpacing.Value is { IsValue: true, Value.Value: 4f });
+            Assert.True(box.WordSpacing.Value is { IsValue: true, Value: { Length: { Value: 4f } } });
         }
 
         [Fact]
@@ -45,8 +46,8 @@ namespace PeachPDF.Tests.Integration
             // compound if a descendant with a different font-size ever read it, since TextArea inherits
             // by reference (see CssBox.NoEms's own doc comment).
             var box = await GetBoxAsync("<div id='el' style='font-size:20px; letter-spacing:1em'></div>");
-            Assert.True(box.LetterSpacing.Value is { IsValue: true } value);
-            Assert.Equal(Length.Unit.Pt, box.LetterSpacing.Value.Value!.Value.Type);
+            Assert.True(box.LetterSpacing.Value is { IsValue: true, Value: { IsCalc: false } });
+            Assert.Equal(Length.Unit.Pt, box.LetterSpacing.Value.Value!.Value.Length!.Value.Type);
         }
 
         [Fact]
@@ -60,7 +61,7 @@ namespace PeachPDF.Tests.Integration
         public async Task RowGap_LengthValue_StoresParsedLength()
         {
             var box = await GetBoxAsync("<div id='el' style='display:grid; row-gap:8px'></div>");
-            Assert.True(box.FlexRowGap.Value is { IsValue: true, Value.Value: 8f });
+            Assert.True(box.FlexRowGap.Value is { IsValue: true, Value: { Length: { Value: 8f } } });
         }
 
         [Fact]
@@ -74,7 +75,7 @@ namespace PeachPDF.Tests.Integration
         public async Task ColumnGap_LengthValue_StoresParsedLength()
         {
             var box = await GetBoxAsync("<div id='el' style='display:grid; column-gap:6px'></div>");
-            Assert.True(box.FlexColumnGap.Value is { IsValue: true, Value.Value: 6f });
+            Assert.True(box.FlexColumnGap.Value is { IsValue: true, Value: { Length: { Value: 6f } } });
         }
 
         // ─── Helpers ─────────────────────────────────────────────────────────────

--- a/src/PeachPDF.Tests/Integration/NormalLengthGroupTypedStorageTests.cs
+++ b/src/PeachPDF.Tests/Integration/NormalLengthGroupTypedStorageTests.cs
@@ -1,0 +1,90 @@
+using PeachPDF.CSS;
+using PeachPDF.Tests.TestSupport;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Direct typed-storage assertions for the "normal | length" group (<c>word-spacing</c>,
+    /// <c>letter-spacing</c>, <c>row-gap</c>, <c>column-gap</c>) - each now backed by
+    /// <c>CssProperty&lt;CssKeywordOrValue&lt;NormalKeyword, Length&gt;&gt;</c>, the second grammar shape
+    /// through the keyword-or-value mechanism after <c>z-index</c>/<c>column-count</c>'s integer-or-auto.
+    /// Complements the existing layout-geometry tests (<c>LetterWordSpacingLayoutIntegrationTests</c>,
+    /// <c>FlexboxIntegrationTests</c>, <c>GridLayoutIntegrationTests</c>, <c>MulticolLayoutIntegrationTests</c>),
+    /// which exercise these properties indirectly through their effect on measured/laid-out positions
+    /// rather than asserting the stored <c>.Value</c> directly.
+    /// </summary>
+    public class NormalLengthGroupTypedStorageTests
+    {
+        [Fact]
+        public async Task WordSpacing_StoresTypedValue_CaseInsensitively()
+        {
+            var box = await GetBoxAsync("<div id='el' style='word-spacing:NORMAL'></div>");
+            Assert.True(box.WordSpacing.Value.IsKeyword);
+        }
+
+        [Fact]
+        public async Task WordSpacing_LengthValue_StoresParsedLength()
+        {
+            var box = await GetBoxAsync("<div id='el' style='word-spacing:4px'></div>");
+            Assert.True(box.WordSpacing.Value is { IsValue: true, Value.Value: 4f });
+        }
+
+        [Fact]
+        public async Task LetterSpacing_StoresTypedValue_CaseInsensitively()
+        {
+            var box = await GetBoxAsync("<div id='el' style='letter-spacing:Normal'></div>");
+            Assert.True(box.LetterSpacing.Value.IsKeyword);
+        }
+
+        [Fact]
+        public async Task LetterSpacing_EmValue_IsEagerlyResolvedToPoints()
+        {
+            // The no-ems valueComputation must still run - a stored "1em" (unresolved) would silently
+            // compound if a descendant with a different font-size ever read it, since TextArea inherits
+            // by reference (see CssBox.NoEms's own doc comment).
+            var box = await GetBoxAsync("<div id='el' style='font-size:20px; letter-spacing:1em'></div>");
+            Assert.True(box.LetterSpacing.Value is { IsValue: true } value);
+            Assert.Equal(Length.Unit.Pt, box.LetterSpacing.Value.Value!.Value.Type);
+        }
+
+        [Fact]
+        public async Task RowGap_StoresTypedValue_CaseInsensitively()
+        {
+            var box = await GetBoxAsync("<div id='el' style='display:grid; row-gap:NORMAL'></div>");
+            Assert.True(box.FlexRowGap.Value.IsKeyword);
+        }
+
+        [Fact]
+        public async Task RowGap_LengthValue_StoresParsedLength()
+        {
+            var box = await GetBoxAsync("<div id='el' style='display:grid; row-gap:8px'></div>");
+            Assert.True(box.FlexRowGap.Value is { IsValue: true, Value.Value: 8f });
+        }
+
+        [Fact]
+        public async Task ColumnGap_StoresTypedValue_CaseInsensitively()
+        {
+            var box = await GetBoxAsync("<div id='el' style='display:grid; column-gap:Normal'></div>");
+            Assert.True(box.FlexColumnGap.Value.IsKeyword);
+        }
+
+        [Fact]
+        public async Task ColumnGap_LengthValue_StoresParsedLength()
+        {
+            var box = await GetBoxAsync("<div id='el' style='display:grid; column-gap:6px'></div>");
+            Assert.True(box.FlexColumnGap.Value is { IsValue: true, Value.Value: 6f });
+        }
+
+        // ─── Helpers ─────────────────────────────────────────────────────────────
+
+        private static async Task<PeachPDF.Html.Core.Dom.CssBox> GetBoxAsync(string bodyHtml)
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(bodyHtml));
+            var box = LayoutHarness.FindById(root, "el");
+            Assert.NotNull(box);
+            return box!;
+        }
+    }
+}

--- a/src/PeachPDF/CSS/Enumerations/NormalKeyword.cs
+++ b/src/PeachPDF/CSS/Enumerations/NormalKeyword.cs
@@ -1,0 +1,8 @@
+namespace PeachPDF.CSS
+{
+    /// <summary>The keyword side of a <c>&lt;value&gt; | normal</c>-shaped property's <see cref="CssKeywordOrValue{TEnum,TValue}"/>.</summary>
+    internal enum NormalKeyword
+    {
+        Normal
+    }
+}

--- a/src/PeachPDF/CSS/LengthOrCalc.cs
+++ b/src/PeachPDF/CSS/LengthOrCalc.cs
@@ -1,0 +1,23 @@
+namespace PeachPDF.CSS
+{
+    /// <summary>
+    /// The value side of a keyword-or-value length property whose grammar accepts <c>calc()</c> (e.g.
+    /// <c>word-spacing</c>/<c>letter-spacing</c>/<c>row-gap</c>/<c>column-gap</c>'s
+    /// <c>normal | &lt;length&gt;</c>): either resolved to a concrete <see cref="Length"/> at cascade time
+    /// (the common case - an absolute-only <c>calc()</c> has already folded to a literal length by Layer
+    /// A's <c>CalcSerializer</c> before this is ever constructed), or - when the authored text is a
+    /// <c>calc()</c> mixing relative units (<c>em</c>/<c>rem</c>/<c>%</c>/<c>cq*</c>) that can't fold
+    /// without layout context - the <c>calc()</c>'s own text, evaluated lazily by
+    /// <c>CssValueParser.ParseLength</c> at consumption time (where a real <c>CssBox</c> supplies that
+    /// context). Mirrors <c>GridTrackSize</c>'s identical "keep calc's reconstructed text, Layer B
+    /// evaluates it" pattern for grid track sizes (see <c>GridTrackListGrammar</c>'s
+    /// <c>IsLengthPercentageCalc</c> handling) - the same trick, ported to this union's value side.
+    /// </summary>
+    internal readonly record struct LengthOrCalc
+    {
+        public Length? Length { get; init; }
+        public string? CalcText { get; init; }
+
+        public bool IsCalc => CalcText is not null;
+    }
+}

--- a/src/PeachPDF/CSS/LengthOrCalc.cs
+++ b/src/PeachPDF/CSS/LengthOrCalc.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace PeachPDF.CSS
 {
     /// <summary>
@@ -12,9 +14,24 @@ namespace PeachPDF.CSS
     /// context). Mirrors <c>GridTrackSize</c>'s identical "keep calc's reconstructed text, Layer B
     /// evaluates it" pattern for grid track sizes (see <c>GridTrackListGrammar</c>'s
     /// <c>IsLengthPercentageCalc</c> handling) - the same trick, ported to this union's value side.
+    /// <para>
+    /// The "exactly one is set" invariant is enforced by the constructor, mirroring
+    /// <see cref="CssKeywordOrValue{TEnum,TValue}"/> - <c>default(LengthOrCalc)</c> (both null) bypasses it
+    /// the same way, but the only construction site, <c>CssValueParser.TryParseLengthOrCalc</c>
+    /// (namespace <c>PeachPDF.Html.Core.Parse</c>), always goes through this constructor.
+    /// </para>
     /// </summary>
     internal readonly record struct LengthOrCalc
     {
+        public LengthOrCalc(Length? length, string? calcText)
+        {
+            if (length is null == calcText is null)
+                throw new ArgumentException("Exactly one of length or calcText must be provided.");
+
+            Length = length;
+            CalcText = calcText;
+        }
+
         public Length? Length { get; init; }
         public string? CalcText { get; init; }
 

--- a/src/PeachPDF/CSS/Model/Map.cs
+++ b/src/PeachPDF/CSS/Model/Map.cs
@@ -279,6 +279,11 @@ namespace PeachPDF.CSS
             {
                 {Keywords.Auto, AutoKeyword.Auto}
             }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        public static readonly FrozenDictionary<string, NormalKeyword> NormalKeywords =
+            new Dictionary<string, NormalKeyword>(StringComparer.OrdinalIgnoreCase)
+            {
+                {Keywords.Normal, NormalKeyword.Normal}
+            }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
         public static readonly FrozenDictionary<string, BoxSizingMode> BoxSizingModes =
             new Dictionary<string, BoxSizingMode>(StringComparer.OrdinalIgnoreCase)
             {

--- a/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
@@ -347,7 +347,16 @@ namespace PeachPDF.Html.Core.Dom
         #region Non-cascaded helpers
 
         /// <summary>Ensures that the specified length is converted to pixels if necessary.</summary>
-        protected string NoEms(string length)
+        /// <remarks>
+        /// Internal, not protected: for a <c>keyword-or-value</c>-shaped property (<c>word-spacing</c>/
+        /// <c>letter-spacing</c>), <c>RegistryEmitter.BuildHtmlAssignment</c> calls this on the raw
+        /// authored text *before* <c>CssKeywordOrValueParser.FromCssText</c> parses it, from the
+        /// generated <c>CssPropertyRegistry</c> class (a same-assembly, but unrelated, type) - see the
+        /// source generator's <c>StylePropertiesEmitter</c> doc comment for why the resolution has to
+        /// happen there rather than in this box's own generated property setter once the setter's
+        /// parameter is a typed union instead of a string.
+        /// </remarks>
+        internal string NoEms(string length)
         {
             var len = new CssLength(length);
             if (len.Unit == CssUnit.Ems)

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineColumns.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineColumns.cs
@@ -86,9 +86,9 @@ namespace PeachPDF.Html.Core.Dom
             // initial value "normal" (CSS Box Alignment Module Level 3 §8.3) behaves differently per
             // layout mode — flex/grid resolve it to 0, multicol resolves it to exactly 1em (the value
             // the spec itself mandates for "normal" in a multi-column container).
-            var gap = columnsBox.FlexColumnGap == CssConstants.Normal
-                ? CssValueParser.ParseLength("1em", containerWidth, columnsBox)
-                : CssValueParser.ParseLength(columnsBox.FlexColumnGap, containerWidth, columnsBox);
+            var gap = columnsBox.FlexColumnGap.Value is { IsValue: true, Value: { } columnGapLength }
+                ? CssValueParser.ParseLength(columnGapLength, containerWidth, columnsBox)
+                : CssValueParser.ParseLength(new Length(1f, Length.Unit.Em), containerWidth, columnsBox);
             var (columnCount, columnWidth) = ResolveColumns(columnsBox, containerWidth, gap);
 
             if (columnCount <= 1)

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineFlex.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineFlex.cs
@@ -1510,7 +1510,7 @@ namespace PeachPDF.Html.Core.Dom
         private double ParseCrossGap(double mainSize) =>
             ParseGap(_isRow ? _flexBox.FlexRowGap : _flexBox.FlexColumnGap, mainSize);
 
-        private double ParseGap(CssProperty<CssKeywordOrValue<NormalKeyword, Length>> gap, double contentBase) =>
+        private double ParseGap(CssProperty<CssKeywordOrValue<NormalKeyword, LengthOrCalc>> gap, double contentBase) =>
             gap.Value is { IsValue: true, Value: { } length } ? CssValueParser.ParseLength(length, contentBase, _flexBox) : 0;
 
         // ─── Layout helpers ───────────────────────────────────────────────────────

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineFlex.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineFlex.cs
@@ -1505,14 +1505,13 @@ namespace PeachPDF.Html.Core.Dom
         // column-gap = between items in a row direction (main axis gap for row flex)
         // row-gap    = between items in a column direction (main axis gap for column flex)
         private double ParseMainGap(double mainSize) =>
-            CssValueParser.ParseLength(
-                _isRow ? _flexBox.FlexColumnGap : _flexBox.FlexRowGap,
-                mainSize, _flexBox);
+            ParseGap(_isRow ? _flexBox.FlexColumnGap : _flexBox.FlexRowGap, mainSize);
 
         private double ParseCrossGap(double mainSize) =>
-            CssValueParser.ParseLength(
-                _isRow ? _flexBox.FlexRowGap : _flexBox.FlexColumnGap,
-                mainSize, _flexBox);
+            ParseGap(_isRow ? _flexBox.FlexRowGap : _flexBox.FlexColumnGap, mainSize);
+
+        private double ParseGap(CssProperty<CssKeywordOrValue<NormalKeyword, Length>> gap, double contentBase) =>
+            gap.Value is { IsValue: true, Value: { } length } ? CssValueParser.ParseLength(length, contentBase, _flexBox) : 0;
 
         // ─── Layout helpers ───────────────────────────────────────────────────────
 

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineGrid.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineGrid.cs
@@ -1665,7 +1665,7 @@ namespace PeachPDF.Html.Core.Dom
             return defs;
         }
 
-        private double ParseGap(CssProperty<CssKeywordOrValue<NormalKeyword, Length>> gap, double contentBase) =>
+        private double ParseGap(CssProperty<CssKeywordOrValue<NormalKeyword, LengthOrCalc>> gap, double contentBase) =>
             gap.Value is { IsValue: true, Value: { } length } ? CssValueParser.ParseLength(length, contentBase, _gridBox) : 0;
 
         private static string FormatLayoutUnits(double value) =>

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineGrid.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineGrid.cs
@@ -1665,8 +1665,8 @@ namespace PeachPDF.Html.Core.Dom
             return defs;
         }
 
-        private double ParseGap(string value, double contentBase) =>
-            CssValueParser.ParseLength(value, contentBase, _gridBox);
+        private double ParseGap(CssProperty<CssKeywordOrValue<NormalKeyword, Length>> gap, double contentBase) =>
+            gap.Value is { IsValue: true, Value: { } length } ? CssValueParser.ParseLength(length, contentBase, _gridBox) : 0;
 
         private static string FormatLayoutUnits(double value) =>
             value.ToString("F4", CultureInfo.InvariantCulture) + "pt";

--- a/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
+++ b/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
@@ -532,9 +532,9 @@ namespace PeachPDF.Html.Core.Dom
         {
             if (!double.IsNaN(ActualLetterSpacing)) return;
 
-            _actualLetterSpacing = Style.Text.LetterSpacing == CssConstants.Normal
-                ? 0
-                : CssValueParser.ParseLength(Style.Text.LetterSpacing, 1, Owner);
+            _actualLetterSpacing = Style.Text.LetterSpacing.Value is { IsValue: true, Value: { } letterSpacing }
+                ? CssValueParser.ParseLength(letterSpacing, 1, Owner)
+                : 0;
         }
 
         /// <summary>The length/percentage component of <c>text-indent</c>, resolved to layout units. Which

--- a/src/PeachPDF/Html/Core/Parse/CssValueParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/CssValueParser.cs
@@ -274,13 +274,13 @@ namespace PeachPDF.Html.Core.Parse
         {
             if (Length.TryParse(value, out var length))
             {
-                result = new LengthOrCalc { Length = length };
+                result = new LengthOrCalc(length, null);
                 return true;
             }
 
             if (IsCalcFunction(value))
             {
-                result = new LengthOrCalc { CalcText = value };
+                result = new LengthOrCalc(null, value);
                 return true;
             }
 

--- a/src/PeachPDF/Html/Core/Parse/CssValueParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/CssValueParser.cs
@@ -231,6 +231,23 @@ namespace PeachPDF.Html.Core.Parse
         }
 
         /// <summary>
+        /// Resolves an already-parsed <see cref="Length"/> (e.g. a keyword-or-value cascade property's
+        /// <c>CssKeywordOrValue{TEnum,Length}.Value</c>) to pixels against <paramref name="box"/>'s own
+        /// em/rem/container-relative-unit context — the same box-context extraction the string-based
+        /// <see cref="ParseLength(string,double,CssBox)"/> overload uses, without re-serializing the
+        /// already-typed length back to text just to re-parse it.
+        /// </summary>
+        /// <param name="length">The already-parsed length</param>
+        /// <param name="hundredPercent">Equivalent to 100 percent when length is a percentage</param>
+        /// <param name="box"></param>
+        public static double ParseLength(Length length, double hundredPercent, CssBox box)
+        {
+            var (containerInlinePt, containerBlockPt) = box.GetContainerRelativeUnitBasis();
+
+            return length.ToPixels(box.GetEmHeight(), box.GetRemHeight(), hundredPercent, containerInlinePt, containerBlockPt);
+        }
+
+        /// <summary>
         /// Parses a length. Lengths are followed by an unit identifier (e.g. 10px, 3.1em)
         /// </summary>
         /// <param name="length">Specified length</param>

--- a/src/PeachPDF/Html/Core/Parse/CssValueParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/CssValueParser.cs
@@ -248,6 +248,47 @@ namespace PeachPDF.Html.Core.Parse
         }
 
         /// <summary>
+        /// Resolves a <see cref="LengthOrCalc"/> (a keyword-or-value cascade property's
+        /// <c>CssKeywordOrValue{TEnum,LengthOrCalc}.Value</c>, e.g. <c>word-spacing</c>) to pixels -
+        /// either directly, for the already-resolved <see cref="Length"/> case, or by evaluating the
+        /// stored <c>calc()</c> text against <paramref name="box"/>'s real context, for a relative-unit
+        /// <c>calc()</c> that couldn't fold at cascade time. See <see cref="LengthOrCalc"/>'s own doc
+        /// comment for why this deferred-text case exists.
+        /// </summary>
+        public static double ParseLength(LengthOrCalc value, double hundredPercent, CssBox box) =>
+            value.IsCalc
+                ? ParseLength(value.CalcText!, hundredPercent, box)
+                : ParseLength(value.Length!.Value, hundredPercent, box);
+
+        /// <summary>
+        /// Parses a <c>&lt;length&gt;</c> that may also be a <c>calc()</c> expression needing layout-time
+        /// context to resolve (mixed <c>em</c>/<c>rem</c>/<c>%</c>/<c>cq*</c> units) - the
+        /// <see cref="LengthOrCalc"/>-shaped counterpart to the plain <see cref="Length.TryParse"/> a
+        /// keyword-or-value property's "length" valueType otherwise uses. An absolute-only <c>calc()</c>
+        /// has already folded to a literal length string by the time this runs (Layer A's
+        /// <c>CalcSerializer</c>), so it resolves via the plain <see cref="Length"/> case below exactly
+        /// like any other length; only a genuinely relative-unit <c>calc()</c> takes the deferred-text
+        /// path.
+        /// </summary>
+        public static bool TryParseLengthOrCalc(string value, out LengthOrCalc result)
+        {
+            if (Length.TryParse(value, out var length))
+            {
+                result = new LengthOrCalc { Length = length };
+                return true;
+            }
+
+            if (IsCalcFunction(value))
+            {
+                result = new LengthOrCalc { CalcText = value };
+                return true;
+            }
+
+            result = default;
+            return false;
+        }
+
+        /// <summary>
         /// Parses a length. Lengths are followed by an unit identifier (e.g. 10px, 3.1em)
         /// </summary>
         /// <param name="length">Specified length</param>

--- a/src/PeachPDF/Html/Core/Utils/CssUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/CssUtils.cs
@@ -36,12 +36,12 @@ namespace PeachPDF.Html.Core.Utils
         {
             var w = box.ActualFont.GetWhitespaceWidth(g);
 
-            if (!(string.IsNullOrEmpty(box.WordSpacing) || box.WordSpacing == CssConstants.Normal))
+            if (box.WordSpacing.Value is { IsValue: true, Value: { } wordSpacing })
             {
                 // word-spacing is a plain length in the same layout coordinate space as margin/padding/
                 // width/etc.; ParseLength resolves every unit (including spec-correct CSS px) through
                 // the shared Length.ToPixels conversion.
-                w += CssValueParser.ParseLength(box.WordSpacing, 0, box);
+                w += CssValueParser.ParseLength(wordSpacing, 0, box);
             }
 
             return w;

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -1642,7 +1642,7 @@
     },
     {
       "name": "word-spacing",
-      "comment": "CssKeywordOrValue<NormalKeyword, Length>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText. The eager em-to-pt resolution (valueComputation \"no-ems\") that used to run in the CssBox setter now runs in RegistryEmitter.BuildHtmlAssignment against the raw text before FromCssText parses it — see StylePropertiesEmitter's doc comment.",
+      "comment": "CssKeywordOrValue<NormalKeyword, LengthOrCalc>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText. The eager em-to-pt resolution (valueComputation \"no-ems\") that used to run in the CssBox setter now runs in RegistryEmitter.BuildHtmlAssignment against the raw text before FromCssText parses it — see StylePropertiesEmitter's doc comment.",
       "inherited": true,
       "initialValue": "normal",
       "cssDataType": {
@@ -1654,7 +1654,7 @@
       },
       "html": {
         "propertyPath": "WordSpacing",
-        "csharpDataType": "CssProperty<CssKeywordOrValue<NormalKeyword, Length>>",
+        "csharpDataType": "CssProperty<CssKeywordOrValue<NormalKeyword, LengthOrCalc>>",
         "area": "TextArea",
         "valueComputation": "no-ems",
         "getterExpression": "{box}.WordSpacing.ToString()"
@@ -1662,7 +1662,7 @@
     },
     {
       "name": "letter-spacing",
-      "comment": "CssKeywordOrValue<NormalKeyword, Length>-backed (issue #598's follow-up). Same no-ems eager em-resolution as word-spacing — see its comment.",
+      "comment": "CssKeywordOrValue<NormalKeyword, LengthOrCalc>-backed (issue #598's follow-up). Same no-ems eager em-resolution as word-spacing — see its comment.",
       "inherited": true,
       "initialValue": "normal",
       "cssDataType": {
@@ -1674,7 +1674,7 @@
       },
       "html": {
         "propertyPath": "LetterSpacing",
-        "csharpDataType": "CssProperty<CssKeywordOrValue<NormalKeyword, Length>>",
+        "csharpDataType": "CssProperty<CssKeywordOrValue<NormalKeyword, LengthOrCalc>>",
         "area": "TextArea",
         "valueComputation": "no-ems",
         "getterExpression": "{box}.LetterSpacing.ToString()"
@@ -2150,7 +2150,7 @@
     },
     {
       "name": "row-gap",
-      "comment": "CssKeywordOrValue<NormalKeyword, Length>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText.",
+      "comment": "CssKeywordOrValue<NormalKeyword, LengthOrCalc>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText.",
       "inherited": false,
       "initialValue": "normal",
       "cssDataType": {
@@ -2162,14 +2162,14 @@
       },
       "html": {
         "propertyPath": "FlexRowGap",
-        "csharpDataType": "CssProperty<CssKeywordOrValue<NormalKeyword, Length>>",
+        "csharpDataType": "CssProperty<CssKeywordOrValue<NormalKeyword, LengthOrCalc>>",
         "area": "FlexArea",
         "getterExpression": "{box}.FlexRowGap.ToString()"
       }
     },
     {
       "name": "column-gap",
-      "comment": "CssKeywordOrValue<NormalKeyword, Length>-backed (issue #598's follow-up). See CssLayoutEngineColumns.ResolveColumns for multicol's spec-mandated 'normal' => 1em special case (flex/grid instead resolve 'normal' to 0) — unaffected by this storage change, just a call-site consumption detail to preserve.",
+      "comment": "CssKeywordOrValue<NormalKeyword, LengthOrCalc>-backed (issue #598's follow-up). See CssLayoutEngineColumns.ResolveColumns for multicol's spec-mandated 'normal' => 1em special case (flex/grid instead resolve 'normal' to 0) — unaffected by this storage change, just a call-site consumption detail to preserve.",
       "inherited": false,
       "initialValue": "normal",
       "cssDataType": {
@@ -2181,7 +2181,7 @@
       },
       "html": {
         "propertyPath": "FlexColumnGap",
-        "csharpDataType": "CssProperty<CssKeywordOrValue<NormalKeyword, Length>>",
+        "csharpDataType": "CssProperty<CssKeywordOrValue<NormalKeyword, LengthOrCalc>>",
         "area": "FlexArea",
         "getterExpression": "{box}.FlexColumnGap.ToString()"
       }

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -1642,40 +1642,42 @@
     },
     {
       "name": "word-spacing",
+      "comment": "CssKeywordOrValue<NormalKeyword, Length>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText. The eager em-to-pt resolution (valueComputation \"no-ems\") that used to run in the CssBox setter now runs in RegistryEmitter.BuildHtmlAssignment against the raw text before FromCssText parses it — see StylePropertiesEmitter's doc comment.",
       "inherited": true,
       "initialValue": "normal",
-      "cssDataType": [
-        "length",
-        "keyword"
-      ],
-      "supportedValues": [
-        "normal"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "keyword-or-value",
+        "enumType": "NormalKeyword",
+        "keywordMap": "Map.NormalKeywords",
+        "fallback": "NormalKeyword.Normal",
+        "valueType": "length"
+      },
       "html": {
         "propertyPath": "WordSpacing",
-        "csharpDataType": "string",
+        "csharpDataType": "CssProperty<CssKeywordOrValue<NormalKeyword, Length>>",
         "area": "TextArea",
-        "valueComputation": "no-ems"
+        "valueComputation": "no-ems",
+        "getterExpression": "{box}.WordSpacing.ToString()"
       }
     },
     {
       "name": "letter-spacing",
+      "comment": "CssKeywordOrValue<NormalKeyword, Length>-backed (issue #598's follow-up). Same no-ems eager em-resolution as word-spacing — see its comment.",
       "inherited": true,
       "initialValue": "normal",
-      "cssDataType": [
-        "length",
-        "keyword"
-      ],
-      "supportedValues": [
-        "normal"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "keyword-or-value",
+        "enumType": "NormalKeyword",
+        "keywordMap": "Map.NormalKeywords",
+        "fallback": "NormalKeyword.Normal",
+        "valueType": "length"
+      },
       "html": {
         "propertyPath": "LetterSpacing",
-        "csharpDataType": "string",
+        "csharpDataType": "CssProperty<CssKeywordOrValue<NormalKeyword, Length>>",
         "area": "TextArea",
-        "valueComputation": "no-ems"
+        "valueComputation": "no-ems",
+        "getterExpression": "{box}.LetterSpacing.ToString()"
       }
     },
     {
@@ -2148,38 +2150,40 @@
     },
     {
       "name": "row-gap",
+      "comment": "CssKeywordOrValue<NormalKeyword, Length>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText.",
       "inherited": false,
       "initialValue": "normal",
-      "cssDataType": [
-        "length",
-        "keyword"
-      ],
-      "supportedValues": [
-        "normal"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "keyword-or-value",
+        "enumType": "NormalKeyword",
+        "keywordMap": "Map.NormalKeywords",
+        "fallback": "NormalKeyword.Normal",
+        "valueType": "length"
+      },
       "html": {
         "propertyPath": "FlexRowGap",
-        "csharpDataType": "string",
-        "area": "FlexArea"
+        "csharpDataType": "CssProperty<CssKeywordOrValue<NormalKeyword, Length>>",
+        "area": "FlexArea",
+        "getterExpression": "{box}.FlexRowGap.ToString()"
       }
     },
     {
       "name": "column-gap",
+      "comment": "CssKeywordOrValue<NormalKeyword, Length>-backed (issue #598's follow-up). See CssLayoutEngineColumns.ResolveColumns for multicol's spec-mandated 'normal' => 1em special case (flex/grid instead resolve 'normal' to 0) — unaffected by this storage change, just a call-site consumption detail to preserve.",
       "inherited": false,
       "initialValue": "normal",
-      "cssDataType": [
-        "length",
-        "keyword"
-      ],
-      "supportedValues": [
-        "normal"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "keyword-or-value",
+        "enumType": "NormalKeyword",
+        "keywordMap": "Map.NormalKeywords",
+        "fallback": "NormalKeyword.Normal",
+        "valueType": "length"
+      },
       "html": {
         "propertyPath": "FlexColumnGap",
-        "csharpDataType": "string",
-        "area": "FlexArea"
+        "csharpDataType": "CssProperty<CssKeywordOrValue<NormalKeyword, Length>>",
+        "area": "FlexArea",
+        "getterExpression": "{box}.FlexColumnGap.ToString()"
       }
     },
     {


### PR DESCRIPTION
## Summary

Part of the #598 initiative to replace raw-string CSS property storage with typed `CssBox` storage (case-insensitive by construction, instead of relying on the validation layer alone).

- Converts `word-spacing`, `letter-spacing`, `row-gap`, `column-gap` (all `normal | <length>`) from raw strings to `CssProperty<CssKeywordOrValue<NormalKeyword, LengthOrCalc>>` — the third property batch through the "keyword-or-value" generator mechanism, after `z-index` and `column-count`.
- Adds a new `NormalKeyword` enum / `Map.NormalKeywords` keyword map.
- Moves `word-spacing`/`letter-spacing`'s existing eager em-to-pt resolution (`valueComputation: "no-ems"`) from `CssBox`'s generated setter into `RegistryEmitter.BuildHtmlAssignment`, which is the only place left with both the raw authored text and a `CssBox` in scope once the property is typed. `CssBox.NoEms` is now `internal` instead of `protected` for the generated registry (an unrelated same-assembly class) to call it.
- Consumption sites (`CssUtils.WhiteSpace`, `DerivedStyle.MeasureLetterSpacing`, the flex/grid gap parsers, and multicol's `normal`→`1em` special case per CSS Box Alignment 3 §8.3) now consume the already-parsed value directly via a new `CssValueParser.ParseLength(Length, double, CssBox)` overload instead of round-tripping through `.ToString()`.
- Fixes a real regression found and confirmed during development: the generator's keyword-or-value `"length"` validation clause used the broad `CssValueParser.IsValidLength` (which accepts `calc()`) while storage parsed via the narrower `Length.TryParse` (which can't evaluate `calc()` at all) — so a `calc()` expression mixing relative units (e.g. `calc(1em + 2px)`) would pass validation but then silently store the wrong keyword-fallback value instead of the authored one. Fixed properly (not just documented as a gap) by adding a new `LengthOrCalc` union type mirroring the pre-existing `GridTrackSize` calc-deferral pattern: an absolute-only `calc()` still folds to a literal length upstream as before, but a `calc()` mixing relative units now stores its reconstructed text and is evaluated lazily at consumption time, restoring full parity with pre-conversion calc() support for these four properties.
- `LengthOrCalc`'s "exactly one of `Length`/`CalcText` is set" invariant is enforced by its constructor, mirroring the sibling `CssKeywordOrValue<TEnum,TValue>` union.

## Test plan

- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (7945 passed, 9 skipped)
- [x] `dotnet test PeachPDF.SourceGenerators.Tests/PeachPDF.SourceGenerators.Tests.csproj` — green (109 passed)
- [x] Diff coverage 95% vs base (`diff-cover`), above the 90% gate
- [x] New `NormalLengthGroupTypedStorageTests.cs` — case-insensitive `normal`, length-value storage for all four properties
- [x] New/updated regression tests in `CalcIntegrationTests.cs` proving `calc()` with relative units evaluates correctly (not just parses) for `word-spacing` and `column-gap`
- [x] New golden-file tests in `GeneratorGoldenFileTests.cs` for the `LengthOrCalc`-shaped codegen
- [x] Post-change review pass on the complete diff (no genuine defects found)