### PR TITLE
Convert font-weight and flex-basis to typed keyword-or-value storage

### DIFF
--- a/.claude/accepted-gaps/font-weight-inline-style-rejects-non-hundred-integers.md
+++ b/.claude/accepted-gaps/font-weight-inline-style-rejects-non-hundred-integers.md
@@ -1,0 +1,22 @@
+# `font-weight`: inline-style parsing rejects non-hundred integer weights
+
+Tracking issue: [#655](https://github.com/jhaygood86/PeachPDF/issues/655).
+
+Per [CSS Fonts Level 4](https://www.w3.org/TR/css-fonts-4/#font-weight-prop), `font-weight`'s
+`<font-weight-absolute>` grammar is `normal | bold | <number [1,1000]>` - any number in that range,
+not just multiples of 100.
+
+PeachPDF's Layer A CSS-OM parser (`FontWeightProperty`'s `WeightIntegerConverter`, backed by
+`ValueExtensions.IsWeight`) only accepts exact multiples of 100 in `[100,900]` - the legacy CSS2.1 set.
+An inline style like `font-weight: 550` is rejected at parse time and the whole declaration is dropped
+before it ever reaches `CssBox`'s cascaded style.
+
+This is inconsistent with the `CssBox`/generated-registry side, which deliberately keeps `font-weight`'s
+integer grammar unconstrained (see `css-properties.json`'s `font-weight` entry) since
+`FontWeightResolver`/`FontResolver.PickNearestWeight` already handle arbitrary integers via
+`int.TryParse` - only the Layer A inline-style/stylesheet parsing path has this narrower restriction.
+
+**Deliberately out of scope** of the #598 typed-storage conversion that found it (a
+`CssKeywordOrValue<FontWeightKeyword, int>` storage-shape change, not a Layer A grammar change) -
+fixing this means relaxing `ValueExtensions.IsWeight`, a change to the CSS-OM parsing layer unrelated to
+how `CssBox` stores the resolved value.

--- a/src/PeachPDF.Tests/CSS/DocumentTreePseudoClassTests.cs
+++ b/src/PeachPDF.Tests/CSS/DocumentTreePseudoClassTests.cs
@@ -186,7 +186,7 @@ public class DocumentTreePseudoClassTests
 
         var box = await Box(html, "deep");
         Assert.Equal(Blue, box.Color);
-        Assert.Equal("bold", box.FontWeight);
+        Assert.Equal("bold", box.FontWeight.ToString());
     }
 
     [Fact]

--- a/src/PeachPDF.Tests/Html/Core/Utils/CssUtilsTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Utils/CssUtilsTests.cs
@@ -25,7 +25,7 @@ namespace PeachPDF.Tests.Html.Core.Utils
             Assert.Equal(box.Position.ToString(), CssUtils.GetPropertyValue(box, "position"));
             Assert.Equal(box.Overflow.ToString(), CssUtils.GetPropertyValue(box, "overflow"));
             Assert.Equal(box.TextAlign.ToString(), CssUtils.GetPropertyValue(box, "text-align"));
-            Assert.Equal(box.FontWeight, CssUtils.GetPropertyValue(box, "font-weight"));
+            Assert.Equal(box.FontWeight.ToString(), CssUtils.GetPropertyValue(box, "font-weight"));
             Assert.Equal(box.ZIndex.ToString(), CssUtils.GetPropertyValue(box, "z-index"));
         }
 

--- a/src/PeachPDF.Tests/Integration/FirstLetterPseudoElementIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FirstLetterPseudoElementIntegrationTests.cs
@@ -82,7 +82,7 @@ namespace PeachPDF.Tests.Integration
             // Both rules (from two separate cascade phases matching the same box) actually applied to
             // the one synthesized box, rather than only the first ever taking effect.
             Assert.Equal("rgb(255, 0, 0)", firstLetterBoxes[0].Color);
-            Assert.Equal(CssConstants.Bold, firstLetterBoxes[0].FontWeight);
+            Assert.Equal(CssConstants.Bold, firstLetterBoxes[0].FontWeight.ToString());
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/FontShorthandIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FontShorthandIntegrationTests.cs
@@ -26,7 +26,7 @@ namespace PeachPDF.Tests.Integration
 
             Assert.NotNull(el);
             Assert.Equal("italic", el!.FontStyle);
-            Assert.Equal("bold", el.FontWeight);
+            Assert.Equal("bold", el.FontWeight.ToString());
             Assert.Equal("16px", el.FontSize);
             Assert.Equal("1.4", el.LineHeight);
             Assert.Contains("Arial", el.FontFamily);
@@ -43,7 +43,7 @@ namespace PeachPDF.Tests.Integration
             var el = FindById(root, "el");
 
             Assert.NotNull(el);
-            Assert.Equal("bold", el!.FontWeight);
+            Assert.Equal("bold", el!.FontWeight.ToString());
             Assert.Equal("16px", el.FontSize);
             Assert.Equal("1.4", el.LineHeight);
             Assert.Contains("Arial", el.FontFamily);
@@ -64,7 +64,7 @@ namespace PeachPDF.Tests.Integration
             var el = FindById(root, "el");
 
             Assert.NotNull(el);
-            Assert.Equal("bold", el!.FontWeight);
+            Assert.Equal("bold", el!.FontWeight.ToString());
             Assert.Equal("16px", el.FontSize);
             Assert.Equal("1.4", el.LineHeight);
             Assert.Contains("Arial", el.FontFamily);
@@ -89,7 +89,7 @@ namespace PeachPDF.Tests.Integration
 
             Assert.NotNull(el);
             Assert.Equal("normal", el!.FontStyle);
-            Assert.Equal("bold", el.FontWeight);
+            Assert.Equal("bold", el.FontWeight.ToString());
             Assert.Equal("16px", el.FontSize);
         }
 

--- a/src/PeachPDF.Tests/Integration/FontWeightFlexBasisTypedStorageTests.cs
+++ b/src/PeachPDF.Tests/Integration/FontWeightFlexBasisTypedStorageTests.cs
@@ -1,0 +1,129 @@
+using PeachPDF.CSS;
+using PeachPDF.Html.Core.Parse;
+using PeachPDF.Tests.TestSupport;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Direct typed-storage assertions for <c>font-weight</c> (now
+    /// <c>CssProperty&lt;CssKeywordOrValue&lt;FontWeightKeyword, int&gt;&gt;</c>) and <c>flex-basis</c> (now
+    /// <c>CssProperty&lt;CssKeywordOrValue&lt;FlexBasisKeyword, LengthOrCalc&gt;&gt;</c>) - the first two
+    /// keyword-or-value properties needing a dedicated keyword enum instead of reusing
+    /// <c>AutoKeyword</c>/<c>NormalKeyword</c>. Complements <c>FontShorthandIntegrationTests</c>
+    /// (<c>ActualNumericWeight</c> resolution) and <c>FlexboxIntegrationTests</c> (layout geometry), which
+    /// exercise these properties indirectly rather than asserting the stored <c>.Value</c> directly.
+    /// </summary>
+    public class FontWeightFlexBasisTypedStorageTests
+    {
+        [Fact]
+        public async Task FontWeight_Normal_StoresTheKeyword_CaseInsensitively()
+        {
+            var box = await GetFontWeightBoxAsync("Normal");
+            Assert.True(box.FontWeight.Value is { IsKeyword: true, Keyword: FontWeightKeyword.Normal });
+        }
+
+        [Fact]
+        public async Task FontWeight_Bold_StoresTheKeyword_CaseInsensitively()
+        {
+            var box = await GetFontWeightBoxAsync("BOLD");
+            Assert.True(box.FontWeight.Value is { IsKeyword: true, Keyword: FontWeightKeyword.Bold });
+        }
+
+        [Fact]
+        public async Task FontWeight_Bolder_StoresTheKeyword_CaseInsensitively()
+        {
+            var box = await GetFontWeightBoxAsync("Bolder");
+            Assert.True(box.FontWeight.Value is { IsKeyword: true, Keyword: FontWeightKeyword.Bolder });
+        }
+
+        [Fact]
+        public async Task FontWeight_Lighter_StoresTheKeyword_CaseInsensitively()
+        {
+            var box = await GetFontWeightBoxAsync("lighter");
+            Assert.True(box.FontWeight.Value is { IsKeyword: true, Keyword: FontWeightKeyword.Lighter });
+        }
+
+        private static async Task<PeachPDF.Html.Core.Dom.CssBox> GetFontWeightBoxAsync(string authored)
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                $"<div id='t' style='font-weight:{authored}'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+            Assert.NotNull(box);
+            return box!;
+        }
+
+        [Fact]
+        public async Task FontWeight_NumericValue_StoresParsedInteger()
+        {
+            // A multiple of 100: the Layer A CSS-OM's own FontWeightProperty/WeightIntegerConverter
+            // (ValueExtensions.IsWeight) restricts inline-style parsing to the legacy 100-900-by-100 set
+            // before the value ever reaches CssUtils.SetPropertyValue - a pre-existing, unrelated
+            // asymmetry with the generated registry's own deliberately-unconstrained integer clause (see
+            // the font-weight JSON entry's comment). Using a value both paths accept keeps this test about
+            // the typed-storage conversion, not that separate gap.
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='font-weight:600'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.FontWeight.Value is { IsValue: true, Value: 600 });
+        }
+
+        [Fact]
+        public async Task FlexBasis_Auto_StoresTheAutoKeyword_CaseInsensitively()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div style='display:flex'><div id='t' style='flex-basis:AUTO'></div></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.FlexBasis.Value is { IsKeyword: true, Keyword: FlexBasisKeyword.Auto });
+        }
+
+        [Fact]
+        public async Task FlexBasis_Content_StoresTheContentKeyword()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div style='display:flex'><div id='t' style='flex-basis:content'></div></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.FlexBasis.Value is { IsKeyword: true, Keyword: FlexBasisKeyword.Content });
+        }
+
+        [Fact]
+        public async Task FlexBasis_LengthValue_StoresParsedLength()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div style='display:flex'><div id='t' style='flex-basis:120px'></div></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.FlexBasis.Value is { IsValue: true, Value: { IsCalc: false, Length: { Value: 120f } } });
+        }
+
+        [Fact]
+        public async Task FlexBasis_RelativeUnitCalc_EvaluatesLazily()
+        {
+            // font-size:20px resolves to an actual font size of 15pt (1px = 0.75pt), so
+            // calc(2em + 10px) = 2*15pt + 10px(=7.5pt) = 37.5pt.
+            var (calcRoot, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div style='display:flex'><div id='t' style='font-size:20px; flex-basis:calc(2em + 10px)'></div></div>"));
+
+            var box = LayoutHarness.FindById(calcRoot, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.FlexBasis.Value is { IsValue: true, Value: { IsCalc: true } });
+
+            var resolved = CssValueParser.ParseLength(box.FlexBasis.Value.Value!.Value, 0, box);
+            Assert.Equal(37.5, resolved, 2);
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/GlobalKeywordCascadeTests.cs
+++ b/src/PeachPDF.Tests/Integration/GlobalKeywordCascadeTests.cs
@@ -697,7 +697,7 @@ namespace PeachPDF.Tests.Integration
             Assert.NotNull(el);
             Assert.Equal("black", el!.Color);
             Assert.Equal("rgb(255, 255, 0)", el.BackgroundColor);
-            Assert.Equal("bold", el.FontWeight);
+            Assert.Equal("bold", el.FontWeight.ToString());
         }
 
         [Fact]

--- a/src/PeachPDF/CSS/Enumerations/FlexBasisKeyword.cs
+++ b/src/PeachPDF/CSS/Enumerations/FlexBasisKeyword.cs
@@ -1,0 +1,10 @@
+namespace PeachPDF.CSS
+{
+    /// <summary>The keyword side of <c>flex-basis</c>'s <c>auto | content | &lt;length-percentage&gt;</c>
+    /// grammar, for its <see cref="CssKeywordOrValue{TEnum,TValue}"/>.</summary>
+    internal enum FlexBasisKeyword
+    {
+        Auto,
+        Content
+    }
+}

--- a/src/PeachPDF/CSS/Enumerations/FontWeightKeyword.cs
+++ b/src/PeachPDF/CSS/Enumerations/FontWeightKeyword.cs
@@ -1,0 +1,12 @@
+namespace PeachPDF.CSS
+{
+    /// <summary>The keyword side of <c>font-weight</c>'s <c>normal | bold | bolder | lighter | &lt;number&gt;</c>
+    /// grammar, for its <see cref="CssKeywordOrValue{TEnum,TValue}"/>.</summary>
+    internal enum FontWeightKeyword
+    {
+        Normal,
+        Bold,
+        Bolder,
+        Lighter
+    }
+}

--- a/src/PeachPDF/CSS/Model/Map.cs
+++ b/src/PeachPDF/CSS/Model/Map.cs
@@ -284,6 +284,20 @@ namespace PeachPDF.CSS
             {
                 {Keywords.Normal, NormalKeyword.Normal}
             }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        public static readonly FrozenDictionary<string, FontWeightKeyword> FontWeightKeywords =
+            new Dictionary<string, FontWeightKeyword>(StringComparer.OrdinalIgnoreCase)
+            {
+                {Keywords.Normal, FontWeightKeyword.Normal},
+                {Keywords.Bold, FontWeightKeyword.Bold},
+                {Keywords.Bolder, FontWeightKeyword.Bolder},
+                {Keywords.Lighter, FontWeightKeyword.Lighter}
+            }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        public static readonly FrozenDictionary<string, FlexBasisKeyword> FlexBasisKeywords =
+            new Dictionary<string, FlexBasisKeyword>(StringComparer.OrdinalIgnoreCase)
+            {
+                {Keywords.Auto, FlexBasisKeyword.Auto},
+                {Keywords.Content, FlexBasisKeyword.Content}
+            }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
         public static readonly FrozenDictionary<string, BoxSizingMode> BoxSizingModes =
             new Dictionary<string, BoxSizingMode>(StringComparer.OrdinalIgnoreCase)
             {

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineFlex.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineFlex.cs
@@ -290,18 +290,20 @@ namespace PeachPDF.Html.Core.Dom
             // since auto-width block boxes fill the entire containing block instead of their intrinsic size).
             // A percentage flex-basis against an indefinite main axis resolves to nothing per spec
             // (§4.5), so it must fall through to auto/content-based sizing rather than resolving to 0.
-            bool isIndefinitePercentageBasis = mainSizeIndefinite && box.FlexBasis.EndsWith('%');
+            var flexBasis = box.FlexBasis.Value;
+            var isIndefinitePercentageBasis = mainSizeIndefinite &&
+                flexBasis.Value is { IsCalc: false, Length: { Type: Length.Unit.Percent } };
             double hypothetical;
-            if (box.FlexBasis is not ("auto" or "content" or "") && !isIndefinitePercentageBasis)
+            if (flexBasis.IsValue && !isIndefinitePercentageBasis)
             {
                 // CSS flex-basis = content size; hypothetical = outer size = content + padding + border
-                hypothetical = CssValueParser.ParseLength(box.FlexBasis, mainSize, box) + MainPaddingBorder(box);
+                hypothetical = CssValueParser.ParseLength(flexBasis.Value!.Value, mainSize, box) + MainPaddingBorder(box);
             }
-            else if (box.FlexBasis != "content" && _isRow && CssValueParser.IsValidLength(box.Width))
+            else if (flexBasis.Keyword is not FlexBasisKeyword.Content && _isRow && CssValueParser.IsValidLength(box.Width))
             {
                 hypothetical = CssValueParser.ParseLength(box.Width, mainSize, box) + MainPaddingBorder(box);
             }
-            else if (box.FlexBasis != "content" && !_isRow && CssValueParser.IsValidLength(box.Height))
+            else if (flexBasis.Keyword is not FlexBasisKeyword.Content && !_isRow && CssValueParser.IsValidLength(box.Height))
             {
                 hypothetical = CssValueParser.ParseLength(box.Height, mainSize, box) + MainPaddingBorder(box);
             }

--- a/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
+++ b/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
@@ -962,7 +962,7 @@ namespace PeachPDF.Html.Core.Dom
                 if (_actualNumericWeight is { } cached) return cached;
 
                 var parentWeight = Owner.ParentBox is { } parent ? parent.ActualNumericWeight : 400;
-                var resolved = FontWeightResolver.Resolve(Style.Font.FontWeight, parentWeight);
+                var resolved = FontWeightResolver.Resolve(Style.Font.FontWeight.Value, parentWeight);
                 _actualNumericWeight = resolved;
                 return resolved;
             }

--- a/src/PeachPDF/Html/Core/Utils/FontWeightResolver.cs
+++ b/src/PeachPDF/Html/Core/Utils/FontWeightResolver.cs
@@ -1,3 +1,5 @@
+using PeachPDF.CSS;
+
 namespace PeachPDF.Html.Core.Utils
 {
     /// <summary>
@@ -9,29 +11,49 @@ namespace PeachPDF.Html.Core.Utils
     /// </summary>
     internal static class FontWeightResolver
     {
+        /// <summary>
+        /// Overload for a caller with no typed <see cref="CssKeywordOrValue{TEnum,TValue}"/> in hand -
+        /// today, only <c>MarginBoxRenderer</c>'s <c>@page</c> margin-box font resolution, which reads the
+        /// CSS-OM <see cref="PeachPDF.CSS.StyleDeclaration"/>'s own raw <c>font-weight</c> string rather
+        /// than a <c>CssBox</c>'s cascaded value.
+        /// </summary>
         /// <param name="fontWeightValue">The raw CSS font-weight value (keyword or numeric string).</param>
         /// <param name="parentWeight">The parent's own resolved numeric weight, used by <c>bolder</c>/<c>lighter</c>.</param>
         internal static int Resolve(string fontWeightValue, int parentWeight)
         {
             if (int.TryParse(fontWeightValue, out var numeric))
-                return numeric;
+                return Resolve(new CssKeywordOrValue<FontWeightKeyword, int>(null, numeric), parentWeight);
 
-            return fontWeightValue switch
+            return Resolve(
+                Map.FontWeightKeywords.TryGetValue(fontWeightValue, out var keyword)
+                    ? new CssKeywordOrValue<FontWeightKeyword, int>(keyword, null)
+                    : default,
+                parentWeight);
+        }
+
+        /// <param name="fontWeight">The parsed <c>font-weight</c> value.</param>
+        /// <param name="parentWeight">The parent's own resolved numeric weight, used by <c>bolder</c>/<c>lighter</c>.</param>
+        internal static int Resolve(CssKeywordOrValue<FontWeightKeyword, int> fontWeight, int parentWeight)
+        {
+            if (fontWeight.IsValue)
+                return fontWeight.Value!.Value;
+
+            return fontWeight.Keyword switch
             {
-                CssConstants.Bold => 700,
+                FontWeightKeyword.Bold => 700,
                 // CSS2.1 §15.6's own worked example table ("bolder"/"lighter" columns against an
                 // inherited 100-900 value) - not a fixed "always bold"/"always normal" as this box's own
                 // FontWeight text might otherwise suggest:
                 //   inherited: 100 200 300 400 500 600 700 800 900
                 //     bolder:  400 400 400 700 700 900 900 900 900
                 //    lighter:  100 100 100 100 100 400 400 700 700
-                CssConstants.Bolder => parentWeight switch
+                FontWeightKeyword.Bolder => parentWeight switch
                 {
                     < 400 => 400,
                     <= 500 => 700,
                     _ => 900
                 },
-                CssConstants.Lighter => parentWeight switch
+                FontWeightKeyword.Lighter => parentWeight switch
                 {
                     <= 500 => 100,
                     <= 700 => 400,

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -1872,26 +1872,21 @@
     },
     {
       "name": "font-weight",
-      "comment": "CSS Fonts 4's <number> form is validated as a plain integer (FontWeightResolver/FontResolver.PickNearestWeight use int.TryParse, not a fractional number) - no 1-1000 range is enforced by that parse itself, so the integer clause is left unbounded rather than asserting a range this codebase doesn't actually check.",
+      "comment": "CssKeywordOrValue<FontWeightKeyword, int>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText. CSS Fonts 4's <number> form is validated as a plain integer (FontWeightResolver/FontResolver.PickNearestWeight use int.TryParse, not a fractional number) - no 1-1000 range is enforced by that parse itself, so the integer clause is left unbounded rather than asserting a range this codebase doesn't actually check.",
       "inherited": true,
       "initialValue": "normal",
-      "cssDataType": [
-        "keyword",
-        {
-          "type": "integer"
-        }
-      ],
-      "supportedValues": [
-        "normal",
-        "bold",
-        "bolder",
-        "lighter"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "keyword-or-value",
+        "enumType": "FontWeightKeyword",
+        "keywordMap": "Map.FontWeightKeywords",
+        "fallback": "FontWeightKeyword.Normal",
+        "valueType": "integer"
+      },
       "html": {
         "propertyPath": "FontWeight",
-        "csharpDataType": "string",
-        "area": "FontArea"
+        "csharpDataType": "CssProperty<CssKeywordOrValue<FontWeightKeyword, int>>",
+        "area": "FontArea",
+        "getterExpression": "{box}.FontWeight.ToString()"
       }
     },
     {
@@ -2110,21 +2105,21 @@
     },
     {
       "name": "flex-basis",
+      "comment": "CssKeywordOrValue<FlexBasisKeyword, LengthOrCalc>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText.",
       "inherited": false,
       "initialValue": "auto",
-      "cssDataType": [
-        "length",
-        "keyword"
-      ],
-      "supportedValues": [
-        "auto",
-        "content"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "keyword-or-value",
+        "enumType": "FlexBasisKeyword",
+        "keywordMap": "Map.FlexBasisKeywords",
+        "fallback": "FlexBasisKeyword.Auto",
+        "valueType": "length"
+      },
       "html": {
         "propertyPath": "FlexBasis",
-        "csharpDataType": "string",
-        "area": "FlexArea"
+        "csharpDataType": "CssProperty<CssKeywordOrValue<FlexBasisKeyword, LengthOrCalc>>",
+        "area": "FlexArea",
+        "getterExpression": "{box}.FlexBasis.ToString()"
       }
     },
     {


### PR DESCRIPTION
## Summary

Part of the #598 initiative to replace raw-string CSS property storage with typed `CssBox` storage.

- Converts `font-weight` and `flex-basis` — the seventh and eighth keyword-or-value batches, and the first two needing a brand-new keyword enum (`FontWeightKeyword`, `FlexBasisKeyword`) rather than reusing `AutoKeyword`/`NormalKeyword`.
- `font-weight` → `CssProperty<CssKeywordOrValue<FontWeightKeyword, int>>`, keeping the registry's pre-existing deliberately-unconstrained integer grammar. `FontWeightResolver.Resolve` is rewritten against the typed union, with a new string-based overload preserved for `MarginBoxRenderer.BuildFont`'s `@page` margin-box font resolution (which reads the CSS-OM `StyleDeclaration.FontWeight` string, a structurally different call site from `CssBox`'s cascaded value).
- `flex-basis` → `CssProperty<CssKeywordOrValue<FlexBasisKeyword, LengthOrCalc>>`, reusing the `LengthOrCalc` value side the margin/inset groups introduced. `CssLayoutEngineFlex.MeasureItem`'s flex-basis resolution is migrated (`width`/`height` themselves stay plain strings, out of scope here).
- Found and documented (not fixed, out of scope) a real pre-existing gap while writing tests: the Layer A CSS-OM's `FontWeightProperty` only accepts exact multiples of 100 for inline-style parsing, narrower than CSS Fonts 4's actual `<number [1,1000]>` grammar. Filed as #655 with an accepted-gap note (this PR doesn't fix it).

## Test plan

- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (7972 passed, 9 skipped)
- [x] `dotnet test PeachPDF.SourceGenerators.Tests/PeachPDF.SourceGenerators.Tests.csproj` — green (109 passed)
- [x] Diff coverage 100% vs base (`diff-cover`)
- [x] New `FontWeightFlexBasisTypedStorageTests.cs` — case-insensitive keyword storage for all four `font-weight` keywords, numeric-value storage, `flex-basis` `auto`/`content`/length/percentage storage, and a relative-unit `calc()` evaluating lazily
- [x] Post-change review pass on the complete diff (no genuine defects found)