### PR TITLE
Fix float:right not narrowing line-wrap width

### DIFF
--- a/.claude/recent-fixes/2026-08-09-float-right-line-wrap-limit-used-the-wrong-collision-test.md
+++ b/.claude/recent-fixes/2026-08-09-float-right-line-wrap-limit-used-the-wrong-collision-test.md
@@ -1,0 +1,52 @@
+# `float:right` now narrows line-wrap width instead of letting text overlap it
+
+## The load-bearing idea
+
+`DomUtils.GetLastRightIntersectingFloatBox` - called once per word from `CssLayoutEngine.FlowBox`
+(`CssLayoutEngine.cs:1595`) to compute `actualLimitRight`, the right-hand wrap boundary for the
+current line - queried `GetFirstIntersectingFloatBox` in `Floating.Left` mode even though it exists
+to answer a right-float question. `IsFloatIntersecting`'s `Floating.Left` branch tests whether the
+cursor's *current* X position is already inside a float's horizontal span - correct for a left
+float, which text starts flush against and must be pushed right past the moment it walks into one,
+but structurally incapable of detecting a right float in advance: the cursor only enters a right
+float's span after the overlap has already happened. Words were placed straight through
+`float:right` boxes instead of wrapping before reaching their left edge.
+
+The two kinds of float constrain a line in different shapes, not just on different sides: a left
+float caps where the cursor itself currently sits (a point-collision, answered correctly by
+`GetLastLeftIntersectingFloatBox`'s existing point-collision-then-push loop, left unchanged), while
+a right float caps how far right the cursor is *allowed to reach in advance* - a lookahead,
+independent of the cursor's current position or the word being placed. `IsFloatIntersecting`'s
+`Floating.Right` branch does not compute this lookahead either; working through the arithmetic it
+would actually be given by this caller, it reduces to "the float's left edge is far to the right of
+the word" (true when the float *isn't* an obstruction), because that branch exists for a different
+caller (`CssLayoutEngine.FloatBoxRight`, placing a *new* float:right box) and was never a fit for
+bounding in-flow text either.
+
+The fix replaces the whole method with a dedicated single-pass scan
+(`FindNarrowestRightFloatBox`/`ScanForNarrowestRightFloatBox`, same ancestor/preceding-sibling
+traversal shape as `FindIntersectingFloatBox`) that finds, among every `float:right` box whose
+vertical span covers the current row, the one with the smallest left edge
+(`Location.X - ActualMarginLeft`) - the actual binding constraint, computed without reference to
+where the cursor currently is or how wide the word being placed is. That let the `referenceWidth`
+parameter and the old method's 10000-iteration collision-retry loop both go away: a single
+recursive pass already finds the global minimum, so there is nothing left to retry.
+
+## Left floats were checked, not assumed
+
+Every call site of `GetLastLeftIntersectingFloatBox` (`CssLayoutEngine.cs` lines 1550, 1658, 1714)
+re-runs it at line start, after every wrap, and after every word placement, always to re-push
+`coordinates.CurrentX` past whatever left float currently occupies that exact position. That is
+the point-collision shape a left float actually needs, unchanged by this fix. A new
+`FloatLeft_StillNarrowsLineWrapWidth_AfterTheRightFloatFix` test locks this in explicitly rather
+than leaving it as an unverified assumption riding on the right-float fix.
+
+## Evidence
+
+- New `FloatRight_NarrowsLineWrapWidth_SoTextWrapsBeforeReachingIt`
+  (`FloatLayoutRegressionTests.cs`): confirmed failing before the fix (a word landed at
+  `Rectangle.Right=224.36`, past the float's left edge at `206`), passing after.
+- New `FloatLeft_StillNarrowsLineWrapWidth_AfterTheRightFloatFix`: passed both before and after,
+  confirming the left-float path was already correct and stayed that way.
+- Full `net8.0` suite and `dotnet build PeachPDF.slnx -t:Rebuild` (0 warnings) both green after the
+  change.

--- a/src/PeachPDF.Tests/Integration/FloatLayoutRegressionTests.cs
+++ b/src/PeachPDF.Tests/Integration/FloatLayoutRegressionTests.cs
@@ -268,6 +268,84 @@ namespace PeachPDF.Tests.Integration
         }
 
         [Fact]
+        public async Task FloatRight_NarrowsLineWrapWidth_SoTextWrapsBeforeReachingIt()
+        {
+            // DomUtils.GetLastRightIntersectingFloatBox used to query
+            // GetFirstIntersectingFloatBox in Floating.Left mode - a point-collision test that can
+            // only detect a right float once the cursor has already walked into its span, never in
+            // advance. That let words on the row overlapping the float's vertical span
+            // ([0, 50pt)) be placed straight through it instead of wrapping before its left edge
+            // (300pt container - 100pt float = 200pt).
+            var html = Wrap(@"
+                <div style='width:300pt;'>
+                    <div id='f' style='float:right; width:100pt; height:50pt;'></div>
+                    <p id='text' style='margin:0;'>this line of text should wrap before it reaches the floated box on the right</p>
+                </div>");
+
+            var (root, _) = await BuildAndLayout(html);
+            var floatBox = FindById(root, "f")!;
+            var text = FindById(root, "text")!;
+            var floatLeftEdge = floatBox.Location.X - floatBox.ActualMarginLeft;
+
+            var wordsOverlappingFloat = WordsOverlappingVerticalSpan(text, floatBox.Location.Y, floatBox.ActualBottom);
+
+            Assert.NotEmpty(wordsOverlappingFloat);
+
+            foreach (var word in wordsOverlappingFloat)
+            {
+                Assert.True(word.Rectangle.Right <= floatLeftEdge + 1,
+                    $"word '{word.Text}' at Rectangle.Right={word.Rectangle.Right} overlaps the float:right " +
+                    $"box, whose left edge (including margin) is at {floatLeftEdge}");
+            }
+        }
+
+        [Fact]
+        public async Task FloatLeft_StillNarrowsLineWrapWidth_AfterTheRightFloatFix()
+        {
+            // Companion to the float:right fix above: GetLastLeftIntersectingFloatBox implements a
+            // different (point-collision-then-push) algorithm that was already correct for
+            // float:left, and must remain so. Every word overlapping the float's vertical span must
+            // start at or after the float's right edge, and the paragraph must wrap to more lines
+            // than an unfloated control.
+            const string longText =
+                "this line of text should wrap below and around the floated box on the left before it reaches the container edge";
+
+            var withFloatHtml = Wrap($@"
+                <div style='width:300pt;'>
+                    <div id='f' style='float:left; width:100pt; height:50pt;'></div>
+                    <p id='text' style='margin:0;'>{longText}</p>
+                </div>");
+
+            var withoutFloatHtml = Wrap($@"
+                <div style='width:300pt;'>
+                    <p id='text' style='margin:0;'>{longText}</p>
+                </div>");
+
+            var (withFloatRoot, _) = await BuildAndLayout(withFloatHtml);
+            var (withoutFloatRoot, _) = await BuildAndLayout(withoutFloatHtml);
+
+            var floatBox = FindById(withFloatRoot, "f")!;
+            var withFloatText = FindById(withFloatRoot, "text")!;
+            var withoutFloatText = FindById(withoutFloatRoot, "text")!;
+            var floatRightEdge = floatBox.ActualRight + floatBox.ActualMarginRight;
+
+            var wordsOverlappingFloat = WordsOverlappingVerticalSpan(withFloatText, floatBox.Location.Y, floatBox.ActualBottom);
+
+            Assert.NotEmpty(wordsOverlappingFloat);
+
+            foreach (var word in wordsOverlappingFloat)
+            {
+                Assert.True(word.Rectangle.Left >= floatRightEdge - 1,
+                    $"word '{word.Text}' at Rectangle.Left={word.Rectangle.Left} starts before the float:left " +
+                    $"box's right edge (including margin) at {floatRightEdge}");
+            }
+
+            Assert.True(withFloatText.ActualBoxSizingHeight > withoutFloatText.ActualBoxSizingHeight,
+                $"narrowing the line width with a float:left should force extra line wraps and a taller box " +
+                $"(with float: {withFloatText.ActualBoxSizingHeight}, without: {withoutFloatText.ActualBoxSizingHeight})");
+        }
+
+        [Fact]
         public async Task ClearLeft_IgnoresAPrecedingFloatRightSibling()
         {
             // clear:left only clears past float:left siblings - a float:right sibling must not push it
@@ -370,6 +448,29 @@ namespace PeachPDF.Tests.Integration
                 if (found is not null) return found;
             }
             return null;
+        }
+
+        private static List<CssRect> WordsOverlappingVerticalSpan(CssBox box, double top, double bottom)
+        {
+            List<CssRect> words = [];
+            CollectWordsOverlappingVerticalSpan(box, top, bottom, words);
+            return words;
+        }
+
+        private static void CollectWordsOverlappingVerticalSpan(CssBox box, double top, double bottom, List<CssRect> words)
+        {
+            foreach (var word in box.Words)
+            {
+                if (word.Top < bottom && word.Top + word.Height > top)
+                {
+                    words.Add(word);
+                }
+            }
+
+            foreach (var child in box.Boxes)
+            {
+                CollectWordsOverlappingVerticalSpan(child, top, bottom, words);
+            }
         }
 
         private static CssBox? FindById(CssBox box, string id)

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -1592,7 +1592,7 @@ namespace PeachPDF.Html.Core.Dom
                             coordinates.MaxBottom += box.ActualLineHeight - (coordinates.MaxBottom - coordinates.CurrentY);
 
                         var actualLimitRight = limitRight;
-                        var lastRightIntersectingFloatBox = DomUtils.GetLastRightIntersectingFloatBox(box, coordinates, word.FullWidth);
+                        var lastRightIntersectingFloatBox = DomUtils.GetLastRightIntersectingFloatBox(box, coordinates);
 
                         if (lastRightIntersectingFloatBox is not null)
                         {

--- a/src/PeachPDF/Html/Core/Utils/DomUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/DomUtils.cs
@@ -692,38 +692,80 @@ namespace PeachPDF.Html.Core.Utils
             return lastIntersectingFloat;
         }
 
-        public static CssBox? GetLastRightIntersectingFloatBox(CssBox box, CssLineBoxCoordinates coordinates, double referenceWidth)
+        /// <summary>
+        /// A right float's constraint on a line is unlike a left float's: a left float caps where
+        /// the cursor itself currently sits (a point-collision test, correct in
+        /// <see cref="GetLastLeftIntersectingFloatBox"/> above), but a right float caps how far
+        /// right the cursor is *allowed to reach in advance* - a lookahead, independent of the
+        /// cursor's current position or the word being placed. Reusing the point-collision test
+        /// here (as this method used to, by querying <see cref="GetFirstIntersectingFloatBox"/> in
+        /// <see cref="Floating.Left"/> mode) can only detect the float once the cursor has already
+        /// walked into its span, never before - so this scans for every float:right box whose
+        /// vertical span covers the current row and returns the one with the smallest left edge,
+        /// which is the actual binding constraint regardless of where the cursor is right now.
+        /// </summary>
+        public static CssBox? GetLastRightIntersectingFloatBox(CssBox box, CssLineBoxCoordinates coordinates)
         {
-            var left = coordinates.CurrentX;
-            CssBox? lastIntersectingFloat = null;
+            var container = box.HtmlContainer;
+            container?.RecordFloatScanCall();
 
-            // See the matching bound in GetLastLeftIntersectingFloatBox above for why this is needed.
-            var iterations = 0;
-            while (iterations++ < 10000)
+            // See GetFirstIntersectingFloatBox above for why this short-circuit exists.
+            if (container?.HasFloatedBoxes != true)
             {
-                CssFloatCoordinates floatCoordinates = new()
-                {
-                    Left = left,
-                    Top = coordinates.CurrentY,
-                    MarginLeft = box.ActualMarginLeft,
-                    MarginRight = box.ActualMarginRight,
-                    MaxBottom = coordinates.MaxBottom,
-                    ReferenceWidth = referenceWidth,
-                    Right = left + referenceWidth
-                };
-
-                var intersectingFloat = GetFirstIntersectingFloatBox(box, floatCoordinates, Floating.Left);
-
-                if (intersectingFloat is null)
-                {
-                    break;
-                }
-
-                left = intersectingFloat.ActualRight + intersectingFloat.ActualMarginRight;
-                lastIntersectingFloat = intersectingFloat;
+                return null;
             }
 
-            return lastIntersectingFloat;
+            var boxesVisited = 0;
+            var narrowest = FindNarrowestRightFloatBox(box, coordinates.CurrentY, ref boxesVisited);
+            container.RecordFloatScanBoxVisits(boxesVisited);
+            return narrowest;
+        }
+
+        /// <summary>
+        /// Same ancestor/preceding-sibling traversal shape as <see cref="FindIntersectingFloatBox"/>,
+        /// but accumulates the narrowest match across the whole walk instead of returning on the
+        /// first hit - the wrap-limit query needs the binding constraint among every float:right box
+        /// covering this row, not merely the first one the traversal order happens to reach.
+        /// </summary>
+        private static CssBox? FindNarrowestRightFloatBox(CssBox reference, double top, ref int boxesVisited)
+        {
+            CssBox? narrowest = null;
+            var narrowestLeft = double.PositiveInfinity;
+
+            while (reference.ParentBox is not null)
+            {
+                var currentBoxIdx = reference.ParentBox.Boxes.IndexOf(reference);
+
+                for (var i = 0; i < currentBoxIdx; i++)
+                {
+                    ScanForNarrowestRightFloatBox(reference.ParentBox.Boxes[i], top, ref narrowest, ref narrowestLeft, ref boxesVisited);
+                }
+
+                reference = reference.ParentBox;
+            }
+
+            return narrowest;
+        }
+
+        private static void ScanForNarrowestRightFloatBox(CssBox box, double top, ref CssBox? narrowest, ref double narrowestLeft, ref int boxesVisited)
+        {
+            boxesVisited++;
+
+            if (box.Float.Value == Floating.Right && box.Location.Y <= top && top < box.ActualBottom)
+            {
+                var left = box.Location.X - box.ActualMarginLeft;
+
+                if (left < narrowestLeft)
+                {
+                    narrowestLeft = left;
+                    narrowest = box;
+                }
+            }
+
+            foreach (var childBox in box.Boxes)
+            {
+                ScanForNarrowestRightFloatBox(childBox, top, ref narrowest, ref narrowestLeft, ref boxesVisited);
+            }
         }
 
         public static CssBox? GetNearestParentElementBox(CssBox box)


### PR DESCRIPTION
## Summary
- `DomUtils.GetLastRightIntersectingFloatBox` queried `GetFirstIntersectingFloatBox` in `Floating.Left` mode - a point-collision test that only works for left floats (the cursor starts flush against them). For a right float approached from the left, that test can only fire once the cursor has already walked into the float's span, so text was placed straight through `float:right` boxes instead of wrapping before their left edge.
- Replaced it with a dedicated single-pass scan (`FindNarrowestRightFloatBox`/`ScanForNarrowestRightFloatBox`) that finds, among every `float:right` box whose vertical span covers the current row, the one with the smallest left edge - the actual binding constraint, independent of the cursor's current position or the word being placed. This also drops the now-unused `referenceWidth` parameter and the old method's 10000-iteration retry loop, since a single recursive pass already finds the global minimum.
- `GetLastLeftIntersectingFloatBox` was checked, not just assumed correct: its point-collision-then-push algorithm is the right tool for `float:left`, whose constraint genuinely is about the cursor's current position, so it is unchanged. A new test locks this in.

## Test plan
- [x] New `FloatRight_NarrowsLineWrapWidth_SoTextWrapsBeforeReachingIt` - confirmed failing before the fix (word landed at `Rectangle.Right=224.36`, past the float's left edge at `206`), passing after.
- [x] New `FloatLeft_StillNarrowsLineWrapWidth_AfterTheRightFloatFix` - confirms `float:left` wrapping is unaffected.
- [x] Full `net8.0` suite: 8417 passed, 0 failed, 9 skipped.
- [x] `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings.
- [x] Coverage: every new/changed line in `DomUtils.cs`/`CssLayoutEngine.cs` hit by at least one test.