### PR TITLE
Convert top/left/right/bottom to typed keyword-or-value storage

### DIFF
--- a/src/PeachPDF.Tests/Html/Core/Dom/ComputedStyleTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/ComputedStyleTests.cs
@@ -197,13 +197,19 @@ namespace PeachPDF.Tests.Html.Core.Dom
             // §9.4.3 says a relatively/absolutely positioned box's offsets should carry over here, same as
             // Left/Top/Width/Height already did. Unifying storage onto ComputedStyle.Bottom/.Right (see
             // CssBox.StyleProperties.cs's InheritStyle) fixes this for real; this test locks the fix in.
-            var source = new CssBox(null, null) { Bottom = "13px", Right = "17px" };
+            var source = new CssBox(null, null)
+            {
+                Bottom = CssKeywordOrValueParser.FromCssText<AutoKeyword, LengthOrCalc>(
+                    "13px", Map.AutoKeywords, CssValueParser.TryParseLengthOrCalc, AutoKeyword.Auto),
+                Right = CssKeywordOrValueParser.FromCssText<AutoKeyword, LengthOrCalc>(
+                    "17px", Map.AutoKeywords, CssValueParser.TryParseLengthOrCalc, AutoKeyword.Auto)
+            };
             var clone = new CssBox(null, null);
 
             clone.InheritStyle(source, everything: true);
 
-            Assert.Equal("13px", clone.Bottom);
-            Assert.Equal("17px", clone.Right);
+            Assert.Equal("13px", clone.Bottom.ToString());
+            Assert.Equal("17px", clone.Right.ToString());
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/InsetPositionGroupTypedStorageTests.cs
+++ b/src/PeachPDF.Tests/Integration/InsetPositionGroupTypedStorageTests.cs
@@ -1,0 +1,134 @@
+using PeachPDF.CSS;
+using PeachPDF.Tests.TestSupport;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Direct typed-storage assertions for the inset/position group (<c>top/left/right/bottom</c>), now
+    /// backed by <c>CssProperty&lt;CssKeywordOrValue&lt;AutoKeyword, LengthOrCalc&gt;&gt;</c> - reusing the
+    /// same <c>LengthOrCalc</c> value side <c>margin-top/right/bottom/left</c> introduced. Complements
+    /// <c>AbsolutePositioningIntegrationTests</c>/<c>Acid2RegressionTests</c>, which exercise these
+    /// properties indirectly through their effect on layout geometry rather than asserting the stored
+    /// <c>.Value</c> directly.
+    /// </summary>
+    public class InsetPositionGroupTypedStorageTests
+    {
+        [Fact]
+        public async Task Auto_StoresTheAutoKeyword_CaseInsensitively()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='position:relative; top:AUTO'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.Top.Value is { IsKeyword: true, Keyword: AutoKeyword.Auto });
+        }
+
+        [Fact]
+        public async Task LengthValue_StoresParsedLength()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='position:relative; left:15px'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.Left.Value is { IsValue: true, Value: { IsCalc: false, Length: { Value: 15f } } });
+        }
+
+        [Fact]
+        public async Task PercentageValue_StoresParsedPercentage()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='position:relative; right:10%'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.Right.Value is
+            {
+                IsValue: true,
+                Value: { IsCalc: false, Length: { Type: Length.Unit.Percent, Value: 10f } }
+            });
+        }
+
+        [Fact]
+        public async Task RelativePositioning_BottomOnly_ShiftsUpwards_MatchingLeftTopFallback()
+        {
+            // CSS 2.1 §9.4.3: "bottom" applies with its sign flipped when "top" is auto. This exact
+            // shape (only bottom set) is what a prior fix restored after it was found to be a silent
+            // no-op - re-verified here now that the offsets are typed rather than raw strings. Using
+            // "pt" (the internal layout unit) directly sidesteps the 1px = 0.75pt conversion entirely.
+            var (calcRoot, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='position:relative; bottom:15pt'>x</div>"));
+            var (staticRoot, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t2' style='position:relative;'>x</div>"));
+
+            var box = LayoutHarness.FindById(calcRoot, "t");
+            var staticBox = LayoutHarness.FindById(staticRoot, "t2");
+
+            Assert.NotNull(box);
+            Assert.NotNull(staticBox);
+            Assert.True(box!.Bottom.Value is { IsValue: true, Value: { IsCalc: false, Length: { Value: 15f } } });
+            Assert.Equal(staticBox!.Location.Y - 15, box.Location.Y, 2);
+        }
+
+        [Fact]
+        public async Task RelativeUnitCalc_EvaluatesAgainstTheBoxsOwnFontSize()
+        {
+            // font-size:20px resolves to an actual font size of 15pt (1px = 0.75pt), so
+            // calc(2em + 10px) = 2*15pt + 10px(=7.5pt) = 37.5pt.
+            var (calcRoot, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='position:relative; font-size:20px; left:calc(2em + 10px)'>x</div>"));
+            var (absoluteRoot, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='position:relative; font-size:20px; left:37.5pt'>x</div>"));
+
+            var calcBox = LayoutHarness.FindById(calcRoot, "t");
+            var absoluteBox = LayoutHarness.FindById(absoluteRoot, "t");
+
+            Assert.NotNull(calcBox);
+            Assert.NotNull(absoluteBox);
+            Assert.True(calcBox!.Left.Value is { IsValue: true, Value: { IsCalc: true } });
+            Assert.Equal(absoluteBox!.Location.X, calcBox.Location.X, 2);
+        }
+
+        [Fact]
+        public async Task AbsolutePositioning_LeftAutoRightSet_FallsBackToRightEdge()
+        {
+            // CSS 2.1 §10.3.7: left:auto with right set falls back to positioning from the right edge.
+            // The expected X is derived from the container's own runtime geometry (ClientRight) rather
+            // than a hand-computed absolute pixel value, so the assertion isn't coupled to unrelated
+            // px-to-pt conversion or UA-stylesheet default-margin details.
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='container' style='position:relative; width:200pt; height:100pt;'>" +
+                "<div id='t' style='position:absolute; right:20pt; width:50pt; height:50pt;'></div>" +
+                "</div>"));
+
+            var container = LayoutHarness.FindById(root, "container");
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(container);
+            Assert.NotNull(box);
+            Assert.True(box!.Left.Value.IsKeyword);
+            Assert.True(box.Right.Value is { IsValue: true, Value: { IsCalc: false, Length: { Value: 20f } } });
+            Assert.Equal(container!.ClientRight - box.ActualWidth - 20, box.Location.X, 2);
+        }
+
+        [Fact]
+        public async Task LogicalInsetBlockStart_ResolvesIntoThePhysicalPropertyTyped()
+        {
+            // writing-mode: vertical-rl maps block-start to the physical right edge (same mapping the
+            // margin group's equivalent test verifies against LogicalPropertyResolver.BlockStart).
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='position:relative; writing-mode:vertical-rl; inset-block-start:12px'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.Right.Value is { IsValue: true, Value: { IsCalc: false, Length: { Value: 12f } } });
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssBox.LogicalProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.LogicalProperties.cs
@@ -134,12 +134,14 @@ namespace PeachPDF.Html.Core.Dom
 
         private void ApplyInset(PhysicalSide side, string value)
         {
+            var parsed = CssKeywordOrValueParser.FromCssText<AutoKeyword, LengthOrCalc>(
+                value, Map.AutoKeywords, CssValueParser.TryParseLengthOrCalc, AutoKeyword.Auto);
             switch (side)
             {
-                case PhysicalSide.Top: Top = value; break;
-                case PhysicalSide.Right: Right = value; break;
-                case PhysicalSide.Bottom: Bottom = value; break;
-                default: Left = value; break;
+                case PhysicalSide.Top: Top = parsed; break;
+                case PhysicalSide.Right: Right = parsed; break;
+                case PhysicalSide.Bottom: Bottom = parsed; break;
+                default: Left = parsed; break;
             }
         }
 

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -4191,6 +4191,37 @@ namespace PeachPDF.Html.Core.Dom
         }
 
         /// <summary>
+        /// CSS 2.1 §9.4.3's near/far offset resolution for one axis: the near offset (<c>left</c>/<c>top</c>)
+        /// wins when set; if it's <c>auto</c> and the far offset (<c>right</c>/<c>bottom</c>) isn't, the far
+        /// offset applies with its sign flipped; if both are <c>auto</c>, the offset is 0.
+        /// </summary>
+        private static double ResolveNearFarOffset(
+            CssProperty<CssKeywordOrValue<AutoKeyword, LengthOrCalc>> near,
+            CssProperty<CssKeywordOrValue<AutoKeyword, LengthOrCalc>> far,
+            double basis, CssBox box)
+        {
+            var nearValue = near.Value;
+            var farValue = far.Value;
+
+            if (nearValue.IsValue || !farValue.IsValue)
+            {
+                return nearValue.Value is { } n ? CssValueParser.ParseLength(n, basis, box) : 0;
+            }
+
+            return -CssValueParser.ParseLength(farValue.Value!.Value, basis, box);
+        }
+
+        /// <summary>
+        /// Resolves a <c>left</c>/<c>top</c>/<c>right</c>/<c>bottom</c> offset for the absolute/fixed
+        /// positioning branches below, where the counterpart edge is never consulted (unlike the
+        /// relative-positioning near/far resolution in <see cref="ResolveNearFarOffset"/>) - an <c>auto</c>
+        /// offset simply contributes 0.
+        /// </summary>
+        private static double ResolveOffsetOrZero(
+            CssProperty<CssKeywordOrValue<AutoKeyword, LengthOrCalc>> offset, double basis, CssBox box) =>
+            offset.Value.Value is { } value ? CssValueParser.ParseLength(value, basis, box) : 0;
+
+        /// <summary>
         /// Writes the offset <see cref="ResolveBlockChildOffset"/> decided on, positions
         /// <paramref name="child"/> under whichever positioning scheme it uses, and registers the used page
         /// name it lands on.
@@ -4241,12 +4272,8 @@ namespace PeachPDF.Html.Core.Dom
                     // StaticBottom recovers by backing RelativeOffsetY out again. Acid2's
                     // ".smile div { position: relative; bottom: -1em }" is exactly this: the mouth
                     // bar paints 1em lower, but ".chin"'s position must not move with it.
-                    var offsetX = child.Left is not CssConstants.Auto || child.Right is CssConstants.Auto
-                        ? CssValueParser.ParseLength(child.Left, child.ActualWidth, child)
-                        : -CssValueParser.ParseLength(child.Right, child.ActualWidth, child);
-                    var offsetY = child.Top is not CssConstants.Auto || child.Bottom is CssConstants.Auto
-                        ? CssValueParser.ParseLength(child.Top, child.ActualHeight, child)
-                        : -CssValueParser.ParseLength(child.Bottom, child.ActualHeight, child);
+                    var offsetX = ResolveNearFarOffset(child.Left, child.Right, child.ActualWidth, child);
+                    var offsetY = ResolveNearFarOffset(child.Top, child.Bottom, child.ActualHeight, child);
 
                     child.RelativeOffsetX = offsetX;
                     child.RelativeOffsetY = offsetY;
@@ -4268,10 +4295,10 @@ namespace PeachPDF.Html.Core.Dom
                     // ".picture" (which has a 1em border) exercises both of these: the missing
                     // margin alone lands the box ~36px/60px off, on top of the next sibling.
                     var left = nearestPositionedAncestor.ClientLeft + child.ActualMarginLeft +
-                               CssValueParser.ParseLength(child.Left, nearestPositionedAncestor.ActualWidth, child);
+                               ResolveOffsetOrZero(child.Left, nearestPositionedAncestor.ActualWidth, child);
 
                     var top = nearestPositionedAncestor.ClientTop + child.ActualMarginTop +
-                              CssValueParser.ParseLength(child.Top, nearestPositionedAncestor.ActualHeight, child);
+                              ResolveOffsetOrZero(child.Top, nearestPositionedAncestor.ActualHeight, child);
 
                     child.Location = new RPoint(left, top);
                 }
@@ -4288,8 +4315,8 @@ namespace PeachPDF.Html.Core.Dom
                     // (CSS2.1 §10.1: the initial containing block), not ScrollOffset (a scroll
                     // position, not a size) - not exercised by this fixture (uses em, not %) but
                     // wrong regardless.
-                    var left = child.ActualMarginLeft + CssValueParser.ParseLength(child.Left, child.HtmlContainer!.PageSize.Width, child);
-                    var top = child.ActualMarginTop + CssValueParser.ParseLength(child.Top, child.HtmlContainer!.PageSize.Height, child);
+                    var left = child.ActualMarginLeft + ResolveOffsetOrZero(child.Left, child.HtmlContainer!.PageSize.Width, child);
+                    var top = child.ActualMarginTop + ResolveOffsetOrZero(child.Top, child.HtmlContainer!.PageSize.Height, child);
                     child.Location = new RPoint(left, top);
                 }
             }
@@ -4540,11 +4567,11 @@ namespace PeachPDF.Html.Core.Dom
 
             if (Position.Value is PositionMode.Absolute)
             {
-                if (Left is CssConstants.Auto && Right is not CssConstants.Auto)
+                if (Left.Value.IsKeyword && Right.Value.IsValue)
                 {
                     var nearestPositionedAncestor = DomUtils.GetNearestPositionedAncestor(this);
 
-                    var right = CssValueParser.ParseLength(Right, nearestPositionedAncestor.ActualWidth, this);
+                    var right = CssValueParser.ParseLength(Right.Value.Value!.Value, nearestPositionedAncestor.ActualWidth, this);
                     var actualRight = nearestPositionedAncestor.ClientRight + nearestPositionedAncestor.ActualPaddingRight - right;
 
                     var delta = actualRight - ActualRight;
@@ -4557,11 +4584,11 @@ namespace PeachPDF.Html.Core.Dom
                 // this method), but `bottom` was never read anywhere, so a box relying on `bottom` with
                 // `top: auto` silently stayed at the containing block's top edge instead of being placed
                 // relative to its bottom edge.
-                if (Top is CssConstants.Auto && Bottom is not CssConstants.Auto)
+                if (Top.Value.IsKeyword && Bottom.Value.IsValue)
                 {
                     var nearestPositionedAncestor = DomUtils.GetNearestPositionedAncestor(this);
 
-                    var bottom = CssValueParser.ParseLength(Bottom, nearestPositionedAncestor.ActualHeight, this);
+                    var bottom = CssValueParser.ParseLength(Bottom.Value.Value!.Value, nearestPositionedAncestor.ActualHeight, this);
 
                     // Unlike ActualRight/ActualWidth (resolved for every box, including this ancestor,
                     // before its children are laid out - see the GetBoxWidth call earlier in this

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -781,14 +781,14 @@ namespace PeachPDF.Html.Core.Dom
             if (box is { Width: CssConstants.Auto, Position.Value: PositionMode.Absolute })
             {
                 var absCb = PercentageBase(box);
-                if (box.Left != CssConstants.Auto && box.Right != CssConstants.Auto)
+                if (box.Left.Value.IsValue && box.Right.Value.IsValue)
                 {
                     // CSS 2.1 §10.3.7: an absolutely-positioned box with auto width but both `left` and
                     // `right` set fills the space between them in the containing block (rather than shrinking
                     // to fit its content). This is what sizes a Charts.css area/line `td::before` (auto width,
                     // `inset: 0`) to cover its cell.
-                    var left = CssValueParser.ParseLength(box.Left, absCb.Size.Width, box);
-                    var right = CssValueParser.ParseLength(box.Right, absCb.Size.Width, box);
+                    var left = CssValueParser.ParseLength(box.Left.Value.Value!.Value, absCb.Size.Width, box);
+                    var right = CssValueParser.ParseLength(box.Right.Value.Value!.Value, absCb.Size.Width, box);
                     // An over-constrained fill (left + right wider than the containing block) clamps to 0, per
                     // CSS 2.1 §10.3.7 (a used width is never negative).
                     width = Math.Max(0, absCb.Size.Width - left - right - box.ActualMarginLeft - box.ActualMarginRight - box.ActualBoxSizeIncludedWidth);
@@ -881,15 +881,15 @@ namespace PeachPDF.Html.Core.Dom
                 }
             }
             else if (box.Position.Value is PositionMode.Absolute
-                     && box.Top != CssConstants.Auto && box.Bottom != CssConstants.Auto
+                     && box.Top.Value.IsValue && box.Bottom.Value.IsValue
                      && heightCb.IsHeightCalculated)
             {
                 // CSS 2.1 §10.6.4: an absolutely-positioned box with auto height but both `top` and `bottom`
                 // set fills the space between them in the containing block. The counterpart of the §10.3.7
                 // width rule above; sizes a Charts.css area/line `td::before` (auto height, `inset: 0`) to
                 // its cell's height.
-                var top = CssValueParser.ParseLength(box.Top, heightCb.Size.Height, box);
-                var bottom = CssValueParser.ParseLength(box.Bottom, heightCb.Size.Height, box);
+                var top = CssValueParser.ParseLength(box.Top.Value.Value!.Value, heightCb.Size.Height, box);
+                var bottom = CssValueParser.ParseLength(box.Bottom.Value.Value!.Value, heightCb.Size.Height, box);
                 // Over-constrained fill clamps to 0 (a used height is never negative), per CSS 2.1 §10.6.4.
                 height = Math.Max(0, heightCb.Size.Height - top - bottom - box.ActualMarginTop - box.ActualMarginBottom);
             }

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -813,74 +813,78 @@
     },
     {
       "name": "left",
+      "comment": "CssKeywordOrValue<AutoKeyword, LengthOrCalc>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText.",
       "inherited": false,
       "initialValue": "auto",
-      "cssDataType": [
-        "length",
-        "keyword"
-      ],
-      "supportedValues": [
-        "auto"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "keyword-or-value",
+        "enumType": "AutoKeyword",
+        "keywordMap": "Map.AutoKeywords",
+        "fallback": "AutoKeyword.Auto",
+        "valueType": "length"
+      },
       "html": {
         "propertyPath": "Left",
-        "csharpDataType": "string",
-        "area": "BoxModelArea"
+        "csharpDataType": "CssProperty<CssKeywordOrValue<AutoKeyword, LengthOrCalc>>",
+        "area": "BoxModelArea",
+        "getterExpression": "{box}.Left.ToString()"
       }
     },
     {
       "name": "top",
+      "comment": "CssKeywordOrValue<AutoKeyword, LengthOrCalc>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText.",
       "inherited": false,
       "initialValue": "auto",
-      "cssDataType": [
-        "length",
-        "keyword"
-      ],
-      "supportedValues": [
-        "auto"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "keyword-or-value",
+        "enumType": "AutoKeyword",
+        "keywordMap": "Map.AutoKeywords",
+        "fallback": "AutoKeyword.Auto",
+        "valueType": "length"
+      },
       "html": {
         "propertyPath": "Top",
-        "csharpDataType": "string",
-        "area": "BoxModelArea"
+        "csharpDataType": "CssProperty<CssKeywordOrValue<AutoKeyword, LengthOrCalc>>",
+        "area": "BoxModelArea",
+        "getterExpression": "{box}.Top.ToString()"
       }
     },
     {
       "name": "right",
+      "comment": "CssKeywordOrValue<AutoKeyword, LengthOrCalc>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText.",
       "inherited": false,
       "initialValue": "auto",
-      "cssDataType": [
-        "length",
-        "keyword"
-      ],
-      "supportedValues": [
-        "auto"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "keyword-or-value",
+        "enumType": "AutoKeyword",
+        "keywordMap": "Map.AutoKeywords",
+        "fallback": "AutoKeyword.Auto",
+        "valueType": "length"
+      },
       "html": {
         "propertyPath": "Right",
-        "csharpDataType": "string",
-        "area": "BoxModelArea"
+        "csharpDataType": "CssProperty<CssKeywordOrValue<AutoKeyword, LengthOrCalc>>",
+        "area": "BoxModelArea",
+        "getterExpression": "{box}.Right.ToString()"
       }
     },
     {
       "name": "bottom",
+      "comment": "CssKeywordOrValue<AutoKeyword, LengthOrCalc>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText.",
       "inherited": false,
       "initialValue": "auto",
-      "cssDataType": [
-        "length",
-        "keyword"
-      ],
-      "supportedValues": [
-        "auto"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "keyword-or-value",
+        "enumType": "AutoKeyword",
+        "keywordMap": "Map.AutoKeywords",
+        "fallback": "AutoKeyword.Auto",
+        "valueType": "length"
+      },
       "html": {
         "propertyPath": "Bottom",
-        "csharpDataType": "string",
-        "area": "BoxModelArea"
+        "csharpDataType": "CssProperty<CssKeywordOrValue<AutoKeyword, LengthOrCalc>>",
+        "area": "BoxModelArea",
+        "getterExpression": "{box}.Bottom.ToString()"
       }
     },
     {


### PR DESCRIPTION
## Summary

Part of the #598 initiative to replace raw-string CSS property storage with typed `CssBox` storage.

- Converts `top`, `left`, `right`, `bottom` to `CssProperty<CssKeywordOrValue<AutoKeyword, LengthOrCalc>>` — the sixth keyword-or-value batch, and the higher-risk (positioned-offset resolution) half of the margin/inset group split. The margin half (`margin-top/right/bottom/left`) landed in a prior, already-merged PR.
- The 8 `inset-block/inline-start/end` logical properties stay `string?` scratch space by design, matching the margin group precedent. Only `CssBox.LogicalProperties.cs`'s `ApplyInset` changed — a structural match of the already-merged `ApplyMargin`.
- Migrates the delicate `CommitBlockChildOffset` positioned-offset resolution in `CssBox.cs` — relative/absolute/fixed positioning, CSS 2.1 §9.4.3's near/far offset resolution, §10.3.7/§10.6.4's absolute auto-width/height fill-space resolution, and the left-auto/right-set + top-auto/bottom-set post-layout fallback corrections — via two small shared helpers (`ResolveNearFarOffset`, `ResolveOffsetOrZero`) that are deliberately literal translations of the prior string-ternary logic, since this code carries a lot of Acid2-regression history. Also migrates `CssLayoutEngine.cs`'s absolute auto-width/height fill-space branches.
- Full test suite, including every Acid2-tagged regression test, passes unchanged.

## Test plan

- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (7963 passed, 9 skipped), including `--filter "FullyQualifiedName~Acid2"` (106/106)
- [x] `dotnet test PeachPDF.SourceGenerators.Tests/PeachPDF.SourceGenerators.Tests.csproj` — green (109 passed)
- [x] Diff coverage 100% vs base (`diff-cover`)
- [x] New `InsetPositionGroupTypedStorageTests.cs` — case-insensitive `auto`, length/percentage storage, relative-positioning near/far fallback, relative-unit `calc()` evaluating lazily, absolute `left:auto`/`right:set` fallback (asserted against the container's own runtime geometry, not a hand-computed constant), and a logical `inset-block-start` resolution check under `writing-mode: vertical-rl`
- [x] Post-change review pass on the complete diff (no genuine defects found; review included hand-tracing every near/far/auto combination against the prior logic and mutation-testing the new tests to confirm they're load-bearing)