### PR TITLE
Fix forced break inside a table cell being lost or over-walked

### DIFF
--- a/.claude/migration-notes/2026-08-08-forced-break-inside-a-table-cell-now-actually-honored.md
+++ b/.claude/migration-notes/2026-08-08-forced-break-inside-a-table-cell-now-actually-honored.md
@@ -1,0 +1,15 @@
+# A forced break inside a table cell is now actually honored
+
+**Landed:** 2026-08-08 — A table cell's position is its engine's, not a mover's to relocate (issue #512)
+**Doc section:** docs/html-css-support.md § [Fragmentation](../../docs/html-css-support.md) ("a break value on a box *inside* a cell is likewise the table's row grid to answer") — the doc text already described the intended behavior; the layout code did not match it.
+**Verified against v0.9.8:** `git show v0.9.8:src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs` has neither `PositionAssignedByEngine` nor `RowHoldsAnInternalForcedBreak` — the defect predates the tag.
+
+A `break-before`/`break-after: page` (or a directional value) on a block inside a `<td>`/`<th>` could
+silently fail to move that content to the next page at all once the row it was in crossed a page-band
+boundary — the content simply flowed on as if the break value were not there. Depending on exact
+geometry, the row could instead land the broken content one page further than the break value asked
+for. Both were caused by the table engine re-running a straddling cell's own layout a second time
+internally (see the recent-fixes entry for the full mechanism), which silently spent the break's
+one-shot retake latch. A document relying on a forced break inside a table cell to open a new page at
+a specific point should now see it land exactly where the break value names, with no missing or extra
+page.

--- a/.claude/recent-fixes/2026-08-08-a-table-cells-position-is-its-engines-not-a-mover-to-relocate.md
+++ b/.claude/recent-fixes/2026-08-08-a-table-cells-position-is-its-engines-not-a-mover-to-relocate.md
@@ -1,0 +1,55 @@
+# A table cell's position is its engine's, not a mover's to relocate
+
+_Landed 2026-08-08._
+
+**A `break-before: page` on a block inside a `<td>` was silently dropped, or walked one page
+further than it asked for, once its row straddled a band boundary**
+([issue #512](https://github.com/jhaygood86/PeachPDF/issues/512)). Two independent defects
+compounded into the numbers the issue reported (an 8-row, 50pt-row table on a 260pt band: row 4's
+cell measured `rowTop=166.0 maxBottom=310.0`, 144pt for 40pt of real content).
+
+**Root cause A, the deeper one.** `CssLayoutEngineTable` lays out every cell via
+`await cell.PerformLayout(g)` without ever setting `CssBox.PositionAssignedByEngine = true` — unlike
+the flex/grid engines, which already do this for their own items
+(`Fragmentation/ItemContentCommit.cs`'s `CommitLayout`). Every `<td>`/`<th>` gets `overflow: hidden`
+from the UA stylesheet (`CssDefaults.cs`), which makes `MonolithicContent.IsScrollContainer` — and so
+`IsMonolithic` — true for essentially every cell. `CssBox.PerformLayoutEpilogue`'s §4.3 "monolithic"
+mover, built for ordinary block-flow content that can be moved by re-deriving its own position, then
+decided a straddling cell should be laid out again — but `CssBox.ResolveBlockChildOffset` already
+special-cases `ActualDisplay == TableCell` to never reposition one (the table engine owns that), so
+the retry cannot honour the relocation it decided; it can only repeat the cell's own content layout at
+the same top. On that second, silent pass, the forced-break child's one-shot retake latch
+(`CssBox.PlacedByForcedBreak`) was already spent by the first pass, so the break did not fire again
+and the child fell back to flowing normally. Fixed by wrapping the cell's layout call with
+`cell.PositionAssignedByEngine = true` / `finally { cell.PositionAssignedByEngine = false; }`,
+mirroring `ItemContentCommit.CommitLayout`'s own pattern — the same #166 engine-independence boundary
+`BreakPropagation.CanTravelOutOf` already draws for a break value travelling *out* of a cell, now also
+drawn for the epilogue movers that would otherwise try to move the cell itself.
+
+**Root cause B, layered on top.** Even with A fixed, a cell's forced break lands its content at the
+real destination band's top the first time — the row is laid out at its true row-top coordinate, not
+a provisional one a later translation corrects, so nothing about that placement is wrong. But
+`CssLayoutEngineTable`'s straddle correction (`StraddleCorrectionAppliesTo`) read the resulting
+`cursor.MaxBottom - rowTop` as ordinary row content that overflowed its band, and retracted and
+re-placed the whole row on the next one. The retraction's `PassRewind.RollBackTo(null, row.Boxes)`
+resets every descendant's forced-break retake latch, so the same break fires *again* relative to the
+row's new position and walks the content one fragmentainer further than the value asked for. Fixed by
+a fifth decline on `StraddleCorrectionAppliesTo`: `RowHoldsAnInternalForcedBreak` walks the row's
+cells for any descendant with `PlacedByForcedBreak == true` and, if found, leaves the row's
+already-correct geometry alone rather than retrying it.
+
+**Both were measured independently load-bearing** by reverting each in isolation against the new
+test: reverting A alone dropped the break (content landed on the first page instead of the second);
+reverting B alone walked it one page too far (third page instead of second).
+
+Tests: `TableRowCursorBandTests.ARowsInternalForcedBreak_IsNotWalkedFurtherByTheStraddleCorrection`.
+Full `net8.0` suite: 8316 passing, 9 skipped (pre-existing, platform-specific), 0 failed. 100% diff
+coverage on the changed lines. `dotnet build PeachPDF.slnx -t:Rebuild`: zero warnings.
+
+**Not investigated further:** whether `PositionAssignedByEngine = true` on every cell (not only ones
+with an internal forced break) also changes `break-inside: avoid`/widows-orphans behaviour for a
+`<td>` that carries those properties directly rather than relying on the row loop's own stopping
+mechanism. This mirrors flex/grid's already-shipped treatment of their own items and is believed
+correct (a cell's position is never block flow's to begin with, so these movers' whole premise — "lay
+this box out again somewhere else" — never applied to one), but no fixture isolates that scenario
+specifically.

--- a/src/PeachPDF.Tests/Integration/TableRowCursorBandTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableRowCursorBandTests.cs
@@ -373,5 +373,41 @@ namespace PeachPDF.Tests.Integration
 
             Assert.Equal(0, container.CursorSpills);
         }
+
+        /// <summary>
+        /// A <c>break-before: page</c> on a block inside a cell already lands that block at the real next
+        /// band's top the first time the cell is laid out - the row is placed at its true row-top
+        /// coordinate, not a provisional one a later translation corrects. The straddle correction used to
+        /// read the gap that break opened as ordinary row content, retract the row and place it again on
+        /// the next band, which asked <c>CssBox.ForcedBreakTopFor</c> the same question a second time and
+        /// walked the break's target one band further than the value asked for
+        /// (<see href="https://github.com/jhaygood86/PeachPDF/issues/512">issue #512</see>).
+        /// </summary>
+        [Fact]
+        public async Task ARowsInternalForcedBreak_IsNotWalkedFurtherByTheStraddleCorrection()
+        {
+            var rows = string.Concat(Enumerable.Range(1, 8).Select(i =>
+                i == 4
+                    ? "<tr><td style='vertical-align:top'><div style='height:10pt'>before</div>"
+                      + "<div id='after' style='height:30pt;break-before:page'>after</div></td></tr>"
+                    : $"<tr><td style='vertical-align:top'><div style='height:50pt'>row {i}</div></td></tr>"));
+
+            var (root, container) = await LayoutHarness.LayoutAsync(
+                LayoutHarness.Wrap($"<table style='width:100%;border-collapse:collapse'>{rows}</table>"),
+                pageHeight: PageHeight, margin: Margin);
+
+            var placed = RowsOf(root);
+            Assert.Equal(8, placed.Count);
+
+            var after = LayoutHarness.FindById(root, "after")!;
+
+            // The break's own target: the next band, not the one after it.
+            Assert.Equal(1, container.SlotStartingAt(after.Location.Y));
+
+            // The fifth row follows immediately below the fourth's real content - not pushed to a further
+            // band by the break firing a second time.
+            Assert.Equal(1, container.SlotStartingAt(placed[4].Location.Y));
+            Assert.True(placed[4].Location.Y >= placed[3].ActualBottom - 1.01);
+        }
     }
 }

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -2435,7 +2435,14 @@ namespace PeachPDF.Html.Core.Dom
         /// at the position <see cref="CssLayoutEngineFlex.AssignLocations"/>/line relocation already
         /// assigned it — every earlier item layout in those engines is a *measurement*, moved into place by
         /// translation afterward; this one is the item's real, final content layout, with nothing after it
-        /// to correct a wrong position back.
+        /// to correct a wrong position back. <c>CssLayoutEngineTable</c> sets it too, around every
+        /// <c>await cell.PerformLayout(g)</c>: a cell's own <c>Location</c> is this engine's decision in
+        /// exactly the same #166 sense, and its default UA <c>overflow: hidden</c> (<c>CssDefaults</c>)
+        /// already makes <see cref="Fragmentation.MonolithicContent.IsMonolithic"/> true for it, so without
+        /// this every cell whose content reached a page boundary took the movers below - silently spending
+        /// a forced break's one-shot retake latch on a retry that
+        /// <see cref="ResolveBlockChildOffset"/> cannot honour for a <c>TableCell</c>-display box
+        /// (<see href="https://github.com/jhaygood86/PeachPDF/issues/512">issue #512</see>).
         /// </para>
         /// <para>
         /// <b>It no longer decides whether the box is placed.</b> That is now the frame's own question,

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
@@ -2088,7 +2088,7 @@ namespace PeachPDF.Html.Core.Dom
         /// asks the same question of what the row actually measured, which is only knowable here.
         /// </para>
         /// <para>
-        /// Four things make it decline, and each is a case where moving the row would be worse than
+        /// Five things make it decline, and each is a case where moving the row would be worse than
         /// leaving it:
         /// <list type="bullet">
         /// <item><description>
@@ -2111,6 +2111,19 @@ namespace PeachPDF.Html.Core.Dom
         /// <item><description>
         /// <b>The fragmentainer has a band of its own.</b> Inside a multi-column column the page grid does
         /// not describe the fragmentainer being filled, so its bands answer nothing here.
+        /// </description></item>
+        /// <item><description>
+        /// <b>A cell already took a forced break of its own.</b> A block inside a <c>&lt;td&gt;</c> is
+        /// ordinary block-flow content — <see cref="MonolithicContent.PaginatesItsOwnContent"/> does not
+        /// name a table cell — so its <c>break-before</c>/<c>break-after</c> already placed it at the real
+        /// next fragmentainer's top the first time the cell laid it out; the row is laid out at its true
+        /// row-top coordinate, not a provisional one a later translation corrects, so that placement is
+        /// already right. Retracting and re-placing the row asks
+        /// <see cref="CssBox.ForcedBreakTopFor"/> the same question again from the new top and takes the
+        /// same break a second time, walking the content one fragmentainer further than the value asked
+        /// for (<see href="https://github.com/jhaygood86/PeachPDF/issues/512">issue #512</see>). Declining
+        /// leaves the row's already-correct geometry alone — the interior gap this leaves between the two
+        /// halves is the break's own page skip, not room a later band could still use.
         /// </description></item>
         /// </list>
         /// </para>
@@ -2139,7 +2152,43 @@ namespace PeachPDF.Html.Core.Dom
 
             if (rowTop - HtmlContainerInt.PageBoundaryEpsilon <= container.PageTopOf(slot)) return false;
 
+            if (RowHoldsAnInternalForcedBreak(_bodyRows[rowIndex])) return false;
+
             return cursor.MaxBottom - rowTop <= RoomForARowIn(container, slot + 1);
+        }
+
+        /// <summary>
+        /// Whether something inside <paramref name="row"/>'s own cells took a forced break of its own —
+        /// see the fifth decline on <see cref="StraddleCorrectionAppliesTo"/> for why that rules out
+        /// moving the row.
+        /// </summary>
+        /// <remarks>
+        /// Not the row-level break <see cref="ForcedBreakFallsBeforeRow"/> reads: that is a value on the
+        /// row (or a row group it begins) read <i>before</i> the row is placed. This is read <i>after</i>,
+        /// off <see cref="CssBox.PlacedByForcedBreak"/>, which only a box block flow actually placed can
+        /// have set — a cell itself never does, since the table engine positions cells directly rather
+        /// than through <c>CssBox.PlaceBlockChild</c>.
+        /// </remarks>
+        private static bool RowHoldsAnInternalForcedBreak(CssBox row)
+        {
+            foreach (var cell in row.Boxes)
+            {
+                if (cell is not CssSpacingBox && BoxOrDescendantPlacedByForcedBreak(cell)) return true;
+            }
+
+            return false;
+        }
+
+        private static bool BoxOrDescendantPlacedByForcedBreak(CssBox box)
+        {
+            if (box.PlacedByForcedBreak) return true;
+
+            foreach (var child in box.Boxes)
+            {
+                if (BoxOrDescendantPlacedByForcedBreak(child)) return true;
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -2606,7 +2655,28 @@ namespace PeachPDF.Html.Core.Dom
                 // stopping point and the ones that finished are simply not in the carried list.
                 if (cursor.CarriedTokenFor(cell) is { } carried) cell.ResumeAt(carried, null);
 
-                await cell.PerformLayout(g);
+                // This cell's position is this engine's own decision, not block flow's - the same #166
+                // boundary that stops a break value travelling out of a cell (BreakPropagation.CanTravelOutOf)
+                // - so the flag says the same thing to its epilogue that CssLayoutEngineFlex/Grid's own
+                // commit pass already says to a flex/grid item's (ItemContentCommit.CommitLayout): the §4.3
+                // movers (avoid/monolithic, widows/orphans, the keep-with-next retry) all answer "this box
+                // does not fit, so lay it out again somewhere else" by re-running its own content layout in
+                // place - CssBox.ResolveBlockChildOffset never actually moves a table-cell-display box, so
+                // the retry cannot honour what it decided, only repeat the layout at the same top. Every
+                // <td>'s UA-default overflow:hidden (CssDefaults) already makes MonolithicContent.IsMonolithic
+                // true for it, so without this every cell whose content reaches a page boundary took that
+                // retry - silently dropping a forced break inside it the second time through, since the
+                // break's own one-shot latch (CssBox.PlacedByForcedBreak) was already spent by the first run
+                // (issue #512).
+                cell.PositionAssignedByEngine = true;
+                try
+                {
+                    await cell.PerformLayout(g);
+                }
+                finally
+                {
+                    cell.PositionAssignedByEngine = false;
+                }
 
                 // Did this cell finish? Asked here because here is the only place the answer exists: a
                 // box's record is cleared at the start of its next layout, and the engine's whole-table


### PR DESCRIPTION
## Summary
- A `break-before`/`break-after: page` (or a directional value) on a block inside a `<td>`/`<th>` could be silently dropped, or land the content one page further than it asked for, once the row it belongs to crosses a page-band boundary.
- Root cause A: every `<td>`/`<th>` defaults to `overflow: hidden`, making `MonolithicContent.IsMonolithic` true for essentially every cell. `CssBox.PerformLayoutEpilogue`'s §4.3 "monolithic" mover then decided a straddling cell should be relocated and laid out again - but `ResolveBlockChildOffset` never actually repositions a `TableCell`-display box (the table engine owns that), so the retry just repeats the cell's content layout at the same top, silently spending the forced break's one-shot retake latch. Fixed by marking cells `PositionAssignedByEngine` during their layout pass, mirroring what the flex/grid engines already do for their own items via `ItemContentCommit`.
- Root cause B, layered on top: `CssLayoutEngineTable`'s straddle correction could still retract a row whose cell already correctly took an internal forced break and re-place the whole row on the next band, causing the same break to retake a second time and walk one fragmentainer further than it asked for. Fixed by declining the straddle correction when a row holds an internal forced break.
- Both were confirmed independently load-bearing by reverting each in isolation against the new regression test.

Fixes #512

## Test plan
- [x] New regression test `TableRowCursorBandTests.ARowsInternalForcedBreak_IsNotWalkedFurtherByTheStraddleCorrection`, confirmed to fail (in two different ways) with either fix reverted
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0`: 8316 passed, 0 failed, 9 skipped (pre-existing, platform-specific)
- [x] `dotnet build PeachPDF.slnx -t:Rebuild`: zero warnings
- [x] 100% diff coverage on the changed lines (`diff-cover`)