### PR TITLE
Convert font-stretch to typed keyword storage

### DIFF
--- a/src/PeachPDF.Tests/Integration/FontShorthandIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FontShorthandIntegrationTests.cs
@@ -120,6 +120,10 @@ namespace PeachPDF.Tests.Integration
         [InlineData("expanded", 7)]
         [InlineData("ultra-condensed", 1)]
         [InlineData("ultra-expanded", 9)]
+        [InlineData("extra-condensed", 2)]
+        [InlineData("semi-condensed", 4)]
+        [InlineData("semi-expanded", 6)]
+        [InlineData("extra-expanded", 8)]
         public async Task FontStretch_ResolvesToExpectedNumericScale(string keyword, int expected)
         {
             var html = $"""
@@ -132,7 +136,7 @@ namespace PeachPDF.Tests.Integration
             var el = FindById(root, "el");
 
             Assert.NotNull(el);
-            Assert.Equal(keyword, el!.FontStretch);
+            Assert.Equal(keyword, el!.FontStretch.ToString());
             Assert.Equal(expected, el.ActualStretch);
         }
 
@@ -149,7 +153,7 @@ namespace PeachPDF.Tests.Integration
             var el = FindById(root, "el");
 
             Assert.NotNull(el);
-            Assert.Equal("condensed", el!.FontStretch);
+            Assert.Equal("condensed", el!.FontStretch.ToString());
             Assert.Equal(3, el.ActualStretch);
         }
 
@@ -160,7 +164,7 @@ namespace PeachPDF.Tests.Integration
             var el = FindById(root, "el");
 
             Assert.NotNull(el);
-            Assert.Equal("normal", el!.FontStretch);
+            Assert.Equal("normal", el!.FontStretch.ToString());
             Assert.Equal(5, el.ActualStretch);
         }
 

--- a/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
+++ b/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
@@ -988,7 +988,7 @@ namespace PeachPDF.Html.Core.Dom
             {
                 if (_actualStretch is { } cached) return cached;
 
-                var resolved = FontStretchResolver.Resolve(Style.Font.FontStretch);
+                var resolved = FontStretchResolver.Resolve(Style.Font.FontStretch.Value);
                 _actualStretch = resolved;
                 return resolved;
             }

--- a/src/PeachPDF/Html/Core/Utils/FontStretchResolver.cs
+++ b/src/PeachPDF/Html/Core/Utils/FontStretchResolver.cs
@@ -1,3 +1,4 @@
+using PeachPDF.CSS;
 using PeachPDF.Fonts;
 
 namespace PeachPDF.Html.Core.Utils
@@ -12,6 +13,12 @@ namespace PeachPDF.Html.Core.Utils
     {
         internal const int Normal = 5;
 
+        /// <summary>
+        /// Resolves a raw <c>font-stretch</c> descriptor string (e.g. an <c>@font-face</c> descriptor -
+        /// see <see cref="FontFaceDescriptorResolver.ResolveStretch"/> - a CSS-OM string, not a
+        /// <see cref="Dom.CssBox"/>'s cascaded value) rather than the typed <see cref="FontStretch"/> the
+        /// <see cref="Resolve(FontStretch)"/> overload below consumes.
+        /// </summary>
         internal static int Resolve(string fontStretchValue) => fontStretchValue switch
         {
             CssConstants.UltraCondensed => 1,
@@ -22,6 +29,19 @@ namespace PeachPDF.Html.Core.Utils
             CssConstants.Expanded => 7,
             CssConstants.ExtraExpanded => 8,
             CssConstants.UltraExpanded => 9,
+            _ => Normal
+        };
+
+        internal static int Resolve(FontStretch fontStretch) => fontStretch switch
+        {
+            FontStretch.UltraCondensed => 1,
+            FontStretch.ExtraCondensed => 2,
+            FontStretch.Condensed => 3,
+            FontStretch.SemiCondensed => 4,
+            FontStretch.SemiExpanded => 6,
+            FontStretch.Expanded => 7,
+            FontStretch.ExtraExpanded => 8,
+            FontStretch.UltraExpanded => 9,
             _ => Normal
         };
     }

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -1882,25 +1882,20 @@
     },
     {
       "name": "font-stretch",
+      "comment": "CssProperty<FontStretch>-backed (issue #598's follow-up: typed enum storage instead of a raw string) - reuses the pre-existing FontStretch enum/Map.FontStretches map, already used by FontStretchResolver/the legacy CSS-OM layer.",
       "inherited": true,
       "initialValue": "normal",
-      "cssDataType": "keyword",
-      "supportedValues": [
-        "normal",
-        "ultra-condensed",
-        "extra-condensed",
-        "condensed",
-        "semi-condensed",
-        "semi-expanded",
-        "expanded",
-        "extra-expanded",
-        "ultra-expanded"
-      ],
-      "keywordComparison": "ordinal-ignore-case",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "FontStretch",
+        "keywordMap": "Map.FontStretches",
+        "fallback": "FontStretch.Normal"
+      },
       "html": {
         "propertyPath": "FontStretch",
-        "csharpDataType": "string",
-        "area": "FontArea"
+        "csharpDataType": "CssProperty<FontStretch>",
+        "area": "FontArea",
+        "getterExpression": "{box}.FontStretch.ToString()"
       }
     },
     {


### PR DESCRIPTION
## Summary

`font-stretch` was listed in issue #598's Group A classification table (pure-keyword properties) but was never actually converted by any of the Group A batch PRs — it slipped through every batch and was only caught by an end-to-end verification pass immediately after the `line-height` PR (#658), which was believed to be the initiative's final property. This PR closes that gap.

- Converts `font-stretch` from `csharpDataType: "string"` to `CssProperty&lt;FontStretch&gt;`, reusing the pre-existing `FontStretch` enum (`src/PeachPDF/CSS/Enumerations/FontStretch.cs`) and `Map.FontStretches` map (already used by the legacy CSS-OM/`FontFaceRule` layer) — neither needed to be created, mirroring the `box-sizing`/`direction` enum-keyword precedent already established elsewhere in `css-properties.json`.
- `FontStretchResolver`: kept the existing `Resolve(string)` overload unchanged (still used by `FontFaceDescriptorResolver.ResolveStretch`, an `@font-face` descriptor parser unrelated to `CssBox`'s cascaded value), added a new `Resolve(FontStretch)` typed overload with an identical switch-arm mapping, just re-keyed on the enum.
- `DerivedStyle.ActualStretch` migrated to read the typed `.Value` instead of the raw string.

`font-stretch`'s case-insensitive keyword acceptance already predates this PR (fixed by the original #598 canonicalization fix), so this is purely the deferred typed-storage completion — no user-visible behavior change, no migration note needed.

## Test plan

- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings, 0 errors
- [x] `dotnet test PeachPDF.Tests --framework net8.0` — 8001 passed, 9 skipped (pre-existing/platform-conditional), 0 failed
- [x] Diff coverage vs. `main` — 100%
- [x] Extended the existing `FontStretch_ResolvesToExpectedNumericScale` theory from 4 to 8 cases (covering every non-default keyword arm of the new typed `Resolve(FontStretch)` switch)
- [x] Post-change review pass — no defects found; independently verified `Map.FontStretches`' 9 keys are byte-for-byte identical to the old `supportedValues` array (no silent widening/narrowing), and that `getterExpression`/generated registry wiring matches the `box-sizing`/`direction` precedent exactly

This is expected to be the actual final PR in the #598 typed-storage initiative.
