### PR TITLE
Reduce complexity and improve coverage of DomParser.TranslateAttributes

### DIFF
--- a/.claude/migration-notes/2026-08-05-font-face-attribute-no-longer-crashes.md
+++ b/.claude/migration-notes/2026-08-05-font-face-attribute-no-longer-crashes.md
@@ -1,0 +1,7 @@
+# `<font face="...">` no longer crashes layout, and now applies the font
+
+**Landed:** 2026-08-05
+**Doc section:** none — `html-css-support.md` never documented `face` (it was silently broken), so there is no existing callout to update.
+**Verified against v0.9.8:** the `NotImplementedException` throw is present verbatim at `v0.9.8` (`DomParser.cs`'s `HtmlConstants.Face` case) — this is a genuine change since the last release, not a pre-existing fix that only reads as new.
+
+Any document containing the legacy `<font face="...">` attribute previously threw an uncaught `NotImplementedException` during layout, regardless of the attribute's value. `face` now resolves against installed font families the same way the CSS `font-family` property does (`CssValueParser.GetFontFamilyByName`): the first comma-separated candidate that's actually installed is applied, or the document's default font is used if none of them are — never a crash.

--- a/.claude/migration-notes/2026-08-05-font-face-attribute-no-longer-crashes.md
+++ b/.claude/migration-notes/2026-08-05-font-face-attribute-no-longer-crashes.md
@@ -1,7 +1,7 @@
-# `<font face="...">` no longer crashes layout, and now applies the font
+# `<font face="...">` no longer crashes while rendering, and now applies the font
 
-**Landed:** 2026-08-05
+**Landed:** 2026-08-05 (2c8a4139) — Reduce complexity and improve coverage of TranslateAttributes
 **Doc section:** none — `html-css-support.md` never documented `face` (it was silently broken), so there is no existing callout to update.
 **Verified against v0.9.8:** the `NotImplementedException` throw is present verbatim at `v0.9.8` (`DomParser.cs`'s `HtmlConstants.Face` case) — this is a genuine change since the last release, not a pre-existing fix that only reads as new.
 
-Any document containing the legacy `<font face="...">` attribute previously threw an uncaught `NotImplementedException` during layout, regardless of the attribute's value. `face` now resolves against installed font families the same way the CSS `font-family` property does (`CssValueParser.GetFontFamilyByName`): the first comma-separated candidate that's actually installed is applied, or the document's default font is used if none of them are — never a crash.
+Any document containing the legacy `<font face="...">` attribute previously threw an uncaught `NotImplementedException` while its style was being resolved (during `DomParser`'s cascade phase, before layout ever runs), regardless of the attribute's value. `face` now resolves against installed font families the same way the CSS `font-family` property does (`CssValueParser.GetFontFamilyByName`): the first comma-separated candidate that's actually installed is applied, or the document's default font is used if none of them are — never a crash.

--- a/src/PeachPDF.Tests/Integration/PresentationalAttributeIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/PresentationalAttributeIntegrationTests.cs
@@ -5,6 +5,8 @@ using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Entities;
 using PeachPDF.Html.Core.Utils;
 using PeachPDF.PdfSharpCore.Drawing;
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace PeachPDF.Tests.Integration
@@ -164,7 +166,7 @@ namespace PeachPDF.Tests.Integration
         }
 
         [Fact]
-        public async Task BorderAttribute_OnTable_SetsSolidBorderAndAttemptsCellCascade()
+        public async Task BorderAttribute_OnTable_SetsSolidBorderOnTheTableItself()
         {
             // Exercises TranslateBorder's tag.Name == "table" branch, which (attempts to) cascade a 1px
             // solid border onto every cell via ApplyTableBorder/SetForAllCells - which has the same
@@ -295,11 +297,21 @@ namespace PeachPDF.Tests.Integration
         [Fact]
         public async Task FaceAttribute_WithResolvableFont_SetsFontFamily()
         {
-            var (root, _) = await BuildAndLayout(Wrap($"<font id='f' face='{CssConstants.DefaultFont}'>x</font>"));
+            // Deliberately NOT CssConstants.DefaultFont: DerivedStyle lazily resolves a null/empty
+            // FontFamily to the default font once layout runs (see the "unresolvable" test below), so
+            // asserting the default font here wouldn't distinguish "GetFontFamilyByName actually
+            // resolved this" from "resolution was skipped entirely and the fallback papered over it".
+            // Picking an installed family that ISN'T the platform default keeps this test meaningful
+            // across the CI matrix (Windows/macOS/Linux each resolve a different default).
+            var adapter = new PdfSharpAdapter();
+            var alternativeFont = CssConstants.GetInstalledFontFamilyNames()
+                .First(f => !f.Equals(CssConstants.DefaultFont, StringComparison.OrdinalIgnoreCase) && adapter.IsFontExists(f));
+
+            var (root, _) = await BuildAndLayout(Wrap($"<font id='f' face='{alternativeFont}'>x</font>"));
             var font = FindById(root, "f")!;
 
-            Assert.Equal(CssConstants.DefaultFont, font.FontFamily);
-            Assert.Equal(CssConstants.DefaultFont, font.FontFamilyList);
+            Assert.Equal(alternativeFont, font.FontFamily);
+            Assert.Equal(alternativeFont, font.FontFamilyList);
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/PresentationalAttributeIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/PresentationalAttributeIntegrationTests.cs
@@ -2,6 +2,8 @@ using PeachPDF.Adapters;
 using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Entities;
+using PeachPDF.Html.Core.Utils;
 using PeachPDF.PdfSharpCore.Drawing;
 using System.Threading.Tasks;
 
@@ -139,6 +141,180 @@ namespace PeachPDF.Tests.Integration
             var div = FindById(root, "d")!;
 
             Assert.Equal(VerticalAlignment.Middle, div.VerticalAlign.Value);
+        }
+
+        [Fact]
+        public async Task BackgroundAttribute_SetsBackgroundImage()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<div id='d' background='x.png'>x</div>"));
+            var div = FindById(root, "d")!;
+
+            var layer = Assert.Single(div.BackgroundImages!);
+            var urlImage = Assert.IsType<CssImage.Url>(layer);
+            Assert.Equal("x.png", urlImage.Href);
+        }
+
+        [Fact]
+        public async Task BgcolorAttribute_SetsBackgroundColor()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<div id='d' bgcolor='red'>x</div>"));
+            var div = FindById(root, "d")!;
+
+            Assert.Equal("red", div.BackgroundColor);
+        }
+
+        [Fact]
+        public async Task BorderAttribute_OnTable_SetsSolidBorderAndAttemptsCellCascade()
+        {
+            // Exercises TranslateBorder's tag.Name == "table" branch, which (attempts to) cascade a 1px
+            // solid border onto every cell via ApplyTableBorder/SetForAllCells - which has the same
+            // pre-existing #636 gap as CellpaddingAttribute_DoesNotYetReachTableCells above and
+            // PresentationalBorderAttribute_OnAPlainElement_ForcesSolidOnAllSides's comment in
+            // BorderStylePaintIntegrationTests, so only the table's own border is asserted here.
+            var (root, _) = await BuildAndLayout(Wrap("<table id='t' border='1'><tr><td>x</td></tr></table>"));
+            var table = FindById(root, "t")!;
+
+            Assert.Equal(LineStyle.Solid, table.BorderTopStyle.Value);
+            Assert.Equal("1px", table.BorderTopWidth);
+        }
+
+        [Fact]
+        public async Task BordercolorAttribute_SetsAllBorderColors()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<div id='d' bordercolor='red'>x</div>"));
+            var div = FindById(root, "d")!;
+
+            Assert.Equal("red", div.BorderLeftColor);
+            Assert.Equal("red", div.BorderTopColor);
+            Assert.Equal("red", div.BorderRightColor);
+            Assert.Equal("red", div.BorderBottomColor);
+        }
+
+        [Fact]
+        public async Task CellspacingAttribute_SetsBorderSpacing()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<table id='t' cellspacing='5'><tr><td>x</td></tr></table>"));
+            var table = FindById(root, "t")!;
+
+            Assert.Equal("5px", table.BorderSpacing);
+        }
+
+        [Fact]
+        public async Task CellpaddingAttribute_DoesNotYetReachTableCells()
+        {
+            // ApplyTablePadding's TD-cascading path (SetForAllCells) has the same pre-existing gap as
+            // ApplyTableBorder's (see PresentationalBorderAttribute_OnAPlainElement_ForcesSolidOnAllSides's
+            // comment in BorderStylePaintIntegrationTests): it doesn't traverse the anonymous
+            // table-row-group box CSS inserts around a bare <tr>, so cellpadding never actually reaches
+            // the cell today - tracked separately as issue #636, out of scope here. This documents the
+            // current (pre-existing) behavior rather than silently leaving the `cellpadding` switch-case
+            // uncovered.
+            var (root, _) = await BuildAndLayout(Wrap("<table id='t' cellpadding='5'><tr><td id='c'>x</td></tr></table>"));
+            var cell = FindById(root, "c")!;
+
+            Assert.Equal("0", cell.PaddingLeft);
+        }
+
+        [Fact]
+        public async Task ColorAttribute_SetsColor()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<div id='d' color='blue'>x</div>"));
+            var div = FindById(root, "d")!;
+
+            Assert.Equal("blue", div.Color);
+        }
+
+        [Fact]
+        public async Task HeightAttribute_SetsHeight()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<div id='d' height='50'>x</div>"));
+            var div = FindById(root, "d")!;
+
+            Assert.Equal("50px", div.Height);
+        }
+
+        [Fact]
+        public async Task HspaceAttribute_SetsLeftAndRightMargin()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<img id='i' hspace='10' src='x.png' width='10' height='10'>"));
+            var img = FindById(root, "i")!;
+
+            Assert.Equal("10px", img.MarginLeft.ToString());
+            Assert.Equal("10px", img.MarginRight.ToString());
+        }
+
+        [Fact]
+        public async Task VspaceAttribute_SetsTopAndBottomMargin()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<img id='i' vspace='10' src='x.png' width='10' height='10'>"));
+            var img = FindById(root, "i")!;
+
+            Assert.Equal("10px", img.MarginTop.ToString());
+            Assert.Equal("10px", img.MarginBottom.ToString());
+        }
+
+        [Fact]
+        public async Task WidthAttribute_SetsWidth()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<div id='d' width='50'>x</div>"));
+            var div = FindById(root, "d")!;
+
+            Assert.Equal("50px", div.Width);
+        }
+
+        [Fact]
+        public async Task SizeAttribute_OnHr_SetsHeight()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<hr id='h' size='3'>"));
+            var hr = FindById(root, "h")!;
+
+            Assert.Equal("3px", hr.Height);
+        }
+
+        [Fact]
+        public async Task SizeAttribute_OnFont_WithValidValue_SetsFontSize()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<font id='f' size='large'>x</font>"));
+            var font = FindById(root, "f")!;
+
+            Assert.Equal("large", font.FontSize.ToString());
+        }
+
+        [Fact]
+        public async Task SizeAttribute_OnFont_WithInvalidValue_LeavesFontSizeUnchanged()
+        {
+            // A bare legacy HTML size scale value ("+2", or "1"-"7") matches neither a CSS font-size
+            // keyword nor a valid length, so it must be left alone rather than forced to "medium" -
+            // see the comment on TranslateFontSize (issue #642's accepted-gap convention).
+            var (root, _) = await BuildAndLayout(Wrap("<font id='f' size='+2'>x</font>"));
+            var font = FindById(root, "f")!;
+
+            Assert.Equal("medium", font.FontSize.ToString());
+        }
+
+        [Fact]
+        public async Task FaceAttribute_WithResolvableFont_SetsFontFamily()
+        {
+            var (root, _) = await BuildAndLayout(Wrap($"<font id='f' face='{CssConstants.DefaultFont}'>x</font>"));
+            var font = FindById(root, "f")!;
+
+            Assert.Equal(CssConstants.DefaultFont, font.FontFamily);
+            Assert.Equal(CssConstants.DefaultFont, font.FontFamilyList);
+        }
+
+        [Fact]
+        public async Task FaceAttribute_WithUnresolvableFont_FallsBackToDefaultFontButKeepsRawList()
+        {
+            // GetFontFamilyByName returns null when no candidate resolves (see
+            // CssValueParserFontFamilyTests), but DerivedStyle lazily resolves a null/empty FontFamily to
+            // CssConstants.DefaultFont once layout runs (the same fallback CSS's own unresolvable
+            // font-family gets) - FontFamilyList is untouched by that fallback, so it still holds the raw
+            // attribute text.
+            var (root, _) = await BuildAndLayout(Wrap("<font id='f' face='__DefinitelyNotARealFontFamily__'>x</font>"));
+            var font = FindById(root, "f")!;
+
+            Assert.Equal(CssConstants.DefaultFont, font.FontFamily);
+            Assert.Equal("__DefinitelyNotARealFontFamily__", font.FontFamilyList);
         }
 
         // ─── Helpers ─────────────────────────────────────────────────────────────

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -700,7 +700,7 @@ namespace PeachPDF.Html.Core.Parse
 
             if (box.HtmlTag != null)
             {
-                TranslateAttributes(box.HtmlTag, box);
+                TranslateAttributes(box.HtmlTag, box, valueParser);
             }
 
             // 5. Inline normal; revert target is the author-normal-applied state (unchanged from
@@ -1393,11 +1393,14 @@ namespace PeachPDF.Html.Core.Parse
         }
 
         /// <summary>
-        /// 
+        /// Translates deprecated HTML presentational attributes (e.g. <c>align</c>, <c>bgcolor</c>,
+        /// <c>border</c>) directly into their equivalent typed <see cref="CssBox"/> properties, bypassing
+        /// the CSS cascade, per legacy HTML rendering conventions.
         /// </summary>
-        /// <param name="tag"></param>
-        /// <param name="box"></param>
-        private static void TranslateAttributes(HtmlTag tag, CssBox box)
+        /// <param name="tag">The source element whose attributes are translated.</param>
+        /// <param name="box">The box receiving the translated presentational values.</param>
+        /// <param name="valueParser">Used to resolve <c>face</c> against installed font families via <see cref="CssValueParser.GetFontFamilyByName"/>.</param>
+        private static void TranslateAttributes(HtmlTag tag, CssBox box, CssValueParser valueParser)
         {
             if (!tag.HasAttributes()) return;
 
@@ -1409,38 +1412,7 @@ namespace PeachPDF.Html.Core.Parse
                 switch (att)
                 {
                     case HtmlConstants.Align:
-                        if (tag.Name.Equals(HtmlConstants.Img, StringComparison.OrdinalIgnoreCase))
-                        {
-                            switch (value)
-                            {
-                                case HtmlConstants.Left:
-                                    box.VerticalAlign = CssProperty<VerticalAlignment>.FromValue(CssConstants.Top, VerticalAlignment.Top);
-                                    box.Float = CssProperty<Floating>.FromValue(CssConstants.Left, Floating.Left);
-                                    break;
-                                case HtmlConstants.Right:
-                                    box.VerticalAlign = CssProperty<VerticalAlignment>.FromValue(CssConstants.Top, VerticalAlignment.Top);
-                                    box.Float = CssProperty<Floating>.FromValue(CssConstants.Right, Floating.Right);
-                                    break;
-                                case HtmlConstants.Bottom:
-                                    box.VerticalAlign = CssProperty<VerticalAlignment>.FromValue(CssConstants.Baseline, VerticalAlignment.Baseline);
-                                    break;
-                                case HtmlConstants.Middle:
-                                    box.VerticalAlign = CssProperty<VerticalAlignment>.FromValue(CssConstants.PeachBaselineMiddle, VerticalAlignment.PeachBaselineMiddle);
-                                    break;
-                                case HtmlConstants.Top:
-                                    box.VerticalAlign = CssProperty<VerticalAlignment>.FromValue(CssConstants.Top, VerticalAlignment.Top);
-                                    break;
-                            }
-                        }
-                        else
-                        {
-                            if (value is HtmlConstants.Left or HtmlConstants.Center or HtmlConstants.Right or HtmlConstants.Justify)
-                                box.TextAlign = CssProperty<HorizontalAlignment>.FromCssText(value.ToLower(), Map.HorizontalAlignments, HorizontalAlignment.Start);
-                            else
-                                box.VerticalAlign = CssProperty<VerticalAlignment>.FromCssText(value, Map.VerticalAlignments, VerticalAlignment.Baseline);
-
-                        }
-
+                        TranslateAlign(tag, box, value);
                         break;
                     case HtmlConstants.Background:
                         box.BackgroundImages = [new CssImage.Url(value.ToLower())];
@@ -1449,19 +1421,7 @@ namespace PeachPDF.Html.Core.Parse
                         box.BackgroundColor = value.ToLower();
                         break;
                     case HtmlConstants.Border:
-                        if (!string.IsNullOrEmpty(value) && value != "0")
-                            box.BorderLeftStyle = box.BorderTopStyle = box.BorderRightStyle = box.BorderBottomStyle = SolidBorderStyle;
-                        box.BorderLeftWidth = box.BorderTopWidth = box.BorderRightWidth = box.BorderBottomWidth = TranslateLength(value);
-
-                        if (tag.Name.Equals(HtmlConstants.Table, StringComparison.OrdinalIgnoreCase))
-                        {
-                            if (value != "0")
-                                ApplyTableBorder(box, "1px");
-                        }
-                        else
-                        {
-                            box.BorderTopStyle = box.BorderLeftStyle = box.BorderRightStyle = box.BorderBottomStyle = SolidBorderStyle;
-                        }
+                        TranslateBorder(tag, box, value);
                         break;
                     case HtmlConstants.Bordercolor:
                         box.BorderLeftColor = box.BorderTopColor = box.BorderRightColor = box.BorderBottomColor = value.ToLower();
@@ -1476,8 +1436,8 @@ namespace PeachPDF.Html.Core.Parse
                         box.Color = value.ToLower();
                         break;
                     case HtmlConstants.Face:
-                        //box.FontFamily = _cssParser.ParseFontFamily(value);
-                        throw new NotImplementedException();
+                        TranslateFace(box, valueParser, value);
+                        break;
                     case HtmlConstants.Height:
                         box.Height = TranslateLength(value);
                         break;
@@ -1489,27 +1449,7 @@ namespace PeachPDF.Html.Core.Parse
                         box.WhiteSpace = CssProperty<Whitespace>.FromValue(CssConstants.NoWrap, Whitespace.NoWrap);
                         break;
                     case HtmlConstants.Size:
-                        if (tag.Name.Equals(HtmlConstants.Hr, StringComparison.OrdinalIgnoreCase))
-                            box.Height = TranslateLength(value);
-                        else if (tag.Name.Equals(HtmlConstants.Font, StringComparison.OrdinalIgnoreCase))
-                        {
-                            // HTML's legacy <font size> is a "1"-"7" (or "+N"/"-N" relative) scale, never
-                            // a CSS keyword or length - there is no translation table for it here, so a
-                            // real-world value never validates against either side of FontSize's grammar.
-                            // FromCssText's own fallback always assigns *something* (unlike a raw string
-                            // assignment, which just held the unrecognized text for later, equally-inert,
-                            // downstream failure), so skip the assignment entirely when the value doesn't
-                            // validate - leaving whatever the cascade already produced in place, per how
-                            // browsers generally treat an unrecognized presentational-attribute value
-                            // (same convention as the valign/align attribute's own accepted gap, issue
-                            // #642) - rather than silently forcing every <font size="N"> to "medium".
-                            var trimmed = value.Trim();
-                            if (Map.FontSizeKeywords.ContainsKey(trimmed) || CssValueParser.TryParseLengthOrCalc(trimmed, out _))
-                            {
-                                box.FontSize = CssKeywordOrValueParser.FromCssText<FontSizeKeyword, LengthOrCalc>(
-                                    value, Map.FontSizeKeywords, CssValueParser.TryParseLengthOrCalc, FontSizeKeyword.Medium);
-                            }
-                        }
+                        TranslateSize(tag, box, value);
                         break;
                     case HtmlConstants.Valign:
                         box.VerticalAlign = CssProperty<VerticalAlignment>.FromCssText(value, Map.VerticalAlignments, VerticalAlignment.Baseline);
@@ -1522,6 +1462,122 @@ namespace PeachPDF.Html.Core.Parse
                         box.Width = TranslateLength(value);
                         break;
                 }
+            }
+        }
+
+        /// <summary>
+        /// Translates the <c>align</c> attribute - an <c>img</c> maps it to float/vertical-align, any
+        /// other element maps it to text-align (or falls back to the same vertical-align keyword
+        /// mapping <c>valign</c> uses, for a horizontally-invalid value historically seen in the wild).
+        /// </summary>
+        private static void TranslateAlign(HtmlTag tag, CssBox box, string value)
+        {
+            if (tag.Name.Equals(HtmlConstants.Img, StringComparison.OrdinalIgnoreCase))
+                TranslateImgAlign(box, value);
+            else
+                TranslateGenericAlign(box, value);
+        }
+
+        private static void TranslateImgAlign(CssBox box, string value)
+        {
+            switch (value)
+            {
+                case HtmlConstants.Left:
+                    box.VerticalAlign = CssProperty<VerticalAlignment>.FromValue(CssConstants.Top, VerticalAlignment.Top);
+                    box.Float = CssProperty<Floating>.FromValue(CssConstants.Left, Floating.Left);
+                    break;
+                case HtmlConstants.Right:
+                    box.VerticalAlign = CssProperty<VerticalAlignment>.FromValue(CssConstants.Top, VerticalAlignment.Top);
+                    box.Float = CssProperty<Floating>.FromValue(CssConstants.Right, Floating.Right);
+                    break;
+                case HtmlConstants.Bottom:
+                    box.VerticalAlign = CssProperty<VerticalAlignment>.FromValue(CssConstants.Baseline, VerticalAlignment.Baseline);
+                    break;
+                case HtmlConstants.Middle:
+                    box.VerticalAlign = CssProperty<VerticalAlignment>.FromValue(CssConstants.PeachBaselineMiddle, VerticalAlignment.PeachBaselineMiddle);
+                    break;
+                case HtmlConstants.Top:
+                    box.VerticalAlign = CssProperty<VerticalAlignment>.FromValue(CssConstants.Top, VerticalAlignment.Top);
+                    break;
+            }
+        }
+
+        private static void TranslateGenericAlign(CssBox box, string value)
+        {
+            if (value is HtmlConstants.Left or HtmlConstants.Center or HtmlConstants.Right or HtmlConstants.Justify)
+                box.TextAlign = CssProperty<HorizontalAlignment>.FromCssText(value.ToLower(), Map.HorizontalAlignments, HorizontalAlignment.Start);
+            else
+                box.VerticalAlign = CssProperty<VerticalAlignment>.FromCssText(value, Map.VerticalAlignments, VerticalAlignment.Baseline);
+        }
+
+        /// <summary>
+        /// Translates the <c>border</c> attribute: sets the border width (and, unless "0", a solid
+        /// style) on the element itself, additionally cascading a 1px solid border to every cell when
+        /// the element is a <c>table</c>.
+        /// </summary>
+        private static void TranslateBorder(HtmlTag tag, CssBox box, string value)
+        {
+            if (!string.IsNullOrEmpty(value) && value != "0")
+                box.BorderLeftStyle = box.BorderTopStyle = box.BorderRightStyle = box.BorderBottomStyle = SolidBorderStyle;
+            box.BorderLeftWidth = box.BorderTopWidth = box.BorderRightWidth = box.BorderBottomWidth = TranslateLength(value);
+
+            if (tag.Name.Equals(HtmlConstants.Table, StringComparison.OrdinalIgnoreCase))
+            {
+                if (value != "0")
+                    ApplyTableBorder(box, "1px");
+            }
+            else
+            {
+                box.BorderTopStyle = box.BorderLeftStyle = box.BorderRightStyle = box.BorderBottomStyle = SolidBorderStyle;
+            }
+        }
+
+        /// <summary>
+        /// Translates the legacy <c>face</c> attribute (e.g. <c>&lt;font face="Arial, sans-serif"&gt;</c>)
+        /// into the same <see cref="CssBox.FontFamily"/>/<see cref="CssBox.FontFamilyList"/> multi-field
+        /// write the CSS <c>font-family</c> property's own custom setter performs, resolving against
+        /// installed fonts via <see cref="CssValueParser.GetFontFamilyByName"/>.
+        /// </summary>
+        private static void TranslateFace(CssBox box, CssValueParser valueParser, string value)
+        {
+            box.FontFamily = valueParser.GetFontFamilyByName(value);
+            box.FontFamilyList = value;
+        }
+
+        /// <summary>
+        /// Translates the <c>size</c> attribute - meaning differs by element: an <c>hr</c>'s <c>size</c>
+        /// is its height, a <c>font</c>'s <c>size</c> is its legacy 1-7 (or relative) font-size scale.
+        /// </summary>
+        private static void TranslateSize(HtmlTag tag, CssBox box, string value)
+        {
+            if (tag.Name.Equals(HtmlConstants.Hr, StringComparison.OrdinalIgnoreCase))
+                TranslateHrSize(box, value);
+            else if (tag.Name.Equals(HtmlConstants.Font, StringComparison.OrdinalIgnoreCase))
+                TranslateFontSize(box, value);
+        }
+
+        private static void TranslateHrSize(CssBox box, string value)
+        {
+            box.Height = TranslateLength(value);
+        }
+
+        private static void TranslateFontSize(CssBox box, string value)
+        {
+            // HTML's legacy <font size> is a "1"-"7" (or "+N"/"-N" relative) scale, never
+            // a CSS keyword or length - there is no translation table for it here, so a
+            // real-world value never validates against either side of FontSize's grammar.
+            // FromCssText's own fallback always assigns *something* (unlike a raw string
+            // assignment, which just held the unrecognized text for later, equally-inert,
+            // downstream failure), so skip the assignment entirely when the value doesn't
+            // validate - leaving whatever the cascade already produced in place, per how
+            // browsers generally treat an unrecognized presentational-attribute value
+            // (same convention as the valign/align attribute's own accepted gap, issue
+            // #642) - rather than silently forcing every <font size="N"> to "medium".
+            var trimmed = value.Trim();
+            if (Map.FontSizeKeywords.ContainsKey(trimmed) || CssValueParser.TryParseLengthOrCalc(trimmed, out _))
+            {
+                box.FontSize = CssKeywordOrValueParser.FromCssText<FontSizeKeyword, LengthOrCalc>(
+                    value, Map.FontSizeKeywords, CssValueParser.TryParseLengthOrCalc, FontSizeKeyword.Medium);
             }
         }
 

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -1551,14 +1551,9 @@ namespace PeachPDF.Html.Core.Parse
         private static void TranslateSize(HtmlTag tag, CssBox box, string value)
         {
             if (tag.Name.Equals(HtmlConstants.Hr, StringComparison.OrdinalIgnoreCase))
-                TranslateHrSize(box, value);
+                box.Height = TranslateLength(value);
             else if (tag.Name.Equals(HtmlConstants.Font, StringComparison.OrdinalIgnoreCase))
                 TranslateFontSize(box, value);
-        }
-
-        private static void TranslateHrSize(CssBox box, string value)
-        {
-            box.Height = TranslateLength(value);
         }
 
         private static void TranslateFontSize(CssBox box, string value)


### PR DESCRIPTION
## Summary

- Splits `DomParser.TranslateAttributes`'s single 15-case switch (with `align` and `size` each nesting a second tag-name-dependent branch) into small per-attribute handler methods (`TranslateAlign`/`TranslateImgAlign`/`TranslateGenericAlign`, `TranslateBorder`, `TranslateSize`/`TranslateFontSize`, `TranslateFace`), keeping the switch itself as a thin dispatcher. Fills in the method's previously-empty XML doc `<param>` tags.
- Fixes the `face` attribute (`<font face="Arial">`), which previously threw `NotImplementedException` for any real document using it. It now resolves against installed font families the same way the CSS `font-family` property's own custom setter does (`CssValueParser.GetFontFamilyByName`), threading the cascade's existing `CssValueParser` instance through to the method.
- Adds test coverage for every previously-untested branch of the method (`background`, `bgcolor`, `bordercolor`, `cellspacing`, `color`, `height`, `hspace`, `vspace`, `width`, `size` on both `<hr>`/`<font>`, and `face`), including two tests that honestly document a pre-existing, already-tracked gap (issue #636 — `SetForAllCells` doesn't traverse the anonymous table-row-group box CSS inserts around a bare `<tr>`) rather than silently leaving those branches uncovered.
- Adds a migration note recording the `face` attribute's user-visible behavior change.

## Test plan

- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings across the whole solution
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (8026 tests)
- [x] Diff coverage via `dotnet test --collect:"XPlat Code Coverage" --settings PeachPDF.Tests/coverlet.runsettings` + `diff-cover` against `origin/main` — 100% on changed lines
- [x] Independent review pass against the diff (extraction fidelity verified byte-for-byte against the pre-refactor method, `valueParser` threading, test correctness); findings addressed in a follow-up commit
