### PR TITLE
Undo a hyphenation split when its line is discarded at a fragmentainer break

### DIFF
--- a/.claude/migration-notes/2026-08-08-hyphenation-split-no-longer-survives-a-discarded-fragmentainer-line.md
+++ b/.claude/migration-notes/2026-08-08-hyphenation-split-no-longer-survives-a-discarded-fragmentainer-line.md
@@ -1,0 +1,13 @@
+# A hyphenated word split at a page/column boundary no longer keeps an unnecessary hyphen
+
+**Landed:** 2026-08-08 — A hyphenation split made for one fragmentainer's measure survives into the resumed pass (issue #344)
+**Doc section:** none — the previous behavior was never described in `docs/html-css-support.md`'s `hyphens` coverage; there is nothing to correct there.
+**Verified against v0.9.8:** `git show v0.9.8:src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs` shows `TryHyphenateWord`'s prefix/suffix split with no linkage back to the original word and no undo path in `CreateLineBoxes`'s discard branch — the defect predates the tag.
+
+With `hyphens: auto` (or an explicit soft hyphen), a word whose hyphenation split happened to fall on
+the exact line a page or column break discarded could show a needless hyphen on the following page —
+the split (prefix ending in `-`, suffix continuing it) was computed against that now-abandoned line's
+own remaining width and was carried forward unchanged, even though the resumed page's fresh, undivided
+width could fit the whole original word without splitting it at all. A document relying on automatic
+or soft-hyphen hyphenation near a page or column boundary should now see that word re-hyphenated (or
+left whole) against the width it actually lands on, rather than keeping a stale, unnecessary hyphen.

--- a/.claude/recent-fixes/2026-08-08-hyphenation-split-undone-when-its-line-is-discarded.md
+++ b/.claude/recent-fixes/2026-08-08-hyphenation-split-undone-when-its-line-is-discarded.md
@@ -1,0 +1,77 @@
+# A hyphenation split made for one fragmentainer pass no longer survives into the resumed pass
+
+Closes [#344](https://github.com/jhaygood86/PeachPDF/issues/344).
+
+## The load-bearing idea
+
+`CssLayoutEngine.FlowBox`'s hyphenation branch (`TryHyphenateWord`) mutates the owning box's
+`CssBox.Words` list **in place**: `b.Words[wordIndex] = prefixWord; b.Words.Insert(wordIndex + 1,
+suffixWord);`. A resumed fragmentainer pass re-walks that same list from the top, so a split made
+against one pass's remaining line width was still there, unchanged, on the next pass - even when the
+line it was made for is the exact line `CreateLineBoxes` discards at the break (css-break-3 §4.1: a
+line box never straddles a fragmentainer, so the whole in-progress line is thrown away and rebuilt by
+the resumed pass). The discard already re-flows every other word in that line fresh; the split
+prefix/suffix pair was the one piece of state that didn't reset, so it could show up as two words
+(with a needless hyphen) on the resumed page where the whole original word would have fit against the
+fresh, undivided width.
+
+The fix: `CssRectWord` gained two internal links (`PreSplitWord`, `HyphenationSuffix`) that
+`TryHyphenateWord` now sets on the prefix it creates, pointing back at the original whole word and at
+its own suffix half. `CreateLineBoxes`'s discard path calls a new
+`CssLayoutEngine.UndoAbandonedHyphenationSplits(discardedLine)` before marking the discarded line's
+words as belonging to the next fragmentainer: for any word in that line that is a hyphenation prefix,
+it removes the suffix from the owner box's `Words` list and replaces the prefix's slot with the
+original word, so the resumed pass encounters the whole word again and decides fresh whether to
+hyphenate at all.
+
+## The other half that wasn't obvious from the issue text
+
+The restored original word has never been positioned this pass, so `Top`/`Left` are whatever it last
+carried - nothing, since the split moved it out of the flow before it was ever reached. Left alone,
+that "nothing" is indistinguishable from a genuinely-placed word to
+`FragmentEmitter`'s `if (box.Words[i].AwaitsTheNextFragmentainer) continue;` guard (`TryGetWordRect`
+falls back to `word.Rectangle`, i.e. whatever stale/default rect the object carries, when there is no
+snapshot). The loop that sets `AwaitsTheNextFragmentainer = true` for the rest of the discarded line's
+words runs against the line's own word list, which still names the discarded *prefix* object, not the
+word that replaced it - so the restored word needs the flag set explicitly, in the undo method itself,
+or it could be wrongly claimed into the fragment that is about to close.
+
+## Which shape was actually reachable
+
+Only a prefix ending up as a member of the discarded line's own word list triggers the undo - which
+happens when `word.WouldStraddleFragmentainer()` (checked immediately after the prefix is placed,
+before the loop ever reaches the suffix) trips on the prefix itself. The other shape - a prefix already
+committed to an earlier, kept line, with only its suffix alone starting the fragmentainer that gets
+thrown away - is an ordinary hyphen straddling the break and is *not* touched: the suffix carries no
+`PreSplitWord`/`HyphenationSuffix` of its own (only the prefix TryHyphenateWord creates does), so
+`UndoAbandonedHyphenationSplits`'s pattern match never matches it, by construction rather than by an
+extra check.
+
+## What didn't pan out
+
+A pixel-perfect end-to-end fragmentation repro turned out to be far more sensitive than expected:
+plain horizontal line-wrapping geometry is entirely page-position-independent in this engine (the same
+preceding same-line content reflows to the same width on every page), so a hyphenation decision made
+in one pass and one made fresh on resume are provably identical unless *something* narrows the line
+differently between the two passes - a float is the natural real-world cause, but getting a float's
+absolute bottom edge to land inside the exact word's line while also clearing the next page's absolute
+content top turned out to need a very narrow, fragile window of page-height values, not something
+worth pinning a regression test to. The mechanism itself doesn't depend on floats at all - it depends
+only on the prefix's own placement tripping the straddle check - so the regression coverage instead
+exercises `CssLayoutEngine.UndoAbandonedHyphenationSplits` directly against hand-built words carrying
+the same linkage `TryHyphenateWord` sets, which is deterministic and doesn't fight page geometry.
+
+## Evidence
+
+- New `HyphenationSplitUndoTests.cs` (5 cases): a prefix alone in the discarded line restores the
+  original word and sets `AwaitsTheNextFragmentainer`; the same with other words surrounding the split
+  in the box's word list; an ordinary (non-hyphenated) word is left untouched; the legitimate
+  suffix-alone-starts-the-next-fragmentainer shape is left untouched; an empty discarded line is a
+  no-op.
+- Full `net8.0` suite (excluding an unrelated file with in-progress, uncommitted changes from a
+  concurrent investigation into issue #395 that was already present in the working tree before this
+  change and is unaffected by it): 8207 passed, 0 failed, 9 skipped.
+- `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings.
+- Coverage: all new/changed lines in `CssLayoutEngine.cs`/`CssRectWord.cs` hit at least once
+  (`dotnet test --collect:"XPlat Code Coverage"`), including the real (non-test-only) call site inside
+  `TryHyphenateWord` and the merge path inside `UndoAbandonedHyphenationSplits`.

--- a/src/PeachPDF.Tests/Html/Core/Dom/HyphenationSplitUndoTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/HyphenationSplitUndoTests.cs
@@ -1,0 +1,123 @@
+using PeachPDF.Html.Core.Dom;
+
+namespace PeachPDF.Tests.Html.Core.Dom
+{
+    /// <summary>
+    /// <c>CssLayoutEngine.TryHyphenateWord</c> mutates the owning box's <see cref="CssBox.Words"/> list
+    /// in place - splitting one word into a prefix/suffix pair - and a resumed fragmentainer pass
+    /// re-walks that same, already-mutated list. <c>CreateLineBoxes.UndoAbandonedHyphenationSplits</c>
+    /// (issue #344) undoes a split whose prefix ends up part of a line the pass discards at a break, so
+    /// the resumed pass decides afresh against the width it will actually have, rather than re-flowing a
+    /// stale prefix/suffix pair where the whole original word would have fit. These tests exercise that
+    /// mechanism directly, against hand-built words carrying the same linkage
+    /// <c>TryHyphenateWord</c> sets, rather than depending on a specific page geometry to trigger it.
+    /// </summary>
+    public class HyphenationSplitUndoTests
+    {
+        [Fact]
+        public void DiscardedLine_PrefixIsFirstMemberOfSplit_RestoresOriginalWordInOwnerBoxWords()
+        {
+            var owner = new CssBox(null, null);
+            var original = new CssRectWord(owner, "antidisestablishmentarianism", true, true);
+            var prefix = new CssRectWord(owner, "an-", true, false) { PreSplitWord = original };
+            var suffix = new CssRectWord(owner, "tidisestablishmentarianism", false, true);
+            prefix.HyphenationSuffix = suffix;
+
+            owner.Words.Add(prefix);
+            owner.Words.Add(suffix);
+
+            var line = new CssLineBox(owner);
+            line.Words.Add(prefix);
+
+            CssLayoutEngine.UndoAbandonedHyphenationSplits(line);
+
+            Assert.Single(owner.Words);
+            Assert.Same(original, owner.Words[0]);
+
+            // Never positioned this pass - FragmentEmitter must not read its (meaningless) Top/Left as
+            // a real placement and claim it into the fragment that is about to close.
+            Assert.True(original.AwaitsTheNextFragmentainer);
+        }
+
+        [Fact]
+        public void DiscardedLine_SplitSurroundedByOtherWords_OnlyTheSplitPairIsMerged()
+        {
+            var owner = new CssBox(null, null);
+            var before = new CssRectWord(owner, "before", true, true);
+            var original = new CssRectWord(owner, "antidisestablishmentarianism", true, true);
+            var prefix = new CssRectWord(owner, "an-", true, false) { PreSplitWord = original };
+            var suffix = new CssRectWord(owner, "tidisestablishmentarianism", false, true);
+            prefix.HyphenationSuffix = suffix;
+            var after = new CssRectWord(owner, "after", true, true);
+
+            owner.Words.Add(before);
+            owner.Words.Add(prefix);
+            owner.Words.Add(suffix);
+            owner.Words.Add(after);
+
+            var line = new CssLineBox(owner);
+            line.Words.Add(before);
+            line.Words.Add(prefix);
+
+            CssLayoutEngine.UndoAbandonedHyphenationSplits(line);
+
+            Assert.Equal([before, original, after], owner.Words);
+        }
+
+        [Fact]
+        public void DiscardedLine_OrdinaryWord_IsLeftUntouched()
+        {
+            var owner = new CssBox(null, null);
+            var word = new CssRectWord(owner, "plain", true, true);
+            owner.Words.Add(word);
+
+            var line = new CssLineBox(owner);
+            line.Words.Add(word);
+
+            CssLayoutEngine.UndoAbandonedHyphenationSplits(line);
+
+            Assert.Single(owner.Words);
+            Assert.Same(word, owner.Words[0]);
+        }
+
+        // The legitimate case (not #344's bug): the prefix already committed to an earlier, kept line -
+        // it is never a member of the line being discarded - and only the suffix, alone, starts the
+        // fragmentainer that got thrown away. That is an ordinary hyphen straddling the break, and must
+        // survive unchanged: the suffix carries no PreSplitWord/HyphenationSuffix of its own, so the
+        // pattern match in UndoAbandonedHyphenationSplits never matches it.
+        [Fact]
+        public void DiscardedLine_SuffixAloneWithoutItsPrefix_IsLeftUntouched()
+        {
+            var owner = new CssBox(null, null);
+            var original = new CssRectWord(owner, "antidisestablishmentarianism", true, true);
+            var prefix = new CssRectWord(owner, "an-", true, false) { PreSplitWord = original };
+            var suffix = new CssRectWord(owner, "tidisestablishmentarianism", false, true);
+            prefix.HyphenationSuffix = suffix;
+
+            owner.Words.Add(prefix);
+            owner.Words.Add(suffix);
+
+            // prefix already committed to an earlier, kept line - not part of the discarded one.
+            var keptLine = new CssLineBox(owner);
+            keptLine.Words.Add(prefix);
+
+            var discardedLine = new CssLineBox(owner);
+            discardedLine.Words.Add(suffix);
+
+            CssLayoutEngine.UndoAbandonedHyphenationSplits(discardedLine);
+
+            Assert.Equal([prefix, suffix], owner.Words);
+        }
+
+        [Fact]
+        public void DiscardedLine_Empty_DoesNothing()
+        {
+            var owner = new CssBox(null, null);
+            var line = new CssLineBox(owner);
+
+            CssLayoutEngine.UndoAbandonedHyphenationSplits(line);
+
+            Assert.Empty(owner.Words);
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -375,6 +375,8 @@ namespace PeachPDF.Html.Core.Dom
                 // fragmentainer being left - and that fragmentainer's fragments are frozen at the end of this
                 // pass, before the resumed pass re-places them. §4.1 has already decided they belong to the
                 // next fragmentainer, so mark them as such; being positioned again clears it.
+                UndoAbandonedHyphenationSplits(coordinates.Line);
+
                 foreach (var word in coordinates.Line.Words)
                 {
                     word.AwaitsTheNextFragmentainer = true;
@@ -1840,6 +1842,49 @@ namespace PeachPDF.Html.Core.Dom
         }
 
         /// <summary>
+        /// Undoes any hyphenation split (<see cref="TryHyphenateWord"/>) whose prefix ended up part of
+        /// <paramref name="discardedLine"/> - a line <see cref="CreateLineBoxes"/> is throwing away
+        /// because the flow it belongs to is resuming in the next fragmentainer. The split mutated its
+        /// owning box's <see cref="CssBox.Words"/> list in place against this line's own (now
+        /// irrelevant) remaining width, and a resumed pass re-walks that same list - so left alone, the
+        /// split would survive unchanged into the resumed pass's fresh, undivided width, showing up as
+        /// two words (with a needless hyphen) where the whole original word would have fit
+        /// (<see href="https://github.com/jhaygood86/PeachPDF/issues/344">#344</see>). Restoring the
+        /// original word here instead lets the resumed pass decide afresh whether to hyphenate at all.
+        /// </summary>
+        /// <remarks>
+        /// Only reachable for a prefix: the suffix half of a split that already wrapped onto its own,
+        /// separately-kept line is never a member of <paramref name="discardedLine"/>'s own word list,
+        /// so an ordinary hyphen straddling the fragmentainer break itself - suffix alone starting the
+        /// next fragmentainer, prefix already committed to the one that just closed - is left untouched.
+        /// </remarks>
+        internal static void UndoAbandonedHyphenationSplits(CssLineBox discardedLine)
+        {
+            foreach (var word in discardedLine.Words)
+            {
+                if (word is not CssRectWord { PreSplitWord: { } original, HyphenationSuffix: { } suffix } prefix)
+                    continue;
+
+                var ownerWords = prefix.OwnerBox.Words;
+                var prefixIndex = ownerWords.IndexOf(prefix);
+
+                if (prefixIndex < 0) continue;
+
+                ownerWords.Remove(suffix);
+                ownerWords[prefixIndex] = original;
+
+                // The restored word has never been positioned this pass, so its Top/Left are whatever
+                // it last carried (nothing, for a word this split had never let reach placement) - not
+                // the "unset" state FragmentEmitter's own AwaitsTheNextFragmentainer check relies on to
+                // tell a genuinely-placed word from one whose position means nothing yet. Set explicitly
+                // rather than left to default, since the loop that sets it for prefix/suffix's own
+                // discarded-line siblings runs against the line's word list, which still names the
+                // now-discarded prefix object, not this replacement.
+                original.AwaitsTheNextFragmentainer = true;
+            }
+        }
+
+        /// <summary>
         /// Tries to split <paramref name="word"/> at the widest of its precomputed
         /// <see cref="CssRect.HyphenationCandidates"/> (set by <see cref="CssBox.ParseToWords"/> — either
         /// an explicit soft hyphen position or an automatic <c>HyphenationEngine</c> suggestion) whose
@@ -1880,6 +1925,12 @@ namespace PeachPDF.Html.Core.Dom
                     Width = g.MeasureString(suffixText, b.ActualFont, b.ActualTextShapingFeatures).Width,
                     Height = b.ActualFont.Height
                 };
+
+                // Recorded so a discarded fragmentainer line can undo this split rather than carry it
+                // into the resumed pass unchanged - see CssRectWord.HyphenationSuffix.
+                prefix.PreSplitWord = word;
+                prefix.HyphenationSuffix = suffix;
+
                 return true;
             }
 

--- a/src/PeachPDF/Html/Core/Dom/CssRectWord.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssRectWord.cs
@@ -103,6 +103,28 @@ namespace PeachPDF.Html.Core.Dom
         internal void ReplaceText(string text) => _text = text;
 
         /// <summary>
+        /// Set only on a hyphenation-created prefix (<c>CssLayoutEngine.TryHyphenateWord</c>): the
+        /// single word it was split from, still carrying that word's own
+        /// <see cref="CssRect.HyphenationCandidates"/>. Lets a discarded fragmentainer line's split be
+        /// undone by restoring this in place of the prefix/suffix pair - see
+        /// <see cref="HyphenationSuffix"/> and issue #344.
+        /// </summary>
+        internal CssRect? PreSplitWord { get; set; }
+
+        /// <summary>
+        /// Set only on a hyphenation-created prefix: the suffix <c>TryHyphenateWord</c> created
+        /// alongside it. A resumed fragmentainer pass re-walks the same word list a split mutated in
+        /// place (<c>CssBox.Words</c>), so a split made against one pass's remaining line width would
+        /// otherwise survive into the next pass's fresh, undivided width unchanged - re-flowed as two
+        /// words with a hyphen neither the original word nor a fresh hyphenation decision would have
+        /// produced. <c>CssLayoutEngine.CreateLineBoxes</c> uses this (together with
+        /// <see cref="PreSplitWord"/>) to merge the pair back into one word whenever the line the split
+        /// was made for is itself discarded at a break, so the resumed pass decides afresh instead of
+        /// re-flowing a stale split.
+        /// </summary>
+        internal CssRectWord? HyphenationSuffix { get; set; }
+
+        /// <summary>
         /// Represents this word for debugging purposes
         /// </summary>
         /// <returns></returns>


### PR DESCRIPTION
## Summary
- `CssLayoutEngine.TryHyphenateWord` splits a word into a prefix/suffix pair by mutating the owning box's `Words` list in place. A resumed fragmentainer pass re-walks that same list, so a split made against one pass's remaining line width survived unchanged into the resumed pass's fresh, undivided width whenever the split's prefix ended up part of the line `CreateLineBoxes` discards at the break - showing a needless hyphen where the whole word would have fit.
- `CssRectWord` now links a hyphenation prefix back to the original (pre-split) word and its own suffix half. `CreateLineBoxes`'s discard path uses that link (`CssLayoutEngine.UndoAbandonedHyphenationSplits`) to merge the pair back into the original word before the resumed pass re-walks it, so the resumed pass decides afresh whether to hyphenate at all against the width it will actually have.
- The restored word is explicitly marked `AwaitsTheNextFragmentainer` since it was never positioned this pass - otherwise `FragmentEmitter`'s guard against stale word positions wouldn't recognize it and could wrongly claim it into the fragment that is about to close.
- The legitimate "ordinary hyphen straddles the break" shape (prefix already committed to an earlier, kept line; only the suffix alone starts the next fragmentainer) is left untouched by construction - the suffix carries no `PreSplitWord`/`HyphenationSuffix` of its own.

## Test plan
- [x] New `HyphenationSplitUndoTests.cs` (5 cases) exercising `UndoAbandonedHyphenationSplits` directly against hand-built words carrying the same linkage `TryHyphenateWord` sets.
- [x] Full `net8.0` suite passes (8207 passed, 0 failed, 9 skipped).
- [x] `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings.
- [x] Coverage: all new/changed lines hit at least once (`dotnet test --collect:"XPlat Code Coverage"`).

Fixes #344