### PR TITLE
Convert margin-top/right/bottom/left to typed keyword-or-value storage

### DIFF
--- a/src/PeachPDF.Tests/CSS/UnmatchableSelectorRegistrationTests.cs
+++ b/src/PeachPDF.Tests/CSS/UnmatchableSelectorRegistrationTests.cs
@@ -37,7 +37,7 @@ public class UnmatchableSelectorRegistrationTests
             "<p id='p'>text</p>");
         var box = await Box(html, "p");
         Assert.Equal("rgb(0, 0, 255)", box.Color);
-        Assert.Equal("8pt", box.MarginTop);
+        Assert.Equal("8pt", box.MarginTop.ToString());
     }
 
     [Theory]

--- a/src/PeachPDF.Tests/Integration/CustomPropertiesIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/CustomPropertiesIntegrationTests.cs
@@ -90,7 +90,7 @@ namespace PeachPDF.Tests.Integration
             var el = FindById(root, "el");
 
             Assert.NotNull(el);
-            Assert.Equal("10px", el!.MarginTop);
+            Assert.Equal("10px", el!.MarginTop.ToString());
         }
 
         [Fact]
@@ -126,7 +126,7 @@ namespace PeachPDF.Tests.Integration
             var child = FindById(root, "child");
 
             Assert.NotNull(child);
-            Assert.Equal("0", child!.MarginTop);
+            Assert.Equal("0", child!.MarginTop.ToString());
         }
 
         [Fact]
@@ -142,10 +142,10 @@ namespace PeachPDF.Tests.Integration
             var el = FindById(root, "el");
 
             Assert.NotNull(el);
-            Assert.Equal("10px", el!.MarginTop);
-            Assert.Equal("10px", el.MarginBottom);
-            Assert.Equal("20px", el.MarginLeft);
-            Assert.Equal("20px", el.MarginRight);
+            Assert.Equal("10px", el!.MarginTop.ToString());
+            Assert.Equal("10px", el.MarginBottom.ToString());
+            Assert.Equal("20px", el.MarginLeft.ToString());
+            Assert.Equal("20px", el.MarginRight.ToString());
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/GlobalKeywordCascadeTests.cs
+++ b/src/PeachPDF.Tests/Integration/GlobalKeywordCascadeTests.cs
@@ -53,7 +53,7 @@ namespace PeachPDF.Tests.Integration
             var child = FindById(root, "child");
 
             Assert.NotNull(child);
-            Assert.Equal("30px", child!.MarginTop);
+            Assert.Equal("30px", child!.MarginTop.ToString());
         }
 
         [Fact]
@@ -128,7 +128,7 @@ namespace PeachPDF.Tests.Integration
             var el = FindById(root, "el");
 
             Assert.NotNull(el);
-            Assert.Equal("0", el!.MarginTop);
+            Assert.Equal("0", el!.MarginTop.ToString());
         }
 
         [Fact]
@@ -185,7 +185,7 @@ namespace PeachPDF.Tests.Integration
             var el = FindById(root, "el");
 
             Assert.NotNull(el);
-            Assert.Equal("0", el!.MarginTop);
+            Assert.Equal("0", el!.MarginTop.ToString());
         }
 
         [Fact]
@@ -291,7 +291,7 @@ namespace PeachPDF.Tests.Integration
             var el = FindById(root, "el");
 
             Assert.NotNull(el);
-            Assert.Equal("0", el!.MarginTop);
+            Assert.Equal("0", el!.MarginTop.ToString());
         }
 
         // ── revert-layer ──────────────────────────────────────────────────────
@@ -742,7 +742,7 @@ namespace PeachPDF.Tests.Integration
 
             Assert.NotNull(el);
             Assert.Equal("rgb(0, 0, 255)", el!.Color);
-            Assert.Equal("12px", el.MarginTop);
+            Assert.Equal("12px", el.MarginTop.ToString());
             Assert.Equal("rgb(255, 255, 0)", el.BackgroundColor);
         }
 
@@ -926,7 +926,7 @@ namespace PeachPDF.Tests.Integration
             var body = FindById(root, "b");
 
             Assert.NotNull(body);
-            Assert.Equal("8px", body!.MarginTop);
+            Assert.Equal("8px", body!.MarginTop.ToString());
         }
 
         // ── helpers ───────────────────────────────────────────────────────────

--- a/src/PeachPDF.Tests/Integration/MarginGroupTypedStorageTests.cs
+++ b/src/PeachPDF.Tests/Integration/MarginGroupTypedStorageTests.cs
@@ -1,0 +1,117 @@
+using PeachPDF.CSS;
+using PeachPDF.Tests.TestSupport;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Direct typed-storage assertions for the margin group (<c>margin-top/right/bottom/left</c>), now
+    /// backed by <c>CssProperty&lt;CssKeywordOrValue&lt;AutoKeyword, LengthOrCalc&gt;&gt;</c> - reusing the
+    /// same <c>LengthOrCalc</c> value side <c>column-width</c> introduced. Complements
+    /// <c>AutoMarginWidthIntegrationTests</c>/<c>LogicalPropertiesWritingModeIntegrationTests</c>, which
+    /// exercise these properties indirectly through their effect on layout geometry rather than asserting
+    /// the stored <c>.Value</c> directly.
+    /// </summary>
+    public class MarginGroupTypedStorageTests
+    {
+        [Fact]
+        public async Task Auto_StoresTheAutoKeyword_CaseInsensitively()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='margin-top:AUTO'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.MarginTop.Value is { IsKeyword: true, Keyword: AutoKeyword.Auto });
+        }
+
+        [Fact]
+        public async Task LengthValue_StoresParsedLength()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='margin-left:15px'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.MarginLeft.Value is { IsValue: true, Value: { IsCalc: false, Length: { Value: 15f } } });
+        }
+
+        [Fact]
+        public async Task PercentageValue_StoresParsedPercentage()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='margin-right:10%'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.MarginRight.Value is
+            {
+                IsValue: true,
+                Value: { IsCalc: false, Length: { Type: Length.Unit.Percent, Value: 10f } }
+            });
+        }
+
+        [Fact]
+        public async Task RelativeUnitCalc_EvaluatesAgainstTheBoxsOwnFontSize()
+        {
+            // font-size:20px resolves to an actual font size of 15pt (1px = 0.75pt), so
+            // calc(2em + 10px) = 2*15pt + 10px(=7.5pt) = 37.5pt.
+            var (calcRoot, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='font-size:20px; margin-bottom:calc(2em + 10px)'></div>"));
+            var (absoluteRoot, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='font-size:20px; margin-bottom:37.5pt'></div>"));
+
+            var calcBox = LayoutHarness.FindById(calcRoot, "t");
+            var absoluteBox = LayoutHarness.FindById(absoluteRoot, "t");
+
+            Assert.NotNull(calcBox);
+            Assert.NotNull(absoluteBox);
+            Assert.True(calcBox!.MarginBottom.Value is { IsValue: true, Value: { IsCalc: true } });
+            Assert.Equal(absoluteBox!.ActualMarginBottom, calcBox.ActualMarginBottom, 2);
+        }
+
+        [Fact]
+        public async Task HspaceAttribute_SetsLeftAndRightMarginsTyped()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<img id='t' src='x.png' hspace='10' />"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.MarginLeft.Value is { IsValue: true, Value: { IsCalc: false, Length: { Value: 10f } } });
+            Assert.True(box.MarginRight.Value is { IsValue: true, Value: { IsCalc: false, Length: { Value: 10f } } });
+        }
+
+        [Fact]
+        public async Task VspaceAttribute_SetsTopAndBottomMarginsTyped()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<img id='t' src='x.png' vspace='5' />"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.MarginTop.Value is { IsValue: true, Value: { IsCalc: false, Length: { Value: 5f } } });
+            Assert.True(box.MarginBottom.Value is { IsValue: true, Value: { IsCalc: false, Length: { Value: 5f } } });
+        }
+
+        [Fact]
+        public async Task LogicalMarginBlockStart_ResolvesIntoThePhysicalPropertyTyped()
+        {
+            // writing-mode: vertical-rl maps block-start to the physical right edge (CLAUDE.md's own
+            // worked example for this resolution).
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='writing-mode:vertical-rl; margin-block-start:12px'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.MarginRight.Value is { IsValue: true, Value: { IsCalc: false, Length: { Value: 12f } } });
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssBox.LogicalProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.LogicalProperties.cs
@@ -1,4 +1,5 @@
 using PeachPDF.CSS;
+using PeachPDF.Html.Core.Parse;
 using PeachPDF.Html.Core.Utils;
 
 namespace PeachPDF.Html.Core.Dom
@@ -109,12 +110,14 @@ namespace PeachPDF.Html.Core.Dom
 
         private void ApplyMargin(PhysicalSide side, string value)
         {
+            var parsed = CssKeywordOrValueParser.FromCssText<AutoKeyword, LengthOrCalc>(
+                value, Map.AutoKeywords, CssValueParser.TryParseLengthOrCalc, AutoKeyword.Auto);
             switch (side)
             {
-                case PhysicalSide.Top: MarginTop = value; break;
-                case PhysicalSide.Right: MarginRight = value; break;
-                case PhysicalSide.Bottom: MarginBottom = value; break;
-                default: MarginLeft = value; break;
+                case PhysicalSide.Top: MarginTop = parsed; break;
+                case PhysicalSide.Right: MarginRight = parsed; break;
+                case PhysicalSide.Bottom: MarginBottom = parsed; break;
+                default: MarginLeft = parsed; break;
             }
         }
 

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -515,7 +515,10 @@ namespace PeachPDF.Html.Core.Dom
         /// <summary>
         /// Gets the actual top's Margin
         /// </summary>
-        public double ActualMarginTop => CssValueParser.ParseLength(MarginTop, ContainingBlock.Size.Width, this);
+        public double ActualMarginTop =>
+            MarginTop.Value is { IsValue: true, Value: { } marginTop }
+                ? CssValueParser.ParseLength(marginTop, ContainingBlock.Size.Width, this)
+                : 0;
 
         /// <summary>
         /// Gets the actual Margin on the left
@@ -525,7 +528,10 @@ namespace PeachPDF.Html.Core.Dom
         /// <summary>
         /// Gets the actual Margin of the bottom
         /// </summary>
-        public double ActualMarginBottom => CssValueParser.ParseLength(MarginBottom, ContainingBlock.Size.Width, this);
+        public double ActualMarginBottom =>
+            MarginBottom.Value is { IsValue: true, Value: { } marginBottom }
+                ? CssValueParser.ParseLength(marginBottom, ContainingBlock.Size.Width, this)
+                : 0;
 
         /// <summary>
         /// Gets the actual Margin on the right

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -515,12 +515,13 @@ namespace PeachPDF.Html.Core.Dom
 
         public static double GetActualMarginLeft(CssBox box, double? boxWidth = null)
         {
-            if (box.MarginLeft is not CssConstants.Auto)
+            var marginLeft = box.MarginLeft.Value;
+            if (marginLeft.IsValue)
             {
-                return CssValueParser.ParseLength(box.MarginLeft, box.ContainingBlock.Size.Width, box);
+                return CssValueParser.ParseLength(marginLeft.Value!.Value, box.ContainingBlock.Size.Width, box);
             }
 
-            if (box.MarginRight is not CssConstants.Auto) return 0;
+            if (box.MarginRight.Value.IsValue) return 0;
 
             if (box.DerivedStyle.ActualDisplay.StartsWith("table-") && box.DerivedStyle.ActualDisplay != CssConstants.TableCaption)
             {
@@ -545,12 +546,13 @@ namespace PeachPDF.Html.Core.Dom
 
         public static double GetActualMarginRight(CssBox box, double? boxWidth = null)
         {
-            if (box.MarginRight is not CssConstants.Auto)
+            var marginRight = box.MarginRight.Value;
+            if (marginRight.IsValue)
             {
-                return CssValueParser.ParseLength(box.MarginRight, box.ContainingBlock.Size.Width, box);
+                return CssValueParser.ParseLength(marginRight.Value!.Value, box.ContainingBlock.Size.Width, box);
             }
 
-            if (box.MarginLeft is not CssConstants.Auto) return 0;
+            if (box.MarginLeft.Value.IsValue) return 0;
 
             if (box.DerivedStyle.ActualDisplay.StartsWith("table-") && box.DerivedStyle.ActualDisplay != CssConstants.TableCaption)
             {

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineFlex.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineFlex.cs
@@ -1475,10 +1475,10 @@ namespace PeachPDF.Html.Core.Dom
             _isRow ? box.ActualMarginRight : box.ActualMarginBottom;
 
         private bool IsMainMarginBeforeAuto(CssBox box) =>
-            (_isRow ? box.MarginLeft : box.MarginTop) == CssConstants.Auto;
+            (_isRow ? box.MarginLeft : box.MarginTop).Value.IsKeyword;
 
         private bool IsMainMarginAfterAuto(CssBox box) =>
-            (_isRow ? box.MarginRight : box.MarginBottom) == CssConstants.Auto;
+            (_isRow ? box.MarginRight : box.MarginBottom).Value.IsKeyword;
 
         private double MainPaddingBorder(CssBox box) =>
             _isRow

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
@@ -338,7 +338,7 @@ namespace PeachPDF.Html.Core.Dom
             // Once per table, for the same reason the whole-table pre-checks below are: the offset is
             // derived from the containing block rather than from where the table currently is, so a
             // continuation adding it again would center an already-centered table a second time.
-            if (!_continuesAPreviousPass && _tableBox.MarginLeft is CssConstants.Auto)
+            if (!_continuesAPreviousPass && _tableBox.MarginLeft.Value.IsKeyword)
             {
                 _tableBox.Location = _tableBox.Location with
                 {

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -1482,7 +1482,8 @@ namespace PeachPDF.Html.Core.Parse
                         box.Height = TranslateLength(value);
                         break;
                     case HtmlConstants.Hspace:
-                        box.MarginRight = box.MarginLeft = TranslateLength(value);
+                        box.MarginRight = box.MarginLeft = CssKeywordOrValueParser.FromCssText<AutoKeyword, LengthOrCalc>(
+                            TranslateLength(value), Map.AutoKeywords, CssValueParser.TryParseLengthOrCalc, AutoKeyword.Auto);
                         break;
                     case HtmlConstants.Nowrap:
                         box.WhiteSpace = CssProperty<Whitespace>.FromValue(CssConstants.NoWrap, Whitespace.NoWrap);
@@ -1497,7 +1498,8 @@ namespace PeachPDF.Html.Core.Parse
                         box.VerticalAlign = CssProperty<VerticalAlignment>.FromCssText(value, Map.VerticalAlignments, VerticalAlignment.Baseline);
                         break;
                     case HtmlConstants.Vspace:
-                        box.MarginTop = box.MarginBottom = TranslateLength(value);
+                        box.MarginTop = box.MarginBottom = CssKeywordOrValueParser.FromCssText<AutoKeyword, LengthOrCalc>(
+                            TranslateLength(value), Map.AutoKeywords, CssValueParser.TryParseLengthOrCalc, AutoKeyword.Auto);
                         break;
                     case HtmlConstants.Width:
                         box.Width = TranslateLength(value);

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -689,74 +689,78 @@
     },
     {
       "name": "margin-bottom",
+      "comment": "CssKeywordOrValue<AutoKeyword, LengthOrCalc>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText.",
       "inherited": false,
       "initialValue": "0",
-      "cssDataType": [
-        "length",
-        "keyword"
-      ],
-      "supportedValues": [
-        "auto"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "keyword-or-value",
+        "enumType": "AutoKeyword",
+        "keywordMap": "Map.AutoKeywords",
+        "fallback": "AutoKeyword.Auto",
+        "valueType": "length"
+      },
       "html": {
         "propertyPath": "MarginBottom",
-        "csharpDataType": "string",
-        "area": "BoxModelArea"
+        "csharpDataType": "CssProperty<CssKeywordOrValue<AutoKeyword, LengthOrCalc>>",
+        "area": "BoxModelArea",
+        "getterExpression": "{box}.MarginBottom.ToString()"
       }
     },
     {
       "name": "margin-left",
+      "comment": "CssKeywordOrValue<AutoKeyword, LengthOrCalc>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText.",
       "inherited": false,
       "initialValue": "0",
-      "cssDataType": [
-        "length",
-        "keyword"
-      ],
-      "supportedValues": [
-        "auto"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "keyword-or-value",
+        "enumType": "AutoKeyword",
+        "keywordMap": "Map.AutoKeywords",
+        "fallback": "AutoKeyword.Auto",
+        "valueType": "length"
+      },
       "html": {
         "propertyPath": "MarginLeft",
-        "csharpDataType": "string",
-        "area": "BoxModelArea"
+        "csharpDataType": "CssProperty<CssKeywordOrValue<AutoKeyword, LengthOrCalc>>",
+        "area": "BoxModelArea",
+        "getterExpression": "{box}.MarginLeft.ToString()"
       }
     },
     {
       "name": "margin-right",
+      "comment": "CssKeywordOrValue<AutoKeyword, LengthOrCalc>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText.",
       "inherited": false,
       "initialValue": "0",
-      "cssDataType": [
-        "length",
-        "keyword"
-      ],
-      "supportedValues": [
-        "auto"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "keyword-or-value",
+        "enumType": "AutoKeyword",
+        "keywordMap": "Map.AutoKeywords",
+        "fallback": "AutoKeyword.Auto",
+        "valueType": "length"
+      },
       "html": {
         "propertyPath": "MarginRight",
-        "csharpDataType": "string",
-        "area": "BoxModelArea"
+        "csharpDataType": "CssProperty<CssKeywordOrValue<AutoKeyword, LengthOrCalc>>",
+        "area": "BoxModelArea",
+        "getterExpression": "{box}.MarginRight.ToString()"
       }
     },
     {
       "name": "margin-top",
+      "comment": "CssKeywordOrValue<AutoKeyword, LengthOrCalc>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText.",
       "inherited": false,
       "initialValue": "0",
-      "cssDataType": [
-        "length",
-        "keyword"
-      ],
-      "supportedValues": [
-        "auto"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "keyword-or-value",
+        "enumType": "AutoKeyword",
+        "keywordMap": "Map.AutoKeywords",
+        "fallback": "AutoKeyword.Auto",
+        "valueType": "length"
+      },
       "html": {
         "propertyPath": "MarginTop",
-        "csharpDataType": "string",
-        "area": "BoxModelArea"
+        "csharpDataType": "CssProperty<CssKeywordOrValue<AutoKeyword, LengthOrCalc>>",
+        "area": "BoxModelArea",
+        "getterExpression": "{box}.MarginTop.ToString()"
       }
     },
     {


### PR DESCRIPTION
## Summary

Part of the #598 initiative to replace raw-string CSS property storage with typed `CssBox` storage.

- Converts `margin-top`, `margin-right`, `margin-bottom`, `margin-left` to `CssProperty<CssKeywordOrValue<AutoKeyword, LengthOrCalc>>` — the fifth keyword-or-value batch, and the margin half of a deliberate split of the larger 16-property margin/inset group. The inset/position half (`top`/`left`/`right`/`bottom` + their logical counterparts) follows in a separate PR — that group's positioned-offset resolution code carries a lot of history and deserves its own focused review.
- The 8 CSS Logical Properties (`margin-block/inline-start/end`, `inset-*`) stay `string?` resolution scratch space by design, matching the existing `border-*-style` precedent. Only `CssBox.LogicalProperties.cs`'s `ApplyMargin` changed, to parse the resolved logical text through the same `CssKeywordOrValueParser.FromCssText` used everywhere else before assigning into the now-typed physical field.
- Migrates consumption sites: `CssBox.ActualMarginTop/Bottom`, `CssLayoutEngine.GetActualMarginLeft/Right` (auto-margin/table-centering fallback chain), `CssLayoutEngineTable`'s deferred table auto-centering pass, `CssLayoutEngineFlex`'s auto-margin distribution checks, and `DomParser`'s legacy `hspace`/`vspace` HTML presentational attributes. `hspace`/`vspace` had zero prior test coverage — closed with two new tests.

## Test plan

- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (7956 passed, 9 skipped)
- [x] `dotnet test PeachPDF.SourceGenerators.Tests/PeachPDF.SourceGenerators.Tests.csproj` — green (109 passed)
- [x] Diff coverage 100% vs base (`diff-cover`)
- [x] New `MarginGroupTypedStorageTests.cs` — case-insensitive `auto`, length storage, percentage storage, relative-unit `calc()` evaluating lazily, `hspace`/`vspace` typed storage, and a logical `margin-block-start` → physical `margin-right` resolution check under `writing-mode: vertical-rl`
- [x] Post-change review pass on the complete diff (no genuine defects found)