### PR TITLE
Convert line-height to typed keyword-or-value storage

### DIFF
--- a/.claude/migration-notes/2026-08-05-unitless-line-height-now-resolves-instead-of-collapsing-to-zero.md
+++ b/.claude/migration-notes/2026-08-05-unitless-line-height-now-resolves-instead-of-collapsing-to-zero.md
@@ -1,0 +1,21 @@
+# A bare unitless `line-height` (e.g. `line-height: 1.5`) now resolves correctly instead of collapsing to 0
+
+**Landed:** 2026-08-05 — Convert `line-height` to typed keyword-or-value storage (#598 follow-up)
+**Doc section:** docs/html-css-support.md § [line-height row](../../docs/html-css-support.md)
+
+`line-height`'s grammar is `normal | <number> | <length-percentage>` (CSS Inline Layout 3 §4). Before
+this change, a bare unitless number (`line-height: 1.5`) validated as CSS-legal, but the string-based
+resolver (`CssValueParser.ParseLength`) had no case for a number with no unit suffix — it fell through to
+`Length.Unit.None`, which `Length.ToPixels` resolves to 0. Every real-world unitless `line-height`
+declaration therefore silently collapsed the element's used line height to 0, rather than the spec's
+"number × the element's own font size" (CSS2.1 §10.8.1).
+
+Converting `line-height` to typed `CssProperty<CssKeywordOrValue<NormalKeyword, LengthOrUnitless>>`
+storage required a real resolution path for the bare-number case as part of building the new
+`LengthOrUnitless` union type — there was no way to store a validated-but-unhandled state the way the old
+string field could. `LengthOrUnitless`'s `Unitless` side now resolves to `Unitless × box.GetEmHeight()`
+(the box's own resolved font size), matching spec.
+
+A document that declared a unitless `line-height` (a common authoring pattern, e.g. `line-height: 1.5`)
+will now see visibly taller line boxes/leading than before, matching browsers, instead of lines packed at
+their content height with no extra leading.

--- a/src/PeachPDF.SourceGenerators.Tests/GeneratorGoldenFileTests.cs
+++ b/src/PeachPDF.SourceGenerators.Tests/GeneratorGoldenFileTests.cs
@@ -282,6 +282,34 @@ namespace PeachPDF.SourceGenerators.Tests
         }
 
         [Fact]
+        public void Emits_KeywordOrValue_Validation_And_Storage_For_A_Length_Or_Unitless_Or_Normal_Property()
+        {
+            var json = """
+                {
+                  "properties": [
+                    { "name": "line-height", "inherited": true, "initialValue": "normal",
+                      "cssDataType": { "type": "keyword-or-value", "enumType": "NormalKeyword", "keywordMap": "Map.NormalKeywords",
+                        "fallback": "NormalKeyword.Normal", "valueType": "length-or-unitless" },
+                      "html": { "propertyPath": "Transform", "csharpDataType": "string", "area": "VisualEffectsArea" } }
+                  ]
+                }
+                """;
+
+            var result = GeneratorTestHost.Run(json, StubSources.MinimalCssBoxAndSvgElement);
+
+            var generated = result.Results.Single().GeneratedSources
+                .Single(s => s.HintName == "CssPropertyRegistry.g.cs").SourceText.ToString();
+
+            Assert.Contains(
+                "private static bool Validate_LineHeight(CssValueParser parser, string value) => " +
+                "Map.NormalKeywords.ContainsKey(value) || global::PeachPDF.Html.Core.Parse.CssValueParser.TryParseLengthOrUnitless(value, out _);",
+                generated);
+            Assert.Contains(
+                "box.Transform = global::PeachPDF.CSS.CssKeywordOrValueParser.FromCssText<NormalKeyword, global::PeachPDF.CSS.LengthOrUnitless>(value, Map.NormalKeywords, global::PeachPDF.Html.Core.Parse.CssValueParser.TryParseLengthOrUnitless, NormalKeyword.Normal);",
+                generated);
+        }
+
+        [Fact]
         public void Emits_KeywordOrValue_Validation_Narrowed_By_Min_For_An_Integer_Or_Auto_Property()
         {
             var json = """

--- a/src/PeachPDF.SourceGenerators/Emit/KeywordOrValueGrammar.cs
+++ b/src/PeachPDF.SourceGenerators/Emit/KeywordOrValueGrammar.cs
@@ -4,9 +4,10 @@ using PeachPDF.SourceGenerators.Model;
 namespace PeachPDF.SourceGenerators.Emit
 {
     /// <summary>
-    /// The single place a <c>DataTypeKind.KeywordOrValue</c> entry's <c>valueType</c> ("integer"/"length")
-    /// maps to real C# — the value-side validation clause, the storage type, and the <c>TryParse</c>-shaped
-    /// parser to hand to <see cref="global::PeachPDF.CSS.CssKeywordOrValueParser.FromCssText{TEnum,TValue}"/>.
+    /// The single place a <c>DataTypeKind.KeywordOrValue</c> entry's <c>valueType</c>
+    /// ("integer"/"length"/"length-or-unitless") maps to real C# — the value-side validation clause, the
+    /// storage type, and the <c>TryParse</c>-shaped parser to hand to
+    /// <see cref="global::PeachPDF.CSS.CssKeywordOrValueParser.FromCssText{TEnum,TValue}"/>.
     /// <see cref="ValidatorExpressionBuilder"/> and <see cref="RegistryEmitter"/> both consult this rather
     /// than each declaring (and separately guarding) their own copy of the valueType switch. An entry's
     /// optional <see cref="DataTypeSpec.Min"/>/<see cref="DataTypeSpec.Max"/> — the same JSON <c>min</c>/
@@ -47,6 +48,13 @@ namespace PeachPDF.SourceGenerators.Emit
             "length" => new Resolved(
                 "global::PeachPDF.Html.Core.Parse.CssValueParser.TryParseLengthOrCalc(value, out _)",
                 "global::PeachPDF.CSS.LengthOrCalc", "global::PeachPDF.Html.Core.Parse.CssValueParser.TryParseLengthOrCalc"),
+            // line-height's own non-keyword grammar (<length-percentage> | <number>) - a superset of
+            // "length" that also accepts a bare unitless multiplier (CSS Inline Layout 3 §4). See
+            // LengthOrUnitless's own doc comment for why the unitless side needs no separate deferred-calc
+            // case the way the length side does.
+            "length-or-unitless" => new Resolved(
+                "global::PeachPDF.Html.Core.Parse.CssValueParser.TryParseLengthOrUnitless(value, out _)",
+                "global::PeachPDF.CSS.LengthOrUnitless", "global::PeachPDF.Html.Core.Parse.CssValueParser.TryParseLengthOrUnitless"),
             _ => throw new NotSupportedException(
                 $"\"{entry.Name}\" declares a keyword-or-value cssDataType with valueType \"{dt.ValueType}\", " +
                 "which KeywordOrValueGrammar does not yet implement."),

--- a/src/PeachPDF.SourceGenerators/Model/DataTypeSpec.cs
+++ b/src/PeachPDF.SourceGenerators/Model/DataTypeSpec.cs
@@ -51,7 +51,8 @@ namespace PeachPDF.SourceGenerators.Model
         public string? KeywordMap { get; }
         public string? Fallback { get; }
 
-        // "keyword-or-value" — the non-keyword side's grammar/C# type ("integer" or "length")
+        // "keyword-or-value" — the non-keyword side's grammar/C# type ("integer", "length", or
+        // "length-or-unitless")
         public string? ValueType { get; }
 
         public DataTypeSpec(DataTypeKind kind, double? min = null, double? max = null,

--- a/src/PeachPDF.Tests/Integration/Acid2FeatureVerificationTests.cs
+++ b/src/PeachPDF.Tests/Integration/Acid2FeatureVerificationTests.cs
@@ -1023,7 +1023,7 @@ namespace PeachPDF.Tests.Integration
             // as declared.
             var expectedPt = 2 * parent.ActualFont.Size;
             Assert.Equal($"{expectedPt.ToString(System.Globalization.NumberFormatInfo.InvariantInfo)}pt", box.FontSize.ToString());
-            Assert.Equal("24px", box.LineHeight);
+            Assert.Equal("24px", box.LineHeight.ToString());
         }
 
         // ─── vertical-align: bottom on an inline REPLACED element (not text) ───────

--- a/src/PeachPDF.Tests/Integration/FontShorthandIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FontShorthandIntegrationTests.cs
@@ -28,7 +28,7 @@ namespace PeachPDF.Tests.Integration
             Assert.Equal("italic", el!.FontStyle);
             Assert.Equal("bold", el.FontWeight.ToString());
             Assert.Equal("16px", el.FontSize.ToString());
-            Assert.Equal("1.4", el.LineHeight);
+            Assert.Equal("1.4", el.LineHeight.ToString());
             Assert.Contains("Arial", el.FontFamily);
         }
 
@@ -45,7 +45,7 @@ namespace PeachPDF.Tests.Integration
             Assert.NotNull(el);
             Assert.Equal("bold", el!.FontWeight.ToString());
             Assert.Equal("16px", el.FontSize.ToString());
-            Assert.Equal("1.4", el.LineHeight);
+            Assert.Equal("1.4", el.LineHeight.ToString());
             Assert.Contains("Arial", el.FontFamily);
             Assert.DoesNotContain("+", el.FontFamily);
             Assert.DoesNotContain("calc", el.FontFamily);
@@ -66,7 +66,7 @@ namespace PeachPDF.Tests.Integration
             Assert.NotNull(el);
             Assert.Equal("bold", el!.FontWeight.ToString());
             Assert.Equal("16px", el.FontSize.ToString());
-            Assert.Equal("1.4", el.LineHeight);
+            Assert.Equal("1.4", el.LineHeight.ToString());
             Assert.Contains("Arial", el.FontFamily);
         }
 

--- a/src/PeachPDF.Tests/Integration/LineHeightTypedStorageTests.cs
+++ b/src/PeachPDF.Tests/Integration/LineHeightTypedStorageTests.cs
@@ -125,6 +125,20 @@ namespace PeachPDF.Tests.Integration
             Assert.Equal(36d, box!.ActualLineHeight, 2);
         }
 
+        [Fact]
+        public async Task RelativeUnitCalc_ActualLineHeight_EvaluatesLazilyAgainstTheBoxsOwnContext()
+        {
+            // calc(1em + 4px) on a 20pt font-size box: 1em -> 20pt (the box's own font size, the same
+            // emFactor GetEmHeight() would supply), 4px -> 3pt (PointsPerPx), for 23pt total.
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='font-size:20pt;line-height:calc(1em + 4px)'>x</div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.Equal(23d, box!.ActualLineHeight, 2);
+        }
+
         // ─── Helpers ─────────────────────────────────────────────────────────────
 
         private static async Task<PeachPDF.Html.Core.Dom.CssBox> GetLineHeightBoxAsync(string authored)

--- a/src/PeachPDF.Tests/Integration/LineHeightTypedStorageTests.cs
+++ b/src/PeachPDF.Tests/Integration/LineHeightTypedStorageTests.cs
@@ -1,0 +1,140 @@
+using PeachPDF.CSS;
+using PeachPDF.Tests.TestSupport;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Direct typed-storage assertions for <c>line-height</c>, now backed by
+    /// <c>CssProperty&lt;CssKeywordOrValue&lt;NormalKeyword, LengthOrUnitless&gt;&gt;</c> - the tenth and
+    /// final keyword-or-value batch. Complements <c>FontShorthandIntegrationTests</c> (which exercises
+    /// <c>line-height</c> indirectly through the <c>font</c> shorthand's slash-separated syntax) and
+    /// <c>Acid2FeatureVerificationTests</c>' <c>FontShorthand_SlashSeparatedLineHeight_...</c> case.
+    /// </summary>
+    public class LineHeightTypedStorageTests
+    {
+        [Fact]
+        public async Task NormalKeyword_StoresTheKeyword_CaseInsensitively()
+        {
+            var box = await GetLineHeightBoxAsync("NORMAL");
+            Assert.True(box.LineHeight.Value is { IsKeyword: true, Keyword: NormalKeyword.Normal });
+        }
+
+        [Fact]
+        public async Task UnitlessNumber_StoresAsUnitlessMultiplier()
+        {
+            var box = await GetLineHeightBoxAsync("1.5");
+            Assert.True(box.LineHeight.Value is
+            {
+                IsValue: true,
+                Value: { IsUnitless: true, Unitless: 1.5d }
+            });
+        }
+
+        [Fact]
+        public async Task AbsoluteLength_StoresParsedLength()
+        {
+            var box = await GetLineHeightBoxAsync("24px");
+            Assert.True(box.LineHeight.Value is
+            {
+                IsValue: true,
+                Value: { IsUnitless: false, LengthOrCalc: { IsCalc: false, Length: { Type: Length.Unit.Px, Value: 24f } } }
+            });
+        }
+
+        [Fact]
+        public async Task Percentage_StoresParsedLength()
+        {
+            // line-height accepts <length-percentage>, not just <length> - LengthOrCalc (reused as-is from
+            // word-spacing/letter-spacing/row-gap/column-gap/margin/inset/font-size) already covers this.
+            var box = await GetLineHeightBoxAsync("150%");
+            Assert.True(box.LineHeight.Value is
+            {
+                IsValue: true,
+                Value: { LengthOrCalc: { IsCalc: false, Length: { Type: Length.Unit.Percent, Value: 150f } } }
+            });
+        }
+
+        [Fact]
+        public async Task RelativeUnitCalc_StaysDeferred_NotEagerlyResolved()
+        {
+            var box = await GetLineHeightBoxAsync("calc(1em + 4px)");
+            Assert.True(box.LineHeight.Value is
+            {
+                IsValue: true,
+                Value: { IsUnitless: false, LengthOrCalc: { IsCalc: true } }
+            });
+        }
+
+        [Fact]
+        public async Task BareNumberCalc_FoldsToALiteralUnitlessMultiplier()
+        {
+            // CalcCategory.Number always folds at cascade time (Layer A's CalcSerializer), unlike
+            // CalcCategory.LengthPercentage - so calc(1 + 0.5) is indistinguishable, by the time it
+            // reaches this union, from a literal "1.5". No deferred-calc slot is needed on the unitless
+            // side because of this (see LengthOrUnitless's own doc comment).
+            var box = await GetLineHeightBoxAsync("calc(1 + 0.5)");
+            Assert.True(box.LineHeight.Value is
+            {
+                IsValue: true,
+                Value: { IsUnitless: true, Unitless: 1.5d }
+            });
+        }
+
+        // ─── ActualLineHeight resolution (not just storage) ────────────────────────
+
+        [Fact]
+        public async Task NormalKeyword_ActualLineHeight_ResolvesToOnePointTwoTimesFontSize()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='font-size:20pt;line-height:normal'>x</div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.Equal(1.2 * 20, box!.ActualLineHeight, 2);
+        }
+
+        [Fact]
+        public async Task UnitlessNumber_ActualLineHeight_ResolvesToTheMultiplierTimesTheBoxsOwnFontSize()
+        {
+            // Regression-guard: before this conversion, a bare unitless line-height (e.g. "1.5") validated
+            // but silently collapsed ActualLineHeight to 0 - the old string-based ParseLength had no case
+            // for a number with no unit token (Length.Unit.None resolves to 0 in Length.ToPixels).
+            // LengthOrUnitless's Unitless side fixes this (CSS2.1 §10.8.1: the number times the element's
+            // own font size).
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='font-size:20pt;line-height:1.5'>x</div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.Equal(30d, box!.ActualLineHeight, 2);
+        }
+
+        [Fact]
+        public async Task AbsoluteLength_ActualLineHeight_ResolvesToTheLengthItself()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='t' style='font-size:20pt;line-height:36pt'>x</div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+
+            Assert.NotNull(box);
+            Assert.Equal(36d, box!.ActualLineHeight, 2);
+        }
+
+        // ─── Helpers ─────────────────────────────────────────────────────────────
+
+        private static async Task<PeachPDF.Html.Core.Dom.CssBox> GetLineHeightBoxAsync(string authored)
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                $"<div id='t' style='line-height:{authored}'></div>"));
+
+            var box = LayoutHarness.FindById(root, "t");
+            Assert.NotNull(box);
+            return box!;
+        }
+    }
+}

--- a/src/PeachPDF/CSS/LengthOrUnitless.cs
+++ b/src/PeachPDF/CSS/LengthOrUnitless.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace PeachPDF.CSS
+{
+    /// <summary>
+    /// The value side of <c>line-height</c>'s <c>normal | &lt;number&gt; | &lt;length-percentage&gt;</c>
+    /// grammar (CSS Inline Layout 3 §4) once the keyword (<c>normal</c>) side is factored out by the outer
+    /// <see cref="CssKeywordOrValue{TEnum,TValue}"/>: either a <see cref="CSS.LengthOrCalc"/> (the
+    /// <c>&lt;length-percentage&gt;</c> case, itself already a union of a resolved <see cref="Length"/> and
+    /// a deferred relative-unit <c>calc()</c> — see its own doc comment), or a bare unitless multiplier
+    /// (e.g. <c>line-height: 1.5</c>), which CSS2.1 §10.8.1 defines as the element's own font size scaled
+    /// by that number — recomputed per box, not resolved at cascade time, so no separate deferred-calc case
+    /// is needed on this side: an absolute-only <c>calc()</c> number expression has already folded to a
+    /// literal numeric string by Layer A's <c>CalcSerializer</c> (<c>CalcCategory.Number</c> always folds,
+    /// unlike <c>CalcCategory.LengthPercentage</c>) before this type is ever constructed.
+    /// <para>
+    /// The "exactly one is set" invariant is enforced by the constructor, mirroring
+    /// <see cref="LengthOrCalc"/>/<see cref="CssKeywordOrValue{TEnum,TValue}"/> — <c>default(LengthOrUnitless)</c>
+    /// (both null) bypasses it the same way, but the only construction site,
+    /// <c>CssValueParser.TryParseLengthOrUnitless</c> (namespace <c>PeachPDF.Html.Core.Parse</c>), always
+    /// goes through this constructor.
+    /// </para>
+    /// </summary>
+    internal readonly record struct LengthOrUnitless
+    {
+        public LengthOrUnitless(LengthOrCalc? lengthOrCalc, double? unitless)
+        {
+            if (lengthOrCalc is null == unitless is null)
+                throw new ArgumentException("Exactly one of lengthOrCalc or unitless must be provided.");
+
+            LengthOrCalc = lengthOrCalc;
+            Unitless = unitless;
+        }
+
+        public LengthOrCalc? LengthOrCalc { get; init; }
+        public double? Unitless { get; init; }
+
+        public bool IsUnitless => Unitless is not null;
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
+++ b/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
@@ -1097,9 +1097,9 @@ namespace PeachPDF.Html.Core.Dom
         #region Line-height
 
         /// <summary>Gets the line height. Recomputed fresh every call, not cached.</summary>
-        public double ActualLineHeight => Style.Text.LineHeight is CssConstants.Normal
-            ? 1.2 * GetEmHeight()
-            : CssValueParser.ParseLength(Style.Text.LineHeight, Owner.Size.Height, Owner);
+        public double ActualLineHeight => Style.Text.LineHeight.Value.Value is { } lineHeight
+            ? CssValueParser.ParseLength(lineHeight, Owner.Size.Height, Owner)
+            : 1.2 * GetEmHeight();
 
         #endregion
 

--- a/src/PeachPDF/Html/Core/Parse/CssValueParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/CssValueParser.cs
@@ -289,6 +289,48 @@ namespace PeachPDF.Html.Core.Parse
         }
 
         /// <summary>
+        /// Resolves a <see cref="LengthOrUnitless"/> (<c>line-height</c>'s
+        /// <c>CssKeywordOrValue{NormalKeyword,LengthOrUnitless}.Value</c>) to pixels - either through the
+        /// same <see cref="LengthOrCalc"/> resolution every other keyword-or-value length property uses,
+        /// or, for a bare unitless multiplier, by scaling <paramref name="box"/>'s own font size (CSS2.1
+        /// §10.8.1: "the used value of the property is this number multiplied by the element's font
+        /// size" - <paramref name="box"/>'s own, not an ancestor's, which is what makes storing the raw
+        /// multiplier and recomputing per box, rather than resolving once at cascade time, the correct
+        /// inheritance behavior here).
+        /// </summary>
+        public static double ParseLength(LengthOrUnitless value, double hundredPercent, CssBox box) =>
+            value.IsUnitless
+                ? value.Unitless!.Value * box.GetEmHeight()
+                : ParseLength(value.LengthOrCalc!.Value, hundredPercent, box);
+
+        /// <summary>
+        /// Parses <c>line-height</c>'s non-keyword grammar - a <c>&lt;length-percentage&gt;</c> (itself
+        /// possibly a deferred-calc, via <see cref="TryParseLengthOrCalc"/>) or a bare unitless multiplier
+        /// number. A bare-number <c>calc()</c> (e.g. <c>calc(1 + 0.5)</c>) has already folded to a literal
+        /// numeric string by Layer A's <c>CalcSerializer</c> (<c>CalcCategory.Number</c> always folds, unlike
+        /// <c>CalcCategory.LengthPercentage</c>) before this runs, so it's indistinguishable from - and
+        /// handled by - the plain <see cref="double.TryParse(string,NumberStyles,IFormatProvider,out double)"/>
+        /// fallback below.
+        /// </summary>
+        public static bool TryParseLengthOrUnitless(string value, out LengthOrUnitless result)
+        {
+            if (TryParseLengthOrCalc(value, out var lengthOrCalc))
+            {
+                result = new LengthOrUnitless(lengthOrCalc, null);
+                return true;
+            }
+
+            if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var unitless))
+            {
+                result = new LengthOrUnitless(null, unitless);
+                return true;
+            }
+
+            result = default;
+            return false;
+        }
+
+        /// <summary>
         /// Parses a length. Lengths are followed by an unit identifier (e.g. 10px, 3.1em)
         /// </summary>
         /// <param name="length">Specified length</param>

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -1501,22 +1501,21 @@
     },
     {
       "name": "line-height",
-      "comment": "A unitless multiplier value (e.g. 'line-height: 1.5') is not modeled here and reports unsupported - IsValidLength requires a unit or a bare zero, matching ParseLength's own length-only reading at DerivedStyle.ActualLineHeight. customValidator deliberately excludes 'auto' - CSS Inline Layout 3's grammar is 'normal | <number> | <length-percentage>', auto was never part of it; DerivedStyle.ActualLineHeight has no special case for it and would silently collapse line height to 0 if it were accepted (a pre-existing quirk carried over from the old IsValidLengthProperty helper written for width/height-style 'auto' properties, not spec-derived).",
+      "comment": "CssKeywordOrValue<NormalKeyword, LengthOrUnitless>-backed (issue #598's follow-up) - the tenth and final keyword-or-value batch. Fixes a real pre-existing bug along the way: a bare unitless multiplier (e.g. 'line-height: 1.5') previously validated but silently collapsed ActualLineHeight to 0 (the old string-based ParseLength had no case for a number with no unit token); LengthOrUnitless's Unitless side now resolves it correctly (CSS2.1 §10.8.1: the number times the element's own font size). 'auto' is deliberately not in supportedValues - CSS Inline Layout 3's grammar is 'normal | <number> | <length-percentage>', auto was never part of it.",
       "inherited": true,
       "initialValue": "normal",
-      "cssDataType": [
-        "length",
-        "keyword"
-      ],
-      "supportedValues": [
-        "normal"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "keyword-or-value",
+        "enumType": "NormalKeyword",
+        "keywordMap": "Map.NormalKeywords",
+        "fallback": "NormalKeyword.Normal",
+        "valueType": "length-or-unitless"
+      },
       "html": {
         "propertyPath": "LineHeight",
-        "csharpDataType": "string",
+        "csharpDataType": "CssProperty<CssKeywordOrValue<NormalKeyword, LengthOrUnitless>>",
         "area": "TextArea",
-        "customValidator": "global::PeachPDF.Html.Core.Parse.CssValueParser.IsValidLength({value}) || {value} == \"normal\" || double.TryParse({value}, global::System.Globalization.NumberStyles.Float, global::System.Globalization.CultureInfo.InvariantCulture, out _)"
+        "getterExpression": "{box}.LineHeight.ToString()"
       }
     },
     {

--- a/src/PeachPDF/css-properties.schema.json
+++ b/src/PeachPDF/css-properties.schema.json
@@ -138,7 +138,7 @@
             "enumType": { "type": "string" },
             "keywordMap": { "type": "string" },
             "fallback": { "type": "string" },
-            "valueType": { "type": "string", "enum": ["integer", "length"], "description": "The non-keyword side's grammar and TValue — must match a TryParse-shaped parser (int.TryParse, Length.TryParse) RegistryEmitter knows how to call." },
+            "valueType": { "type": "string", "enum": ["integer", "length", "length-or-unitless"], "description": "The non-keyword side's grammar and TValue — must match a TryParse-shaped parser (int.TryParse, Length.TryParse, CssValueParser.TryParseLengthOrUnitless) RegistryEmitter knows how to call." },
             "min": { "type": "number", "description": "Narrows an \"integer\" valueType's validation clause — same field/meaning as the plain \"integer\" DataTypeKind's own \"min\" (e.g. column-count's <integer> must be >= 1) — see KeywordOrValueGrammar." },
             "max": { "type": "number", "description": "Narrows an \"integer\" valueType's validation clause — same field/meaning as the plain \"integer\" DataTypeKind's own \"max\" — see KeywordOrValueGrammar." }
           }


### PR DESCRIPTION
## Summary

Converts `line-height` — the final property in the issue #598 typed-storage initiative — to `CssProperty&lt;CssKeywordOrValue&lt;NormalKeyword, LengthOrUnitless&gt;&gt;`.

- Adds a new `LengthOrUnitless` union type (`src/PeachPDF/CSS/LengthOrUnitless.cs`), wrapping the existing `LengthOrCalc` union plus a bare unitless-multiplier case, for `line-height`'s `normal | &lt;number&gt; | &lt;length-percentage&gt;` grammar (CSS Inline Layout 3 §4).
- Wires a new `"length-or-unitless"` `valueType` through the source generator's `KeywordOrValueGrammar`, alongside the existing `"integer"`/`"length"` cases.
- Rewrites `DerivedStyle.ActualLineHeight` to read the typed union instead of string-comparing against `"normal"`.

**Fixes a real pre-existing bug along the way**: a bare unitless `line-height` (e.g. `line-height: 1.5`) previously validated as CSS-legal but silently collapsed `ActualLineHeight` to 0 — the old string-based `ParseLength` had no case for a number with no unit token. Building `LengthOrUnitless` requires deciding what the unitless case resolves to, so this is fixed as part of the conversion rather than reproduced. See the migration note for details.

## Test plan

- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings, 0 errors
- [x] `dotnet test PeachPDF.Tests --framework net8.0` — 7997 passed, 9 skipped (pre-existing/platform-conditional), 0 failed
- [x] `dotnet test PeachPDF.SourceGenerators.Tests` — 110 passed
- [x] Diff coverage vs. `main` — 97% (single uncovered line is `LengthOrUnitless`'s defensive constructor guard, same untested-by-precedent shape as `LengthOrCalc`'s identical guard)
- [x] New `LineHeightTypedStorageTests.cs`: storage assertions (keyword, unitless-number, length, percentage, deferred relative-unit calc(), bare-number calc() folding to a literal unitless multiplier) plus `ActualLineHeight` resolution assertions (normal → 1.2× font-size, unitless → multiplier × the box's own font-size — the regression this PR fixes, absolute length, and a deferred calc() evaluating lazily against the box's own context)
- [x] New generator golden-file test for the `"length-or-unitless"` codegen shape
- [x] Post-change review pass — found and fixed a schema/comment drift (the JSON schema's `valueType` enum hadn't been extended for the new value)

This completes the #598 typed-storage initiative — every keyword-valued CSS property `CssBox` stores is now typed rather than a raw string.
