### PR TITLE
Fix PixelsPerPoint direction in @page em/rem margins and NoEms

### DIFF
--- a/.claude/migration-notes/2026-08-07-page-margin-and-em-spacing-under-non-default-pixelsperpoint.md
+++ b/.claude/migration-notes/2026-08-07-page-margin-and-em-spacing-under-non-default-pixelsperpoint.md
@@ -1,0 +1,20 @@
+# `@page` `em`/`rem` margins and `em`-based `text-indent`/`word-spacing`/`letter-spacing` under a non-default `PixelsPerInch`
+
+Previously, under a non-default `PdfGenerateConfig.PixelsPerInch` (anything other than the default 72),
+or when `ShrinkToFit`/`ScaleToPageSize` moved the effective pixels-per-point away from 1.0 for otherwise
+ordinary content, two kinds of `em`/`rem`-relative lengths resolved to the wrong absolute size:
+
+- A base `@page { margin: ... }` (or `margin-top`/`margin-left`/etc.) declared in `em` or `rem` resolved
+  against the root font-size divided by pixels-per-point *twice*, instead of once - the produced margin
+  was too small by a factor of `PixelsPerInch / 72` squared. This affected the `em` basis only when no
+  `@page { font-size }` override was declared on the base rule; the `rem` basis was affected
+  unconditionally.
+- `text-indent`, `word-spacing`, and `letter-spacing` declared in `em` resolved against the declaring
+  element's font-size with the same double-scaling, also producing a value too small by that same
+  squared factor.
+
+Both are now correct: an `em`/`rem` `@page` margin, and an `em`-valued `text-indent`/`word-spacing`/
+`letter-spacing`, resolve to the same true-CSS-points value regardless of `PixelsPerInch` or
+`ShrinkToFit`/`ScaleToPageSize`, matching their behavior at the (unaffected) default `PixelsPerInch` of
+72. Documents that only ever used the default `PixelsPerInch` with `ShrinkToFit`/`ScaleToPageSize`
+disabled saw no change.

--- a/.claude/recent-fixes/2026-08-07-page-margin-and-noems-em-basis-pixelsperpoint-direction.md
+++ b/.claude/recent-fixes/2026-08-07-page-margin-and-noems-em-basis-pixelsperpoint-direction.md
@@ -1,0 +1,55 @@
+# `@page` margin and `NoEms` em/rem basis: PixelsPerPoint correction was inverted
+
+Closes [#631](https://github.com/jhaygood86/PeachPDF/issues/631).
+
+## The bug
+
+`CssBox.GetEmHeight()`/`GetRemHeight()` return a value in the PDF adapter's device-scaled
+font-measurement space, not true CSS points: `PdfSharpAdapter.CreateFontInt` divides a requested
+font size by `PixelsPerPoint` once to reach that space. Two call sites treated the result as if it
+were already true points and then divided by `PixelsPerPoint` *again*, compounding into a value wrong
+by `PixelsPerPoint²`:
+
+1. `DomParser.ApplyPageStylesOnce`'s `@page` margin em/rem basis (`emPt`/`PageLengthContext`'s rem
+   argument) - used whenever a base `@page` margin is declared in `em`/`rem` and no `@page { font-size
+   }` overrides the em basis (the rem basis is unaffected by that override and always hits this path).
+2. `CssBox.NoEms` - the eager em-to-pt conversion generated code runs on `text-indent`/`word-spacing`/
+   `letter-spacing`'s raw authored text before cascade.
+
+Both are invisible at the library's default `PixelsPerInch` of 72 (`PixelsPerPoint == 1`, where
+multiplying and dividing are indistinguishable), and most of the existing test suite's own harnesses
+pin `PixelsPerPoint` to 1.0 explicitly - which is exactly why this shipped unnoticed. A non-default
+`PixelsPerInch`, or the `ShrinkToFit`/`ScaleToPageSize` features (which legitimately move
+`PixelsPerPoint` away from 1.0 for ordinary content), both trigger it.
+
+## The fix
+
+Multiply by `pixelsPerPoint` instead of dividing, undoing `CreateFontInt`'s division - the identical
+correction already established for the same "device-scaled font space → true CSS points" conversion in
+`DerivedStyle.ActualFont`'s `parentSize`/`remSize` inputs and `CssBox.ResolveFontSizeValueComputation`
+(the font-size PR, [#632](https://github.com/jhaygood86/PeachPDF/pull/632), that originally surfaced
+this issue). `DomParser.ApplyPageStylesOnce`'s `htmlContainer.PageSize.Width / pixelsPerPoint` line was
+*not* touched - `PageSize` is pre-multiplied by `PixelsPerPoint` under an unrelated, page-geometry-specific
+convention (see `HtmlContainerInt.MarginTop`'s own doc comment), so it scales in the opposite direction
+and dividing there was already correct.
+
+An existing test, `PageMarginUnitConsistencyIntegrationTests.FirstPageEmMarginOverride_ScalesByPixelsPerPoint_ExactlyOnce`,
+computed its own expected value with the same wrong division direction (`container.Root!.GetEmHeight() /
+ppp`), so it was itself asserting the bug as correct for the per-page-rule code path
+(`PageRuleResolver.ResolvePageMargins`, which consumes the same `PageLengthContext.EmPt` `ApplyPageStylesOnce`
+now computes correctly). Corrected to multiply, matching the sibling test
+`FirstPageEmMarginOverride_DrivesBandGeometry`'s already-correct expected value (`2 * 11pt = 22pt`), which
+is indistinguishable from the old formula only at the default `PixelsPerPoint` of 1.
+
+## Evidence
+
+New file `PixelsPerPointEmResolutionIntegrationTests.cs`: two tests for the `@page` margin em/rem basis
+(one isolating the em branch via the UA-default root font-size with no `@page { font-size }` override,
+one isolating the rem branch by setting a base-rule `font-size` that decouples it from the em basis) and
+three for `NoEms` (`text-indent`, `letter-spacing`, `word-spacing`), all at a non-default `PixelsPerInch`/
+`PixelsPerPoint`. All 5 verified to fail on pre-fix code (via `git stash` of the two source files alone)
+with exactly the `PixelsPerPoint`-squared-off values the issue predicts, and pass post-fix. Full suite
+(`dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0`): 8192 passed, 0 failed (one
+`ContainerQueryLayoutIntegrationTests` failure seen on one run is the already-documented pre-existing
+cross-test flake, unrelated to this change - reproduces on a clean `main` checkout). `diff-cover` against
+`main`: 100% diff coverage. `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings.

--- a/src/PeachPDF.Tests/Integration/PageMarginUnitConsistencyIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/PageMarginUnitConsistencyIntegrationTests.cs
@@ -126,9 +126,14 @@ namespace PeachPDF.Tests.Integration
                 """, ppp);
 
             // MarginTopPt stays in true points; the band height applies the ppp scaling exactly
-            // once (issue-#113 discipline): band = sheetPx - (mT + mB) * ppp.
+            // once (issue-#113 discipline): band = sheetPx - (mT + mB) * ppp. GetEmHeight() itself
+            // is in the adapter's device-scaled font-measurement space (CreateFontInt divides a
+            // requested size by PixelsPerPoint to get there - see DerivedStyle.ActualFont's own doc
+            // comment), so undoing that division (multiplying back by ppp) is what recovers the true
+            // CSS points value - not dividing again (issue #631: the previous formula here asserted
+            // the same double-division bug DomParser.ApplyPageStylesOnce had).
             var marginTopPt = container.PageGeometry.GetPage(0).MarginTopPt;
-            var emPt = container.Root!.GetEmHeight() / ppp;
+            var emPt = container.Root!.GetEmHeight() * ppp;
             Assert.Equal(2 * emPt, marginTopPt, 3);
 
             var sheetPx = container.PageSize.Height + container.MarginTop + container.MarginBottom;

--- a/src/PeachPDF.Tests/Integration/PixelsPerPointEmResolutionIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/PixelsPerPointEmResolutionIntegrationTests.cs
@@ -1,0 +1,193 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Adapters.Entities;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore.Drawing;
+using PeachPDF.Tests.TestSupport;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Issue #631: two call sites read <see cref="CssBox.GetEmHeight"/>/<see cref="CssBox.GetRemHeight"/>
+    /// as if the result were already true CSS points. It is not - <c>PdfSharpAdapter.CreateFontInt</c>
+    /// divides a requested size by <c>PixelsPerPoint</c> once to reach the adapter's device-scaled
+    /// font-measurement space, so undoing that division (multiplying back by <c>PixelsPerPoint</c>) is
+    /// required before treating either as a true-point em/rem basis - exactly the correction
+    /// <see cref="DerivedStyle.ActualFont"/>'s own <c>parentSize</c>/<c>remSize</c> inputs and
+    /// <see cref="CssBox.ResolveFontSizeValueComputation"/> already apply (see
+    /// <see cref="FontSizeInheritanceIntegrationTests"/>). Both bugs are invisible at the library's
+    /// default <c>PixelsPerInch</c> of 72 (<c>PixelsPerPoint == 1</c>), so every fixture here uses a
+    /// non-default value to actually exercise the scaling.
+    /// </summary>
+    public class PixelsPerPointEmResolutionIntegrationTests
+    {
+        // Bug 1: DomParser.ApplyPageStylesOnce's @page margin em/rem basis.
+
+        [Fact]
+        public async Task PageMarginEm_ResolvesAgainstRootFontSize_UnderNonDefaultPixelsPerInch()
+        {
+            // No @page { font-size } is declared, so the em basis is root.GetEmHeight() - the UA-default
+            // "medium" root font-size (11pt, CssConstants.FontSize) - taking the exact path this issue
+            // reports. PixelsPerInch = 144 => PixelsPerPoint = 2.
+            var config = new PdfGenerateConfig
+            {
+                ManualPageWidth = 400,
+                ManualPageHeight = 600,
+                PixelsPerInch = 144,
+            };
+            config.SetMargins(0);
+
+            const string html = """
+                <!DOCTYPE html><html><head><style>
+                @page { size: 300pt 500pt; margin-left: 2em; }
+                body { margin: 0; }
+                </style></head><body><p>content</p></body></html>
+                """;
+
+            var (_, container) = await PdfGeneratorLayoutHarness.LayoutAsync(html, config);
+
+            Assert.NotNull(container.CssPageSize);
+
+            // True CSS points: 2 * 11pt = 22pt. HtmlContainerInt.MarginLeft lives in the page-level
+            // internal pixel space (true points pre-multiplied by PixelsPerPoint - see
+            // DomParser.CascadeApplyPageStyles's own doc comment), so 22 * 2 = 44. The pre-fix code
+            // instead divided root.GetEmHeight() by PixelsPerPoint a second time, landing on
+            // 22 / PixelsPerPoint (11) internal units - a PixelsPerPoint-squared-sized error in true
+            // points, exactly the 5.5pt figure this issue reports.
+            Assert.Equal(44.0, container.MarginLeft, 3);
+        }
+
+        [Fact]
+        public async Task PageMarginRem_ResolvesAgainstRootFontSize_UnderNonDefaultPixelsPerInch()
+        {
+            // A base @page { font-size } decouples the em basis (resolved directly via
+            // MarginBoxRenderer.ResolveFontSizePt, bypassing the buggy path entirely) from the rem basis
+            // (always root.GetRemHeight(), unaffected by @page's own font-size) - isolating this fixture
+            // to the rem line specifically. The root itself keeps the UA-default 11pt font-size.
+            var config = new PdfGenerateConfig
+            {
+                ManualPageWidth = 400,
+                ManualPageHeight = 600,
+                PixelsPerInch = 144,
+            };
+            config.SetMargins(0);
+
+            const string html = """
+                <!DOCTYPE html><html><head><style>
+                @page { size: 300pt 500pt; font-size: 20pt; margin-left: 3rem; }
+                body { margin: 0; }
+                </style></head><body><p>content</p></body></html>
+                """;
+
+            var (_, container) = await PdfGeneratorLayoutHarness.LayoutAsync(html, config);
+
+            Assert.NotNull(container.CssPageSize);
+
+            // True CSS points: 3 * 11pt (root's own UA-default font-size, not the page's 20pt) = 33pt.
+            // Internal units: 33 * 2 = 66.
+            Assert.Equal(66.0, container.MarginLeft, 3);
+        }
+
+        // Bug 2: CssBox.NoEms's em basis for text-indent/word-spacing/letter-spacing.
+
+        [Fact]
+        public async Task TextIndentEm_ResolvesAgainstDeclaringFontSize_UnderNonDefaultPixelsPerPoint()
+        {
+            var root = await BuildAndLayout(
+                "<div id='parent' style='font-size:20pt'>" +
+                "<p id='target' style='margin:0;text-indent:2em'>content</p>" +
+                "</div>", pixelsPerPoint: 2.0);
+
+            var target = FindById(root, "target");
+            Assert.NotNull(target);
+
+            // True CSS points: 2 * 20pt = 40pt, independent of PixelsPerPoint - ordinary box geometry
+            // (unlike page-level margins) is never pre-multiplied by PixelsPerPoint. The pre-fix NoEms
+            // instead converted 2 * (20 / PixelsPerPoint) = 20pt here - half the correct value.
+            Assert.Equal(40.0, target!.ActualTextIndent, 3);
+        }
+
+        [Fact]
+        public async Task LetterSpacingEm_ResolvesAgainstDeclaringFontSize_UnderNonDefaultPixelsPerPoint()
+        {
+            var spacedRoot = await BuildAndLayout(
+                "<p id='target' style='font-size:20pt;letter-spacing:0.5em'>AAAA</p>", pixelsPerPoint: 2.0);
+            var plainRoot = await BuildAndLayout(
+                "<p id='target' style='font-size:20pt'>AAAA</p>", pixelsPerPoint: 2.0);
+
+            var spaced = FindById(spacedRoot, "target");
+            var plain = FindById(plainRoot, "target");
+            Assert.NotNull(spaced);
+            Assert.NotNull(plain);
+
+            var spacedWidth = CssBox.FirstWordOccurence(spaced!, spaced!.LineBoxes[0])!.Width;
+            var plainWidth = CssBox.FirstWordOccurence(plain!, plain!.LineBoxes[0])!.Width;
+
+            // 0.5em at a declaring font-size of 20pt is 10pt per gap, regardless of PixelsPerPoint - see
+            // LetterWordSpacingLayoutIntegrationTests.LetterSpacing_EmValue_ResolvesAgainstFontSize_InLayoutPoints,
+            // which asserts the identical relationship at the default PixelsPerPoint of 1.
+            Assert.Equal(plainWidth + 4 * 10, spacedWidth, 1);
+        }
+
+        [Fact]
+        public async Task WordSpacingEm_ResolvesAgainstDeclaringFontSize_UnderNonDefaultPixelsPerPoint()
+        {
+            var spacedRoot = await BuildAndLayout(
+                "<p id='target' style='font-size:20pt;word-spacing:0.5em'>AA BB</p>", pixelsPerPoint: 2.0);
+            var plainRoot = await BuildAndLayout(
+                "<p id='target' style='font-size:20pt'>AA BB</p>", pixelsPerPoint: 2.0);
+
+            var spaced = FindById(spacedRoot, "target");
+            var plain = FindById(plainRoot, "target");
+            Assert.NotNull(spaced);
+            Assert.NotNull(plain);
+
+            var spacedWords = spaced!.LineBoxes[0].Words;
+            var plainWords = plain!.LineBoxes[0].Words;
+
+            var spacedGap = spacedWords[1].Left - spacedWords[0].Right;
+            var plainGap = plainWords[1].Left - plainWords[0].Right;
+
+            // 0.5em at a declaring font-size of 20pt is 10pt of additional inter-word gap, regardless of
+            // PixelsPerPoint.
+            Assert.Equal(plainGap + 10, spacedGap, 1);
+        }
+
+        // ─── Helpers ─────────────────────────────────────────────────────────────
+
+        private static async Task<CssBox> BuildAndLayout(string bodyHtml, double pixelsPerPoint)
+        {
+            var html = $"<!DOCTYPE html><html><head></head><body>{bodyHtml}</body></html>";
+
+            var adapter = new PdfSharpAdapter { PixelsPerPoint = pixelsPerPoint };
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            var size = new XSize(595, 842);
+            container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+            container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+            var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            return container.Root!;
+        }
+
+        private static CssBox? FindById(CssBox box, string id)
+        {
+            var val = box.HtmlTag?.TryGetAttribute("id", "");
+            if (val != null && val.Equals(id, System.StringComparison.OrdinalIgnoreCase))
+                return box;
+
+            foreach (var child in box.Boxes)
+            {
+                var found = FindById(child, id);
+                if (found != null) return found;
+            }
+            return null;
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
@@ -361,10 +361,17 @@ namespace PeachPDF.Html.Core.Dom
             var len = new CssLength(length);
             if (len.Unit == CssUnit.Ems)
             {
-                // GetEmHeight() is the em size in layout units (points), and the result is later
-                // re-parsed through ParseLength - so serialize as "pt" (identity), not "px" (which
-                // now resolves at the spec-correct 0.75pt and would shrink the value on re-parse).
-                length = len.ConvertEmToPoints(GetEmHeight()).ToString();
+                // GetEmHeight() is in the adapter's device-scaled font-measurement space (see
+                // DerivedStyle.ActualFont's own doc comment) - CreateFontInt divides a requested size
+                // by PixelsPerPoint once to get there, so that division has to be undone here before
+                // treating it as true CSS points, the same correction ResolveFontSizeValueComputation
+                // below applies to parent.ActualFont.Size. Usually invisible (PixelsPerPoint defaults
+                // to 1.0) but wrong by a factor of PixelsPerPoint under a non-default PixelsPerInch or
+                // ShrinkToFit/ScaleToPageSize (issue #631). The result is later re-parsed through
+                // ParseLength - so serialize as "pt" (identity), not "px" (which now resolves at the
+                // spec-correct 0.75pt and would shrink the value on re-parse).
+                var pixelsPerPoint = (HtmlContainer?.Adapter as PdfSharpAdapter)?.PixelsPerPoint ?? 1.0;
+                length = len.ConvertEmToPoints(GetEmHeight() * pixelsPerPoint).ToString();
             }
             return length;
         }

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -320,13 +320,18 @@ namespace PeachPDF.Html.Core.Parse
             // 1px = 0.75pt via Length.PointsPerPx) resolve straight to raw, unscaled points - for
             // those, multiplying by pixelsPerPoint once at the end (below) is exactly the scaling
             // needed. But its percentage/em/rem branches resolve against
-            // hundredPercent/emFactor/remFactor - here, htmlContainer.PageSize.Width and
-            // root.GetEmHeight()/GetRemHeight(), which are THEMSELVES already in pixelsPerPoint-scaled
-            // internal space - so passing them through unscaled and then multiplying the whole result
-            // by pixelsPerPoint again would double-scale a percentage/em/rem @page margin. Dividing
-            // these three bases down to true-point space first, so ParseLength's result is uniformly
-            // in true points regardless of which unit branch it took, then scaling that single result
-            // by pixelsPerPoint once, keeps every unit type correct.
+            // hundredPercent/emFactor/remFactor - here, htmlContainer.PageSize.Width (internal
+            // pixel space, i.e. true points already multiplied by PixelsPerPoint - see
+            // CascadeApplyPageStyles's own doc comment) and root.GetEmHeight()/GetRemHeight() (the
+            // adapter's device-scaled font-measurement space, i.e. true points already DIVIDED by
+            // PixelsPerPoint - CreateFontInt's own doc comment, and DerivedStyle.ActualFont's) - these
+            // two scale in OPPOSITE directions relative to PixelsPerPoint, so each needs its own
+            // correction to reach true-point space: PageSize.Width is divided, GetEmHeight()/
+            // GetRemHeight() are multiplied (issue #631 - the previous code divided both, which left
+            // the em/rem basis wrong by PixelsPerPoint² once the final multiply below re-applied the
+            // scaling). Normalizing all three bases to true-point space first, so ParseLength's result
+            // is uniformly in true points regardless of which unit branch it took, then scaling that
+            // single result by pixelsPerPoint once, keeps every unit type correct.
             // The same true-point bases the base rule resolves relative units against, captured as
             // this parse pass's shared snapshot so per-page rules (resolved later, at band-geometry/
             // paint time via PageRuleResolver.ResolvePageMargins) see identical numbers - SetContent
@@ -343,12 +348,12 @@ namespace PeachPDF.Html.Core.Parse
                 .Select(r => r.Style?.FontSize)
                 .LastOrDefault(fs => !string.IsNullOrEmpty(fs));
             var emPt = string.IsNullOrEmpty(basePageFontSize)
-                ? root.GetEmHeight() / pixelsPerPoint
+                ? root.GetEmHeight() * pixelsPerPoint
                 : MarginBoxRenderer.ResolveFontSizePt(basePageFontSize);
 
             var lengthContext = new PageLengthContext(
                 emPt,
-                root.GetRemHeight() / pixelsPerPoint,
+                root.GetRemHeight() * pixelsPerPoint,
                 htmlContainer.PageSize.Width / pixelsPerPoint);
             htmlContainer.PageLengthContext = lengthContext;
 


### PR DESCRIPTION
## Summary
- `DomParser.ApplyPageStylesOnce`'s `@page` margin `em`/`rem` basis and `CssBox.NoEms` (`text-indent`/`word-spacing`/`letter-spacing`) both read `GetEmHeight()`/`GetRemHeight()` as if already in true CSS points. They aren't: `PdfSharpAdapter.CreateFontInt` divides a requested font size by `PixelsPerPoint` once to reach the adapter's device-scaled font-measurement space, so both sites divided a second time, producing a value wrong by `PixelsPerPoint²` under a non-default `PixelsPerInch` or `ShrinkToFit`/`ScaleToPageSize`.
- Fixed by multiplying by `PixelsPerPoint` instead, matching the existing correction already used in `DerivedStyle.ActualFont` and `CssBox.ResolveFontSizeValueComputation`.
- Also corrects an existing test (`PageMarginUnitConsistencyIntegrationTests.FirstPageEmMarginOverride_ScalesByPixelsPerPoint_ExactlyOnce`) whose own expected-value formula asserted the same wrong direction for the per-page-rule margin path.

## Test plan
- [x] New `PixelsPerPointEmResolutionIntegrationTests.cs`: 5 tests covering the `@page` margin `em`/`rem` basis and `text-indent`/`letter-spacing`/`word-spacing`'s `em` resolution at non-default `PixelsPerInch`/`PixelsPerPoint`.
- [x] All 5 verified to fail against pre-fix code (via `git stash` of the two source files) and pass post-fix.
- [x] Full suite: `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - 8192 passed, 0 failed.
- [x] `diff-cover` against `main`: 100% diff coverage.
- [x] `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings.

Fixes #631