### PR TITLE
Apply atomic-inline vertical inset before the fragmentation break decision

### DIFF
--- a/.claude/migration-notes/2026-08-09-inline-block-lines-near-a-page-or-column-boundary-move-whole.md
+++ b/.claude/migration-notes/2026-08-09-inline-block-lines-near-a-page-or-column-boundary-move-whole.md
@@ -1,0 +1,14 @@
+# `inline-block` lines near a page or column boundary now move whole
+
+Previously: an `inline-block` element (e.g. a padded `<button>`) whose vertical padding/border pushed its
+text past a page or column boundary could have that boundary decided using a position that hadn't yet had
+the padding applied, then relocated word-by-word after the fact. In a fragmented layout (multi-column
+content, or content nested inside a table cell) this could leave part of a line's words on one page/column
+and the rest effectively orphaned relative to the line-level break the rest of the document already
+honors, rather than moving the whole line together.
+
+Now: the padding/border inset is applied before the boundary decision is made, so an `inline-block`'s line
+that doesn't fit moves to the next page or column as a whole - consistent with how every other line in the
+document already breaks (CSS Fragmentation Module Level 3 §4.1: a line box is a monolithic break unit).
+This only changes rendering for content within a padding/border's width of a fragmentation boundary;
+ordinary `inline-block` layout away from a boundary is unaffected.

--- a/.claude/recent-fixes/2026-08-09-atomic-inline-vertical-inset-pre-shifted-instead-of-relocated-after.md
+++ b/.claude/recent-fixes/2026-08-09-atomic-inline-vertical-inset-pre-shifted-instead-of-relocated-after.md
@@ -1,0 +1,61 @@
+# Atomic-inline vertical inset pre-shifted instead of relocated after
+
+_Landed 2026-08-09._
+
+[Issue #333](https://github.com/jhaygood86/PeachPDF/issues/333): `CssLayoutEngine.FlowBox`'s
+`ApplyAtomicInlineVerticalInsets`/`OffsetFlowedWords` shifted an atomic inline-level box's
+(`display:inline-block`) already-placed words down by its own border-top+padding-top (CSS2.1 §8.1),
+then re-ran the pre-#321 per-word `CssRect.BreakPage()` relocation on each shifted word - *after* the
+line's break-token decision had already been made, so the shift could silently push a line back across
+a fragmentainer boundary the token model had just decided was fine.
+
+**Fixed by pre-shifting instead of correcting after the fact.** `FlowBox`'s per-child loop now shifts
+`coordinates.CurrentY` by the child's own top inset *before* flowing its content (gated on
+`childOpensHere`, so a continuation resuming in a later fragmentainer never re-pays a padding it already
+paid on an earlier one), restoring it afterward only if the child's content stayed on the line it
+started on (detected by comparing `coordinates.Line` by reference - an inline-block's content can wrap
+onto more than one internal line inside the same recursive call, and a wrapped later line's `CurrentY`
+already derives correctly from the pre-shifted `MaxBottom`, not from re-adding the shift). This lets the
+existing, unmodified per-word `WouldStraddleFragmentainer` check make the correct call the first time,
+for every internal line, not just the first - `CreateLineBoxes` can only discard one in-progress line at
+a time, so a shift-then-recheck design (discovering the straddle only after the whole subtree had
+already been placed) could never have handled a straddle on a line *other* than the last one.
+
+**The second call site the issue's own follow-up comments flagged as blocking full closure turned out to
+already be resolved.** `FlowBox`'s own `else { word.BreakPage(); }` arm (taken when
+`coordinates.Fragmentainer` is null) was, at the time #333 was filed, the only mechanism that paginated a
+table cell's text - the table engine ran behind a detached fragmentainer. That changed with #464 (closed
+2026-07-30, part of the #390 epic): `CssBox.LayoutContents`'s table arm no longer runs behind a detached
+fragmentainer, and cell content now sees a live one like everything else. Verified this made the `else`
+arm dead by running the full suite after removing it entirely (8418 passing, including every
+`TableCellLineFragmentationTests` case and `StraddlingImage_MovesWholeThroughTheWordPath`, whose own
+comment had claimed it still needed the legacy relocation - that comment predated the migration and was
+simply stale). This let `CssRect.BreakPage`/`WouldStraddleItsOwnBand` be deleted outright (exactly two
+production callers, both retired here) along with `CssBox.BreakPage`/`CssSpacingBox.BreakPage` (zero
+production callers - only three now-removed unit tests exercised it directly).
+
+**A real double-counting bug surfaced during review, not by reading the diff but by A/B-testing it against
+`main`.** `FlowBox.FinalizeFlowBoxExit`'s "handle height setting" fallback (extends a block's `MaxBottom`
+to cover an atomic inline box's own declared height when its flowed content came out shorter, e.g. a
+button whose padding exceeds one small text line) anchors the correction on `startY`, captured at the
+*callee's own* entry - which, for a box reached through the recursive branch, is now the pre-shifted
+content-box top rather than the border-box top the fallback's `ActualHeight` term assumes. Left alone,
+the top inset would be counted twice for exactly the boxes this whole fix targets. Fixed by reconstructing
+the true border-box top (`startY` minus the same inset, recomputed from the box's own properties) before
+either of `FinalizeFlowBoxExit`'s two fallbacks (height and the analogous width/rect one) use it. Neither
+the pre-existing test (a `>=` lower bound, which an over-large height still satisfies) nor this fix's own
+first pair of new tests (word position only) would have caught it - closed with a new test asserting the
+block's height against an exact expected value, confirmed to fail without the `trueStartY` correction.
+
+Tests: two new multi-column tests in `InlineBlockHeightRegressionTests.cs` pin the fragmentainer case
+specifically - a single-line inline-block whose padding-top alone crosses a column boundary (whole line
+moves, and since nothing was kept anywhere the resumed pass re-applies the inset once), and a two-internal-line
+box (via forced `<br>`) where only the second line straddles and moves alone *without* re-applying the
+inset (a genuine continuation, not a fresh opening of the box's content) - plus a tight height-equality
+test pinning the `FinalizeFlowBoxExit` fix. `orphans:1; widows:1` is set explicitly in the two-line
+fixture to isolate the mechanism under test from the UA default orphans/widows relaxation (which would
+otherwise refuse to leave a single orphan line behind and move the whole two-line box - a different,
+already-tested mechanism). `column-fill: auto` is set to get sequential column filling rather than the
+default balance, which redistributes content across columns even when it would all fit in one. Full net8.0
+suite: 8419 passing, 9 skipped (pre-existing). CLI: 96/96. 100% diff coverage. `dotnet build
+PeachPDF.slnx -t:Rebuild`: 0 warnings.

--- a/src/PeachPDF.Tests/Html/Core/Fragments/FragmentEmitterTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Fragments/FragmentEmitterTests.cs
@@ -225,8 +225,9 @@ namespace PeachPDF.Tests.Html.Core.Fragments
 
             Assert.NotEmpty(perWord);
 
-            // Words are monolithic - CssRect.BreakPage relocates a whole word rather than splitting
-            // it - so no word may be claimed by two fragmentainers.
+            // Words are monolithic - CssRect.WouldStraddleFragmentainer moves a whole straddling line
+            // to the next fragmentainer rather than splitting a word across the boundary - so no word
+            // may be claimed by two fragmentainers.
             Assert.All(perWord, entry => Assert.Single(entry.Value.Distinct()));
         }
 

--- a/src/PeachPDF.Tests/Html/Core/HtmlContainerIntPageGridTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/HtmlContainerIntPageGridTests.cs
@@ -10,8 +10,9 @@ namespace PeachPDF.Tests.Html.Core
     /// derived <see cref="HtmlContainerInt.PageBandHeightOf"/>/<see cref="HtmlContainerInt.PageBottomOf"/>/
     /// <see cref="HtmlContainerInt.NextPageTopOf"/> every page-boundary decision now routes through.
     /// On the uniform grid these identities pin the arithmetic the raw-math call sites were migrated
-    /// away from (modulo in CssBox/CssRect.BreakPage, hand-rolled pageIndex/pageTop in the table and
-    /// multicol engines).
+    /// away from (hand-rolled pageIndex/pageTop in the table and multicol engines; the pre-#321
+    /// per-word/per-box <c>CssRect</c>/<c>CssBox.BreakPage</c> relocation this migrated away from
+    /// entirely was retired by issue #333).
     /// </summary>
     public class HtmlContainerIntPageGridTests
     {
@@ -80,52 +81,6 @@ namespace PeachPDF.Tests.Html.Core
                 Assert.Equal(k, container.PageIndexOf(container.PageTopOf(k)));
         }
 
-        // ── CssBox.BreakPage (the block-level relocation used by table spacing boxes) ──
-
-        [Fact]
-        public void CssBoxBreakPage_StraddlingBox_RelocatesToNextSlotTop()
-        {
-            var container = CreateContainer();
-            var box = PeachPDF.Html.Core.Dom.CssBox.CreateBlock();
-            box.HtmlContainer = container;
-            box.Location = new RPoint(0, MarginTop + BandHeight - 50);
-            box.ActualBottom = MarginTop + BandHeight + 50;
-
-            Assert.True(box.BreakPage());
-            // The slot's own content edge, per css-break-3 §2. This used to land one unit below it,
-            // to keep the relocated box off the exact boundary value - a question PageIndexOf's own
-            // epsilon already answers, as the flush-fit case below shows.
-            Assert.Equal(container.PageTopOf(1), box.Location.Y);
-            Assert.Equal(1, container.PageIndexOf(box.Location.Y));
-        }
-
-        [Fact]
-        public void CssBoxBreakPage_FlushFitAtBoundary_DoesNotRelocate()
-        {
-            // A box ending exactly ON a slot boundary is wholly inside the earlier slot - the
-            // flush-fit epsilon makes it a non-break (the historical modulo formulation spuriously
-            // relocated it a full page).
-            var container = CreateContainer();
-            var box = PeachPDF.Html.Core.Dom.CssBox.CreateBlock();
-            box.HtmlContainer = container;
-            box.Location = new RPoint(0, MarginTop + BandHeight - 100);
-            box.ActualBottom = MarginTop + BandHeight;
-
-            Assert.False(box.BreakPage());
-            Assert.Equal(MarginTop + BandHeight - 100, box.Location.Y);
-        }
-
-        [Fact]
-        public void CssBoxBreakPage_TallerThanBand_NeverRelocates()
-        {
-            var container = CreateContainer();
-            var box = PeachPDF.Html.Core.Dom.CssBox.CreateBlock();
-            box.HtmlContainer = container;
-            box.Location = new RPoint(0, MarginTop + 10);
-            box.ActualBottom = MarginTop + 10 + BandHeight + 5;
-
-            Assert.False(box.BreakPage());
-        }
         [Fact]
         public void SlotStartingAt_ATopEdgeFlushOnABoundary_BeginsTheLaterSlot()
         {

--- a/src/PeachPDF.Tests/Integration/FlexReplacedElementPageBreakIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FlexReplacedElementPageBreakIntegrationTests.cs
@@ -25,7 +25,7 @@ namespace PeachPDF.Tests.Integration
     /// content size - <c>AssignLocations</c> always translates the item to its real final position
     /// afterward via <c>CssBox.OffsetTop</c>. But that temporary position can itself straddle a page
     /// boundary, and <see cref="CssLayoutEngine.FlowBox"/>'s per-word page-break-avoidance check
-    /// (<c>CssRect.BreakPage</c>) would fire against it, permanently jumping the item's phantom word
+    /// (<c>CssRect.WouldStraddleFragmentainer</c>) would fire against it, permanently jumping the item's phantom word
     /// to the next page - independently of the item's own <c>Location</c>, which stays put. The later
     /// translation only shifts <c>Location</c> by a delta computed from itself, so the word's spurious
     /// jump survives untouched, permanently desyncing painted content from its own box.
@@ -42,7 +42,7 @@ namespace PeachPDF.Tests.Integration
     /// that cell - so a re-check at that point could itself fire against a not-yet-relocated
     /// position and reintroduce the exact word/Location desync bug one level later (confirmed by
     /// re-generating and visually inspecting the SVG showcase after adding it). Word-level
-    /// page-break avoidance (<c>CssRect.BreakPage</c>) was therefore simply unavailable for
+    /// page-break avoidance (<c>CssRect.WouldStraddleFragmentainer</c>) was therefore simply unavailable for
     /// content inside any <c>display:flex</c> container, in exchange for correctness.
     ///
     /// <b>Superseded, for one shape, by issue #430's fix.</b> <c>CssLayoutEngineFlex</c> now runs a

--- a/src/PeachPDF.Tests/Integration/InlineBlockHeightRegressionTests.cs
+++ b/src/PeachPDF.Tests/Integration/InlineBlockHeightRegressionTests.cs
@@ -44,6 +44,44 @@ namespace PeachPDF.Tests.Integration
                 $"Block height ({height}) must cover the inline-block's own 200px of vertical padding");
         }
 
+        // A tighter companion to the test above: asserts the block's height against the button's own
+        // measured insets and word height, not just a loose lower bound - a lower bound alone cannot
+        // catch OVER-counting. This is the shape that let the pre-shift design (issue #333) land with
+        // FinalizeFlowBoxExit's "handle height setting" fallback silently double-counting the button's
+        // own top inset (border-top+padding-top) for a box reached through FlowBox's recursive branch:
+        // `startY`, captured at that nested call's own entry, already named the content-box top (this
+        // issue's pre-shift), while ActualHeight is a border-box measurement, so summing them counted
+        // the top inset twice. `height >= 200` alone does not notice a result that is too large.
+        [Fact]
+        public async Task PaddedInlineBlock_SoleContentOfBlock_BlockHeightMatchesInsetsExactly()
+        {
+            const string html = @"<!DOCTYPE html>
+<html>
+<body style='margin: 0'>
+<div style='height: 300px'>filler</div>
+<div class='wrapper'><button class='btn' style='padding: 100px 14px'>Go</button></div>
+</body>
+</html>";
+
+            var (rootBox, _) = await BuildCssBoxTree(html);
+
+            var wrapper = FindBoxByClass(rootBox, "wrapper");
+            var button = FindBoxByClass(rootBox, "btn");
+            Assert.NotNull(wrapper);
+            Assert.NotNull(button);
+
+            var word = FindFirstWord(button!);
+            Assert.NotNull(word);
+
+            var expectedHeight = button!.ActualBorderTopWidth + button.ActualPaddingTop
+                + word!.Height
+                + button.ActualBorderBottomWidth + button.ActualPaddingBottom;
+            var actualHeight = wrapper!.ActualBottom - wrapper.Location.Y;
+
+            Assert.True(Math.Abs(actualHeight - expectedHeight) < 0.5,
+                $"Block height ({actualHeight}) must equal the button's own top inset + word height + bottom inset ({expectedHeight}) exactly, not merely cover it - a value this far off (e.g. the top inset counted twice) would still pass a '>=' check");
+        }
+
         [Fact]
         public async Task PaddedInlineBlock_TallerContentLine_DoesNotShrinkBlock()
         {
@@ -213,16 +251,111 @@ namespace PeachPDF.Tests.Integration
                 $"Inset-shifted word must not straddle a page boundary (top={word.Top:F1}, bottom={word.Bottom:F1}, pageHeight={pageHeight})");
         }
 
+        // The multi-column analog of InsetShiftNearPageBoundary_WordsDoNotStraddleThePage: under the
+        // break-token model (issue #333) a fragmentainer straddle discovered by the inset shift must
+        // move the WHOLE line to column 2 - landing at that column's own content top - rather than
+        // merely avoid straddling within column 1's own band (which the pre-#333 per-word relocation
+        // could do just as well, and would make an assertion of "not straddling" alone pass for the
+        // wrong reason). Column 1 comfortably fits the un-inset word; only the padding-top shift pushes
+        // it past the column's bottom.
+        [Fact]
+        public async Task InsetShiftNearColumnBoundary_WholeLineMovesToNextColumn()
+        {
+            var html = @"<!DOCTYPE html>
+<html>
+<body style='margin: 0'>
+<div id='mc' style='columns: 2; column-gap: 0; column-fill: auto; width: 200pt'>
+<div style='height: 220pt'>filler</div>
+<button id='btn' style='padding-top: 60pt'>Go</button>
+</div>
+</body>
+</html>";
+
+            var (root, _) = await BuildCssBoxTree(html, width: 200, height: 300);
+
+            var mc = FindFirst(root, b => b.HtmlTag?.TryGetAttribute("id", "") == "mc");
+            var button = FindFirst(root, b => b.HtmlTag?.TryGetAttribute("id", "") == "btn");
+            Assert.NotNull(mc);
+            Assert.NotNull(button);
+
+            var word = FindFirstWord(button!);
+            Assert.NotNull(word);
+
+            var columnWidth = (mc!.ClientRight - mc.ClientLeft) / 2;
+            Assert.True(word!.Left >= mc.ClientLeft + columnWidth - 0.1,
+                $"expected the inset-shifted line to move whole to column 2 (columnWidth={columnWidth}), word is at x={word.Left}");
+            // The button's only line never got kept anywhere, so this pass genuinely opens the box's
+            // content from its own top - the 60pt padding-top applies here exactly as it would have in
+            // column 1, landing the word at column 2's content top plus its own inset, not at Y~0.
+            Assert.True(Math.Abs(word.Top - 60) < 5,
+                $"expected padding-top (60) to apply once, at column 2's own content top, word top={word.Top}");
+        }
+
+        // An inline-block's content can wrap onto more than one internal line (CssLayoutEngine.FlowBox
+        // recurses into the SAME blockBox.LineBoxes list for it) - the pre-shift design this issue
+        // introduced has to get every such line right individually, not just the first, since
+        // CreateLineBoxes can only discard one in-progress line at a time. Here the first internal line
+        // (after the padding-top shift) still fits column 1; only the second, forced-break line straddles
+        // and moves alone. Distinct from the previous test in a way worth pinning: this resumed pass is a
+        // CONTINUATION of the box's content (its first line already landed in column 1), so padding-top
+        // must NOT apply a second time - only a pass that genuinely opens the box's own content does that.
+        // orphans/widows are relaxed to 1 to isolate that mechanism from this one: the UA default of 2
+        // would otherwise refuse to leave a single orphan line behind and move the whole two-line box,
+        // which is a different (and already-tested) mechanism, not the one under test here.
+        [Fact]
+        public async Task InsetShiftedInlineBlock_SecondInternalLine_MovesAloneToNextColumn()
+        {
+            var html = @"<!DOCTYPE html>
+<html>
+<body style='margin: 0'>
+<div id='mc' style='columns: 2; column-gap: 0; column-fill: auto; width: 200pt; orphans: 1; widows: 1'>
+<div style='height: 150pt'>filler</div>
+<span id='btn' style='display:inline-block; padding-top: 60pt'>First<br>Second</span>
+</div>
+</body>
+</html>";
+
+            var (root, _) = await BuildCssBoxTree(html, width: 200, height: 300);
+
+            var mc = FindFirst(root, b => b.HtmlTag?.TryGetAttribute("id", "") == "mc");
+            var button = FindFirst(root, b => b.HtmlTag?.TryGetAttribute("id", "") == "btn");
+            Assert.NotNull(mc);
+            Assert.NotNull(button);
+
+            var firstWord = AllWords(button!).Single(w => w.Text == "First");
+            var secondWord = AllWords(button!).Single(w => w.Text == "Second");
+
+            var columnWidth = (mc!.ClientRight - mc.ClientLeft) / 2;
+
+            Assert.True(firstWord.Left < mc.ClientLeft + columnWidth - 0.1,
+                $"expected the button's first internal line to stay in column 1, word is at x={firstWord.Left}");
+            Assert.True(secondWord.Left >= mc.ClientLeft + columnWidth - 0.1,
+                $"expected the button's second internal line to move alone to column 2, word is at x={secondWord.Left}");
+            // A continuation, not an opening pass: the box's first line already landed in column 1, so
+            // padding-top must not be re-applied here - the word starts at column 2's raw content top.
+            Assert.True(secondWord.Top < 15,
+                $"expected the resumed (continuation) line to start at column 2's raw content top with no re-applied inset, word top={secondWord.Top}");
+        }
+
         #region Helpers
 
         private static async Task<(CssBox root, HtmlContainerInt container)> BuildCssBoxTree(string html)
         {
+            return await BuildCssBoxTree(html, width: 595, height: 842);
+        }
+
+        private static async Task<(CssBox root, HtmlContainerInt container)> BuildCssBoxTree(string html, double width, double height)
+        {
             var adapter = new PdfSharpAdapter();
             var container = new HtmlContainerInt(adapter);
+            container.MarginTop = 0;
+            container.MarginLeft = 0;
+            container.MarginRight = 0;
+            container.MarginBottom = 0;
 
             await container.SetHtml(html, null);
 
-            var size = new XSize(595, 842);
+            var size = new XSize(width, height);
             container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
             container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
 
@@ -258,6 +391,18 @@ namespace PeachPDF.Tests.Integration
             }
 
             return null;
+        }
+
+        private static List<CssRect> AllWords(CssBox box)
+        {
+            var words = new List<CssRect>(box.Words);
+
+            foreach (var child in box.Boxes)
+            {
+                words.AddRange(AllWords(child));
+            }
+
+            return words;
         }
 
         private static CssBox? FindBoxByClass(CssBox root, string className)

--- a/src/PeachPDF.Tests/Integration/KeepWithNextIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/KeepWithNextIntegrationTests.cs
@@ -128,7 +128,8 @@ namespace PeachPDF.Tests.Integration
 
         // The canonical real-document case: a heading followed by a plain paragraph. The paragraph
         // is not relocated wholesale - word flow pushes its first LINE to the next page
-        // (CssRect.BreakPage) - and the keep-with-next retry must still bring the heading along.
+        // (CssRect.WouldStraddleFragmentainer records a break rather than letting the line straddle)
+        // - and the keep-with-next retry must still bring the heading along.
         [Fact]
         public async Task ParagraphFirstLinePushedByWordFlow_PullsAvoidChainedHeadingAlong()
         {

--- a/src/PeachPDF.Tests/Integration/MonolithicContentLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/MonolithicContentLayoutIntegrationTests.cs
@@ -255,9 +255,10 @@ namespace PeachPDF.Tests.Integration
 
         // The replaced half of §2 reaches the same outcome by a different route: an <img> is forced inline
         // (DomParser.CorrectReplacedElementBoxes), so it never runs the epilogue's mover at all - its whole
-        // word is relocated by CssRect.BreakPage instead. Worth pinning, because the predicate's
-        // CssBoxImage/CssBoxSvg arms are unreachable from the mover and it would be easy to read that as
-        // the rule not being delivered.
+        // word moves through the ordinary per-word fragmentainer check instead
+        // (CssRect.WouldStraddleFragmentainer/InlineBreakToken, in CssLayoutEngine.FlowBox), the same path
+        // any other word takes. Worth pinning, because the predicate's CssBoxImage/CssBoxSvg arms are
+        // unreachable from the mover and it would be easy to read that as the rule not being delivered.
         [Fact]
         public async Task StraddlingImage_MovesWholeThroughTheWordPath()
         {

--- a/src/PeachPDF.Tests/Integration/PerPageGeometryLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/PerPageGeometryLayoutIntegrationTests.cs
@@ -141,9 +141,9 @@ namespace PeachPDF.Tests.Integration
             Assert.Equal(BaseMt + rightBand + leftBand, container.PageTopOf(2));
 
             // Text must fragment at the VARIABLE boundaries: no laid-out word may straddle a slot
-            // boundary (CssRect.BreakPage relocates a straddling line to the next band's top), and
-            // the flow must genuinely reach past the first two bands so several variable
-            // boundaries were actually exercised.
+            // boundary (CssRect.WouldStraddleFragmentainer moves a straddling line to the next band's
+            // top as a whole), and the flow must genuinely reach past the first two bands so several
+            // variable boundaries were actually exercised.
             var words = new List<PeachPDF.Html.Core.Dom.CssRect>();
             CollectWords(container.Root!, words);
             Assert.NotEmpty(words);

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -4468,9 +4468,9 @@ namespace PeachPDF.Html.Core.Dom
             CssLayoutEngine.ApplyHeight(this);
             CssLayoutEngine.ApplyParentHeight(this);
 
-            // css-break keep-with-next at the word-flow fragmentation site: word flow relocates any
-            // line that would straddle a page boundary to the next page (CssRect.BreakPage, called
-            // from CssLayoutEngine.FlowBox). When that happens to this block's FIRST line, the break
+            // css-break keep-with-next at the word-flow fragmentation site: word flow moves any line
+            // that would straddle a page boundary to the next page as a whole (CssRect.WouldStraddleFragmentainer,
+            // asked from CssLayoutEngine.FlowBox). When that happens to this block's FIRST line, the break
             // effectively falls right before this box's content - so preceding siblings chained to it
             // by break-after/break-before: avoid (css-break §3.1, e.g. the UA default
             // `h1-h6 { break-after: avoid }`) must not be left behind on the old page. Move the
@@ -5625,27 +5625,6 @@ namespace PeachPDF.Html.Core.Dom
 
             var inFlowChildren = Boxes.Where(b => !b.IsOutOfFlow && b.DerivedStyle.ActualDisplay != Keywords.None && b != this).ToList();
             return inFlowChildren.Count == 0 || inFlowChildren.All(b => b.IsMarginCollapseThrough(depth + 1));
-        }
-
-        public virtual bool BreakPage()
-        {
-            var container = HtmlContainer;
-
-            if (Size.Height >= container!.PageSize.Height)
-                return false;
-
-            // Given the height guard above, the box straddles a slot boundary exactly when its top
-            // and bottom land in different slots. The epsilons make a flush fit a NON-break: a box
-            // ending exactly ON a boundary is wholly inside the earlier slot (css-break-3 - no
-            // spurious relocation for exact-fit content), where the historical modulo formulation
-            // relocated it by a page.
-            if (container.SlotStartingAt(Location.Y)
-                >= container.SlotEndingAt(ActualBottom))
-                return false;
-
-            Location = Location with { Y = container.NextPageTopOf(Location.Y) };
-
-            return true;
         }
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -1289,10 +1289,22 @@ namespace PeachPDF.Html.Core.Dom
         /// </summary>
         private static void FinalizeFlowBoxExit(CssBox box, CssBox blockBox, CssLineBoxCoordinates coordinates, bool opensHere, int startOrdinal, double startX, double startY)
         {
+            // FlowBox's per-child loop pre-shifts CurrentY by box's own border-top+padding-top before
+            // recursing into an atomic inline-level (display:inline-block) box's content (issue #333),
+            // so when this box was reached that way, `startY` (captured at this call's own entry) names
+            // the CONTENT box's top, not the border box's - while ActualHeight below is a border-box
+            // measurement. The two fallbacks that follow reconstruct this box's own border-box rectangle
+            // from `startY`/`ActualHeight`, so they must undo that shift first, or they double-count the
+            // top inset on top of what ActualHeight already carries. A zero inset (no border/padding, or
+            // a display this box's own pre-shift never applies to) leaves this a no-op.
+            var trueStartY = box.DerivedStyle.ActualDisplay is Keywords.InlineBlock
+                ? startY - (box.ActualBorderTopWidth + box.ActualPaddingTop)
+                : startY;
+
             // handle height setting: the flowed content came out shorter than the box's own
             // ActualHeight (e.g. an inline-block button whose vertical padding exceeds its one
             // small-font text line), so extend MaxBottom to cover the box's full height from
-            // where it started. This must be startY-anchored: the old
+            // where it started. This must be trueStartY-anchored: the old
             // `MaxBottom = ActualHeight - (MaxBottom - startY)` form assigned the deficit as an
             // ABSOLUTE document Y (a tiny value near the page top), dragging MaxBottom above
             // startY - when such a box was a block's last/only inline content, the block's
@@ -1313,9 +1325,9 @@ namespace PeachPDF.Html.Core.Dom
             // box's whole height, so it only means anything for a box this pass both opened and
             // finished. For one it merely walked through the deficit is the box's entire height, which
             // it would then add to the flow all over again.
-            if (opensHere && box.DerivedStyle.ActualDisplay is not Keywords.Inline && coordinates.MaxBottom - startY < box.ActualHeight)
+            if (opensHere && box.DerivedStyle.ActualDisplay is not Keywords.Inline && coordinates.MaxBottom - trueStartY < box.ActualHeight)
             {
-                coordinates.MaxBottom = startY + box.ActualHeight;
+                coordinates.MaxBottom = trueStartY + box.ActualHeight;
             }
 
             // handle width setting
@@ -1333,7 +1345,7 @@ namespace PeachPDF.Html.Core.Dom
             {
                 // hack for actual width handling
                 coordinates.CurrentX += box.ActualWidth - (coordinates.CurrentX - startX);
-                coordinates.Line.Rectangles.Add(box, new RRect(startX, startY, box.ActualWidth, box.ActualHeight));
+                coordinates.Line.Rectangles.Add(box, new RRect(startX, trueStartY, box.ActualWidth, box.ActualHeight));
             }
 
             // handle box that is only a whitespace
@@ -1498,6 +1510,34 @@ namespace PeachPDF.Html.Core.Dom
                 // fragmentainer placed?
                 var childStartOrdinal = coordinates.WordOrdinal;
                 var childOpensHere = childStartOrdinal >= coordinates.ResumeOrdinal;
+
+                // CSS2.1 §8.1 box model: an atomic inline-level box's (display:inline-block) content sits
+                // inside its padding box, border-top+padding-top below its own top edge. Applied here,
+                // before any of b's content is placed, rather than shifting already-placed words
+                // afterward (issue #333) - so the ordinary per-word WouldStraddleFragmentainer check
+                // below sees the real final position from the start, for every line b's own content may
+                // wrap onto, not just the first (CreateLineBoxes can only discard one in-progress line,
+                // so a straddle discovered only on a later internal line would have no way to discard the
+                // earlier ones). Guarded with !ReferenceEquals(b, box) for the self-iteration case
+                // (boxes = [box], b == box) even though the two conditions that would have to coincide
+                // for it to fire never do: self-iteration requires box.Words.Count > 0, but reaching this
+                // loop as a nested FlowBox call at all requires the PARENT's own per-child dispatch to
+                // have found b.Words.Count == 0 (a box holding words directly takes the loop's other,
+                // non-recursive branch instead) - the same b can't satisfy both. Kept explicit rather than
+                // assumed, since a display:inline-block box acquiring direct words in the future would
+                // silently double the shift here rather than fail loudly. Only on the pass that opens b's
+                // own content (childOpensHere): a continuation must not re-push a box's later lines down
+                // by a padding it already paid on an earlier fragmentainer.
+                var appliesAtomicInset = b.DerivedStyle.ActualDisplay is Keywords.InlineBlock && !ReferenceEquals(b, box);
+                var atomicTopInset = appliesAtomicInset ? b.ActualBorderTopWidth + b.ActualPaddingTop : 0;
+                var atomicBottomInset = appliesAtomicInset ? b.ActualBorderBottomWidth + b.ActualPaddingBottom : 0;
+                var preShiftedForAtomicInset = childOpensHere && atomicTopInset > 0;
+                var lineBeforeChild = coordinates.Line;
+
+                if (preShiftedForAtomicInset)
+                {
+                    coordinates.CurrentY += atomicTopInset;
+                }
 
                 var leftSpacing = (b.Position.Value != PositionMode.Absolute && b.Position.Value != PositionMode.Fixed) ? b.ActualMarginLeft + b.ActualBorderLeftWidth + b.ActualPaddingLeft : 0;
                 var rightSpacing = (b.Position.Value != PositionMode.Absolute && b.Position.Value != PositionMode.Fixed) ? b.ActualMarginRight + b.ActualBorderRightWidth + b.ActualPaddingRight : 0;
@@ -1728,45 +1768,46 @@ namespace PeachPDF.Html.Core.Dom
                         // claimed that line in both bands and it painted sliced in half on each. The
                         // giveaway is that wrapping the identical text in a block inside the same cell
                         // was already correct - the nested box is not a cell, so it never took this arm.
-                        if (box is { IsFixed: false } && box.HtmlContainer?.SuppressWordPageBreaks != true)
+                        //
+                        // A null Fragmentainer means there is nothing here to ask (issue #400: "a
+                        // measurement pass names no fragmentainer at all" - the question is meaningless
+                        // there, not merely unanswerable), so this is simply skipped rather than falling
+                        // back to a relocation - issue #333 retired the last caller of the pre-#321
+                        // per-word CssRect.BreakPage mechanism that used to run here.
+                        if (box is { IsFixed: false } && box.HtmlContainer?.SuppressWordPageBreaks != true
+                            && coordinates.Fragmentainer is not null)
                         {
-                            if (coordinates.Fragmentainer is not null)
+                            // The same question CssRect.BreakPage used to ask after the fact, answered
+                            // here instead so this flow can stop before placing the word rather than
+                            // relocating it and carrying on. The break is taken at the start of the line,
+                            // not at this word: a line box is monolithic (css-break-3 §4.1), so the whole
+                            // of it moves to the next fragmentainer rather than leaving its shorter words
+                            // behind.
+                            if (word.WouldStraddleFragmentainer())
                             {
-                                // The same question CssRect.BreakPage asks, answered one step earlier so
-                                // this flow can stop here instead of relocating the word and carrying on.
-                                // The break is taken at the start of the line, not at this word: a line
-                                // box is monolithic (css-break-3 §4.1), so the whole of it moves to the
-                                // next fragmentainer rather than leaving its shorter words behind.
-                                if (word.WouldStraddleFragmentainer())
-                                {
-                                    // CompletedLineCount is filled in by CreateLineBoxes once the
-                                    // in-progress line has been discarded, since that is what fixes how
-                                    // many lines this fragmentainer actually kept.
-                                    coordinates.Break = new InlineBreakToken(
-                                        blockBox,
-                                        // Derived from where the break actually fell (the band this line
-                                        // was trying to sit in), never assumed to be "the pass after this
-                                        // one" - see ResumeSlotForBreakBefore's own remarks.
-                                        word.ResumeSlotForBreakBefore(),
-                                        [], coordinates.LineStartOrdinal, CompletedLineCount: 0,
-                                        FollowsForcedBreak: coordinates.Line.FollowsForcedBreak);
-                                    return;
-                                }
-
-                                // A word too tall for any fragmentainer overflows the one it is in
-                                // rather than breaking (css-break-3 §2) - so the words after it, on this
-                                // same line or a later one, flow into whatever band follows without a
-                                // break ever recording the crossing. Step the cursor there so any further
-                                // fragmentation question this pass asks answers about the band flow has
-                                // actually reached, not the one this overflowing word started in - #435.
-                                if (word.OverflowsEveryFragmentainer())
-                                {
-                                    coordinates.Fragmentainer.StepOverTo(box.HtmlContainer!.SlotEndingAt(word.Bottom));
-                                }
+                                // CompletedLineCount is filled in by CreateLineBoxes once the
+                                // in-progress line has been discarded, since that is what fixes how
+                                // many lines this fragmentainer actually kept.
+                                coordinates.Break = new InlineBreakToken(
+                                    blockBox,
+                                    // Derived from where the break actually fell (the band this line
+                                    // was trying to sit in), never assumed to be "the pass after this
+                                    // one" - see ResumeSlotForBreakBefore's own remarks.
+                                    word.ResumeSlotForBreakBefore(),
+                                    [], coordinates.LineStartOrdinal, CompletedLineCount: 0,
+                                    FollowsForcedBreak: coordinates.Line.FollowsForcedBreak);
+                                return;
                             }
-                            else
+
+                            // A word too tall for any fragmentainer overflows the one it is in
+                            // rather than breaking (css-break-3 §2) - so the words after it, on this
+                            // same line or a later one, flow into whatever band follows without a
+                            // break ever recording the crossing. Step the cursor there so any further
+                            // fragmentation question this pass asks answers about the band flow has
+                            // actually reached, not the one this overflowing word started in - #435.
+                            if (word.OverflowsEveryFragmentainer())
                             {
-                                word.BreakPage();
+                                coordinates.Fragmentainer.StepOverTo(box.HtmlContainer!.SlotEndingAt(word.Bottom));
                             }
                         }
 
@@ -1786,18 +1827,17 @@ namespace PeachPDF.Html.Core.Dom
                     // A box holding its words directly (e.g. a ::before/::after pseudo-element,
                     // whose generated text lives on the box itself rather than an anonymous
                     // child) never goes through the FlowBox recursion below, so it gets its
-                    // atomic-inline vertical insets here. Skipped for the self-iteration case
-                    // (boxes = [box], b == box): there the insets are applied by the PARENT's
-                    // own recursion branch after this call returns - applying both would inset
-                    // the words twice.
+                    // atomic-inline vertical insets (the bottomInset/MaxBottom bookkeeping - the
+                    // topInset itself was already applied before this box's words above were placed)
+                    // here. Skipped for the self-iteration case (boxes = [box], b == box): there the
+                    // insets are applied by the PARENT's own recursion branch after this call returns -
+                    // applying both would double the bottom inset.
                     //
-                    // ...and neither does a box this pass placed nothing for: the inset shifts every
-                    // word the box has flowed, so re-running it on a resumed pass would move an
-                    // earlier fragmentainer's words down again, once per pass after the one that
-                    // placed them.
+                    // ...and neither does a box this pass placed nothing for: a box this pass placed
+                    // none for has already had its bookkeeping done by the pass that placed it.
                     if (!ReferenceEquals(b, box) && coordinates.PlacedSince(childStartOrdinal))
                     {
-                        ApplyAtomicInlineVerticalInsets(b, box, coordinates);
+                        ApplyAtomicInlineVerticalInsets(b, coordinates, atomicBottomInset);
                     }
                 }
                 else if (b.DerivedStyle.ActualDisplay == Keywords.InlineFlex)
@@ -1824,8 +1864,18 @@ namespace PeachPDF.Html.Core.Dom
                     // box it placed none for has already had it.
                     if (coordinates.PlacedSince(childStartOrdinal))
                     {
-                        ApplyAtomicInlineVerticalInsets(b, box, coordinates);
+                        ApplyAtomicInlineVerticalInsets(b, coordinates, atomicBottomInset);
                     }
+                }
+
+                // Undoes the pre-shift above for whatever comes after b on the same line: the shift must
+                // only affect b's own content, never a sibling's. Left alone when b's own content wrapped
+                // onto a new line internally (coordinates.Line changed) - that new CurrentY already comes
+                // from the (correctly pre-shifted) MaxBottom the wrap computed it from, not from this
+                // pre-shift, so there is nothing here to subtract back.
+                if (preShiftedForAtomicInset && ReferenceEquals(lineBeforeChild, coordinates.Line))
+                {
+                    coordinates.CurrentY -= atomicTopInset;
                 }
 
                 // A box whose content was all placed in an earlier fragmentainer is not re-closed here
@@ -1940,74 +1990,55 @@ namespace PeachPDF.Html.Core.Dom
         /// <summary>
         /// CSS2.1 §8.1 box model: an atomic inline-level box's content is laid out inside its
         /// padding box, so its flowed words must sit border+padding-top BELOW the box's top
-        /// edge - <see cref="FlowBox"/> placed them at the line's CurrentY (the box's top).
-        /// Without this inset, <see cref="CssLineBox.UpdateRectangle"/>'s padding expansion
-        /// pushes the box's background/border rect UP above the text instead (a button's label
-        /// hugged its top border). Shifts the flowed words down into the content box and grows
-        /// the flow bottom to cover the full padding box. Plain <c>display: inline</c> boxes
-        /// are excluded per §10.8.1 - their vertical padding paints without taking vertical
-        /// space, which the existing rect expansion alone already models correctly. An
-        /// absolutely/fixed-positioned box still gets its words inset (its content sits inside
-        /// its own padding box regardless), but never grows the in-flow
-        /// <see cref="CssLineBoxCoordinates.MaxBottom"/> - out-of-flow boxes must not affect
-        /// ancestor flow height (CSS2.1 §9.6).
+        /// edge. <see cref="FlowBox"/>'s per-child loop now applies that inset by pre-shifting
+        /// <c>coordinates.CurrentY</c> before b's content is flowed (issue #333), so by the time
+        /// this runs every word b has flowed already sits at its correct final <see cref="CssRect.Top"/> -
+        /// what remains is purely bookkeeping. Without growing <see cref="CssLineBoxCoordinates.MaxBottom"/>
+        /// by the bottom inset, <see cref="CssLineBox.UpdateRectangle"/>'s padding expansion would close
+        /// the box's background/border rect at the last word's own bottom rather than below it (a
+        /// button's label would hug its bottom border). Plain <c>display: inline</c> boxes are excluded
+        /// per §10.8.1 by the caller (their vertical padding paints without taking vertical space, which
+        /// the existing rect expansion alone already models correctly) - <paramref name="bottomInset"/>
+        /// is precomputed as 0 for them. An absolutely/fixed-positioned box still gets its own insets
+        /// (its content sits inside its own padding box regardless) but never grows the in-flow
+        /// <see cref="CssLineBoxCoordinates.MaxBottom"/> - out-of-flow boxes must not affect ancestor flow
+        /// height (CSS2.1 §9.6).
         /// </summary>
         /// <param name="b">the just-flowed inline-level box</param>
-        /// <param name="flowContext">the box whose inline flow <paramref name="b"/> participates in
-        /// (<see cref="FlowBox"/>'s own <c>box</c> parameter) - carries the same fixed/table-cell
-        /// page-break exemptions the per-word flow placement uses</param>
         /// <param name="coordinates">the current line coordinates</param>
-        private static void ApplyAtomicInlineVerticalInsets(CssBox b, CssBox flowContext, CssLineBoxCoordinates coordinates)
+        /// <param name="bottomInset">b's own border-bottom+padding-bottom, precomputed by the caller (0
+        /// when b is not an atomic inline-level box)</param>
+        private static void ApplyAtomicInlineVerticalInsets(CssBox b, CssLineBoxCoordinates coordinates, double bottomInset)
         {
-            if (b.DerivedStyle.ActualDisplay is not Keywords.InlineBlock)
+            if (bottomInset <= 0 || b.Position.Value is PositionMode.Absolute or PositionMode.Fixed)
                 return;
 
-            var topInset = b.ActualBorderTopWidth + b.ActualPaddingTop;
-            var bottomInset = b.ActualBorderBottomWidth + b.ActualPaddingBottom;
+            var maxWordBottom = MaxFlowedWordBottom(b);
 
-            if (topInset <= 0 && bottomInset <= 0)
-                return;
-
-            // Word flow already ran CssRect.BreakPage per word; the inset shift below can push
-            // a line that legitimately fit above a page boundary back across it, so the shifted
-            // words re-check - a monolithic line must land fully within one fragmentainer
-            // (css-break §4). Same exemption as the flow-time call.
-            var breakPages = flowContext is { IsFixed: false };
-            var maxWordBottom = OffsetFlowedWords(b, topInset, breakPages);
-
-            if (maxWordBottom > double.MinValue
-                && b.Position.Value is not (PositionMode.Absolute or PositionMode.Fixed))
+            if (maxWordBottom > double.MinValue)
             {
                 coordinates.MaxBottom = Math.Max(coordinates.MaxBottom, maxWordBottom + bottomInset);
             }
         }
 
         /// <summary>
-        /// Shifts every word already flowed inside <paramref name="box"/>'s subtree down by
-        /// <paramref name="amount"/> (an atomic inline-level box's border+padding-top content
-        /// inset - see <see cref="ApplyAtomicInlineVerticalInsets"/>), optionally re-running the
-        /// page-boundary check on each shifted word, and returns the lowest word bottom after
-        /// the shift, or <see cref="double.MinValue"/> when the subtree holds no words at all.
+        /// The deepest bottom edge among every word already flowed inside <paramref name="box"/>'s
+        /// subtree, or <see cref="double.MinValue"/> when it holds none. A read-only walk - unlike the
+        /// shifting/relocating walk it replaced (issue #333), every word already sits at its correct
+        /// <see cref="CssRect.Top"/> by the time <see cref="ApplyAtomicInlineVerticalInsets"/> runs.
         /// </summary>
-        private static double OffsetFlowedWords(CssBox box, double amount, bool breakPages)
+        private static double MaxFlowedWordBottom(CssBox box)
         {
             var maxBottom = double.MinValue;
 
             foreach (var word in box.Words)
             {
-                word.Top += amount;
-
-                if (breakPages && box.HtmlContainer?.SuppressWordPageBreaks != true)
-                {
-                    word.BreakPage();
-                }
-
                 maxBottom = Math.Max(maxBottom, word.Bottom);
             }
 
             foreach (var child in box.Boxes)
             {
-                maxBottom = Math.Max(maxBottom, OffsetFlowedWords(child, amount, breakPages));
+                maxBottom = Math.Max(maxBottom, MaxFlowedWordBottom(child));
             }
 
             return maxBottom;

--- a/src/PeachPDF/Html/Core/Dom/CssRect.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssRect.cs
@@ -319,30 +319,10 @@ namespace PeachPDF.Html.Core.Dom
         /// Asks <see cref="HtmlContainerInt.BandBeingFilled"/> — the fragmentainer the pass is actually
         /// filling, not merely the band this word's own top happens to fall in. Safe now that
         /// <see href="https://github.com/jhaygood86/PeachPDF/issues/435">#435</see>'s stage 1 makes every
-        /// mechanism that can spill flow past that fragmentainer step the pass cursor to match; before
-        /// that landed, this could only ask the page grid (see <see cref="WouldStraddleItsOwnBand"/>,
-        /// which still does, for the relocation this predicate must never be confused with).
+        /// mechanism that can spill flow past that fragmentainer step the pass cursor to match.
         /// </para>
         /// </remarks>
-        public bool WouldStraddleFragmentainer() => WouldStraddle(BandSource.Filling);
-
-        /// <summary>
-        /// Whether this word, at its current <see cref="Top"/>, has left the band its own top falls in -
-        /// the legacy relocation's question, asked of the page grid rather than the fragmentainer the
-        /// pass is filling.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="BreakPage"/> moves a word to the content top of the band <i>after</i> the one its
-        /// top is in - a coordinate fact about the grid, not a break decision the pass records - so it
-        /// must keep asking this rather than <see cref="WouldStraddleFragmentainer"/>: a word an atomic
-        /// inline's vertical inset has just shifted into a later band, while the pass cursor still names
-        /// an earlier one, is relocated one band on either way, never two.
-        /// </remarks>
-        internal bool WouldStraddleItsOwnBand() => WouldStraddle(BandSource.Grid);
-
-        private enum BandSource { Filling, Grid }
-
-        private bool WouldStraddle(BandSource source)
+        public bool WouldStraddleFragmentainer()
         {
             var container = OwnerBox.HtmlContainer!;
 
@@ -364,12 +344,10 @@ namespace PeachPDF.Html.Core.Dom
                        && HtmlContainerInt.FallsPast(Bottom + reservedEnd, columnBand.Band);
             }
 
-            // The same question, of the band this word started in rather than of the column's. Asking it
-            // as "does the bottom edge fall past that band" rather than as "are the top and bottom in
-            // different slots" is what makes the two arms one question with two bands, instead of two
-            // questions - a slot index is a fact about the page grid, and a column has no slot of its own.
+            // The band this word's own top falls in, asked of the fragmentainer the pass is actually
+            // filling rather than merely of the page grid.
             var gridBand = container.BandStartingAt(Top);
-            var band = source is BandSource.Filling ? container.BandBeingFilled(Top, gridBand) : gridBand;
+            var band = container.BandBeingFilled(Top, gridBand);
 
             return HtmlContainerInt.FallsPast(Bottom + reservedEnd, band);
         }
@@ -445,27 +423,6 @@ namespace PeachPDF.Html.Core.Dom
             var (clonedTop, reservedEnd) = ClonedInsets(container);
 
             return MonolithicContent.FitsNoFragmentainer(Height, clonedTop, reservedEnd, container);
-        }
-
-        public bool BreakPage()
-        {
-            // Non-null for the same reason WouldStraddleItsOwnBand's own read of it is: a word is only
-            // ever asked this during layout, which a box without a container never reaches.
-            var container = OwnerBox.HtmlContainer!;
-
-            // A relocation, not a break decision: this word moves to the content top of the next band
-            // whatever the pass cursor is doing, so it must ask the page grid rather than
-            // WouldStraddleFragmentainer's "is the pass filling this" question.
-            if (!WouldStraddleItsOwnBand())
-                return false;
-
-            // The fragmentainer's own content edge, per css-break-3 §2. This used to land one unit
-            // below it, purely to keep a relocated word off the exact boundary value - a question the
-            // page grid's own epsilons already answer, and which the band-overlap test in the fragment
-            // builder answers the same way (a rect starting exactly at a band top belongs to that band
-            // and overlaps the previous one by zero).
-            Top = container.NextPageTopOf(Top);
-            return true;
         }
     }
 }

--- a/src/PeachPDF/Html/Core/Dom/CssSpacingBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssSpacingBox.cs
@@ -36,11 +36,6 @@ namespace PeachPDF.Html.Core.Dom
         /// </summary>
         public int EndRow { get; }
 
-        public override bool BreakPage()
-        {
-            return ExtendedBox.BreakPage();
-        }
-
         // This box paints nothing of its own. The spanned cell shows through it because the fragment
         // builder makes that cell one of this box's fragment children, so the ordinary paint walk
         // reaches it - rather than this box re-entering paint on a box that lives elsewhere in the tree.

--- a/src/PeachPDF/Html/Core/Fragments/Fragment.cs
+++ b/src/PeachPDF/Html/Core/Fragments/Fragment.cs
@@ -100,8 +100,9 @@ namespace PeachPDF.Html.Core.Fragments
 
     /// <summary>
     /// One laid-out word (or inline replaced run) positioned inside a fragmentainer. Words are
-    /// monolithic — a word never straddles a fragmentainer boundary (see <see cref="CssRect.BreakPage"/>),
-    /// so each <see cref="CssRect"/> produces exactly one <see cref="TextFragment"/>.
+    /// monolithic — a word never straddles a fragmentainer boundary (see
+    /// <see cref="CssRect.WouldStraddleFragmentainer"/>), so each <see cref="CssRect"/> produces
+    /// exactly one <see cref="TextFragment"/>.
     /// </summary>
     /// <param name="Rect">the word's rectangle, in fragmentainer-local coordinates</param>
     /// <param name="Word">the word this fragment positions; the source of its text, font, and style</param>

--- a/src/PeachPDF/Html/Core/HtmlContainerInt.cs
+++ b/src/PeachPDF/Html/Core/HtmlContainerInt.cs
@@ -288,18 +288,17 @@ namespace PeachPDF.Html.Core
 
         /// <summary>
         /// When true, <see cref="CssLayoutEngine.FlowBox"/>'s per-word page-break-avoidance check
-        /// (<see cref="Dom.CssRect.BreakPage"/>, which permanently jumps a replaced-element word's
-        /// <c>Top</c> to the next page) is skipped. Set around a throwaway/measurement-only layout
-        /// pass performed at a temporary, not-yet-final position - see
+        /// (<see cref="Dom.CssRect.WouldStraddleFragmentainer"/>, which stops the pass and records an
+        /// <see cref="Fragmentation.InlineBreakToken"/> rather than placing a word that would straddle
+        /// a fragmentainer boundary) is skipped. Set around a throwaway/measurement-only layout pass
+        /// performed at a temporary, not-yet-final position - see
         /// <see cref="Dom.CssLayoutEngineFlex"/>'s <c>MeasureItem</c>/<c>ResizeItem</c>/stretch
         /// cross-size re-layout, which lay a flex item out at <c>(ClientLeft, ClientTop)</c> purely
         /// to measure its natural size before <c>AssignLocations</c> translates it (via
         /// <c>CssBox.OffsetTop</c>) to its real final position. Without this, a word whose temporary
-        /// position happens to straddle a page boundary gets pushed to the next page during
-        /// measurement - a decision based on coordinates that have nothing to do with where the item
-        /// actually ends up - and that jump silently survives the later translation (which only
-        /// shifts by a delta computed from the box's own <c>Location</c>, not from where its words
-        /// independently drifted to), permanently desyncing the word from its own box.
+        /// position happens to straddle a page boundary would end the measurement pass with a break
+        /// token recorded against coordinates that have nothing to do with where the item actually
+        /// ends up, and that pass is never resumed - permanently desyncing the word from its own box.
         /// </summary>
         internal bool SuppressWordPageBreaks { get; set; }
 


### PR DESCRIPTION
## Summary

- `FlowBox`'s per-word loop asks `WouldStraddleFragmentainer` before placing a word, so a straddling line moves to the next fragmentainer as a whole (css-break-3 §4.1). `ApplyAtomicInlineVerticalInsets`/`OffsetFlowedWords` never migrated onto that model: it shifted an `inline-block`'s already-placed words down by its own top inset *after* the line's break decision had already been made, so the shift could silently re-split a line the token model had already decided was fine. Fixed by pre-shifting `coordinates.CurrentY` before the child's content is flowed instead, so the ordinary per-word check sees the real final position from the start, for every internal line the box's content may wrap onto.
- `FlowBox`'s own per-word loop had a second, bare `CssRect.BreakPage()` fallback for a null fragmentainer. That was load-bearing when #333 was filed (the table engine ran cell content behind a detached fragmentainer), but #464 already closed that gap - cell content sees a live fragmentainer like everything else now. Confirmed by removing the arm and running the full suite (8419 passing, including every table-cell-pagination test).
- `CssRect.BreakPage`/`WouldStraddleItsOwnBand` and `CssBox.BreakPage`/`CssSpacingBox.BreakPage` are deleted as a result - zero remaining callers, verified by grep.
- Also fixes a double-counting bug the above surfaced in `FinalizeFlowBoxExit`'s "handle height setting"/"handle width setting" fallbacks: `startY`, captured at a recursively-flowed box's own entry, now names the pre-shifted content-box top rather than the border-box top those fallbacks assume when reconstructing `ActualHeight`-anchored geometry.

## Test plan

- [x] Full `net8.0` suite: 8419 passing, 9 skipped (pre-existing, platform-specific), 0 failed
- [x] CLI test suite: 96/96 passing
- [x] 100% diff coverage (`diff-cover` against `main`)
- [x] `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings, 0 errors (all TFMs, incl. the source generator and Blazor WASM smoke test)
- [x] New tests: an inline-block whose padding-top alone pushes its line past a column boundary (whole line moves, inset re-applies once since nothing was kept in column 1); a two-internal-line inline-block where only the second line straddles and moves alone *without* re-applying the inset (a continuation, not a fresh opening); a tight height-equality test pinning the `FinalizeFlowBoxExit` fix (confirmed to fail without it)

Fixes #333