### PR TITLE
Fix float:right sitting short of the containing block's right edge with margin-left

### DIFF
--- a/.claude/migration-notes/2026-08-09-float-right-now-reaches-the-containing-blocks-right-edge-with-margin-left-set.md
+++ b/.claude/migration-notes/2026-08-09-float-right-now-reaches-the-containing-blocks-right-edge-with-margin-left-set.md
@@ -1,0 +1,11 @@
+# `float:right` now reaches the containing block's right edge when `margin-left` is set
+
+**Landed:** 2026-08-09 (9d66a066) — Fix float:right sitting short of containing block by its own margin-left
+**Doc section:** none — this behavior was never separately documented, so there's no callout to remove
+**Verified against v0.9.8:** the buggy formula was already present at the `v0.9.8` tag, so this is a genuine fix relative to the last release, in scope for the next release notes.
+
+A `float:right` element with `margin-left` set used to land short of the containing block's right
+edge (or the nearest intersecting float) by exactly its own `margin-left`, even with `margin-right:
+0`. A box's left margin is space to its own left; it must not shift the box's own right edge inward.
+Such elements now render flush against the containing block's right edge as expected — no document
+change is needed to pick up the fix.

--- a/.claude/migration-notes/2026-08-09-float-right-now-reaches-the-containing-blocks-right-edge-with-margin-left-set.md
+++ b/.claude/migration-notes/2026-08-09-float-right-now-reaches-the-containing-blocks-right-edge-with-margin-left-set.md
@@ -1,6 +1,6 @@
 # `float:right` now reaches the containing block's right edge when `margin-left` is set
 
-**Landed:** 2026-08-09 (9d66a066) — Fix float:right sitting short of containing block by its own margin-left
+**Landed:** 2026-08-09 (9d66a066, fd3759a2) — Fix float:right sitting short of containing block by its own margin-left; Fix stray margin-left term in float:right ancestor-intersection check
 **Doc section:** none — this behavior was never separately documented, so there's no callout to remove
 **Verified against v0.9.8:** the buggy formula was already present at the `v0.9.8` tag, so this is a genuine fix relative to the last release, in scope for the next release notes.
 
@@ -9,3 +9,10 @@ edge (or the nearest intersecting float) by exactly its own `margin-left`, even 
 0`. A box's left margin is space to its own left; it must not shift the box's own right edge inward.
 Such elements now render flush against the containing block's right edge as expected — no document
 change is needed to pick up the fix.
+
+A second, related bug in the same area is fixed alongside it: a `float:right` box nested inside a
+narrower, non-floated block used to sometimes fail to extend out and align with a wider ancestor
+`float:right` sibling when the nested box itself had `margin-left` set — an intersection check that
+used to (accidentally) cancel out the first bug's error term instead inflated its own threshold by
+that same `margin-left` once the first bug was fixed. Both bugs shared one root cause and are fixed
+together here.

--- a/src/PeachPDF.Tests/Integration/FloatLayoutRegressionTests.cs
+++ b/src/PeachPDF.Tests/Integration/FloatLayoutRegressionTests.cs
@@ -300,6 +300,27 @@ namespace PeachPDF.Tests.Integration
         }
 
         [Fact]
+        public async Task FloatRight_WithMarginLeft_StillReachesContainingBlockRightEdge()
+        {
+            // CssFloatCoordinates.FloatRightStartX used to subtract MarginLeft a second time on top
+            // of Right already being margin-right-adjusted (FloatBoxRight sets Right = limitRight -
+            // box.ActualMarginRight), shifting a float:right box's own border-box left/right edges an
+            // extra margin-left to the left. A box's left margin is space to its own left - it must
+            // not pull the box's own right edge inward - so with margin-right:0, dd's border-box
+            // right edge should sit flush against dl's ClientRight regardless of margin-left.
+            var html = Wrap(@"
+                <dl style='width:200pt; margin:0; padding:0; border:0;'>
+                    <dd id='dd' style='float:right; width:80pt; height:20pt; margin:0 0 0 10pt;'></dd>
+                </dl>");
+
+            var (root, _) = await BuildAndLayout(html);
+            var dl = FindById(root, "dd")!.ParentBox!;
+            var dd = FindById(root, "dd")!;
+
+            Assert.Equal(dl.ClientRight, dd.ActualRight, 1);
+        }
+
+        [Fact]
         public async Task FloatLeft_StillNarrowsLineWrapWidth_AfterTheRightFloatFix()
         {
             // Companion to the float:right fix above: GetLastLeftIntersectingFloatBox implements a

--- a/src/PeachPDF.Tests/Integration/FloatLayoutRegressionTests.cs
+++ b/src/PeachPDF.Tests/Integration/FloatLayoutRegressionTests.cs
@@ -268,6 +268,33 @@ namespace PeachPDF.Tests.Integration
         }
 
         [Fact]
+        public async Task FloatRight_InNarrowerNestedBlock_WithMarginLeft_StillAvoidsAWiderAncestorFloatRightSibling()
+        {
+            // Companion to the test above, with margin-left added to the nested float: DomUtils.
+            // IsFloatIntersecting's Floating.Right branch used to add coordinates.MarginLeft into the
+            // threshold it compares the ancestor float's left edge against - a leftover term that used
+            // to cancel out CssFloatCoordinates.FloatRightStartX's own margin-left bug, and became a
+            // second, independent bug once that formula was fixed: it inflates the intersection
+            // threshold by the nested float's own margin-left, so an ancestor float whose left edge
+            // falls within that margin-left-wide window goes undetected and the nested float never
+            // extends out to meet it. outerR's left edge (500 - 280 = 220pt) sits inside exactly that
+            // window here (the correct threshold is 200pt, the buggy one 240pt).
+            var html = Wrap(@"
+                <div style='width:500pt;'>
+                    <div id='outerR' style='float:right; width:280pt; height:80pt;'></div>
+                    <div style='width:200pt;'>
+                        <div id='r' style='float:right; width:100pt; height:30pt; margin-left:40pt;'></div>
+                    </div>
+                </div>");
+
+            var (root, _) = await BuildAndLayout(html);
+            var outerR = FindById(root, "outerR")!;
+            var r = FindById(root, "r")!;
+
+            Assert.Equal(outerR.Location.X - outerR.ActualMarginLeft, r.ActualRight, 1);
+        }
+
+        [Fact]
         public async Task FloatRight_NarrowsLineWrapWidth_SoTextWrapsBeforeReachingIt()
         {
             // DomUtils.GetLastRightIntersectingFloatBox used to query

--- a/src/PeachPDF/Html/Core/Entities/CssFloatCoordinates.cs
+++ b/src/PeachPDF/Html/Core/Entities/CssFloatCoordinates.cs
@@ -9,6 +9,6 @@
         public required double MarginLeft { get; set; }
         public required double MarginRight { get; set; }
         public required double ReferenceWidth { get; set; }
-        public double FloatRightStartX => Right - ReferenceWidth - MarginLeft;
+        public double FloatRightStartX => Right - ReferenceWidth;
     }
 }

--- a/src/PeachPDF/Html/Core/Utils/DomUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/DomUtils.cs
@@ -1079,7 +1079,7 @@ namespace PeachPDF.Html.Core.Utils
             switch (floatProp)
             {
                 case Floating.Left when targetRight > currentLeft && targetLeft <= currentLeft:
-                case Floating.Right when targetLeft > coordinates.FloatRightStartX + coordinates.MarginLeft + coordinates.ReferenceWidth + coordinates.MarginRight:
+                case Floating.Right when targetLeft > coordinates.FloatRightStartX + coordinates.ReferenceWidth + coordinates.MarginRight:
                     return true;
                 default:
                     return false;


### PR DESCRIPTION
## Summary

- `CssFloatCoordinates.FloatRightStartX` subtracted `MarginLeft` a second time on top of `Right` already being margin-right-adjusted, pulling a `float:right` box's own right edge inward by its own `margin-left` — a very common real-world pattern (`float:right; margin-left: <gap>`), and also what was blocking ACID1's `dd { float: right; margin: 0 0 0 1em; }` from matching the reference rendering.
- Fixing that surfaced a second, related bug: `DomUtils.IsFloatIntersecting`'s `Floating.Right` branch had a `+ coordinates.MarginLeft` term that used to (accidentally) cancel out the first bug's error, and became its own bug once the first formula was corrected — a nested `float:right` box with `margin-left` could then fail to detect and align with a wider ancestor `float:right` sibling.
- Both fixes are one-line arithmetic corrections; the `float:left` path was already correct and unaffected. See `.claude/migration-notes/2026-08-09-float-right-now-reaches-the-containing-blocks-right-edge-with-margin-left-set.md` for the detailed write-up.

## Test plan

- [x] Added `FloatRight_WithMarginLeft_StillReachesContainingBlockRightEdge` (fails before the first fix, passes after)
- [x] Added `FloatRight_InNarrowerNestedBlock_WithMarginLeft_StillAvoidsAWiderAncestorFloatRightSibling` (fails before the second fix, passes after — verified by temporarily reverting each fix individually)
- [x] Full `net8.0` suite green (8419 passed)
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings
- [x] Diff coverage 100% on both changed lines