### PR TITLE
Catch up stale fragmentainer slots during forward layout instead of at Finish()

### DIFF
--- a/.claude/recent-fixes/2026-08-07-stale-slots-caught-up-during-forward-layout-instead-of-at-finish.md
+++ b/.claude/recent-fixes/2026-08-07-stale-slots-caught-up-during-forward-layout-instead-of-at-finish.md
@@ -1,0 +1,79 @@
+# Stale fragmentainer slots are caught up during forward layout, not left for `Finish()`
+
+Follow-up to `.claude/recent-fixes/2026-08-01-stale-slot-replay-writes-investigated-and-found-not-to-help.md`,
+which investigated (and ruled out) making `Finish()`'s own stale-slot replay write new pruning marks.
+This is a different fix, upstream of that one: most stale slots should never have reached `Finish()`'s
+replay at all.
+
+## The load-bearing idea
+
+`FragmentEmitter.InvalidateFrom` un-freezes an already-emitted slot whenever something moves content that
+was already frozen there. Two of its three real callers reach it from inside the driver's own pass loop
+(`HtmlContainerInt.LayoutDocument`) as part of re-entering an earlier pass, and both already move the
+driver's own resumption point back to what they invalidated — `TryRewindForRunPull` takes `ref int slot`
+for exactly this. The third, dominant one does not: `CssBox`'s `Location` setter calls
+`OnBlockAxisRelocated` on every block-axis reposition, which un-freezes an already-frozen slot through
+`InvalidateEmittedFragmentsFor` when the box being moved already had a fragment — but it has no pass to
+re-enter and nothing to hand the driver, so the driver's own `slot` variable never moves. Measured on the
+css4.pub Icelandic Dictionary: 695 real (non-early-returned) `InvalidateFrom` calls, 602 of them from this
+path (translation), 88 from a multi-column rectangle reset, 5 from a refill — and of the 592 distinct
+slots any of them ever invalidated, **all 592** were still stale when `Finish()` started its replay. None
+were ever covered by a later `EmitPass` call. `Finish()`'s replay is a full, unpruned walk from the
+document root for each one — roughly 145,000 `BuildDraft` calls per orphaned page on this document,
+`~44s` of a `~65-71s` CLI render (measured via temporary `Stopwatch` instrumentation, since removed).
+
+The fix does not touch `BuildDraft`, `_frozen`, or any pruning mark — the exact machinery the prior
+investigation found couldn't be made both safe and effective mid-replay. Instead,
+`FragmentEmitter.CatchUpStaleSlotsBehind(slot)` is called once at the top of every driver-loop iteration,
+before that iteration's own pass runs: it re-freezes every stale slot behind the pass about to run, via
+plain `EmitSlot(stale, mayWrite: true, frontier: stale >= _lastEmittedSlot)` — the same call `Finish()`'s
+own replay already makes for every stale slot, just made the moment the driver would otherwise have moved
+past it instead of at the very end. `EmitSlot`, not `EmitPass`: there is no meaningful incoming/outgoing
+resumption record for a slot nothing here re-enters as a pass, and none is needed — `Finish()`'s own
+replay re-freezes every stale slot without one too, and no test depends on continuation bookkeeping
+`Finish()` itself never re-establishes for a slot it heals this way.
+
+## Why this doesn't reopen the ambiguity the prior investigation found
+
+`Finish()`'s replay couldn't safely write new pruning marks mid-batch because a low stale slot's "empty"
+observation might be contradicted by that same box's real content sitting at a *higher*, not-yet-rewalked
+stale slot in the same batch — layout is over by then, so nothing will ever correct a wrong mark. Called
+from the driver loop instead, that ambiguity doesn't exist: everything at or after the pass about to run
+has not been touched by this layout generation yet, so nothing still to come can retroactively give a
+lower, already-stale slot more content. That is the identical fact `EmitPass`'s own `frontier` argument
+already rests on for an ordinary forward slot — a slot caught up here just reaches that state on a later
+call than the one that first opened it, rather than the one immediately after.
+
+## What was ruled out along the way
+
+- **A `TryRewindForWidows`-specific fix** (reconstructing the invalidated slot's original entry token and
+  re-emitting it via `EmitPass` right after `PassRewind.RollBackTo`) was designed and implemented first,
+  based on an initial (wrong) assumption about which invalidation source dominated. Measuring which
+  caller actually reached `InvalidateFrom` (via a temporary `CallerMemberName`-based tag, since reverted)
+  found `TryRewindForWidows` never fires at all on this document — `TryKeepFewerLinesForWidows`'s own
+  "two fragments only" restriction declines every time here, and the render falls back to the ordinary
+  whole-box push instead. The widows-specific fix was reverted in favor of the general one; both were
+  measured, not assumed.
+- **Reading a box's `Location`/`ActualBottom` directly** instead of walking, considered as a cheaper
+  alternative to eager re-emission, was ruled out again (it already failed once, per
+  `2026-07-31-emission-no-longer-rewalks-the-whole-tree-per-page.md`'s "attempt 2") — this document's
+  `.chapter { columns: 2 }` content lives in per-column `BoxGeometrySnapshot`s, not in the box's own
+  fields, for the entire body.
+
+## Evidence
+
+- Full `net8.0` suite: 8180-8181 passed (varies by 1 run-to-run), 0 failed beyond a single, pre-existing,
+  order-dependent flake in `ContainerQueryLayoutIntegrationTests` (passes standalone every time — see
+  `project_container_query_test_flakiness` in memory) — confirmed unrelated by running in isolation both
+  before and after this change.
+- Same, with `PEACHPDF_VERIFY_FRAGMENT_PRUNING=1`: identical result, zero `PruningDiverged` exceptions.
+- `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings.
+- `diff-cover` against `origin/main`: 100% (8 of 8 coverable lines) — genuinely exercised (5,287 real hits
+  on the re-emission line across the existing suite, confirmed via the raw Cobertura XML, not merely
+  reachable).
+- css4.pub Icelandic Dictionary via the real `peachpdf` CLI (live URL, Release, net10.0): **~62-66s before
+  → ~28s after** (three consecutive runs: 28.1s, 28.0s, 27.9s), comfortably under a 50s target that the
+  pre-fix render missed.
+- Same document's PDF output: 834 pages before and after, **byte-identical extracted text on all 834
+  pages** and **pixel-identical rasterization on all 834 pages** (PyMuPDF, 72 DPI) comparing the pre-fix
+  and post-fix renders.

--- a/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
@@ -880,6 +880,46 @@ namespace PeachPDF.Html.Core.Fragmentation
         }
 
         /// <summary>
+        /// Re-freezes every stale slot behind <paramref name="slot"/> right now, instead of leaving it for
+        /// <see cref="Finish"/>'s own replay to rediscover once the whole document is done.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <see cref="InvalidateFrom"/> is reached from several places that reopen exactly one already-frozen
+        /// slot without ever moving the driver's own resumption point back to it — a pure block-axis
+        /// translation (<c>CssBox</c>'s <c>Location</c> setter, via <c>OnBlockAxisRelocated</c>), a multi-
+        /// column refill, a rectangle reset — none of them a pass re-entry, so none of them has a token to
+        /// hand the driver for a slot it is not about to resume into. Left alone, such a slot sits in
+        /// <see cref="_stale"/> until <see cref="Finish"/>, whose own replay is a full, unpruned walk from the
+        /// document root for every one of them (~145,000 <c>BuildDraft</c> calls apiece on the css4.pub
+        /// Icelandic Dictionary) precisely because writing a new pruning mark mid-replay cannot tell "this
+        /// box's content is behind us for good" apart from "behind us only until the next stale slot in this
+        /// same batch" — see <see cref="Finish"/>'s own remarks. Called here, one slot behind the pass the
+        /// driver is *about* to run, that ambiguity does not exist: everything at or after <paramref name="slot"/>
+        /// has not been touched by this layout yet, so nothing still to come can retroactively give a lower,
+        /// already-stale slot more content. That is the same fact <see cref="EmitPass"/>'s own <c>frontier</c>
+        /// argument rests on for an ordinary forward slot; a slot caught up here just reaches that state on a
+        /// later call than the one that first opened it, rather than the one right after.
+        /// </para>
+        /// <para>
+        /// Plain <see cref="EmitSlot"/>, not <see cref="EmitPass"/>: there is no meaningful incoming/outgoing
+        /// resumption record to hand a slot nothing here re-enters as a pass, and none is needed —
+        /// <see cref="Finish"/>'s own replay re-freezes every stale slot the identical way, without one, and
+        /// no test has ever depended on continuation bookkeeping <see cref="Finish"/> itself never
+        /// re-establishes for a slot it heals.
+        /// </para>
+        /// </remarks>
+        internal void CatchUpStaleSlotsBehind(int slot)
+        {
+            if (_stale.Count == 0) return;
+
+            foreach (var stale in new List<int>(_stale))
+            {
+                if (stale < slot) EmitSlot(stale, mayWrite: true, frontier: stale >= _lastEmittedSlot);
+            }
+        }
+
+        /// <summary>
         /// Materializes the immutable tree. Returns an empty tree when there is nothing to paginate.
         /// </summary>
         internal FragmentTree Finish()

--- a/src/PeachPDF/Html/Core/HtmlContainerInt.cs
+++ b/src/PeachPDF/Html/Core/HtmlContainerInt.cs
@@ -1082,6 +1082,12 @@ namespace PeachPDF.Html.Core
                     var context = new FragmentainerContext(this, Root!, slot);
                     CurrentFragmentainer = context;
 
+                    // A translation, refill, or rectangle reset since the last iteration may have reopened an
+                    // already-frozen slot behind this one without moving the driver back to it (see
+                    // FragmentEmitter.CatchUpStaleSlotsBehind's own remarks) - heal it now, one pass before it
+                    // would otherwise wait for Finish()'s far more expensive replay.
+                    _emitter?.CatchUpStaleSlotsBehind(slot);
+
                     // What this pass was entered with, so a decision discovered on a later one can send the
                     // driver back to it. Recorded before the pass runs, since that is the state re-entering
                     // it needs and nothing the pass produces can be part of it.


### PR DESCRIPTION
## Summary
- `FragmentEmitter.InvalidateFrom` un-freezes an already-emitted slot whenever content already frozen there moves. Pass-re-entry callers (keep-with-next/widows) already move the driver's own resumption cursor back to what they invalidated; the dominant real-world caller - `CssBox`'s `Location` setter, firing on every block-axis reposition of an already-frozen box - has no pass to re-enter and never moves the cursor, so the un-frozen slot sits orphaned until `Finish()`'s full, unpruned replay rediscovers it from the document root.
- Measured on the css4.pub Icelandic Dictionary reference document: 695 real invalidations, 592 distinct slots ever un-frozen, and **every single one** was still stale when `Finish()` started its replay - none were ever covered by an ordinary pass in between.
- Adds `FragmentEmitter.CatchUpStaleSlotsBehind`, called once per driver-loop iteration, which re-freezes anything stale behind the pass about to run using the same call `Finish()` already made for it - just done immediately instead of after ~145,000 wasted `BuildDraft` calls per orphaned page accumulate.
- Full writeup with the evidence chain (including a dead end that was tried and reverted): `.claude/recent-fixes/2026-08-07-stale-slots-caught-up-during-forward-layout-instead-of-at-finish.md`

## Test plan
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - green (one pre-existing, order-dependent `ContainerQueryLayoutIntegrationTests` flake, confirmed unrelated by running in isolation before and after this change)
- [x] Same, with `PEACHPDF_VERIFY_FRAGMENT_PRUNING=1` - identical result, zero `PruningDiverged` exceptions
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` - 0 warnings
- [x] `diff-cover` against `origin/main` - 100% (8 of 8 coverable lines), confirmed genuinely exercised via raw Cobertura hit counts
- [x] css4.pub Icelandic Dictionary via the real `peachpdf` CLI (live URL, Release, net10.0): **~62-66s before -> ~28s after** (three consecutive runs)
- [x] Same document's PDF output: byte-identical extracted text and pixel-identical rasterization on all 834 pages, before vs. after (PyMuPDF)