### PR TITLE
Convert font-size to typed keyword-or-value storage

### DIFF
--- a/src/PeachPDF.SourceGenerators.Tests/GeneratorGoldenFileTests.cs
+++ b/src/PeachPDF.SourceGenerators.Tests/GeneratorGoldenFileTests.cs
@@ -639,27 +639,44 @@ namespace PeachPDF.SourceGenerators.Tests
         }
 
         [Fact]
-        public void Emits_FontSize_ValueComputation_For_Html_ValueComputation_FontSize()
+        public void Emits_FontSizeValueComputation_InTheRegistry_NotTheBoxSetter_ForAKeywordOrValueProperty()
         {
+            // font-size's real shape post-#598-conversion: a keyword-or-value property that also declares
+            // valueComputation "font-size". Like word-spacing/letter-spacing's "no-ems", the box's own
+            // generated setter no longer has a raw string to run the eager em/ex/percent/smaller/larger
+            // resolution against (its parameter is the already-parsed typed union), so the resolution has
+            // to happen in the registry's Set_X, against the raw text, before parsing - via the
+            // hand-written CssBox.ResolveFontSizeValueComputation rather than a generator-emitted switch
+            // (font-size's resolution is data-dependent on ParentBox/HtmlContainer, unlike NoEms's pure
+            // string transform, so it stays a real method rather than inlined C#).
             var json = """
                 {
                   "properties": [
-                    { "name": "font-size", "inherited": true, "initialValue": "medium", "cssDataType": "cssom",
-                      "html": { "propertyPath": "FontSize", "csharpDataType": "string", "area": "FontArea",
-                        "valueComputation": "font-size" } }
+                    { "name": "font-size", "inherited": true, "initialValue": "medium",
+                      "cssDataType": { "type": "keyword-or-value", "enumType": "FontSizeKeyword", "keywordMap": "Map.FontSizeKeywords",
+                        "fallback": "FontSizeKeyword.Medium", "valueType": "length" },
+                      "html": { "propertyPath": "FontSize", "csharpDataType": "CssProperty<CssKeywordOrValue<FontSizeKeyword, LengthOrCalc>>",
+                        "area": "FontArea", "valueComputation": "font-size" } }
                   ]
                 }
                 """;
 
             var result = GeneratorTestHost.Run(json, StubSources.MinimalCssBoxAndSvgElement);
 
-            var generated = result.Results.Single().GeneratedSources
+            var registry = result.Results.Single().GeneratedSources
+                .Single(s => s.HintName == "CssPropertyRegistry.g.cs").SourceText.ToString();
+            var styleProperties = result.Results.Single().GeneratedSources
                 .Single(s => s.HintName == "CssBox.StyleProperties.g.cs").SourceText.ToString();
 
-            Assert.Contains("var points = FontSizeResolver.Resolve(trimmed, parentSizePt, parentSizePt);", generated);
             Assert.Contains(
-                "var newArea = area.SetPropertyValue(area.FontSize, resolved, static (a, v) => a with { FontSize = v });",
-                generated);
+                "box.FontSize = global::PeachPDF.CSS.CssKeywordOrValueParser.FromCssText<FontSizeKeyword, global::PeachPDF.CSS.LengthOrCalc>" +
+                "(box.ResolveFontSizeValueComputation(value), Map.FontSizeKeywords, global::PeachPDF.Html.Core.Parse.CssValueParser.TryParseLengthOrCalc, FontSizeKeyword.Medium);",
+                registry);
+
+            Assert.DoesNotContain("ResolveFontSizeValueComputation(value)", styleProperties);
+            Assert.Contains(
+                "var newArea = area.SetPropertyValue(area.FontSize, value, static (a, v) => a with { FontSize = v });",
+                styleProperties);
         }
 
         [Fact]

--- a/src/PeachPDF.SourceGenerators/Emit/RegistryEmitter.cs
+++ b/src/PeachPDF.SourceGenerators/Emit/RegistryEmitter.cs
@@ -154,6 +154,7 @@ namespace PeachPDF.SourceGenerators.Emit
                 {
                     null => "value",
                     "no-ems" => "box.NoEms(value)",
+                    "font-size" => "box.ResolveFontSizeValueComputation(value)",
                     _ => throw new NotSupportedException(
                         $"\"{entry.Name}\" declares a keyword-or-value cssDataType with html.valueComputation " +
                         $"\"{html.ValueComputation}\", which RegistryEmitter does not implement."),

--- a/src/PeachPDF.SourceGenerators/Emit/StylePropertiesEmitter.cs
+++ b/src/PeachPDF.SourceGenerators/Emit/StylePropertiesEmitter.cs
@@ -17,15 +17,16 @@ namespace PeachPDF.SourceGenerators.Emit
     /// read/write through the area's copy-on-write plumbing (<see cref="ComputedStyleCow"/>), plus an
     /// optional invalidation call afterward (<c>html.invalidates</c>). The handful of properties whose
     /// *stored* value differs from what's handed to their setter declare <c>html.valueComputation</c>:
-    /// <c>font-size</c> ("font-size", see <see cref="EmitFontSizeValueComputation"/>) eagerly resolves a
-    /// parent-relative length to points; <c>word-spacing</c>/<c>letter-spacing</c> ("no-ems") and
-    /// <c>text-indent</c> ("text-indent") eagerly resolve a plain <c>em</c> length the same way, via the
-    /// hand-written <c>NoEms</c>/<c>NoEmsTextIndent</c> helpers this class still keeps on <c>CssBox</c>.
-    /// A <c>keyword-or-value</c>-shaped property declaring <c>valueComputation</c> is the one exception:
-    /// this setter's parameter is already a parsed typed union by the time it runs (there is no raw
-    /// string left for <c>NoEms</c> to act on), so <see cref="RegistryEmitter.BuildHtmlAssignment"/> runs
-    /// the computation itself against the raw authored text, before parsing, and this emitter skips its
-    /// own <c>EmitValueComputation</c> call for that shape entirely (see <see cref="EmitProperty"/>).
+    /// <c>text-indent</c> ("text-indent", still a plain string-typed property) eagerly resolves a plain
+    /// <c>em</c> length to points via this class's own hand-written <c>NoEmsTextIndent</c> helper, emitted
+    /// by <see cref="EmitValueComputation"/> below. Every keyword-or-value-shaped property declaring
+    /// <c>valueComputation</c> instead (<c>word-spacing</c>/<c>letter-spacing</c>'s "no-ems", <c>font-size
+    /// </c>'s "font-size") is the one exception: that setter's parameter is already a parsed typed union
+    /// by the time it runs - there is no raw string left for this class's own computation to act on, so
+    /// <see cref="RegistryEmitter.BuildHtmlAssignment"/> runs the computation itself (via <c>box.NoEms</c>/
+    /// <c>box.ResolveFontSizeValueComputation</c>) against the raw authored text, before parsing, and this
+    /// emitter skips its own <c>EmitValueComputation</c> call entirely for that shape (see
+    /// <see cref="EmitProperty"/>).
     /// </summary>
     internal static class StylePropertiesEmitter
     {
@@ -125,9 +126,6 @@ namespace PeachPDF.SourceGenerators.Emit
         {
             switch (valueComputation)
             {
-                case "font-size":
-                    EmitFontSizeValueComputation(sb);
-                    break;
                 case "no-ems":
                     sb.AppendLine("                var resolved = NoEms(value);");
                     break;
@@ -138,41 +136,6 @@ namespace PeachPDF.SourceGenerators.Emit
                     throw new NotSupportedException(
                         $"\"{entry.Name}\" declares html.valueComputation \"{valueComputation}\", which StylePropertiesEmitter does not implement.");
             }
-        }
-
-        /// <summary>
-        /// <c>font-size</c>'s eager em/ex/percent/smaller/larger-to-absolute-points resolution - fixed,
-        /// generator-owned C#, not derived from JSON data (there is exactly one property that needs this
-        /// shape today). <c>calc()</c> and <c>rem</c> stay lazy, resolved later by
-        /// <see cref="DerivedStyle.ActualFont"/>: <c>calc()</c> needs real layout-time container-query
-        /// information not available at cascade time, and <c>rem</c> resolves against a single, non-chained
-        /// reference so it can't compound across generations regardless of when it resolves. Every other
-        /// parent-relative form needs eager conversion here because <c>InheritStyle</c> adopts the whole
-        /// <c>Font</c> area from parent to child *by reference* - see the hand-written property this
-        /// mirrors (<c>CssBox.StyleProperties.cs</c>'s <c>FontSize</c>, before the storage-generator PR)
-        /// for the full reasoning.
-        /// </summary>
-        private static void EmitFontSizeValueComputation(StringBuilder sb)
-        {
-            sb.AppendLine("                string resolved;");
-            sb.AppendLine("                var trimmed = value.Trim();");
-            sb.AppendLine("                if (!CssValueParser.IsCalcFunction(value) && ParentBox is { } parent &&");
-            sb.AppendLine("                    (CssValueParser.GetCssTokens(value) is [UnitToken unitToken] &&");
-            sb.AppendLine("                        Length.GetUnit(unitToken.Unit) is Length.Unit.Em or Length.Unit.Ex or Length.Unit.Percent");
-            sb.AppendLine("                     || trimmed.Equals(CssConstants.Smaller, StringComparison.OrdinalIgnoreCase)");
-            sb.AppendLine("                     || trimmed.Equals(CssConstants.Larger, StringComparison.OrdinalIgnoreCase)))");
-            sb.AppendLine("                {");
-            sb.AppendLine("                    var pixelsPerPoint = (HtmlContainer?.Adapter as PdfSharpAdapter)?.PixelsPerPoint ?? 1.0;");
-            sb.AppendLine("                    var parentSizePt = parent.ActualFont.Size * pixelsPerPoint;");
-            sb.AppendLine();
-            sb.AppendLine("                    var points = FontSizeResolver.Resolve(trimmed, parentSizePt, parentSizePt);");
-            sb.AppendLine("                    resolved = $\"{points.ToString(System.Globalization.NumberFormatInfo.InvariantInfo)}pt\";");
-            sb.AppendLine("                }");
-            sb.AppendLine("                else");
-            sb.AppendLine("                {");
-            sb.AppendLine("                    resolved = value;");
-            sb.AppendLine("                }");
-            sb.AppendLine();
         }
     }
 }

--- a/src/PeachPDF.Tests/CSS/CssDataRuleIndexingTests.cs
+++ b/src/PeachPDF.Tests/CSS/CssDataRuleIndexingTests.cs
@@ -191,7 +191,7 @@ public class CssDataRuleIndexingTests
         // lookup than the UA rule's own tag bucket, but the same bucket *kind*) must still win.
         var html = Html("h1 { font-size: 10px; }", "<h1>heading</h1>");
         var box = await FindBoxByTag(html, "h1");
-        Assert.Equal("10px", box.FontSize);
+        Assert.Equal("10px", box.FontSize.ToString());
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────────

--- a/src/PeachPDF.Tests/Html/Core/Dom/ComputedStyleTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/ComputedStyleTests.cs
@@ -74,10 +74,11 @@ namespace PeachPDF.Tests.Html.Core.Dom
             box.Color = "rgb(1, 2, 3)";
             var afterFirstWrite = box.ComputedStyle;
 
-            box.FontSize = "14pt";
+            box.FontSize = CssKeywordOrValueParser.FromCssText<FontSizeKeyword, LengthOrCalc>(
+                "14pt", Map.FontSizeKeywords, CssValueParser.TryParseLengthOrCalc, FontSizeKeyword.Medium);
 
             Assert.Equal("rgb(1, 2, 3)", box.Color);
-            Assert.Equal("14pt", box.FontSize);
+            Assert.Equal("14pt", box.FontSize.ToString());
             // Both values must have landed on the box's own instance - this isn't asserting object
             // identity of afterFirstWrite (a second `with` necessarily produces a new record), only that
             // the first write's value survived the second write untouched.

--- a/src/PeachPDF.Tests/Integration/Acid2FeatureVerificationTests.cs
+++ b/src/PeachPDF.Tests/Integration/Acid2FeatureVerificationTests.cs
@@ -1022,7 +1022,7 @@ namespace PeachPDF.Tests.Integration
             // CssBox.StyleProperties.cs's FontSize setter); "24px" line-height is a plain length and stays
             // as declared.
             var expectedPt = 2 * parent.ActualFont.Size;
-            Assert.Equal($"{expectedPt.ToString(System.Globalization.NumberFormatInfo.InvariantInfo)}pt", box.FontSize);
+            Assert.Equal($"{expectedPt.ToString(System.Globalization.NumberFormatInfo.InvariantInfo)}pt", box.FontSize.ToString());
             Assert.Equal("24px", box.LineHeight);
         }
 

--- a/src/PeachPDF.Tests/Integration/FontShorthandIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FontShorthandIntegrationTests.cs
@@ -27,7 +27,7 @@ namespace PeachPDF.Tests.Integration
             Assert.NotNull(el);
             Assert.Equal("italic", el!.FontStyle);
             Assert.Equal("bold", el.FontWeight.ToString());
-            Assert.Equal("16px", el.FontSize);
+            Assert.Equal("16px", el.FontSize.ToString());
             Assert.Equal("1.4", el.LineHeight);
             Assert.Contains("Arial", el.FontFamily);
         }
@@ -44,7 +44,7 @@ namespace PeachPDF.Tests.Integration
 
             Assert.NotNull(el);
             Assert.Equal("bold", el!.FontWeight.ToString());
-            Assert.Equal("16px", el.FontSize);
+            Assert.Equal("16px", el.FontSize.ToString());
             Assert.Equal("1.4", el.LineHeight);
             Assert.Contains("Arial", el.FontFamily);
             Assert.DoesNotContain("+", el.FontFamily);
@@ -65,7 +65,7 @@ namespace PeachPDF.Tests.Integration
 
             Assert.NotNull(el);
             Assert.Equal("bold", el!.FontWeight.ToString());
-            Assert.Equal("16px", el.FontSize);
+            Assert.Equal("16px", el.FontSize.ToString());
             Assert.Equal("1.4", el.LineHeight);
             Assert.Contains("Arial", el.FontFamily);
         }
@@ -90,7 +90,7 @@ namespace PeachPDF.Tests.Integration
             Assert.NotNull(el);
             Assert.Equal("normal", el!.FontStyle);
             Assert.Equal("bold", el.FontWeight.ToString());
-            Assert.Equal("16px", el.FontSize);
+            Assert.Equal("16px", el.FontSize.ToString());
         }
 
         [Theory]

--- a/src/PeachPDF.Tests/Integration/FontSizeTypedStorageTests.cs
+++ b/src/PeachPDF.Tests/Integration/FontSizeTypedStorageTests.cs
@@ -151,6 +151,22 @@ namespace PeachPDF.Tests.Integration
             Assert.True(box!.FontSize.Value is { IsKeyword: true, Keyword: FontSizeKeyword.Large });
         }
 
+        [Fact]
+        public async Task LegacyFontSizeAttribute_UnrecognizedNumericScale_LeavesTheInheritedValueInPlace()
+        {
+            // HTML's legacy <font size> is really a "1"-"7"/relative scale, never a CSS keyword or length
+            // - there's no translation table for it, so a real-world numeric value never validates. The
+            // attribute must be treated as absent (leaving the cascade's own value, "large" here, in
+            // place) rather than forcing every such element to "medium" regardless of the requested size.
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div style='font-size:large'><font id='t' size='3'>x</font></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.FontSize.Value is { IsKeyword: true, Keyword: FontSizeKeyword.Large });
+        }
+
         // ─── Helpers ─────────────────────────────────────────────────────────────
 
         private static async Task<PeachPDF.Html.Core.Dom.CssBox> GetFontSizeBoxAsync(string authored)

--- a/src/PeachPDF.Tests/Integration/FontSizeTypedStorageTests.cs
+++ b/src/PeachPDF.Tests/Integration/FontSizeTypedStorageTests.cs
@@ -1,0 +1,166 @@
+using PeachPDF.CSS;
+using PeachPDF.Tests.TestSupport;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Direct typed-storage assertions for <c>font-size</c>, now backed by
+    /// <c>CssProperty&lt;CssKeywordOrValue&lt;FontSizeKeyword, LengthOrCalc&gt;&gt;</c> - the ninth
+    /// keyword-or-value batch, and the first with a bespoke eager-resolution helper
+    /// (<c>CssBox.ResolveFontSizeValueComputation</c>) instead of a purely mechanical parse. Complements
+    /// <c>FontSizeInheritanceIntegrationTests</c> (the multi-generation compounding regression coverage
+    /// from the original eager-resolution fix, unaffected by this storage-shape conversion) and
+    /// <c>FontShorthandIntegrationTests</c>, which exercise <c>font-size</c> indirectly through
+    /// <c>ActualFontSize</c> rather than asserting the stored <c>.Value</c> directly.
+    /// </summary>
+    public class FontSizeTypedStorageTests
+    {
+        [Fact]
+        public async Task AbsoluteKeyword_StoresTheKeyword_CaseInsensitively()
+        {
+            var box = await GetFontSizeBoxAsync("MEDIUM");
+            Assert.True(box.FontSize.Value is { IsKeyword: true, Keyword: FontSizeKeyword.Medium });
+        }
+
+        [Fact]
+        public async Task LargeKeyword_StoresTheKeyword()
+        {
+            var box = await GetFontSizeBoxAsync("Large");
+            Assert.True(box.FontSize.Value is { IsKeyword: true, Keyword: FontSizeKeyword.Large });
+        }
+
+        [Fact]
+        public async Task AbsoluteLength_StoresParsedLength()
+        {
+            var box = await GetFontSizeBoxAsync("18pt");
+            Assert.True(box.FontSize.Value is { IsValue: true, Value: { IsCalc: false, Length: { Value: 18f } } });
+        }
+
+        [Fact]
+        public async Task PlainEmValue_IsEagerlyResolvedToAbsolutePoints()
+        {
+            // The eager em-to-pt resolution must still run at set-time (not deferred) - a stored "1.5em"
+            // would silently compound across generations since InheritStyle adopts the Font area by
+            // reference (see CssBox.ResolveFontSizeValueComputation's own doc comment, and the original
+            // compounding bug this guards against). Asserting the resolved Type/Value directly (not just
+            // IsCalc: false) proves the transform actually ran - an unconverted "1.5em" Length would also
+            // report IsCalc: false.
+            // font-size:20px resolves to an actual parent font size of 15pt (1px = 0.75pt), so
+            // 1.5em = 1.5 * 15pt = 22.5pt.
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div style='font-size:20px'><span id='t' style='font-size:1.5em'>x</span></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.FontSize.Value is
+            {
+                IsValue: true,
+                Value: { IsCalc: false, Length: { Type: Length.Unit.Pt, Value: 22.5f } }
+            });
+        }
+
+        [Fact]
+        public async Task SmallerKeyword_IsEagerlyResolvedToAbsolutePoints()
+        {
+            // "smaller"/"larger" are transformed away into an absolute Length at set-time too (per the
+            // FontSizeKeyword enum's own doc comment) - they never actually reach FontSizeKeyword.Smaller
+            // on the stored union when a real parent is in scope.
+            // font-size:20px resolves to an actual parent font size of 15pt, so smaller = 15pt - 2 = 13pt
+            // (FontSizeResolver.Resolve's Smaller case).
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div style='font-size:20px'><span id='t' style='font-size:smaller'>x</span></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.FontSize.Value is
+            {
+                IsValue: true,
+                Value: { IsCalc: false, Length: { Type: Length.Unit.Pt, Value: 13f } }
+            });
+        }
+
+        [Fact]
+        public async Task AbsoluteUnitCalc_FoldsToALiteralLength()
+        {
+            // An absolute-only calc() already folds to a literal length string upstream (Layer A's
+            // CalcSerializer), before this property's own eager-resolution helper ever sees it - matching
+            // every other LengthOrCalc-backed property's behavior.
+            var box = await GetFontSizeBoxAsync("calc(12pt + 2px)");
+            Assert.True(box.FontSize.Value is { IsValue: true, Value: { IsCalc: false } });
+        }
+
+        [Fact]
+        public async Task RelativeUnitCalc_StaysDeferred_NotEagerlyResolved()
+        {
+            // Unlike a bare em/ex/%/smaller/larger value, a calc() mixing relative units is deliberately
+            // left lazy at set-time - CssBox.ResolveFontSizeValueComputation's own IsCalcFunction guard
+            // excludes it from eager resolution entirely, and it stays deferred calc text (LengthOrCalc's
+            // mechanism), evaluated later against the box's own font-size-resolution basis.
+            var box = await GetFontSizeBoxAsync("calc(1em + 2px)");
+            Assert.True(box.FontSize.Value is { IsValue: true, Value: { IsCalc: true } });
+        }
+
+        [Fact]
+        public async Task RemValue_StaysUnresolvedText_NotEagerlyFoldedToASpecificPointValue()
+        {
+            // rem resolves against a single, non-chained root reference, so - unlike em/%/smaller/larger -
+            // it doesn't need eager resolution to avoid compounding; it stays a plain Length (Type: Rem),
+            // resolved lazily by FontSizeResolver/DerivedStyle.ActualFont.
+            var box = await GetFontSizeBoxAsync("2rem");
+            Assert.True(box.FontSize.Value is
+            {
+                IsValue: true,
+                Value: { IsCalc: false, Length: { Type: Length.Unit.Rem, Value: 2f } }
+            });
+        }
+
+        // ─── FontSizeResolver's absolute-keyword resolution (not just storage) ─────
+
+        [Theory]
+        [InlineData("xx-small", 11d - 4)]
+        [InlineData("x-small", 11d - 3)]
+        [InlineData("small", 11d - 2)]
+        [InlineData("x-large", 11d + 3)]
+        [InlineData("xx-large", 11d + 4)]
+        public async Task AbsoluteKeyword_ActualFontSize_ResolvesToTheSpecFixedOffset(string keyword, double expected)
+        {
+            // Every keyword offsets the CSS initial font-size (CssConstants.FontSize, 11) by a fixed
+            // amount - not parent-relative, so this must hold regardless of what a parent's own font-size
+            // is. Reads ActualFontSize (not just the stored .Value) to prove FontSizeResolver.Resolve's
+            // typed keyword-side switch, not just parsing, is correct.
+            var box = await GetFontSizeBoxAsync(keyword);
+            Assert.Equal(expected, box.ActualFont.Size, 2);
+        }
+
+        [Fact]
+        public async Task LegacyFontSizeAttribute_RoutesThroughTheTypedParser()
+        {
+            // <font size="..."> (HTML4 presentational attribute) previously assigned the raw string
+            // directly to CssBox.FontSize; now must route through the same CssKeywordOrValueParser every
+            // other assignment site uses.
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<font id='t' size='large'>x</font>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.True(box!.FontSize.Value is { IsKeyword: true, Keyword: FontSizeKeyword.Large });
+        }
+
+        // ─── Helpers ─────────────────────────────────────────────────────────────
+
+        private static async Task<PeachPDF.Html.Core.Dom.CssBox> GetFontSizeBoxAsync(string authored)
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                $"<div id='t' style='font-size:{authored}'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+            Assert.NotNull(box);
+            return box!;
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/GlobalKeywordCascadeTests.cs
+++ b/src/PeachPDF.Tests/Integration/GlobalKeywordCascadeTests.cs
@@ -109,7 +109,7 @@ namespace PeachPDF.Tests.Integration
             var el = FindById(root, "el");
 
             Assert.NotNull(el);
-            Assert.Equal("medium", el!.FontSize);
+            Assert.Equal("medium", el!.FontSize.ToString());
         }
 
         [Fact]
@@ -249,7 +249,7 @@ namespace PeachPDF.Tests.Integration
             var el = FindById(root, "el");
 
             Assert.NotNull(el);
-            Assert.Equal("22pt", el!.FontSize);
+            Assert.Equal("22pt", el!.FontSize.ToString());
         }
 
         [Fact]
@@ -802,7 +802,7 @@ namespace PeachPDF.Tests.Integration
             var el = FindById(root, "el");
 
             Assert.NotNull(el);
-            Assert.Equal("10px", el!.FontSize);
+            Assert.Equal("10px", el!.FontSize.ToString());
         }
 
         [Fact]
@@ -821,7 +821,7 @@ namespace PeachPDF.Tests.Integration
             var el = FindById(root, "el");
 
             Assert.NotNull(el);
-            Assert.Equal("22pt", el!.FontSize);
+            Assert.Equal("22pt", el!.FontSize.ToString());
         }
 
         [Fact]

--- a/src/PeachPDF/CSS/Enumerations/FontSizeKeyword.cs
+++ b/src/PeachPDF/CSS/Enumerations/FontSizeKeyword.cs
@@ -1,0 +1,21 @@
+namespace PeachPDF.CSS
+{
+    /// <summary>The keyword side of <c>font-size</c>'s <c>&lt;absolute-size&gt; | &lt;relative-size&gt; |
+    /// &lt;length-percentage&gt;</c> grammar, for its <see cref="CssKeywordOrValue{TEnum,TValue}"/>.
+    /// <c>Smaller</c>/<c>Larger</c> are relative to the parent's own resolved size (CSS Fonts 4
+    /// <c>&lt;relative-size&gt;</c>); the other seven are fixed offsets from the CSS initial
+    /// (<c>&lt;absolute-size&gt;</c>). Deliberately excludes CSS Fonts 4's <c>xxx-large</c> - see the
+    /// <c>font-size</c> JSON entry's own comment.</summary>
+    internal enum FontSizeKeyword
+    {
+        XxSmall,
+        XSmall,
+        Small,
+        Medium,
+        Large,
+        XLarge,
+        XxLarge,
+        Smaller,
+        Larger
+    }
+}

--- a/src/PeachPDF/CSS/Model/Map.cs
+++ b/src/PeachPDF/CSS/Model/Map.cs
@@ -292,6 +292,19 @@ namespace PeachPDF.CSS
                 {Keywords.Bolder, FontWeightKeyword.Bolder},
                 {Keywords.Lighter, FontWeightKeyword.Lighter}
             }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        public static readonly FrozenDictionary<string, FontSizeKeyword> FontSizeKeywords =
+            new Dictionary<string, FontSizeKeyword>(StringComparer.OrdinalIgnoreCase)
+            {
+                {Keywords.XxSmall, FontSizeKeyword.XxSmall},
+                {Keywords.XSmall, FontSizeKeyword.XSmall},
+                {Keywords.Small, FontSizeKeyword.Small},
+                {Keywords.Medium, FontSizeKeyword.Medium},
+                {Keywords.Large, FontSizeKeyword.Large},
+                {Keywords.XLarge, FontSizeKeyword.XLarge},
+                {Keywords.XxLarge, FontSizeKeyword.XxLarge},
+                {Keywords.Smaller, FontSizeKeyword.Smaller},
+                {Keywords.Larger, FontSizeKeyword.Larger}
+            }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
         public static readonly FrozenDictionary<string, FlexBasisKeyword> FlexBasisKeywords =
             new Dictionary<string, FlexBasisKeyword>(StringComparer.OrdinalIgnoreCase)
             {

--- a/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
@@ -389,6 +389,42 @@ namespace PeachPDF.Html.Core.Dom
         }
 
         /// <summary>
+        /// <c>font-size</c>'s eager em/ex/percent/smaller/larger-to-absolute-points resolution, run by
+        /// <c>RegistryEmitter.BuildHtmlAssignment</c> (the generated <c>CssPropertyRegistry</c>, a
+        /// same-assembly but unrelated class - see <see cref="NoEms"/>'s own doc comment for why) against
+        /// the raw authored text before <c>CssKeywordOrValueParser.FromCssText</c> parses it into
+        /// <see cref="FontSize"/>'s typed union. <c>calc()</c> and <c>rem</c> stay lazy, resolved later by
+        /// <see cref="DerivedStyle.ActualFont"/> via <see cref="FontSizeResolver"/>: <c>calc()</c> needs
+        /// real layout-time container-query information not available at cascade time (the same reason
+        /// every other <c>calc()</c>-accepting keyword-or-value property defers through
+        /// <see cref="PeachPDF.CSS.LengthOrCalc"/>), and <c>rem</c> resolves against a single, non-chained
+        /// reference so it can't compound across generations regardless of when it resolves. Every other
+        /// parent-relative form needs eager conversion here because <c>InheritStyle</c> adopts the whole
+        /// <c>Font</c> area from parent to child *by reference* - a value left as raw relative text would
+        /// be re-resolved by every non-overriding descendant against its own immediate parent, compounding
+        /// the multiplier once per generation (the bug fixed by making this eager - see PR #632's own
+        /// notes for the original investigation).
+        /// </summary>
+        internal string ResolveFontSizeValueComputation(string value)
+        {
+            var trimmed = value.Trim();
+            if (!CssValueParser.IsCalcFunction(value) && ParentBox is { } parent &&
+                (CssValueParser.GetCssTokens(value) is [UnitToken unitToken] &&
+                    Length.GetUnit(unitToken.Unit) is Length.Unit.Em or Length.Unit.Ex or Length.Unit.Percent
+                 || trimmed.Equals(CssConstants.Smaller, StringComparison.OrdinalIgnoreCase)
+                 || trimmed.Equals(CssConstants.Larger, StringComparison.OrdinalIgnoreCase)))
+            {
+                var pixelsPerPoint = (HtmlContainer?.Adapter as PdfSharpAdapter)?.PixelsPerPoint ?? 1.0;
+                var parentSizePt = parent.ActualFont.Size * pixelsPerPoint;
+
+                var points = FontSizeResolver.Resolve(trimmed, parentSizePt, parentSizePt);
+                return $"{points.ToString(System.Globalization.NumberFormatInfo.InvariantInfo)}pt";
+            }
+
+            return value;
+        }
+
+        /// <summary>
         /// Set the style/width/color for all 4 borders on the box.<br/>
         /// if null is given for a value it will not be set.
         /// </summary>

--- a/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
+++ b/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
@@ -877,9 +877,15 @@ namespace PeachPDF.Html.Core.Dom
                     Owner.FontFamily = CssConstants.DefaultFont;
                 }
 
-                if (string.IsNullOrEmpty(Style.Font.FontSize))
+                // Defensive: FontArea's own default already seeds FontSize to "medium" (a real Keyword),
+                // so this is unreachable via any box built from ComputedStyle.Default in the normal way -
+                // kept as a fail-safe for a box whose ComputedStyle was otherwise assembled without going
+                // through that default, mirroring the FontFamily check just above.
+                if (Style.Font.FontSize.Value is { IsKeyword: false, IsValue: false })
                 {
-                    Owner.FontSize = CssConstants.FontSize.ToString(CultureInfo.InvariantCulture) + "pt";
+                    Owner.FontSize = CssKeywordOrValueParser.FromCssText<FontSizeKeyword, LengthOrCalc>(
+                        CssConstants.FontSize.ToString(CultureInfo.InvariantCulture) + "pt",
+                        Map.FontSizeKeywords, CssValueParser.TryParseLengthOrCalc, FontSizeKeyword.Medium);
                 }
 
                 var st = GetActualFontStyleFlags();
@@ -920,7 +926,7 @@ namespace PeachPDF.Html.Core.Dom
                 // Correct only for a box whose ActualFont happens to first be read post-layout - see
                 // .claude/accepted-gaps/font-size-container-relative-units-resolve-to-zero-for-text-content.md.
                 var (containerInlinePt, containerBlockPt) = Owner.GetContainerRelativeUnitBasis();
-                var fsize = FontSizeResolver.Resolve(Style.Font.FontSize, parentSize, remSize,
+                var fsize = FontSizeResolver.Resolve(Style.Font.FontSize.Value, parentSize, remSize,
                     containerInlinePt, containerBlockPt);
 
                 _actualFont = Owner.GetCachedFont(Style.Font.FontFamily!, fsize, st, ActualNumericWeight, ActualStretch, ActualObliqueSkewSinus)

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -1492,8 +1492,24 @@ namespace PeachPDF.Html.Core.Parse
                         if (tag.Name.Equals(HtmlConstants.Hr, StringComparison.OrdinalIgnoreCase))
                             box.Height = TranslateLength(value);
                         else if (tag.Name.Equals(HtmlConstants.Font, StringComparison.OrdinalIgnoreCase))
-                            box.FontSize = CssKeywordOrValueParser.FromCssText<FontSizeKeyword, LengthOrCalc>(
-                                value, Map.FontSizeKeywords, CssValueParser.TryParseLengthOrCalc, FontSizeKeyword.Medium);
+                        {
+                            // HTML's legacy <font size> is a "1"-"7" (or "+N"/"-N" relative) scale, never
+                            // a CSS keyword or length - there is no translation table for it here, so a
+                            // real-world value never validates against either side of FontSize's grammar.
+                            // FromCssText's own fallback always assigns *something* (unlike a raw string
+                            // assignment, which just held the unrecognized text for later, equally-inert,
+                            // downstream failure), so skip the assignment entirely when the value doesn't
+                            // validate - leaving whatever the cascade already produced in place, per how
+                            // browsers generally treat an unrecognized presentational-attribute value
+                            // (same convention as the valign/align attribute's own accepted gap, issue
+                            // #642) - rather than silently forcing every <font size="N"> to "medium".
+                            var trimmed = value.Trim();
+                            if (Map.FontSizeKeywords.ContainsKey(trimmed) || CssValueParser.TryParseLengthOrCalc(trimmed, out _))
+                            {
+                                box.FontSize = CssKeywordOrValueParser.FromCssText<FontSizeKeyword, LengthOrCalc>(
+                                    value, Map.FontSizeKeywords, CssValueParser.TryParseLengthOrCalc, FontSizeKeyword.Medium);
+                            }
+                        }
                         break;
                     case HtmlConstants.Valign:
                         box.VerticalAlign = CssProperty<VerticalAlignment>.FromCssText(value, Map.VerticalAlignments, VerticalAlignment.Baseline);

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -1492,7 +1492,8 @@ namespace PeachPDF.Html.Core.Parse
                         if (tag.Name.Equals(HtmlConstants.Hr, StringComparison.OrdinalIgnoreCase))
                             box.Height = TranslateLength(value);
                         else if (tag.Name.Equals(HtmlConstants.Font, StringComparison.OrdinalIgnoreCase))
-                            box.FontSize = value;
+                            box.FontSize = CssKeywordOrValueParser.FromCssText<FontSizeKeyword, LengthOrCalc>(
+                                value, Map.FontSizeKeywords, CssValueParser.TryParseLengthOrCalc, FontSizeKeyword.Medium);
                         break;
                     case HtmlConstants.Valign:
                         box.VerticalAlign = CssProperty<VerticalAlignment>.FromCssText(value, Map.VerticalAlignments, VerticalAlignment.Baseline);

--- a/src/PeachPDF/Html/Core/Utils/FontSizeResolver.cs
+++ b/src/PeachPDF/Html/Core/Utils/FontSizeResolver.cs
@@ -1,4 +1,5 @@
 using System;
+using PeachPDF.CSS;
 using PeachPDF.Html.Core.Parse;
 
 namespace PeachPDF.Html.Core.Utils
@@ -13,6 +14,12 @@ namespace PeachPDF.Html.Core.Utils
     /// </summary>
     internal static class FontSizeResolver
     {
+        /// <summary>
+        /// Overload for a caller with no typed <see cref="CssKeywordOrValue{TEnum,TValue}"/> in hand -
+        /// today, only <c>MarginBoxRenderer</c>'s <c>@page</c> margin-box font resolution, which reads the
+        /// CSS-OM <see cref="PeachPDF.CSS.StyleDeclaration"/>'s own raw <c>font-size</c> string rather than
+        /// a <c>CssBox</c>'s cascaded value.
+        /// </summary>
         /// <param name="fontSizeValue">The raw CSS font-size value (keyword or length).</param>
         /// <param name="parentSize">Reference size for <c>smaller</c>/<c>larger</c>/<c>em</c>.</param>
         /// <param name="remSize">Reference size for <c>rem</c>.</param>
@@ -40,6 +47,53 @@ namespace PeachPDF.Html.Core.Utils
                 _ => CssValueParser.ParseLength(fontSizeValue, parentSize, parentSize, remSize, null, true,
                     containerInlineSizePt, containerBlockSizePt)
             };
+
+            // A legitimately-parsed font-size of 0 (or any other small value) must be honored, not
+            // silently replaced with the medium default - only a negative computed value (e.g. from a
+            // calc() expression) is spec-clamped, to zero, not to the default.
+            return Math.Max(0, fsize);
+        }
+
+        /// <param name="fontSize">The parsed <c>font-size</c> value. A resolved <see cref="LengthOrCalc"/>
+        /// value plays the role the string overload's <c>_</c> switch arm does (a length/<c>calc()</c> to
+        /// parse); a resolved <see cref="FontSizeKeyword"/> plays the role of its 9 explicit keyword arms.
+        /// By the time this runs, <c>em</c>/<c>ex</c>/<c>%</c>/<c>smaller</c>/<c>larger</c> have already
+        /// been eagerly resolved to an absolute point <see cref="Length"/> at cascade time (see
+        /// <c>CssBox.ResolveFontSizeValueComputation</c>), so only a <c>calc()</c> (deferred via
+        /// <see cref="LengthOrCalc.CalcText"/>, evaluated here against <paramref name="parentSize"/> as its
+        /// own <c>em</c> basis, matching the pre-eager-resolution behavior a bare relative value would have
+        /// gone through) or <c>rem</c> genuinely still needs <paramref name="parentSize"/>/
+        /// <paramref name="remSize"/> at this point.</param>
+        /// <param name="parentSize">Reference size for <c>smaller</c>/<c>larger</c>/a <c>calc()</c>'s own <c>em</c>.</param>
+        /// <param name="remSize">Reference size for <c>rem</c>.</param>
+        /// <param name="containerInlineSizePt">See the string overload's parameter of the same name.</param>
+        /// <param name="containerBlockSizePt">See the string overload's parameter of the same name.</param>
+        internal static double Resolve(CssKeywordOrValue<FontSizeKeyword, LengthOrCalc> fontSize, double parentSize, double remSize,
+            double? containerInlineSizePt = null, double? containerBlockSizePt = null)
+        {
+            double fsize;
+            if (fontSize.Value is { } value)
+            {
+                fsize = value.IsCalc
+                    ? CssValueParser.ParseLength(value.CalcText!, parentSize, parentSize, remSize, null, true,
+                        containerInlineSizePt, containerBlockSizePt)
+                    : value.Length!.Value.ToPixels(parentSize, remSize, parentSize, containerInlineSizePt, containerBlockSizePt);
+            }
+            else
+            {
+                fsize = fontSize.Keyword switch
+                {
+                    FontSizeKeyword.XxSmall => CssConstants.FontSize - 4,
+                    FontSizeKeyword.XSmall => CssConstants.FontSize - 3,
+                    FontSizeKeyword.Small => CssConstants.FontSize - 2,
+                    FontSizeKeyword.Large => CssConstants.FontSize + 2,
+                    FontSizeKeyword.XLarge => CssConstants.FontSize + 3,
+                    FontSizeKeyword.XxLarge => CssConstants.FontSize + 4,
+                    FontSizeKeyword.Smaller => parentSize - 2,
+                    FontSizeKeyword.Larger => parentSize + 2,
+                    _ => CssConstants.FontSize // Medium, or unset (unreachable in practice - see CssKeywordOrValue's own doc comment)
+                };
+            }
 
             // A legitimately-parsed font-size of 0 (or any other small value) must be honored, not
             // silently replaced with the medium default - only a negative computed value (e.g. from a

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -1778,30 +1778,22 @@
     },
     {
       "name": "font-size",
-      "comment": "supportedValues deliberately excludes CSS Fonts 4's xxx-large - FontSizeResolver.Resolve's switch has no case for it, so an accepted 'font-size: xxx-large' would fall through to CssValueParser.ParseLength (which can't parse the bare keyword), Math.Max(0, ...)-clamp to 0, and silently render invisible text rather than being rejected.",
+      "comment": "CssKeywordOrValue<FontSizeKeyword, LengthOrCalc>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText. supportedValues (via FontSizeKeyword/Map.FontSizeKeywords) deliberately excludes CSS Fonts 4's xxx-large - FontSizeResolver.Resolve's switch has no case for it, so an accepted 'font-size: xxx-large' would fall through to the length/calc() value path (which can't parse the bare keyword), Math.Max(0, ...)-clamp to 0, and silently render invisible text rather than being rejected. RegistryEmitter.BuildHtmlAssignment runs CssBox.ResolveFontSizeValueComputation(value) (the html.valueComputation \"font-size\" case) against the raw authored text before FromCssText parses it - see that method's own doc comment for the eager em/ex/percent/smaller/larger-to-points resolution it performs (calc() and rem stay lazy, resolved later by FontSizeResolver.Resolve/DerivedStyle.ActualFont via LengthOrCalc's deferred-calc mechanism).",
       "inherited": true,
       "initialValue": "medium",
-      "cssDataType": [
-        "length",
-        "keyword"
-      ],
-      "supportedValues": [
-        "xx-small",
-        "x-small",
-        "small",
-        "medium",
-        "large",
-        "x-large",
-        "xx-large",
-        "smaller",
-        "larger"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "keyword-or-value",
+        "enumType": "FontSizeKeyword",
+        "keywordMap": "Map.FontSizeKeywords",
+        "fallback": "FontSizeKeyword.Medium",
+        "valueType": "length"
+      },
       "html": {
         "propertyPath": "FontSize",
-        "csharpDataType": "string",
+        "csharpDataType": "CssProperty<CssKeywordOrValue<FontSizeKeyword, LengthOrCalc>>",
         "area": "FontArea",
-        "valueComputation": "font-size"
+        "valueComputation": "font-size",
+        "getterExpression": "{box}.FontSize.ToString()"
       }
     },
     {


### PR DESCRIPTION
## Summary

Part of the #598 initiative to replace raw-string CSS property storage with typed `CssBox` storage.

- Converts `font-size` — the ninth keyword-or-value batch, and the most structurally complex one so far. `font-size` already had eager-resolution machinery from an earlier PR (#632) fixing a real multi-generation compounding bug (`InheritStyle` adopts the whole `Font` area by reference, so a parent-relative value left unresolved compounds once per generation). That logic lived in the generator itself; moving `font-size` to the keyword-or-value shape meant re-homing it into a new hand-written `CssBox.ResolveFontSizeValueComputation`, invoked via the same `"no-ems"`-style pattern `word-spacing`/`letter-spacing` already established.
- New `FontSizeKeyword` enum (9 members). New typed `FontSizeResolver.Resolve` overload added alongside the unchanged string overload (which `MarginBoxRenderer`'s `@page` margin-box resolution keeps using unmodified), carefully preserving the original resolver's exact `em`/`rem`-basis argument wiring — a font-size's own `em` must resolve against the *parent's* font size, never the box's own.
- Migrated `DerivedStyle.ActualFont`'s `FontSize` reads and the legacy `<font size>` HTML presentational attribute.
- **Post-change review found and I fixed a real regression**: the migrated `<font size="N">` handling routed HTML's legacy size scale (never a valid CSS keyword/length) through a parser whose fallback always assigns something, silently forcing every `<font size="N">` to `medium` regardless of `N`. Fixed by skipping the assignment when the value doesn't validate, leaving the cascade's own value in place — the same convention already established for `valign`/`align` (#642).

## Test plan

- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (7987 passed, 9 skipped), including `FontSizeInheritanceIntegrationTests`' original compounding-bug regression suite, unmodified by this diff
- [x] `dotnet test PeachPDF.SourceGenerators.Tests/PeachPDF.SourceGenerators.Tests.csproj` — green (109 passed)
- [x] Diff coverage 92% vs base (`diff-cover`)
- [x] New `FontSizeTypedStorageTests.cs` — keyword/length/calc()/rem storage, `ActualFontSize` resolution for every absolute keyword, eager em/`smaller` transforms verified against exact resolved values, and the legacy `<font size>` regression fix
- [x] Post-change review pass on the complete diff (one real regression found and fixed; see above)