### PR TITLE
Fix SVG fill/stroke/fill-opacity/stroke-opacity invalid-value fallback

### DIFF
--- a/.claude/recent-fixes/2026-08-08-svg-fill-stroke-opacity-fall-back-to-inherited-on-invalid-value.md
+++ b/.claude/recent-fixes/2026-08-08-svg-fill-stroke-opacity-fall-back-to-inherited-on-invalid-value.md
@@ -1,0 +1,45 @@
+# SVG fill/stroke/fill-opacity/stroke-opacity fall back to the inherited value on invalid input
+
+Closes [#675](https://github.com/jhaygood86/PeachPDF/issues/675), a follow-up to
+[#599](https://github.com/jhaygood86/PeachPDF/issues/599)/[#676](https://github.com/jhaygood86/PeachPDF/pull/676)
+found while fixing it — see
+[.claude/recent-fixes/2026-08-07-svg-fill-rule-linecap-linejoin-fall-back-to-inherited-on-invalid-value.md](2026-08-07-svg-fill-rule-linecap-linejoin-fall-back-to-inherited-on-invalid-value.md)
+for the shape this fix reuses.
+
+## The load-bearing idea
+
+`SvgTreeBuilder.ApplyCommon`'s four remaining call sites (`fill`, `stroke`, `fill-opacity`,
+`stroke-opacity`) had the exact class of bug #599 fixed for `fill-rule`/`stroke-linecap`/
+`stroke-linejoin`: they called `SvgPropertyRegistry.TrySet` and ignored its return value, so an invalid
+attribute silently left the field at its `SvgElement` constructor default (black fill, no stroke,
+opacity 1.0) instead of the ancestor's actual inherited value — worse for `fill`/`stroke` than the #599
+case, since `css-properties.json` already declared `svg.invalidBehavior: "inherit"` for both and nothing
+at build time catches an `ApplyCommon` block silently not implementing what the JSON already claimed
+(`ApplyCommon`, not the generator, owns that decision — see CLAUDE.md's generator section). The fix is
+the same `|| !SvgPropertyRegistry.TrySet(...)` shape the other seven properties in `ApplyCommon` already
+use, plus flipping `fill-opacity`/`stroke-opacity`'s `invalidBehavior` from `"leave-unset"` to
+`"inherit"` in `css-properties.json` (`fill`/`stroke`'s JSON already said `"inherit"`; only the C# call
+site was wrong for those two).
+
+## What didn't need to change
+
+`SvgPropertyRegistry.TrySet`, `SvgValueParsers.TryParsePaint`/`TryParseOpacity`, and
+`SvgPropertyRegistryEquivalenceTests.cs` — all already correctly return `false`/leave the field unset on
+invalid input. Only the caller's post-`TrySet` decision changed, identical in shape to #676.
+
+## Evidence
+
+- Four new `SvgTreeBuilderTests.cs` cases (`Fill_InvalidValueOnChild_FallsBackToInheritedFromGroup`,
+  `Stroke_InvalidValueOnChild_FallsBackToInheritedFromGroup`,
+  `FillOpacityAndStrokeOpacity_InvalidValueOnChild_FallBackToInheritedFromGroup`) assert an invalid child
+  value resolves to the ancestor's non-default value, not the hardcoded `SvgElement` default — the
+  scenario the issue's `<g fill="red"><path fill="not-a-color" .../></g>` repro was about.
+- Full `net8.0` suite: 8197 passed, 0 failed, 9 skipped (one `ContainerQueryLayoutIntegrationTests` case
+  failed on an earlier run of the same unmodified suite and passed on a clean re-run — pre-existing
+  cross-test-class flakiness, unrelated to this change).
+- `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings.
+- `diff-cover` against `main`: 100% diff coverage (9/9 lines).
+- New TestHarness swatches added to the `svg` showcase (`Program.cs`, "9 — Fill Rule & Opacity" section)
+  rasterized with both PDFium and MuPDF at 200dpi — visually identical: the invalid-`fill`/`stroke`
+  swatch still renders the group's purple fill / dark stroke, and the invalid-`fill-opacity`/
+  `stroke-opacity` swatch still renders the group's 0.4 opacity (not reset to 1.0), in both renderers.

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -3128,6 +3128,14 @@ var svgHtml = "<!DOCTYPE html><html><head>" + SvgShowcaseCss + "</head><body>" +
             """<svg viewBox="0 0 140 100" width="90" height="64"><g fill="none" stroke="#2980b9" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"><path d="M20,75 L45,25 L70,75" stroke-linecap="not-a-cap" stroke-linejoin="not-a-join"/></g></svg>""",
             "group's round cap/join survive an invalid override")
     ) +
+    Row(
+        SvgSwatch("invalid fill/stroke inherit from group",
+            """<svg viewBox="0 0 100 100" width="80" height="80"><g fill="#8e44ad" stroke="#2c3e50" stroke-width="4"><circle cx="50" cy="50" r="35" fill="not-a-color" stroke="not-a-color"/></g></svg>""",
+            "g fill/stroke set > circle fill/stroke=\"not-a-color\": still purple with dark outline"),
+        SvgSwatch("invalid fill-opacity/stroke-opacity inherit from group",
+            """<svg viewBox="0 0 100 100" width="80" height="80"><g fill-opacity="0.4" stroke-opacity="0.4"><circle cx="50" cy="50" r="35" fill="#e74c3c" fill-opacity="not-a-number" stroke="#2c3e50" stroke-width="10" stroke-opacity="not-a-number"/></g></svg>""",
+            "group's 0.4 fill/stroke opacity survive an invalid override, not reset to 1.0")
+    ) +
 
     "<h2>10 — Transforms: rotate() &amp; skew()</h2>" +
     Row(

--- a/src/PeachPDF.Tests/Svg/SvgTreeBuilderTests.cs
+++ b/src/PeachPDF.Tests/Svg/SvgTreeBuilderTests.cs
@@ -135,6 +135,32 @@ namespace PeachPDF.Tests.Svg
         }
 
         [Fact]
+        public void Fill_InvalidValueOnChild_FallsBackToInheritedFromGroup()
+        {
+            // SVG 1.1 §11.4 / CSS Cascade & Inheritance 4 §3: an invalid value on an inherited
+            // property computes to the inherited value, not the svg-paint default (#675).
+            var document = BuildFrom("""<svg xmlns="http://www.w3.org/2000/svg"><g fill="#ff0000"><path fill="not-a-color" d="M0,0 L10,0 L10,10 Z"/></g></svg>""");
+
+            var group = Assert.IsType<SvgGroupElement>(Assert.Single(document.Children));
+            var path = Assert.IsType<SvgPathElement>(Assert.Single(group.Children));
+            Assert.Equal(SvgPaintKind.Solid, path.Fill.Kind);
+            Assert.Equal(RColor.FromArgb(0xff, 0x00, 0x00), path.Fill.Color);
+        }
+
+        [Fact]
+        public void Stroke_InvalidValueOnChild_FallsBackToInheritedFromGroup()
+        {
+            // SVG 1.1 §11.4 / CSS Cascade & Inheritance 4 §3: an invalid value on an inherited
+            // property computes to the inherited value, not the svg-paint default (#675).
+            var document = BuildFrom("""<svg xmlns="http://www.w3.org/2000/svg"><g stroke="#0000ff"><path stroke="not-a-color" d="M0,0 L10,0" /></g></svg>""");
+
+            var group = Assert.IsType<SvgGroupElement>(Assert.Single(document.Children));
+            var path = Assert.IsType<SvgPathElement>(Assert.Single(group.Children));
+            Assert.Equal(SvgPaintKind.Solid, path.Stroke.Kind);
+            Assert.Equal(RColor.FromArgb(0x00, 0x00, 0xff), path.Stroke.Color);
+        }
+
+        [Fact]
         public void FillOpacityAndStrokeOpacity_AreDistinctFromOpacity()
         {
             var document = BuildFrom("""<svg xmlns="http://www.w3.org/2000/svg"><circle cx="5" cy="5" r="5" opacity="0.8" fill-opacity="0.4" stroke-opacity="0.2"/></svg>""");
@@ -153,6 +179,19 @@ namespace PeachPDF.Tests.Svg
             var group = Assert.IsType<SvgGroupElement>(Assert.Single(document.Children));
             var circle = Assert.IsType<SvgCircleElement>(Assert.Single(group.Children));
             Assert.Equal(0.3, circle.FillOpacity, 3);
+        }
+
+        [Fact]
+        public void FillOpacityAndStrokeOpacity_InvalidValueOnChild_FallBackToInheritedFromGroup()
+        {
+            // SVG 1.1 §11.4 / CSS Cascade & Inheritance 4 §3: an invalid value on an inherited
+            // property computes to the inherited value, not the hardcoded 1.0 default (#675).
+            var document = BuildFrom("""<svg xmlns="http://www.w3.org/2000/svg"><g fill-opacity="0.3" stroke-opacity="0.6"><circle fill-opacity="not-a-number" stroke-opacity="not-a-number" cx="5" cy="5" r="5"/></g></svg>""");
+
+            var group = Assert.IsType<SvgGroupElement>(Assert.Single(document.Children));
+            var circle = Assert.IsType<SvgCircleElement>(Assert.Single(group.Children));
+            Assert.Equal(0.3, circle.FillOpacity, 3);
+            Assert.Equal(0.6, circle.StrokeOpacity, 3);
         }
 
         [Fact]

--- a/src/PeachPDF/Svg/SvgTreeBuilder.cs
+++ b/src/PeachPDF/Svg/SvgTreeBuilder.cs
@@ -840,24 +840,22 @@ namespace PeachPDF.Svg
             // Each property below keeps ApplyCommon's own null/"inherit"/invalid-value fallback
             // decision (which genuinely differs per property — see css-properties.json's svg.invalidBehavior
             // comments) and delegates only the parse-and-validate step to the generated registry, whose
-            // TrySet already returns false without writing the field on failure. That "leave unset on
-            // failure" contract reproduces the old hardcoded-keyword fallback for fill/stroke/fill-opacity/
-            // stroke-opacity exactly, because SvgElement's own constructor defaults were already chosen to
-            // equal those hardcoded fallbacks. fill-rule/stroke-linecap/stroke-linejoin instead check
-            // TrySet's return value and fall back to the inherited value on failure, per SVG 1.1 §11.4
-            // (see #599) — the same shape stroke-width/-miterlimit/-dashoffset/-dasharray already use.
+            // TrySet already returns false without writing the field on failure. fill/stroke/fill-opacity/
+            // stroke-opacity/fill-rule/stroke-linecap/stroke-linejoin all check TrySet's return value and
+            // fall back to the INHERITED value (not a hardcoded default) on invalid input, per SVG 1.1
+            // §11.4 (see #599, #675) — the same shape stroke-width/-miterlimit/-dashoffset/-dasharray
+            // already use. opacity is the one exception (see its own comment below): it is not inherited,
+            // so an invalid value simply leaves the field at its hardcoded default.
 
             var fillAttr = Attr("fill");
-            if (fillAttr is null || fillAttr.Equals("inherit", StringComparison.OrdinalIgnoreCase))
+            if (fillAttr is null || fillAttr.Equals("inherit", StringComparison.OrdinalIgnoreCase)
+                || !SvgPropertyRegistry.TrySet(element, "fill", fillAttr, in ctx))
                 element.Fill = inherited.Fill;
-            else
-                SvgPropertyRegistry.TrySet(element, "fill", fillAttr, in ctx);
 
             var strokeAttr = Attr("stroke");
-            if (strokeAttr is null || strokeAttr.Equals("inherit", StringComparison.OrdinalIgnoreCase))
+            if (strokeAttr is null || strokeAttr.Equals("inherit", StringComparison.OrdinalIgnoreCase)
+                || !SvgPropertyRegistry.TrySet(element, "stroke", strokeAttr, in ctx))
                 element.Stroke = inherited.Stroke;
-            else
-                SvgPropertyRegistry.TrySet(element, "stroke", strokeAttr, in ctx);
 
             // stroke-width/-miterlimit/-dashoffset/-dasharray fall back to the INHERITED value (not a
             // hardcoded default) on an invalid value, unlike the properties above - TrySet's return is
@@ -889,16 +887,14 @@ namespace PeachPDF.Svg
                 element.FillRule = inherited.FillRule;
 
             var fillOpacityAttr = Attr("fill-opacity");
-            if (fillOpacityAttr is null || fillOpacityAttr.Equals("inherit", StringComparison.OrdinalIgnoreCase))
+            if (fillOpacityAttr is null || fillOpacityAttr.Equals("inherit", StringComparison.OrdinalIgnoreCase)
+                || !SvgPropertyRegistry.TrySet(element, "fill-opacity", fillOpacityAttr, in ctx))
                 element.FillOpacity = inherited.FillOpacity;
-            else
-                SvgPropertyRegistry.TrySet(element, "fill-opacity", fillOpacityAttr, in ctx);
 
             var strokeOpacityAttr = Attr("stroke-opacity");
-            if (strokeOpacityAttr is null || strokeOpacityAttr.Equals("inherit", StringComparison.OrdinalIgnoreCase))
+            if (strokeOpacityAttr is null || strokeOpacityAttr.Equals("inherit", StringComparison.OrdinalIgnoreCase)
+                || !SvgPropertyRegistry.TrySet(element, "stroke-opacity", strokeOpacityAttr, in ctx))
                 element.StrokeOpacity = inherited.StrokeOpacity;
-            else
-                SvgPropertyRegistry.TrySet(element, "stroke-opacity", strokeOpacityAttr, in ctx);
 
             var lineCapAttr = Attr("stroke-linecap");
             if (lineCapAttr is null || lineCapAttr.Equals("inherit", StringComparison.OrdinalIgnoreCase)

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -245,7 +245,7 @@
     },
     {
       "name": "fill-opacity",
-      "comment": "Same shape as opacity (see its comment) — TryParseOpacity's own fallback (1.0) already equals both the initial value and SvgElement's FillOpacity constructor default, so 'leave field unwritten on failure' reproduces SvgTreeBuilder.ApplyCommon's existing present-but-invalid behavior exactly (distinct from stroke-width/etc., which fall back to inherited instead).",
+      "comment": "Falls back to the inherited value on an invalid value (invalidBehavior: inherit), per SVG 1.1 §11.4 — see #675; SvgTreeBuilder.ApplyCommon checks TrySet's return value and assigns inherited.FillOpacity on failure, the same shape stroke-width/etc. use.",
       "inherited": true,
       "initialValue": "1",
       "cssDataType": "svg-opacity",
@@ -253,12 +253,12 @@
         "propertyPath": "FillOpacity",
         "csharpDataType": "double",
         "inheritedFrom": "FillOpacity",
-        "invalidBehavior": "leave-unset"
+        "invalidBehavior": "inherit"
       }
     },
     {
       "name": "stroke-opacity",
-      "comment": "Same shape as fill-opacity (see its comment).",
+      "comment": "Same shape as fill-opacity (see its comment) — see #675.",
       "inherited": true,
       "initialValue": "1",
       "cssDataType": "svg-opacity",
@@ -266,7 +266,7 @@
         "propertyPath": "StrokeOpacity",
         "csharpDataType": "double",
         "inheritedFrom": "StrokeOpacity",
-        "invalidBehavior": "leave-unset"
+        "invalidBehavior": "inherit"
       }
     },
     {


### PR DESCRIPTION
## Summary

- `SvgTreeBuilder.ApplyCommon` had four call sites (`fill`, `stroke`, `fill-opacity`, `stroke-opacity`) that called `SvgPropertyRegistry.TrySet(...)` but ignored its return value, so an invalid attribute silently reset to the hardcoded svg-paint/opacity default instead of falling back to the ancestor's inherited value — the same class of bug fixed for `fill-rule`/`stroke-linecap`/`stroke-linejoin` in #676.
- Changed all four to the `|| !SvgPropertyRegistry.TrySet(...)` shape the other seven properties in `ApplyCommon` already use.
- Flipped `fill-opacity`/`stroke-opacity`'s `svg.invalidBehavior` in `css-properties.json` from `"leave-unset"` to `"inherit"` to match (`fill`/`stroke`'s JSON already said `"inherit"`).

## Test plan

- [x] Four new unit tests in `SvgTreeBuilderTests.cs` asserting an invalid child value falls back to the group's inherited value, not the hardcoded default
- [x] Full `net8.0` suite passes (8197 passed, 0 failed, 9 skipped)
- [x] `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings
- [x] `diff-cover` against `main`: 100% diff coverage
- [x] New TestHarness showcase swatches rasterized with both PDFium and MuPDF at 200dpi — visually identical, confirming the inherited fill/stroke/opacity survives an invalid override in both renderers

Fixes #675