### PR TITLE
Convert column-width to typed keyword-or-value storage

### DIFF
--- a/src/PeachPDF.Tests/Integration/ColumnWidthTypedStorageTests.cs
+++ b/src/PeachPDF.Tests/Integration/ColumnWidthTypedStorageTests.cs
@@ -1,0 +1,78 @@
+using PeachPDF.CSS;
+using PeachPDF.Html.Core.Parse;
+using PeachPDF.Tests.TestSupport;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Direct typed-storage assertions for <c>column-width</c>, now backed by
+    /// <c>CssProperty&lt;CssKeywordOrValue&lt;AutoKeyword, LengthOrCalc&gt;&gt;</c> - reusing the
+    /// <c>LengthOrCalc</c> value side <c>word-spacing</c>/<c>letter-spacing</c>/<c>row-gap</c>/
+    /// <c>column-gap</c> introduced, so a relative-unit <c>calc()</c> still evaluates lazily rather than
+    /// being rejected. Complements <c>MulticolLayoutIntegrationTests</c>, which exercises
+    /// <c>column-width</c> indirectly through its effect on column geometry rather than asserting the
+    /// stored <c>.Value</c> directly.
+    /// </summary>
+    public class ColumnWidthTypedStorageTests
+    {
+        [Fact]
+        public async Task Auto_StoresTheAutoKeyword_CaseInsensitively()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='column-width:AUTO'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.ColumnWidth.Value is { IsKeyword: true, Keyword: AutoKeyword.Auto });
+        }
+
+        [Fact]
+        public async Task LengthValue_StoresParsedLength()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='column-width:120px'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.ColumnWidth.Value is { IsValue: true, Value: { IsCalc: false, Length: { Value: 120f } } });
+        }
+
+        [Fact]
+        public async Task AbsoluteUnitCalc_FoldsToALiteralLength()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='column-width:calc(100px + 20px)'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.ColumnWidth.Value is { IsValue: true, Value: { IsCalc: false } });
+        }
+
+        [Fact]
+        public async Task RelativeUnitCalc_EvaluatesAgainstTheBoxsOwnFontSize()
+        {
+            // font-size:20px resolves to an actual font size of 15pt (1px = 0.75pt), so
+            // calc(5em + 20px) = 5*15pt + 20px(=15pt) = 90pt.
+            var (calcRoot, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='font-size:20px; column-width:calc(5em + 20px)'></div>"));
+            var (absoluteRoot, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='font-size:20px; column-width:90pt'></div>"));
+
+            var calcBox = LayoutHarness.FindById(calcRoot, "t");
+            var absoluteBox = LayoutHarness.FindById(absoluteRoot, "t");
+
+            Assert.NotNull(calcBox);
+            Assert.NotNull(absoluteBox);
+            Assert.True(calcBox!.ColumnWidth.Value is { IsValue: true, Value: { IsCalc: true } });
+
+            var calcWidth = CssValueParser.ParseLength(calcBox.ColumnWidth.Value.Value!.Value, 0, calcBox);
+            var absoluteWidth = CssValueParser.ParseLength(absoluteBox!.ColumnWidth.Value.Value!.Value, 0, absoluteBox);
+            Assert.Equal(absoluteWidth, calcWidth, 2);
+        }
+    }
+}

--- a/src/PeachPDF/CSS/CssKeywordOrValue.cs
+++ b/src/PeachPDF/CSS/CssKeywordOrValue.cs
@@ -64,9 +64,13 @@ namespace PeachPDF.CSS
             if (value.Contains("var(", StringComparison.OrdinalIgnoreCase))
                 return CssProperty<CssKeywordOrValue<TEnum, TValue>>.Unresolved(value);
 
-            if (keywordMap.TryGetValue(value.Trim(), out var keyword))
+            var trimmed = value.Trim();
+            if (keywordMap.TryGetValue(trimmed, out var keyword))
+                // Stored canonicalized (lowercase), not the raw input, mirroring CssProperty<T>.FromCssText's
+                // own reasoning (issue #598) - ToString() must round-trip to the canonical spelling
+                // regardless of how the keyword side of this union was cased.
                 return CssProperty<CssKeywordOrValue<TEnum, TValue>>.FromValue(
-                    value, new CssKeywordOrValue<TEnum, TValue>(keyword, null));
+                    trimmed.ToLowerInvariant(), new CssKeywordOrValue<TEnum, TValue>(keyword, null));
 
             if (tryParseValue(value, out var parsed))
                 return CssProperty<CssKeywordOrValue<TEnum, TValue>>.FromValue(

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineColumns.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineColumns.cs
@@ -1082,9 +1082,12 @@ namespace PeachPDF.Html.Core.Dom
             var columnCount = columnsBox.ColumnCount.Value;
             var hasCount = columnCount.IsValue;
             var parsedCount = columnCount.Value.GetValueOrDefault();
-            var hasWidth = columnsBox.ColumnWidth != CssConstants.Auto && CssValueParser.IsValidLength(columnsBox.ColumnWidth);
+            var columnWidth = columnsBox.ColumnWidth.Value;
+            var hasWidth = columnWidth.IsValue;
 
-            var specifiedWidth = hasWidth ? CssValueParser.ParseLength(columnsBox.ColumnWidth, containerWidth, columnsBox) : 0;
+            var specifiedWidth = hasWidth
+                ? CssValueParser.ParseLength(columnWidth.Value.GetValueOrDefault(), containerWidth, columnsBox)
+                : 0;
 
             if (hasCount && hasWidth)
             {

--- a/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
+++ b/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
@@ -1147,7 +1147,7 @@ namespace PeachPDF.Html.Core.Dom
         /// </summary>
         public bool EstablishesMultiColumnContext =>
             Style.MultiColumn.ColumnCount.Value is { IsValue: true } ||
-            (!string.IsNullOrEmpty(Style.MultiColumn.ColumnWidth) && Style.MultiColumn.ColumnWidth != CssConstants.Auto);
+            Style.MultiColumn.ColumnWidth.Value is { IsValue: true };
 
         #endregion
     }

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -2359,20 +2359,21 @@
     },
     {
       "name": "column-width",
+      "comment": "CssKeywordOrValue<AutoKeyword, LengthOrCalc>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText. Reuses word-spacing/letter-spacing/row-gap/column-gap's LengthOrCalc value side so a relative-unit calc() still evaluates lazily at consumption time instead of being rejected.",
       "inherited": false,
       "initialValue": "auto",
-      "cssDataType": [
-        "keyword",
-        "length"
-      ],
-      "supportedValues": [
-        "auto"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "keyword-or-value",
+        "enumType": "AutoKeyword",
+        "keywordMap": "Map.AutoKeywords",
+        "fallback": "AutoKeyword.Auto",
+        "valueType": "length"
+      },
       "html": {
         "propertyPath": "ColumnWidth",
-        "csharpDataType": "string",
-        "area": "MultiColumnArea"
+        "csharpDataType": "CssProperty<CssKeywordOrValue<AutoKeyword, LengthOrCalc>>",
+        "area": "MultiColumnArea",
+        "getterExpression": "{box}.ColumnWidth.ToString()"
       }
     },
     {


### PR DESCRIPTION
## Summary

Part of the #598 initiative to replace raw-string CSS property storage with typed `CssBox` storage.

- Converts `column-width` (`auto | <length>`) from a raw string to `CssProperty<CssKeywordOrValue<AutoKeyword, LengthOrCalc>>` — the fourth property through the "keyword-or-value" generator mechanism, and the first to reuse the `LengthOrCalc` value side built for `word-spacing`/`letter-spacing`/`row-gap`/`column-gap`. `column-width` already supported `calc()` fully before this conversion (its old grammar validated via the broad `IsValidLength`), so reusing `LengthOrCalc` preserves that instead of adding new capability — a relative-unit `calc()` still evaluates lazily at consumption time instead of being rejected.
- Migrates the two consumption sites: `CssLayoutEngineColumns.ResolveColumns` and `DerivedStyle.EstablishesMultiColumnContext`, both preserving their exact prior semantics (a non-positive width still falls through to "no width specified"; a `calc()`-backed value still counts as "not auto").
- Fixes a real latent bug in the shared keyword-or-value mechanism found along the way: `CssKeywordOrValueParser.FromCssText` stored a matched keyword's *raw* authored text instead of canonicalizing its casing, the way the plain-keyword `CssProperty<T>.FromCssText` already does. So `column-width: AUTO` — issue #598's own motivating example — round-tripped back out as `"AUTO"` instead of `"auto"`. This surfaced because an existing `CssUtilsTests` canonicalization test already covered `column-width`. Fixed at the shared parser, which also silently fixes the same latent bug for every other keyword-or-value property's keyword side (`z-index`/`column-count`'s `"auto"`, the normal-length group's `"normal"`).

## Test plan

- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (7949 passed, 9 skipped)
- [x] `dotnet test PeachPDF.SourceGenerators.Tests/PeachPDF.SourceGenerators.Tests.csproj` — green (109 passed)
- [x] Diff coverage 100% vs base (`diff-cover`)
- [x] New `ColumnWidthTypedStorageTests.cs` — case-insensitive `auto`, length storage, absolute-unit `calc()` folding, relative-unit `calc()` evaluating lazily to the same result as an equivalent absolute length
- [x] Post-change review pass on the complete diff (no genuine defects found)