### PR TITLE
Add support for outline / outline-* properties

### DIFF
--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -282,6 +282,22 @@ Percentages are relative to the border-box width (horizontal radius) and height 
 
 Known limitation: `double`/`groove`/`ridge` combined with `border-radius` on the same edge falls back to a single solid-colored stroke at the full border width — full rounded rendering of these three styles (two concentric arcs, or a two-tone beveled arc) is out of scope for CSS1 compliance.
 
+### Outline
+
+| Property | MDN Reference | Notes |
+|----------|--------------|-------|
+| `outline` | [outline](https://developer.mozilla.org/en-US/docs/Web/CSS/outline) | Shorthand for `outline-color`, `outline-style`, `outline-width`, in any order |
+| `outline-color` | [outline-color](https://developer.mozilla.org/en-US/docs/Web/CSS/outline-color) | Any `<color>`, `currentcolor` (the initial value), or the legacy `invert` keyword |
+| `outline-style` | [outline-style](https://developer.mozilla.org/en-US/docs/Web/CSS/outline-style) | `none` (initial), `auto`, `solid`, `dashed`, `dotted`, `double`, `groove`, `ridge`, `inset`, `outset` |
+| `outline-width` | [outline-width](https://developer.mozilla.org/en-US/docs/Web/CSS/outline-width) | `<length>`, or `thin`/`medium`/`thick` |
+| `outline-offset` | [outline-offset](https://developer.mozilla.org/en-US/docs/Web/CSS/outline-offset) | `<length>`, may be negative to pull the outline back over the border |
+
+Unlike `border`, outline is layout-neutral: it never participates in box sizing, is drawn entirely outside the border edge (offset by `outline-offset`), and can visually overlap sibling content without shifting anything. It does not follow `border-radius` — PeachPDF always draws a rectangular outline, which CSS Basic User Interface 4 explicitly leaves as a UA choice (a UA *may* round it to match, but is not required to).
+
+`outline-style: auto` — a UA-defined appearance, typically used for a browser's own focus ring — renders identically to `solid`.
+
+`outline-color: invert` is a legacy value: rather than approximating it with a fixed color, PeachPDF renders it as a true per-pixel color inversion of whatever is underneath the outline, using a PDF blend mode (`/Difference` composited with white, which is mathematically equivalent to inverting the backdrop). This is a genuine inversion, not a fixed guess at a contrasting color, and it composites correctly regardless of what's behind the outline at render time.
+
 ### Box Shadow
 
 | Property | MDN Reference | Notes |
@@ -1475,5 +1491,4 @@ The following CSS features are not supported:
 - **Filters and effects** — `filter`, `backdrop-filter`, `mix-blend-mode` (not parsed at all)
 - **`text-shadow`**
 - **`word-wrap` / `overflow-wrap`**
-- **`outline`** and `outline-*` properties
 - **CSS selectors** — see the [CSS Selectors](#css-selectors) section above for what is and is not supported

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -4571,6 +4571,92 @@ await SaveShowcaseAsync("border_style", "Backgrounds & Borders", "Border Styles"
     "The full set of CSS border styles, from solid and dashed to groove, ridge, inset, and outset.",
     borderStyleHtml, pdfConfig);
 
+// --- outline showcase ---
+
+const string OutlineCss = """
+    <style>
+    @page { size: a4; margin: 15mm }
+    body { font: 8.5pt Arial, sans-serif; margin: 0 }
+    h1 { font-size: 15pt; margin: 0 0 0.3em }
+    h2 { font-size: 10pt; margin: 0.9em 0 0.3em; padding-bottom: 2px; border-bottom: 1px solid #999; break-after: avoid }
+    p.intro { margin: 0 0 0.7em; color: #555; break-after: avoid }
+    table.sw { border-collapse: collapse; width: 100%; margin-bottom: 0.3em }
+    table.sw td { padding: 3px; vertical-align: top; width: 25% }
+    .obox { height: 40px; background: #eee; margin: 12px 8px; }
+    .desc { font-size: 7pt; font-weight: bold; color: #444; margin-bottom: 1px }
+    .css { font-size: 6pt; color: #666; line-height: 1.3; word-break: break-all }
+    </style>
+    """;
+
+static string OutlineStyleSwatch(string desc, string style) =>
+    "<td>" +
+    $"<div class=\"obox\" style=\"outline: 8px {style} #4a90d9\"></div>" +
+    $"<div class=\"desc\">{desc}</div>" +
+    $"<div class=\"css\">outline: 8px {style} #4a90d9</div>" +
+    "</td>";
+
+var outlineHtml = "<!DOCTYPE html><html><head>" + OutlineCss + "</head><body>" +
+
+    "<h1>CSS outline Test Page</h1>" +
+    "<p class=\"intro\">outline never affects box sizing - it paints a ring entirely outside the border edge, offset by outline-offset, and can visually overlap surrounding content without shifting it.</p>" +
+
+    "<h2>outline-style keywords</h2>" +
+    Row(
+        OutlineStyleSwatch("solid", "solid"),
+        OutlineStyleSwatch("dashed", "dashed"),
+        OutlineStyleSwatch("dotted", "dotted"),
+        OutlineStyleSwatch("double", "double")
+    ) +
+    Row(
+        OutlineStyleSwatch("groove", "groove"),
+        OutlineStyleSwatch("ridge", "ridge"),
+        OutlineStyleSwatch("inset", "inset"),
+        OutlineStyleSwatch("outset", "outset")
+    ) +
+    Row(
+        OutlineStyleSwatch("auto (renders as solid)", "auto")
+    ) +
+
+    "<h2>outline-offset</h2>" +
+    "<p class=\"intro\">A negative offset pulls the outline back over the border and padding; a positive offset pushes it further away.</p>" +
+    Row(
+        "<td><div class=\"obox\" style=\"outline: 6px solid #d94a4a; outline-offset: -10px; border: 3px solid #333\"></div>" +
+        "<div class=\"desc\">outline-offset: -10px</div>" +
+        "<div class=\"css\">outline: 6px solid #d94a4a; outline-offset: -10px</div></td>" +
+        "<td><div class=\"obox\" style=\"outline: 6px solid #d94a4a; border: 3px solid #333\"></div>" +
+        "<div class=\"desc\">outline-offset: 0 (default)</div>" +
+        "<div class=\"css\">outline: 6px solid #d94a4a; border: 3px solid #333</div></td>" +
+        "<td><div class=\"obox\" style=\"outline: 6px solid #d94a4a; outline-offset: 10px; border: 3px solid #333\"></div>" +
+        "<div class=\"desc\">outline-offset: 10px</div>" +
+        "<div class=\"css\">outline: 6px solid #d94a4a; outline-offset: 10px</div></td>"
+    ) +
+
+    "<h2>outline-color: invert</h2>" +
+    "<p class=\"intro\">invert performs a true per-pixel color inversion of whatever is underneath the outline (via a PDF blend mode), not an approximation - it reads correctly over any background.</p>" +
+    Row(
+        "<td><div class=\"obox\" style=\"background: #d94a4a; outline: 10px solid invert; outline-offset: -14px\"></div>" +
+        "<div class=\"desc\">over a red background</div>" +
+        "<div class=\"css\">outline: 10px solid invert; outline-offset: -14px</div></td>" +
+        "<td><div class=\"obox\" style=\"background: #2e7d32; outline: 10px solid invert; outline-offset: -14px\"></div>" +
+        "<div class=\"desc\">over a green background</div>" +
+        "<div class=\"css\">outline: 10px solid invert; outline-offset: -14px</div></td>" +
+        "<td><div class=\"obox\" style=\"background: linear-gradient(to right, #222, #eee); outline: 10px solid invert; outline-offset: -14px\"></div>" +
+        "<div class=\"desc\">over a gradient</div>" +
+        "<div class=\"css\">outline: 10px solid invert; outline-offset: -14px</div></td>"
+    ) +
+
+    "<h2>Layout-neutral: outline never shifts surrounding content</h2>" +
+    "<p class=\"intro\">This box's outline is wider than its own padding, so it visually overlaps its siblings - but every box below sits exactly where it would if the outline were removed.</p>" +
+    "<div style=\"background:#eee\">before</div>" +
+    "<div style=\"background:#fff2cc; outline: 20px solid #d94a4a; outline-offset: 6px; margin: 4px 0\">outlined (20px, offset 6px)</div>" +
+    "<div style=\"background:#eee\">after</div>" +
+
+    "</body></html>";
+
+await SaveShowcaseAsync("outline", "Backgrounds & Borders", "Outline",
+    "outline / outline-color / outline-style / outline-width / outline-offset: a layout-neutral ring drawn outside the border edge, including a true per-pixel color inversion for outline-color: invert.",
+    outlineHtml, pdfConfig);
+
 // --- vertical-align showcase ---
 
 static string VerticalAlignSwatch(string desc, string va) =>

--- a/src/PeachPDF.Tests/CSS/PropertyTests/OutlineProperty.cs
+++ b/src/PeachPDF.Tests/CSS/PropertyTests/OutlineProperty.cs
@@ -239,6 +239,61 @@ namespace PeachPDF.Tests.CSS.PropertyTests
             Assert.True(concrete.HasValue);
             Assert.Equal("1px solid rgb(0, 0, 0)", concrete.Value);
         }
+
+        [Fact]
+        public void CssOutlineOffsetPositiveLengthLegal()
+        {
+            var snippet = "outline-offset :  3px";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("outline-offset", property.Name);
+            Assert.False(property.IsImportant);
+            Assert.IsType<OutlineOffsetProperty>(property);
+            var concrete = (OutlineOffsetProperty)property;
+            Assert.False(concrete.IsInherited);
+            Assert.True(concrete.HasValue);
+            Assert.Equal("3px", concrete.Value);
+        }
+
+        [Fact]
+        public void CssOutlineOffsetNegativeLengthLegal()
+        {
+            var snippet = "outline-offset :  -2px";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("outline-offset", property.Name);
+            Assert.False(property.IsImportant);
+            Assert.IsType<OutlineOffsetProperty>(property);
+            var concrete = (OutlineOffsetProperty)property;
+            Assert.False(concrete.IsInherited);
+            Assert.True(concrete.HasValue);
+            Assert.Equal("-2px", concrete.Value);
+        }
+
+        [Fact]
+        public void CssOutlineOffsetKeywordIllegal()
+        {
+            var snippet = "outline-offset :  auto";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("outline-offset", property.Name);
+            Assert.False(property.IsImportant);
+            Assert.IsType<OutlineOffsetProperty>(property);
+            var concrete = (OutlineOffsetProperty)property;
+            Assert.False(concrete.IsInherited);
+            Assert.False(concrete.HasValue);
+        }
+
+        [Fact]
+        public void CssOutlineShorthandDoesNotExpandOffset()
+        {
+            // The outline shorthand is outline-color || outline-style || outline-width only
+            // (CSS-UI-4 §4) - outline-offset is never part of it and must be set independently.
+            var style = ParseDeclarations("outline: 1px solid red; outline-offset: 4px");
+            Assert.Equal("1px solid rgb(255, 0, 0)", style.Outline);
+            Assert.Equal("4px", style.OutlineOffset);
+
+            var styleWithoutOffset = ParseDeclarations("outline: 1px solid red");
+            Assert.Equal("1px solid rgb(255, 0, 0)", styleWithoutOffset.Outline);
+            Assert.Equal(string.Empty, styleWithoutOffset.OutlineOffset);
+        }
     }
 }
 

--- a/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTablePageBreakTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTablePageBreakTests.cs
@@ -799,6 +799,8 @@ namespace PeachPDF.Tests.Html.Core.Dom
             public override void PushClipExclude(PeachPDF.Html.Adapters.Entities.RRect rect) { }
             public override void PushTransform(PeachPDF.Html.Adapters.Entities.RMatrix matrix) { }
             public override void PopTransform() { }
+            public override void PushBlendMode(PeachPDF.Html.Adapters.Entities.RBlendMode mode) { }
+            public override void PopBlendMode() { }
             public override object SetAntiAliasSmoothingMode() => new object();
             public override void ReturnPreviousSmoothingMode(object? prevMode) { }
             public override PeachPDF.Html.Adapters.Entities.RSize MeasureString(string str, PeachPDF.Html.Adapters.RFont font, PeachPDF.Text.TextShapingFeatures? features = null) => new(0, 12);

--- a/src/PeachPDF.Tests/Html/Core/Handlers/StructureTagBuilderTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Handlers/StructureTagBuilderTests.cs
@@ -171,6 +171,8 @@ namespace PeachPDF.Tests.Html.Core.Handlers
 
             public override void PushTransform(RMatrix matrix) { }
             public override void PopTransform() { }
+            public override void PushBlendMode(RBlendMode mode) { }
+            public override void PopBlendMode() { }
             public override void PushClip(RRect rect) => _clipStack.Push(rect);
             public override void PushClip(RGraphicsPath path) => _clipStack.Push(_clipStack.Peek());
             public override void PopClip() { if (_clipStack.Count > 1) _clipStack.Pop(); }

--- a/src/PeachPDF.Tests/Html/Core/Utils/CssUtilsTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Utils/CssUtilsTests.cs
@@ -305,6 +305,61 @@ namespace PeachPDF.Tests.Html.Core.Utils
         }
 
         [Fact]
+        public async Task ApplyCurrentColor_ReplacesOutlineColorCurrentColorWithColorValue()
+        {
+            var (box, parser) = await FindDivBoxAndParser("color: rgb(10, 20, 30); outline-color: currentColor;");
+
+            CssUtils.ApplyCurrentColor(box, parser);
+
+            Assert.Equal("rgb(10, 20, 30)", box.OutlineColor);
+        }
+
+        [Fact]
+        public async Task ApplyCurrentColor_LeavesOutlineColorInvertUntouched()
+        {
+            // "invert" is a distinct keyword from "currentcolor" - ApplyCurrentColor must only rewrite
+            // a literal "currentcolor", never touch any other outline-color value.
+            var (box, parser) = await FindDivBoxAndParser("color: rgb(10, 20, 30); outline-color: invert;");
+
+            CssUtils.ApplyCurrentColor(box, parser);
+
+            Assert.Equal("invert", box.OutlineColor);
+        }
+
+        [Fact]
+        public async Task OutlineStyleAuto_ParsesToOutlineStyleAutoAndRoundTrips()
+        {
+            var (box, parser) = await FindDivBoxAndParser("");
+
+            CssUtils.SetPropertyValue(parser, box, "outline-style", "auto");
+
+            Assert.Equal(PeachPDF.CSS.OutlineStyle.Auto, box.OutlineStyle.Value);
+            Assert.Equal("auto", CssUtils.GetPropertyValue(box, "outline-style"));
+        }
+
+        [Fact]
+        public async Task OutlineStyleAuto_IsRejectedForBorderTopStyle()
+        {
+            // "auto" is outline-style's own value, deliberately kept out of the shared LineStyle/
+            // Map.LineStyles that every border-*-style property still uses.
+            var (box, parser) = await FindDivBoxAndParser("border-top-style: dashed;");
+
+            CssUtils.SetPropertyValue(parser, box, "border-top-style", "auto");
+
+            Assert.Equal("dashed", CssUtils.GetPropertyValue(box, "border-top-style"));
+        }
+
+        [Fact]
+        public async Task OutlineColorInvert_IsRejectedForBorderTopColor()
+        {
+            var (box, parser) = await FindDivBoxAndParser("border-top-color: rgb(1, 2, 3);");
+
+            CssUtils.SetPropertyValue(parser, box, "border-top-color", "invert");
+
+            Assert.Equal("rgb(1, 2, 3)", CssUtils.GetPropertyValue(box, "border-top-color"));
+        }
+
+        [Fact]
         public async Task WhiteSpace_ReturnsPositiveWidth()
         {
             var (box, _) = await FindDivBoxAndParser("font-size: 16px;");
@@ -329,6 +384,7 @@ namespace PeachPDF.Tests.Html.Core.Utils
             ["border-bottom-width", "2px"], ["border-left-width", "3px"], ["border-right-width", "4px"], ["border-top-width", "5px"],
             ["border-bottom-style", "dashed"], ["border-left-style", "dotted"], ["border-right-style", "double"], ["border-top-style", "groove"],
             ["border-bottom-color", "rgb(1, 2, 3)"], ["border-left-color", "rgb(4, 5, 6)"], ["border-right-color", "rgb(7, 8, 9)"], ["border-top-color", "rgb(10, 11, 12)"],
+            ["outline-width", "5px"], ["outline-style", "groove"], ["outline-color", "rgb(10, 11, 12)"], ["outline-offset", "3px"],
             ["border-spacing", "3px"], ["border-collapse", "collapse"], ["box-sizing", "border-box"],
             // "clone" only - a "slice" row would pass with the setter deleted, since slice is the default.
             ["box-decoration-break", "clone"],
@@ -411,6 +467,7 @@ namespace PeachPDF.Tests.Html.Core.Utils
         [InlineData("border-top", "99px solid red", "border-top-width")]
         [InlineData("border-style", "dashed", "border-top-style")]
         [InlineData("border-color", "rgb(9, 9, 9)", "border-top-color")]
+        [InlineData("outline", "9px solid red", "outline-width")]
         [InlineData("flex", "9 9 90px", "flex-grow")]
         [InlineData("flex-flow", "column wrap", "flex-direction")]
         [InlineData("columns", "9 90px", "column-count")]

--- a/src/PeachPDF.Tests/Integration/Acid2RegressionTests.cs
+++ b/src/PeachPDF.Tests/Integration/Acid2RegressionTests.cs
@@ -904,6 +904,8 @@ namespace PeachPDF.Tests.Integration
             public override void DrawImage(RImage image, RRect destRect) => DrawImageCallCount++;
             public override void PushTransform(RMatrix matrix) { }
             public override void PopTransform() { }
+            public override void PushBlendMode(RBlendMode mode) { }
+            public override void PopBlendMode() { }
             public override void PushClip(RRect rect) => _clipStack.Push(rect);
             public override void PushClip(RGraphicsPath path) => _clipStack.Push(_clipStack.Peek());
             public override void PopClip() { if (_clipStack.Count > 1) _clipStack.Pop(); }

--- a/src/PeachPDF.Tests/Integration/FontVariantLigaturesIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FontVariantLigaturesIntegrationTests.cs
@@ -245,6 +245,8 @@ body {{ font-family: 'SS3'; width: 400px; }}
 
             public override void PushTransform(RMatrix matrix) { }
             public override void PopTransform() { }
+            public override void PushBlendMode(RBlendMode mode) { }
+            public override void PopBlendMode() { }
             public override void PushClip(RRect rect) => _clipStack.Push(rect);
             public override void PushClip(RGraphicsPath path) => _clipStack.Push(_clipStack.Peek());
             public override void PopClip() { if (_clipStack.Count > 1) _clipStack.Pop(); }

--- a/src/PeachPDF.Tests/Integration/MulticolLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/MulticolLayoutIntegrationTests.cs
@@ -906,6 +906,8 @@ namespace PeachPDF.Tests.Integration
 
             public override void PushTransform(RMatrix matrix) { }
             public override void PopTransform() { }
+            public override void PushBlendMode(RBlendMode mode) { }
+            public override void PopBlendMode() { }
             public override void PushClip(RRect rect) => _clipStack.Push(rect);
             public override void PushClip(RGraphicsPath path) => _clipStack.Push(_clipStack.Peek());
             public override void PopClip() { if (_clipStack.Count > 1) _clipStack.Pop(); }

--- a/src/PeachPDF.Tests/Integration/OutlineStylePaintIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/OutlineStylePaintIntegrationTests.cs
@@ -1,0 +1,489 @@
+using PeachPDF.Adapters;
+using PeachPDF.CSS;
+using PeachPDF.Html.Adapters.Entities;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore;
+using PeachPDF.Tests.TestSupport;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Verifies <c>outline</c>/<c>outline-color</c>/<c>outline-style</c>/<c>outline-width</c>/
+    /// <c>outline-offset</c> actually paint the right geometry/color/order (issue #697), not just that
+    /// they parse or that painting doesn't throw - per this repo's painting-test convention (see
+    /// <c>BorderStylePaintIntegrationTests</c>). Uses <see cref="TestRecordingGraphics"/> to assert the
+    /// real draw-call sequence, plus one real-PDF content-stream test
+    /// (<see cref="OutlineColorInvert_ProducesADifferenceBlendModeExtGStateInTheRealPdf"/>) proving the
+    /// new <see cref="PeachPDF.Html.Adapters.RGraphics.PushBlendMode"/>/<see cref="PeachPDF.Html.Adapters.RGraphics.PopBlendMode"/>
+    /// primitive actually reaches the PDF-writing layer, not just the test mock.
+    /// </summary>
+    public class OutlineStylePaintIntegrationTests
+    {
+        [Fact]
+        public async Task Outline_PaintsRingOutsetByWidthAndOffset_OutsideTheBorderEdge()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='b' style='width:50pt; height:30pt; outline: 6pt solid rgb(10,20,30); outline-offset: 4pt'>x</div>"));
+            var div = LayoutHarness.FindById(root, "b")!;
+            var rect = FragmentPaintHarness.FragmentOf(container, div).Lines[0].Rect;
+
+            var g = new TestRecordingGraphics();
+            FragmentPaintHarness.PaintBox(container, div, g);
+
+            var polys = g.Log.OfType<TestRecordingGraphics.DrawPolygonCall>().ToList();
+            Assert.Equal(4, polys.Count);
+            Assert.All(polys, p => Assert.Equal(RColor.FromArgb(10, 20, 30), p.Color));
+
+            const double offset = 4;
+            const double width = 6;
+            const double reach = offset + width;
+
+            var top = polys.OrderBy(p => p.Points.Average(pt => pt.Y)).First();
+            var ys = top.Points.Select(pt => pt.Y).ToList();
+            var xs = top.Points.Select(pt => pt.X).ToList();
+            Assert.Equal(rect.Top - offset, ys.Max(), 1);
+            Assert.Equal(rect.Top - reach, ys.Min(), 1);
+            Assert.Equal(rect.Left - reach, xs.Min(), 1);
+            Assert.Equal(rect.Right + reach, xs.Max(), 1);
+
+            var right = polys.OrderByDescending(p => p.Points.Average(pt => pt.X)).First();
+            var rxs = right.Points.Select(pt => pt.X).ToList();
+            Assert.Equal(rect.Right + offset, rxs.Min(), 1);
+            Assert.Equal(rect.Right + reach, rxs.Max(), 1);
+        }
+
+        [Fact]
+        public async Task OutlineOffset_Negative_PullsTheRingInwardPastTheBorderEdge()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='b' style='width:50pt; height:30pt; outline: 6pt solid rgb(10,20,30); outline-offset: -3pt'>x</div>"));
+            var div = LayoutHarness.FindById(root, "b")!;
+            var rect = FragmentPaintHarness.FragmentOf(container, div).Lines[0].Rect;
+
+            var g = new TestRecordingGraphics();
+            FragmentPaintHarness.PaintBox(container, div, g);
+
+            var polys = g.Log.OfType<TestRecordingGraphics.DrawPolygonCall>().ToList();
+            var top = polys.OrderBy(p => p.Points.Average(pt => pt.Y)).First();
+            var ys = top.Points.Select(pt => pt.Y).ToList();
+
+            // offset = -3, width = 6: the ring's inner boundary sits 3pt *inside* the border edge and
+            // its outer boundary sits 3pt outside it - straddling the box's own edge.
+            Assert.Equal(rect.Top + 3, ys.Max(), 1);
+            Assert.Equal(rect.Top - 3, ys.Min(), 1);
+        }
+
+        [Fact]
+        public async Task OutlineStyleAuto_PaintsIdenticallyToSolid()
+        {
+            var (autoRoot, autoContainer) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='b' style='width:40pt; height:40pt; outline-style: auto; outline-width: 5pt; outline-color: rgb(9,9,9)'>x</div>"));
+            var autoDiv = LayoutHarness.FindById(autoRoot, "b")!;
+            Assert.Equal(OutlineStyle.Auto, autoDiv.OutlineStyle.Value);
+
+            var autoG = new TestRecordingGraphics();
+            FragmentPaintHarness.PaintBox(autoContainer, autoDiv, autoG);
+
+            var (solidRoot, solidContainer) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='b' style='width:40pt; height:40pt; outline-style: solid; outline-width: 5pt; outline-color: rgb(9,9,9)'>x</div>"));
+            var solidDiv = LayoutHarness.FindById(solidRoot, "b")!;
+
+            var solidG = new TestRecordingGraphics();
+            FragmentPaintHarness.PaintBox(solidContainer, solidDiv, solidG);
+
+            var autoPolys = autoG.Log.OfType<TestRecordingGraphics.DrawPolygonCall>().ToList();
+            var solidPolys = solidG.Log.OfType<TestRecordingGraphics.DrawPolygonCall>().ToList();
+            Assert.Equal(4, autoPolys.Count);
+            Assert.Equal(solidPolys.Select(p => p.Color), autoPolys.Select(p => p.Color));
+            Assert.Equal(solidPolys.Select(p => p.Points), autoPolys.Select(p => p.Points));
+        }
+
+        [Fact]
+        public async Task OutlineColorCurrentColor_ResolvesToTheElementsOwnColor()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='b' style='width:20pt; height:20pt; color: rgb(7,8,9); outline: 3pt solid'>x</div>"));
+            var div = LayoutHarness.FindById(root, "b")!;
+            // CssUtils.ApplyCurrentColor already rewrites the initial "currentcolor" to the box's own
+            // resolved color during cascade (the same mechanism border-*-color relies on).
+            Assert.Equal("rgb(7, 8, 9)", div.OutlineColor);
+
+            var g = new TestRecordingGraphics();
+            FragmentPaintHarness.PaintBox(container, div, g);
+
+            var polys = g.Log.OfType<TestRecordingGraphics.DrawPolygonCall>().ToList();
+            Assert.Equal(4, polys.Count);
+            Assert.All(polys, p => Assert.Equal(RColor.FromArgb(7, 8, 9), p.Color));
+        }
+
+        [Fact]
+        public async Task OutlineColorInvert_PaintsWhiteWrappedInADifferenceBlendMode()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='b' style='width:20pt; height:20pt; outline: 3pt solid invert'>x</div>"));
+            var div = LayoutHarness.FindById(root, "b")!;
+            Assert.Equal("invert", div.OutlineColor);
+
+            var g = new TestRecordingGraphics();
+            FragmentPaintHarness.PaintBox(container, div, g);
+
+            var pushIndex = g.Log.FindIndex(e => e is TestRecordingGraphics.PushBlendModeCall);
+            var popIndex = g.Log.FindIndex(e => e is TestRecordingGraphics.PopBlendModeCall);
+            Assert.True(pushIndex >= 0, "expected a PushBlendMode call");
+            Assert.True(popIndex > pushIndex, "expected PopBlendMode to follow PushBlendMode");
+            Assert.Equal(RBlendMode.Difference, ((TestRecordingGraphics.PushBlendModeCall)g.Log[pushIndex]).Mode);
+
+            var polys = g.Log.OfType<TestRecordingGraphics.DrawPolygonCall>().ToList();
+            Assert.Equal(4, polys.Count);
+            Assert.All(polys, p => Assert.Equal(RColor.White, p.Color));
+
+            // Every outline draw call sits inside the push/pop bracket.
+            var firstPolyIndex = g.Log.FindIndex(e => e is TestRecordingGraphics.DrawPolygonCall);
+            var lastPolyIndex = g.Log.FindLastIndex(e => e is TestRecordingGraphics.DrawPolygonCall);
+            Assert.True(firstPolyIndex > pushIndex);
+            Assert.True(lastPolyIndex < popIndex);
+        }
+
+        [Fact]
+        public async Task OutlineColorInvert_ProducesADifferenceBlendModeExtGStateInTheRealPdf()
+        {
+            var html = """
+                <!DOCTYPE html><html><body>
+                <div style="width: 40pt; height: 40pt; background: #ff0000; outline: 6pt solid invert; outline-offset: 2pt;"></div>
+                </body></html>
+                """;
+
+            var pdfText = await GetPdfText(html);
+
+            Assert.Contains("/BM /Difference", pdfText);
+        }
+
+        [Fact]
+        public async Task Outline_PaintsAfterBorder_InPaintOrder()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='b' style='width:20pt; height:20pt; border: 2pt solid rgb(1,1,1); outline: 3pt solid rgb(2,2,2)'>x</div>"));
+            var div = LayoutHarness.FindById(root, "b")!;
+
+            var g = new TestRecordingGraphics();
+            FragmentPaintHarness.PaintBox(container, div, g);
+
+            var polys = g.Log.OfType<TestRecordingGraphics.DrawPolygonCall>().ToList();
+            var lastBorderIndex = g.Log.FindLastIndex(e => e is TestRecordingGraphics.DrawPolygonCall p && p.Color == RColor.FromArgb(1, 1, 1));
+            var firstOutlineIndex = g.Log.FindIndex(e => e is TestRecordingGraphics.DrawPolygonCall p && p.Color == RColor.FromArgb(2, 2, 2));
+
+            Assert.True(lastBorderIndex >= 0);
+            Assert.True(firstOutlineIndex >= 0);
+            Assert.True(firstOutlineIndex > lastBorderIndex, "expected outline to paint after border");
+        }
+
+        [Fact]
+        public async Task Outline_PaintsAfterItsOwnTextAndDescendants_NotJustAfterBorder()
+        {
+            // CSS-UI-4 §4: outline "is drawn 'over' a box" - CSS2.1 Appendix E draws it as the very last
+            // step for the element, after its own generated content AND its whole stacking context (every
+            // descendant). A negative outline-offset large enough to reach over the box's own text makes
+            // this observable: the outline ring must still end up on top of that text, not underneath it.
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='b' style='width:100pt; height:30pt; font:10pt Arial; outline: 20pt solid rgb(2,2,2); " +
+                "outline-offset: -25pt; color: rgb(9,9,9)'>x</div>"));
+            var div = LayoutHarness.FindById(root, "b")!;
+
+            var g = new TestRecordingGraphics();
+            FragmentPaintHarness.PaintBox(container, div, g);
+
+            var lastTextIndex = g.Log.FindLastIndex(e => e is TestRecordingGraphics.DrawStringCall);
+            var firstOutlineIndex = g.Log.FindIndex(e => e is TestRecordingGraphics.DrawPolygonCall p && p.Color == RColor.FromArgb(2, 2, 2));
+
+            Assert.True(lastTextIndex >= 0);
+            Assert.True(firstOutlineIndex >= 0);
+            Assert.True(firstOutlineIndex > lastTextIndex, "expected outline to paint after the box's own text");
+        }
+
+        [Theory]
+        [InlineData("dotted")]
+        [InlineData("dashed")]
+        public async Task OutlineStyleDottedOrDashed_DrawsOneMidBandLinePerSide(string style)
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                $"<div id='b' style='width:20pt; height:20pt; outline: 8pt {style} rgb(3,3,3); outline-offset: 2pt'>x</div>"));
+            var div = LayoutHarness.FindById(root, "b")!;
+
+            var g = new TestRecordingGraphics();
+            FragmentPaintHarness.PaintBox(container, div, g);
+
+            var expectedDashStyle = style == "dotted" ? RDashStyle.Dot : RDashStyle.Dash;
+            var lines = g.Log.OfType<TestRecordingGraphics.DrawLineCall>().ToList();
+            Assert.Equal(4, lines.Count);
+            Assert.All(lines, l => Assert.Equal(expectedDashStyle, l.DashStyle));
+            Assert.All(lines, l => Assert.Equal(RColor.FromArgb(3, 3, 3), l.Color));
+            Assert.All(lines, l => Assert.Equal(8, l.Width, 1));
+        }
+
+        [Theory]
+        [InlineData("dotted")]
+        [InlineData("dashed")]
+        public async Task OutlineStyleDottedOrDashed_LinesReachTheRingsOuterCorner_NoGap(string style)
+        {
+            // Unlike border (which bands inward, so a line left at the bare box edges still meets its
+            // neighbor within the box), outline bands outward - a line whose span stops at the box's own
+            // edge leaves the outward-facing corner square entirely uncovered. Each side's line must
+            // extend by its own mid-band distance so it actually reaches its neighbor's endpoint.
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                $"<div id='b' style='width:20pt; height:20pt; outline: 8pt {style} rgb(3,3,3); outline-offset: 2pt'>x</div>"));
+            var div = LayoutHarness.FindById(root, "b")!;
+            var rect = FragmentPaintHarness.FragmentOf(container, div).Lines[0].Rect;
+
+            var g = new TestRecordingGraphics();
+            FragmentPaintHarness.PaintBox(container, div, g);
+
+            const double offset = 2;
+            const double width = 8;
+            var mid = offset + width / 2;
+
+            var lines = g.Log.OfType<TestRecordingGraphics.DrawLineCall>().ToList();
+            var top = lines.Single(l => l.Y1 == l.Y2 && l.Y1 < rect.Top);
+            var left = lines.Single(l => l.X1 == l.X2 && l.X1 < rect.Left);
+
+            // Top's leading endpoint (X1,Y1) and Left's leading endpoint (X1,Y1) must land on the exact
+            // same corner point - (rect.Left - mid, rect.Top - mid) - for the two lines to actually meet
+            // with no hole between them.
+            Assert.Equal(rect.Left - mid, top.X1, 1);
+            Assert.Equal(rect.Top - mid, top.Y1, 1);
+            Assert.Equal(top.X1, left.X1, 1);
+            Assert.Equal(top.Y1, left.Y1, 1);
+        }
+
+        [Fact]
+        public async Task OutlineStyleDouble_DrawsTwoEqualWidthStripesWithGap()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='b' style='width:20pt; height:20pt; outline: 12pt double rgb(51,51,51)'>x</div>"));
+            var div = LayoutHarness.FindById(root, "b")!;
+            var rect = FragmentPaintHarness.FragmentOf(container, div).Lines[0].Rect;
+
+            var g = new TestRecordingGraphics();
+            FragmentPaintHarness.PaintBox(container, div, g);
+
+            // Every horizontal line strictly above the box's own top edge belongs to the top side's pair
+            // of stripes - unambiguous, since the bottom side's stripes sit strictly below rect.Bottom.
+            // Draw order (not Y order) distinguishes them: the near-the-box stripe is always drawn
+            // first (OutlineDrawHandler.DrawDoubleOrGrooveRidge), mirroring BordersDrawHandler's own
+            // outer-then-inner order.
+            var topLines = g.Log.OfType<TestRecordingGraphics.DrawLineCall>()
+                .Where(l => l.Y1 == l.Y2 && l.Y1 < rect.Top).ToList();
+            Assert.Equal(2, topLines.Count);
+
+            var nearBox = topLines[0];
+            var farFromBox = topLines[1];
+            Assert.Equal(RColor.FromArgb(51, 51, 51), nearBox.Color);
+            Assert.Equal(RColor.FromArgb(51, 51, 51), farFromBox.Color);
+            Assert.Equal(4, nearBox.Width, 1);
+            Assert.Equal(4, farFromBox.Width, 1);
+
+            var nearBoxFarEdge = nearBox.Y1 - nearBox.Width / 2;
+            var farFromBoxNearEdge = farFromBox.Y1 + farFromBox.Width / 2;
+            Assert.True(farFromBoxNearEdge < nearBoxFarEdge, "expected a visible gap between the two double-outline stripes");
+        }
+
+        [Fact]
+        public async Task OutlineStyleGroove_OuterStripeIsDarker_InnerStripeIsBaseColor()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='b' style='width:20pt; height:20pt; outline: 12pt groove rgb(51,51,51)'>x</div>"));
+            var div = LayoutHarness.FindById(root, "b")!;
+            var rect = FragmentPaintHarness.FragmentOf(container, div).Lines[0].Rect;
+
+            var g = new TestRecordingGraphics();
+            FragmentPaintHarness.PaintBox(container, div, g);
+
+            // Draw order (not Y order): outer (near the box) is drawn first for groove/ridge too.
+            var topLines = g.Log.OfType<TestRecordingGraphics.DrawLineCall>()
+                .Where(l => l.Y1 == l.Y2 && l.Y1 < rect.Top).ToList();
+            Assert.Equal(2, topLines.Count);
+
+            Assert.Equal(RColor.FromArgb(25, 25, 25), topLines[0].Color);
+            Assert.Equal(RColor.FromArgb(51, 51, 51), topLines[1].Color);
+        }
+
+        [Fact]
+        public async Task OutlineStyleInset_DarkensTopAndLeft_NormalOnRightAndBottom()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='b' style='width:20pt; height:20pt; outline: 6pt inset rgb(100,100,100)'>x</div>"));
+            var div = LayoutHarness.FindById(root, "b")!;
+
+            var g = new TestRecordingGraphics();
+            FragmentPaintHarness.PaintBox(container, div, g);
+
+            var polys = g.Log.OfType<TestRecordingGraphics.DrawPolygonCall>().ToList();
+            Assert.Equal(4, polys.Count);
+
+            var top = polys.OrderBy(p => p.Points.Average(pt => pt.Y)).First();
+            var left = polys.OrderBy(p => p.Points.Average(pt => pt.X)).First();
+            var right = polys.OrderByDescending(p => p.Points.Average(pt => pt.X)).First();
+            var bottom = polys.OrderByDescending(p => p.Points.Average(pt => pt.Y)).First();
+
+            Assert.Equal(RColor.FromArgb(50, 50, 50), top.Color);
+            Assert.Equal(RColor.FromArgb(50, 50, 50), left.Color);
+            Assert.Equal(RColor.FromArgb(100, 100, 100), right.Color);
+            Assert.Equal(RColor.FromArgb(100, 100, 100), bottom.Color);
+        }
+
+        [Fact]
+        public async Task OutlineStyleOutset_DarkensRightAndBottom_NormalOnTopAndLeft()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='b' style='width:20pt; height:20pt; outline: 6pt outset rgb(100,100,100)'>x</div>"));
+            var div = LayoutHarness.FindById(root, "b")!;
+
+            var g = new TestRecordingGraphics();
+            FragmentPaintHarness.PaintBox(container, div, g);
+
+            var polys = g.Log.OfType<TestRecordingGraphics.DrawPolygonCall>().ToList();
+            Assert.Equal(4, polys.Count);
+
+            var top = polys.OrderBy(p => p.Points.Average(pt => pt.Y)).First();
+            var left = polys.OrderBy(p => p.Points.Average(pt => pt.X)).First();
+            var right = polys.OrderByDescending(p => p.Points.Average(pt => pt.X)).First();
+            var bottom = polys.OrderByDescending(p => p.Points.Average(pt => pt.Y)).First();
+
+            Assert.Equal(RColor.FromArgb(100, 100, 100), top.Color);
+            Assert.Equal(RColor.FromArgb(100, 100, 100), left.Color);
+            Assert.Equal(RColor.FromArgb(50, 50, 50), right.Color);
+            Assert.Equal(RColor.FromArgb(50, 50, 50), bottom.Color);
+        }
+
+        [Fact]
+        public async Task OutlineStyleNone_ZeroesActualOutlineWidth_EvenWithANonZeroDeclaredWidth()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='b' style='outline-style: none; outline-width: 6pt'>x</div>"));
+            var div = LayoutHarness.FindById(root, "b")!;
+
+            // DerivedStyle.ActualOutlineWidth zeroes itself when the style is None, independent of
+            // OutlineDrawHandler's own early-out on style - a direct property read (not painting)
+            // exercises that branch.
+            Assert.Equal(0, div.ActualOutlineWidth);
+        }
+
+        [Theory]
+        [InlineData("thin")]
+        [InlineData("medium")]
+        [InlineData("thick")]
+        public async Task OutlineWidthKeywords_ResolveTheSamePixelValuesAsBorder(string keyword)
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                $"<div id='b' style='outline-style: solid; outline-width: {keyword}; border-style: solid; border-width: {keyword}'>x</div>"));
+            var div = LayoutHarness.FindById(root, "b")!;
+
+            // Both reuse CssValueParser.GetActualBorderWidth against the same keyword, so they must
+            // resolve to the exact same pixel value as each other, whatever it is.
+            Assert.Equal(div.ActualBorderTopWidth, div.ActualOutlineWidth, 3);
+            Assert.True(div.ActualOutlineWidth > 0);
+        }
+
+        [Theory]
+        [InlineData("none")]
+        [InlineData("hidden")]
+        public async Task OutlineStyleNoneOrHidden_PaintsNothing(string style)
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                $"<div id='b' style='width:20pt; height:20pt; outline-style: {style}; outline-width: 6pt; outline-color: red'>x</div>"));
+            var div = LayoutHarness.FindById(root, "b")!;
+
+            var g = new TestRecordingGraphics();
+            FragmentPaintHarness.PaintBox(container, div, g);
+
+            Assert.Empty(g.Log.OfType<TestRecordingGraphics.DrawPolygonCall>());
+            Assert.Empty(g.Log.OfType<TestRecordingGraphics.DrawLineCall>());
+        }
+
+        [Fact]
+        public async Task OutlineWidthZero_PaintsNothing()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='b' style='width:20pt; height:20pt; outline: 0 solid red'>x</div>"));
+            var div = LayoutHarness.FindById(root, "b")!;
+
+            var g = new TestRecordingGraphics();
+            FragmentPaintHarness.PaintBox(container, div, g);
+
+            Assert.Empty(g.Log.OfType<TestRecordingGraphics.DrawPolygonCall>());
+            Assert.Empty(g.Log.OfType<TestRecordingGraphics.DrawLineCall>());
+        }
+
+        [Fact]
+        public async Task OutlineOnAWrappingInlineElement_OnlyPaintsTheEdgesEachLineOwns()
+        {
+            // A span forced onto three lines - mirrors BoxDecorationBreakPaintIntegrationTests' own
+            // "Slice_WrappingInline_DrawsNoBorderAtABreak", since outline is gated by the exact same
+            // per-line HasLeftEdge/HasRightEdge flags FragmentPainter already computes for border.
+            var html = LayoutHarness.Wrap(
+                "<div style='width:200pt;font:10pt Arial'>" +
+                "<span id='s' style='outline:2pt solid #00f'>Alpha<br>Beta<br>Gamma</span></div>");
+            var (root, container) = await LayoutHarness.LayoutAsync(html);
+            var span = LayoutHarness.FindById(root, "s")!;
+
+            var g = new TestRecordingGraphics();
+            FragmentPaintHarness.PaintBox(container, span, g);
+
+            var blue = RColor.FromArgb(0, 0, 255);
+            var vertical = g.Log.OfType<TestRecordingGraphics.DrawPolygonCall>()
+                .Where(p => p.Color == blue && IsVerticalEdge(p.Points))
+                .ToList();
+
+            // The leading edge draws once (first line) and the trailing edge once (last line) - never
+            // at either of the two internal wrap points.
+            Assert.Equal(2, vertical.Count);
+        }
+
+        [Fact]
+        public async Task Outline_DoesNotAffectLayout()
+        {
+            var withoutOutline = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='a' style='width:30pt; height:20pt;'>x</div>" +
+                "<div id='b' style='width:30pt; height:20pt;'>y</div>"));
+            var aWithout = LayoutHarness.FindById(withoutOutline.Root, "a")!;
+            var bWithout = LayoutHarness.FindById(withoutOutline.Root, "b")!;
+
+            var withOutline = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='a' style='width:30pt; height:20pt; outline: 20pt solid red; outline-offset: 15pt;'>x</div>" +
+                "<div id='b' style='width:30pt; height:20pt;'>y</div>"));
+            var aWith = LayoutHarness.FindById(withOutline.Root, "a")!;
+            var bWith = LayoutHarness.FindById(withOutline.Root, "b")!;
+
+            // A large outline (offset+width = 35pt, comfortably wider than the box itself) visually
+            // overlaps the sibling below, but must not shift it - outline is layout-neutral by spec.
+            Assert.Equal(aWithout.Location, aWith.Location);
+            Assert.Equal(aWithout.Size, aWith.Size);
+            Assert.Equal(bWithout.Location, bWith.Location);
+            Assert.Equal(bWithout.Size, bWith.Size);
+        }
+
+        // ─── Helpers ─────────────────────────────────────────────────────────────
+
+        private static bool IsVerticalEdge(System.Collections.Generic.IReadOnlyList<RPoint> points)
+        {
+            var width = points.Max(p => p.X) - points.Min(p => p.X);
+            var height = points.Max(p => p.Y) - points.Min(p => p.Y);
+            return height > width;
+        }
+
+        private static async Task<string> GetPdfText(string html)
+        {
+            var generator = new PdfGenerator();
+            var config = new PdfGenerateConfig { PageSize = PageSize.A4, CompressContentStreams = false };
+            config.SetMargins(20);
+            var doc = await generator.GeneratePdf(html, config);
+            var ms = new MemoryStream();
+            doc.Save(ms);
+            return Encoding.Latin1.GetString(ms.ToArray());
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/SmallCapsIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/SmallCapsIntegrationTests.cs
@@ -309,6 +309,8 @@ body {{ font-family: 'SCP'; width: 400px; }}
 
             public override void PushTransform(RMatrix matrix) { }
             public override void PopTransform() { }
+            public override void PushBlendMode(RBlendMode mode) { }
+            public override void PopBlendMode() { }
             public override void PushClip(RRect rect) => _clipStack.Push(rect);
             public override void PushClip(RGraphicsPath path) => _clipStack.Push(_clipStack.Peek());
             public override void PopClip() { if (_clipStack.Count > 1) _clipStack.Pop(); }

--- a/src/PeachPDF.Tests/Integration/StackingContextPaintRegressionTests.cs
+++ b/src/PeachPDF.Tests/Integration/StackingContextPaintRegressionTests.cs
@@ -269,6 +269,8 @@ namespace PeachPDF.Tests.Integration
 
             public override void PushTransform(RMatrix matrix) { }
             public override void PopTransform() { }
+            public override void PushBlendMode(RBlendMode mode) { }
+            public override void PopBlendMode() { }
             public override void PushClip(RRect rect) => _clipStack.Push(rect);
             public override void PushClip(RGraphicsPath path) => _clipStack.Push(_clipStack.Peek());
             public override void PopClip() { if (_clipStack.Count > 1) _clipStack.Pop(); }

--- a/src/PeachPDF.Tests/Integration/TableHeaderPdfRenderingTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableHeaderPdfRenderingTests.cs
@@ -308,6 +308,8 @@ namespace PeachPDF.Tests.Integration
             public override void BeginArtifact() { }
             public override void PushTransform(RMatrix matrix) { }
             public override void PopTransform() { }
+            public override void PushBlendMode(RBlendMode mode) { }
+            public override void PopBlendMode() { }
             public override void PushClip(RRect rect) => _clipStack.Push(rect);
             public override void PushClip(RGraphicsPath path) => _clipStack.Push(_clipStack.Peek());
             public override void PopClip() { if (_clipStack.Count > 1) _clipStack.Pop(); }

--- a/src/PeachPDF.Tests/Integration/TaggedPdfPaintOrderTests.cs
+++ b/src/PeachPDF.Tests/Integration/TaggedPdfPaintOrderTests.cs
@@ -165,6 +165,8 @@ namespace PeachPDF.Tests.Integration
 
             public override void PushTransform(RMatrix matrix) { }
             public override void PopTransform() { }
+            public override void PushBlendMode(RBlendMode mode) { }
+            public override void PopBlendMode() { }
             public override void PushClip(RRect rect) => _clipStack.Push(rect);
             public override void PushClip(RGraphicsPath path) => _clipStack.Push(_clipStack.Peek());
             public override void PopClip() { if (_clipStack.Count > 1) _clipStack.Pop(); }

--- a/src/PeachPDF.Tests/Integration/TransformIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/TransformIntegrationTests.cs
@@ -356,6 +356,8 @@ namespace PeachPDF.Tests.Integration
 
             public override void PushTransform(RMatrix matrix) => LastPushedTransform = matrix;
             public override void PopTransform() { }
+            public override void PushBlendMode(RBlendMode mode) { }
+            public override void PopBlendMode() { }
             public override void PushClip(RRect rect) => _clipStack.Push(rect);
             public override void PushClip(RGraphicsPath path) => _clipStack.Push(_clipStack.Peek());
             public override void PopClip() { if (_clipStack.Count > 1) _clipStack.Pop(); }

--- a/src/PeachPDF.Tests/TestSupport/TestGraphicsAdapter.cs
+++ b/src/PeachPDF.Tests/TestSupport/TestGraphicsAdapter.cs
@@ -197,6 +197,8 @@ namespace PeachPDF.Tests.TestSupport
         public sealed record PushClipCall(RRect Rect);
         public sealed record PopClipCall;
         public sealed record DrawImageCall(RImage Image, RRect DestRect);
+        public sealed record PushBlendModeCall(RBlendMode Mode);
+        public sealed record PopBlendModeCall;
 
         public List<object> Log { get; } = [];
         public List<DrawStringCall> DrawStringCalls { get; } = [];
@@ -261,6 +263,8 @@ namespace PeachPDF.Tests.TestSupport
             Log.Add(new PopClipCall());
         }
         public override void PushClipExclude(RRect rect) { }
+        public override void PushBlendMode(RBlendMode mode) => Log.Add(new PushBlendModeCall(mode));
+        public override void PopBlendMode() => Log.Add(new PopBlendModeCall());
         public override object SetAntiAliasSmoothingMode() => new object();
         public override void ReturnPreviousSmoothingMode(object? prevMode) { }
         public override RGraphicsPath GetGraphicsPath() => new TestGraphicsPath();

--- a/src/PeachPDF/Adapters/GraphicsAdapter.cs
+++ b/src/PeachPDF/Adapters/GraphicsAdapter.cs
@@ -117,6 +117,17 @@ namespace PeachPDF.Adapters
             _g.Restore();
         }
 
+        public override void PushBlendMode(RBlendMode mode)
+        {
+            _g.Save();
+            _g.SetBlendMode(mode.ToString());
+        }
+
+        public override void PopBlendMode()
+        {
+            _g.Restore();
+        }
+
         public override object SetAntiAliasSmoothingMode()
         {
             var prevMode = _g.SmoothingMode;

--- a/src/PeachPDF/CSS/Enumerations/OutlineStyle.cs
+++ b/src/PeachPDF/CSS/Enumerations/OutlineStyle.cs
@@ -1,0 +1,23 @@
+namespace PeachPDF.CSS
+{
+    /// <summary>
+    /// <c>outline-style</c>'s own value set — <c>&lt;'border-style'&gt; | auto</c> (CSS Basic User
+    /// Interface 4 §4) — kept separate from <see cref="LineStyle"/> (used by every <c>border-*-style</c>
+    /// and <c>column-rule-style</c>) so that <c>auto</c> can be a real, paintable value for outline
+    /// without also becoming a silently-accepted value for border, which has no <c>auto</c> keyword.
+    /// </summary>
+    internal enum OutlineStyle : byte
+    {
+        None,
+        Hidden,
+        Dotted,
+        Dashed,
+        Solid,
+        Double,
+        Groove,
+        Ridge,
+        Inset,
+        Outset,
+        Auto
+    }
+}

--- a/src/PeachPDF/CSS/Enumerations/PropertyNames.cs
+++ b/src/PeachPDF/CSS/Enumerations/PropertyNames.cs
@@ -188,6 +188,7 @@ namespace PeachPDF.CSS
         public static readonly string Order = "order";
         public static readonly string Orphans = "orphans";
         public static readonly string OutlineColor = "outline-color";
+        public static readonly string OutlineOffset = "outline-offset";
         public static readonly string OutlineStyle = "outline-style";
         public static readonly string OutlineWidth = "outline-width";
         public static readonly string Outline = "outline";

--- a/src/PeachPDF/CSS/Factories/PropertyFactory.cs
+++ b/src/PeachPDF/CSS/Factories/PropertyFactory.cs
@@ -356,6 +356,7 @@ namespace PeachPDF.CSS
             AddLonghand(PropertyNames.OutlineColor, () => new OutlineColorProperty(), true);
             AddLonghand(PropertyNames.OutlineStyle, () => new OutlineStyleProperty());
             AddLonghand(PropertyNames.OutlineWidth, () => new OutlineWidthProperty(), true);
+            AddLonghand(PropertyNames.OutlineOffset, () => new OutlineOffsetProperty(), true);
 
             AddLonghand(PropertyNames.Overflow, () => new OverflowProperty());
             AddLonghand(PropertyNames.OverflowWrap, () => new OverflowWrapProperty());

--- a/src/PeachPDF/CSS/Model/Converters.cs
+++ b/src/PeachPDF/CSS/Model/Converters.cs
@@ -264,6 +264,13 @@ namespace PeachPDF.CSS
 
         public static readonly IValueConverter DefaultFontFamiliesConverter = Map.DefaultFontFamilies.ToConverter();
         public static readonly IValueConverter LineStyleConverter = Map.LineStyles.ToConverter();
+        /// <summary>
+        /// <c>outline-style</c>'s own converter (<c>&lt;'border-style'&gt; | auto</c>, CSS-UI-4 §4) - a
+        /// separate converter/keyword map from <see cref="LineStyleConverter"/> so that <c>auto</c>
+        /// stays an outline-style-only value; every <c>border-*-style</c>/<c>column-rule-style</c>
+        /// property keeps using <see cref="LineStyleConverter"/> unchanged.
+        /// </summary>
+        public static readonly IValueConverter OutlineStyleConverter = Map.OutlineStyles.ToConverter();
         public static readonly IValueConverter PdfTagTypeConverter = Map.PdfTagTypes.ToConverter();
         public static readonly IValueConverter BackgroundAttachmentConverter = Map.BackgroundAttachments.ToConverter();
         public static readonly IValueConverter BackgroundRepeatConverter = Map.BackgroundRepeats.ToConverter();

--- a/src/PeachPDF/CSS/Model/Map.cs
+++ b/src/PeachPDF/CSS/Model/Map.cs
@@ -107,6 +107,21 @@ namespace PeachPDF.CSS
                 {Keywords.Groove, LineStyle.Groove},
                 {Keywords.Hidden, LineStyle.Hidden}
             }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        public static readonly FrozenDictionary<string, OutlineStyle> OutlineStyles =
+            new Dictionary<string, OutlineStyle>(StringComparer.OrdinalIgnoreCase)
+            {
+                {Keywords.None, OutlineStyle.None},
+                {Keywords.Solid, OutlineStyle.Solid},
+                {Keywords.Double, OutlineStyle.Double},
+                {Keywords.Dotted, OutlineStyle.Dotted},
+                {Keywords.Dashed, OutlineStyle.Dashed},
+                {Keywords.Inset, OutlineStyle.Inset},
+                {Keywords.Outset, OutlineStyle.Outset},
+                {Keywords.Ridge, OutlineStyle.Ridge},
+                {Keywords.Groove, OutlineStyle.Groove},
+                {Keywords.Hidden, OutlineStyle.Hidden},
+                {Keywords.Auto, OutlineStyle.Auto}
+            }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
         public static readonly FrozenDictionary<string, PdfTagType> PdfTagTypes =
             new Dictionary<string, PdfTagType>(StringComparer.OrdinalIgnoreCase)
             {

--- a/src/PeachPDF/CSS/Model/StyleDeclaration.cs
+++ b/src/PeachPDF/CSS/Model/StyleDeclaration.cs
@@ -1309,6 +1309,12 @@ namespace PeachPDF.CSS
             set => SetPropertyValue(PropertyNames.OutlineWidth, value);
         }
 
+        public string OutlineOffset
+        {
+            get => GetPropertyValue(PropertyNames.OutlineOffset);
+            set => SetPropertyValue(PropertyNames.OutlineOffset, value);
+        }
+
         public string Overflow
         {
             get => GetPropertyValue(PropertyNames.Overflow);

--- a/src/PeachPDF/CSS/StyleProperties/Outline/OutlineOffsetProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Outline/OutlineOffsetProperty.cs
@@ -1,0 +1,14 @@
+namespace PeachPDF.CSS
+{
+    internal sealed class OutlineOffsetProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter = Converters.LengthConverter.OrDefault(Length.Zero);
+
+        internal OutlineOffsetProperty()
+            : base(PropertyNames.OutlineOffset, PropertyFlags.Animatable)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/PeachPDF/CSS/StyleProperties/Outline/OutlineProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Outline/OutlineProperty.cs
@@ -6,7 +6,7 @@
     {
         private static readonly IValueConverter StyleConverter = WithAny(
             LineWidthConverter.Option().For(PropertyNames.OutlineWidth),
-            LineStyleConverter.Option().For(PropertyNames.OutlineStyle),
+            OutlineStyleConverter.Option().For(PropertyNames.OutlineStyle),
             InvertedColorConverter.Option().For(PropertyNames.OutlineColor)).OrDefault();
 
         internal OutlineProperty()

--- a/src/PeachPDF/CSS/StyleProperties/Outline/OutlineStyleProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Outline/OutlineStyleProperty.cs
@@ -3,7 +3,7 @@
     internal sealed class OutlineStyleProperty : Property
     {
         private static readonly IValueConverter
-            StyleConverter = Converters.LineStyleConverter.OrDefault(LineStyle.None);
+            StyleConverter = Converters.OutlineStyleConverter.OrDefault(OutlineStyle.None);
 
         internal OutlineStyleProperty()
             : base(PropertyNames.OutlineStyle)

--- a/src/PeachPDF/Html/Adapters/Entities/RBlendMode.cs
+++ b/src/PeachPDF/Html/Adapters/Entities/RBlendMode.cs
@@ -1,0 +1,39 @@
+// "Therefore those skilled at the unorthodox
+// are infinite as heaven and earth,
+// inexhaustible as the great rivers.
+// When they come to an end,
+// they begin again,
+// like the days and months;
+// they die and are reborn,
+// like the four seasons."
+//
+// - Sun Tsu,
+// "The Art of War"
+
+namespace PeachPDF.Html.Adapters.Entities
+{
+    /// <summary>
+    /// A PDF separable/non-separable blend mode (PDF 32000-1 §11.3.5), used with
+    /// <see cref="RGraphics.PushBlendMode"/>/<see cref="RGraphics.PopBlendMode"/> to composite
+    /// subsequent drawing against whatever is already painted underneath it.
+    /// </summary>
+    internal enum RBlendMode
+    {
+        Normal,
+        Multiply,
+        Screen,
+        Overlay,
+        Darken,
+        Lighten,
+        ColorDodge,
+        ColorBurn,
+        HardLight,
+        SoftLight,
+        Difference,
+        Exclusion,
+        Hue,
+        Saturation,
+        Color,
+        Luminosity
+    }
+}

--- a/src/PeachPDF/Html/Adapters/RGraphics.cs
+++ b/src/PeachPDF/Html/Adapters/RGraphics.cs
@@ -157,6 +157,20 @@ namespace PeachPDF.Html.Adapters
         /// </summary>
         public abstract void PopTransform();
 
+        /// <summary>
+        /// Push a PDF blend mode for subsequent drawing, saving state so it can later be undone by
+        /// <see cref="PopBlendMode"/> (stack-shaped, same convention as <see cref="PushClip(RRect)"/>/
+        /// <see cref="PopClip"/>). Used e.g. to composite a fill against the content underneath it via
+        /// <see cref="RBlendMode.Difference"/> for a true color inversion (CSS <c>outline-color: invert</c>).
+        /// </summary>
+        /// <param name="mode">Blend mode to apply to subsequent drawing.</param>
+        public abstract void PushBlendMode(RBlendMode mode);
+
+        /// <summary>
+        /// Pop the most recent <see cref="PushBlendMode"/>, restoring the prior blend mode.
+        /// </summary>
+        public abstract void PopBlendMode();
+
 
         /// <summary>
         /// Restore the clipping region to the initial clip.

--- a/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
@@ -247,6 +247,10 @@ namespace PeachPDF.Html.Core.Dom
         /// <summary>Gets the actual column-rule color (the line drawn between columns in a multi-column container).</summary>
         public RColor ActualColumnRuleColor => DerivedStyle.ActualColumnRuleColor;
 
+        public double ActualOutlineWidth => DerivedStyle.ActualOutlineWidth;
+        public RColor ActualOutlineColor => DerivedStyle.ActualOutlineColor;
+        public double ActualOutlineOffset => DerivedStyle.ActualOutlineOffset;
+
         public double ActualBorderTopLeftRadiusX => DerivedStyle.ActualBorderTopLeftRadiusX;
         public double ActualBorderTopLeftRadiusY => DerivedStyle.ActualBorderTopLeftRadiusY;
         public double ActualBorderTopRightRadiusX => DerivedStyle.ActualBorderTopRightRadiusX;

--- a/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
+++ b/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
@@ -179,6 +179,56 @@ namespace PeachPDF.Html.Core.Dom
 
         #endregion
 
+        #region Outline
+
+        private double _actualOutlineWidth = double.NaN;
+        private RColor _actualOutlineColor = RColor.Empty;
+        private double _actualOutlineOffset = double.NaN;
+
+        public double ActualOutlineWidth
+        {
+            get
+            {
+                if (!double.IsNaN(_actualOutlineWidth)) return _actualOutlineWidth;
+
+                _actualOutlineWidth = CssValueParser.GetActualBorderWidth(Style.Border.OutlineWidth, Owner);
+                if (Style.Border.OutlineStyle.Value == OutlineStyle.None)
+                    _actualOutlineWidth = 0f;
+
+                return _actualOutlineWidth;
+            }
+        }
+
+        /// <summary>
+        /// Unaware of the legacy <c>invert</c> keyword by design - <c>OutlineDrawHandler</c> checks the
+        /// raw <see cref="CssBox.OutlineColor"/> string for <c>"invert"</c> itself and bypasses this
+        /// property entirely in that case, painting via a PDF blend mode instead of a resolved color.
+        /// </summary>
+        public RColor ActualOutlineColor
+        {
+            get
+            {
+                if (_actualOutlineColor.IsEmpty) _actualOutlineColor = Owner.GetActualColor(Style.Border.OutlineColor);
+                return _actualOutlineColor;
+            }
+        }
+
+        public double ActualOutlineOffset
+        {
+            get
+            {
+                if (!double.IsNaN(_actualOutlineOffset)) return _actualOutlineOffset;
+                _actualOutlineOffset = CssValueParser.ParseLength(Style.Border.OutlineOffset, 0, Owner);
+                return _actualOutlineOffset;
+            }
+        }
+
+        internal void InvalidateOutlineWidth() => _actualOutlineWidth = double.NaN;
+        internal void InvalidateOutlineColor() => _actualOutlineColor = RColor.Empty;
+        internal void InvalidateOutlineOffset() => _actualOutlineOffset = double.NaN;
+
+        #endregion
+
         #region Border radii
 
         private double _actualBorderTopLeftRadiusX = double.NaN;

--- a/src/PeachPDF/Html/Core/Handlers/BordersDrawHandler.cs
+++ b/src/PeachPDF/Html/Core/Handlers/BordersDrawHandler.cs
@@ -449,9 +449,11 @@ namespace PeachPDF.Html.Core.Handlers
         }
 
         /// <summary>
-        /// Makes the specified color darker for inset/outset borders.
+        /// Makes the specified color darker for inset/outset borders - also shared by
+        /// <see cref="OutlineDrawHandler"/> for its own inset/outset/groove/ridge shading, since
+        /// darkening a color for a beveled line style isn't a border-specific operation.
         /// </summary>
-        private static RColor Darken(RColor c)
+        internal static RColor Darken(RColor c)
         {
             return RColor.FromArgb(c.R / 2, c.G / 2, c.B / 2);
         }

--- a/src/PeachPDF/Html/Core/Handlers/OutlineDrawHandler.cs
+++ b/src/PeachPDF/Html/Core/Handlers/OutlineDrawHandler.cs
@@ -1,0 +1,263 @@
+using PeachPDF.CSS;
+using PeachPDF.Html.Adapters;
+using PeachPDF.Html.Adapters.Entities;
+using PeachPDF.Html.Core.Dom;
+using System;
+
+namespace PeachPDF.Html.Core.Handlers
+{
+    /// <summary>
+    /// Paints CSS <c>outline</c> - a ring drawn outside the border edge, offset by
+    /// <c>outline-offset</c>, that never affects box sizing (CSS Basic User Interface 4 §4). Structured
+    /// in parallel with <see cref="BordersDrawHandler"/> but simplified: outline has a single
+    /// width/color/style for all four sides (no per-side values to independently miter, unlike border),
+    /// so each side's ring quad is built directly from the box's own two nested "reach" rectangles
+    /// (one at <c>outline-offset</c>, one at <c>outline-offset + outline-width</c>) rather than
+    /// <see cref="BordersDrawHandler"/>'s per-side width bookkeeping. <c>outline-style: auto</c> is
+    /// rendered identically to <c>solid</c> (CSS-UI-4 leaves <c>auto</c>'s actual appearance UA-defined).
+    /// Never follows <c>border-radius</c> - CSS-UI-4 only says a UA <i>may</i> do so.
+    /// </summary>
+    internal static class OutlineDrawHandler
+    {
+        /// <summary>
+        /// Draws the box's outline, if any, around <paramref name="rect"/> (the same border-box
+        /// rectangle <see cref="BordersDrawHandler.DrawBoxBorders"/> receives).
+        /// </summary>
+        /// <param name="g">the device to draw into</param>
+        /// <param name="box">the box to draw the outline for</param>
+        /// <param name="rect">the border-box rectangle the outline surrounds</param>
+        /// <param name="hasLeftEdge">
+        /// whether the box's leading edge belongs to this rectangle - see
+        /// <see cref="BordersDrawHandler.DrawBoxBorders"/>'s own parameter doc. Gates the outline the
+        /// same way it gates border, which is what keeps an inline element wrapped across multiple
+        /// lines from drawing its left/right outline edges on every line.
+        /// </param>
+        /// <param name="hasRightEdge">whether the box's trailing edge belongs to this rectangle</param>
+        /// <param name="hasTopEdge">whether the box's own top edge belongs to this rectangle</param>
+        /// <param name="hasBottomEdge">whether the box's own bottom edge belongs to this rectangle</param>
+        public static void DrawOutline(
+            RGraphics g, CssBox box, RRect rect,
+            bool hasLeftEdge, bool hasRightEdge, bool hasTopEdge, bool hasBottomEdge)
+        {
+            if (rect is not { Width: > 0, Height: > 0 }) return;
+
+            var style = box.OutlineStyle.Value;
+            if (style is OutlineStyle.None or OutlineStyle.Hidden) return;
+
+            var width = box.ActualOutlineWidth;
+            if (width <= 0) return;
+
+            var isInvert = string.Equals(box.OutlineColor, Keywords.Invert, StringComparison.OrdinalIgnoreCase);
+            var color = isInvert ? RColor.White : box.ActualOutlineColor;
+            var offset = box.ActualOutlineOffset;
+            var effectiveStyle = style == OutlineStyle.Auto ? OutlineStyle.Solid : style;
+
+            if (isInvert) g.PushBlendMode(RBlendMode.Difference);
+
+            if (hasTopEdge) DrawSide(Border.Top, g, rect, effectiveStyle, color, width, offset, hasLeftEdge, hasRightEdge, hasTopEdge, hasBottomEdge);
+            if (hasLeftEdge) DrawSide(Border.Left, g, rect, effectiveStyle, color, width, offset, hasLeftEdge, hasRightEdge, hasTopEdge, hasBottomEdge);
+            if (hasBottomEdge) DrawSide(Border.Bottom, g, rect, effectiveStyle, color, width, offset, hasLeftEdge, hasRightEdge, hasTopEdge, hasBottomEdge);
+            if (hasRightEdge) DrawSide(Border.Right, g, rect, effectiveStyle, color, width, offset, hasLeftEdge, hasRightEdge, hasTopEdge, hasBottomEdge);
+
+            if (isInvert) g.PopBlendMode();
+        }
+
+        #region Private methods
+
+        private static void DrawSide(
+            Border side, RGraphics g, RRect rect, OutlineStyle style, RColor color, double width, double offset,
+            bool hasLeftEdge, bool hasRightEdge, bool hasTopEdge, bool hasBottomEdge)
+        {
+            switch (style)
+            {
+                case OutlineStyle.Solid:
+                    DrawRing(side, g, rect, g.GetSolidBrush(color), width, offset, hasLeftEdge, hasRightEdge, hasTopEdge, hasBottomEdge);
+                    break;
+                case OutlineStyle.Inset:
+                    DrawRing(side, g, rect, g.GetSolidBrush(side is Border.Top or Border.Left ? BordersDrawHandler.Darken(color) : color), width, offset, hasLeftEdge, hasRightEdge, hasTopEdge, hasBottomEdge);
+                    break;
+                case OutlineStyle.Outset:
+                    DrawRing(side, g, rect, g.GetSolidBrush(side is Border.Right or Border.Bottom ? BordersDrawHandler.Darken(color) : color), width, offset, hasLeftEdge, hasRightEdge, hasTopEdge, hasBottomEdge);
+                    break;
+                case OutlineStyle.Double:
+                case OutlineStyle.Groove:
+                case OutlineStyle.Ridge:
+                    DrawDoubleOrGrooveRidge(side, g, rect, style, color, width, offset, hasLeftEdge, hasRightEdge, hasTopEdge, hasBottomEdge);
+                    break;
+                default:
+                    // Dotted/dashed draw as a single mid-band line - the corner join itself isn't
+                    // mitred (representing dash/dot patterns as a mitred ring fill is far more involved
+                    // than this repo's scope needs, the same simplification BordersDrawHandler's own
+                    // dotted/dashed branch already accepts), but each line's span still has to reach the
+                    // ring's outer corner point the way DrawRing's does - unlike border, whose bands
+                    // face inward and so always stay within [rect.Left, rect.Right]/[rect.Top,
+                    // rect.Bottom] regardless, outline's bands face outward, so a span left at the bare
+                    // rect edges leaves the whole outward-facing corner square uncovered by any line.
+                    var pen = GetPen(g, style, color, width);
+                    DrawDottedOrDashedLine(side, g, rect, pen, width, offset, hasLeftEdge, hasRightEdge, hasTopEdge, hasBottomEdge);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Builds and fills the ring quad for one side, between the two nested "reach" rectangles at
+        /// distance <paramref name="offset"/> (inner, nearest the box) and
+        /// <paramref name="offset"/> + <paramref name="width"/> (outer, farthest from the box) from the
+        /// box's own edge. Adjacent sides' quads share an exact edge at each corner - see this class's
+        /// own doc comment - so long as both sides are actually drawn (<paramref name="hasLeftEdge"/>
+        /// etc.); when the perpendicular side isn't drawn (an open fragment edge, e.g. mid-wrap on an
+        /// inline element), the quad collapses flush to the box's own edge on that end instead of
+        /// bulging outward with nothing to miter into.
+        /// </summary>
+        private static void DrawRing(
+            Border side, RGraphics g, RRect rect, RBrush brush, double width, double offset,
+            bool hasLeftEdge, bool hasRightEdge, bool hasTopEdge, bool hasBottomEdge)
+        {
+            var reach = offset + width;
+            RPoint[] points;
+
+            switch (side)
+            {
+                case Border.Top:
+                    points =
+                    [
+                        new RPoint(hasLeftEdge ? rect.Left - offset : rect.Left, rect.Top - offset),
+                        new RPoint(hasRightEdge ? rect.Right + offset : rect.Right, rect.Top - offset),
+                        new RPoint(hasRightEdge ? rect.Right + reach : rect.Right, rect.Top - reach),
+                        new RPoint(hasLeftEdge ? rect.Left - reach : rect.Left, rect.Top - reach)
+                    ];
+                    break;
+                case Border.Right:
+                    points =
+                    [
+                        new RPoint(rect.Right + offset, hasTopEdge ? rect.Top - offset : rect.Top),
+                        new RPoint(rect.Right + reach, hasTopEdge ? rect.Top - reach : rect.Top),
+                        new RPoint(rect.Right + reach, hasBottomEdge ? rect.Bottom + reach : rect.Bottom),
+                        new RPoint(rect.Right + offset, hasBottomEdge ? rect.Bottom + offset : rect.Bottom)
+                    ];
+                    break;
+                case Border.Bottom:
+                    points =
+                    [
+                        new RPoint(hasLeftEdge ? rect.Left - offset : rect.Left, rect.Bottom + offset),
+                        new RPoint(hasRightEdge ? rect.Right + offset : rect.Right, rect.Bottom + offset),
+                        new RPoint(hasRightEdge ? rect.Right + reach : rect.Right, rect.Bottom + reach),
+                        new RPoint(hasLeftEdge ? rect.Left - reach : rect.Left, rect.Bottom + reach)
+                    ];
+                    break;
+                default: // Border.Left
+                    points =
+                    [
+                        new RPoint(rect.Left - offset, hasBottomEdge ? rect.Bottom + offset : rect.Bottom),
+                        new RPoint(rect.Left - reach, hasBottomEdge ? rect.Bottom + reach : rect.Bottom),
+                        new RPoint(rect.Left - reach, hasTopEdge ? rect.Top - reach : rect.Top),
+                        new RPoint(rect.Left - offset, hasTopEdge ? rect.Top - offset : rect.Top)
+                    ];
+                    break;
+            }
+
+            g.DrawPolygon(brush, points);
+        }
+
+        /// <summary>
+        /// Draws a "double", "groove", or "ridge" outline as two solid stripes spanning the full side,
+        /// mirroring <c>BordersDrawHandler.DrawDoubleOrGrooveRidgeBorder</c>'s technique but banded
+        /// outward from the border edge (within <c>[offset, offset + width]</c>) instead of inward from
+        /// it, and using one uniform width/color for all four sides rather than border's independent
+        /// per-side values.
+        /// </summary>
+        private static void DrawDoubleOrGrooveRidge(
+            Border side, RGraphics g, RRect rect, OutlineStyle style, RColor color, double width, double offset,
+            bool hasLeftEdge, bool hasRightEdge, bool hasTopEdge, bool hasBottomEdge)
+        {
+            double outerWidth;
+            double innerWidth;
+            RColor outerColor;
+            RColor innerColor;
+
+            if (style == OutlineStyle.Double)
+            {
+                outerWidth = innerWidth = Math.Max(1, Math.Floor(width / 3));
+                outerColor = innerColor = color;
+            }
+            else
+            {
+                outerWidth = innerWidth = width / 2;
+                outerColor = style == OutlineStyle.Groove ? BordersDrawHandler.Darken(color) : color;
+                innerColor = style == OutlineStyle.Groove ? color : BordersDrawHandler.Darken(color);
+            }
+
+            var outerPen = g.GetPen(outerColor);
+            outerPen.Width = outerWidth;
+            outerPen.DashStyle = RDashStyle.Solid;
+
+            var innerPen = g.GetPen(innerColor);
+            innerPen.Width = innerWidth;
+            innerPen.DashStyle = RDashStyle.Solid;
+
+            // "outer"/"inner" name the stripe's position within the ring band (nearest the box edge vs.
+            // farthest from it), matching BordersDrawHandler's own naming for the analogous stripes.
+            var nearBand = offset + outerWidth / 2;
+            var farBand = offset + width - innerWidth / 2;
+
+            switch (side)
+            {
+                case Border.Top:
+                    g.DrawLine(outerPen, hasLeftEdge ? rect.Left - nearBand : rect.Left, rect.Top - nearBand, hasRightEdge ? rect.Right + nearBand : rect.Right, rect.Top - nearBand);
+                    g.DrawLine(innerPen, hasLeftEdge ? rect.Left - farBand : rect.Left, rect.Top - farBand, hasRightEdge ? rect.Right + farBand : rect.Right, rect.Top - farBand);
+                    break;
+                case Border.Right:
+                    g.DrawLine(outerPen, rect.Right + nearBand, hasTopEdge ? rect.Top - nearBand : rect.Top, rect.Right + nearBand, hasBottomEdge ? rect.Bottom + nearBand : rect.Bottom);
+                    g.DrawLine(innerPen, rect.Right + farBand, hasTopEdge ? rect.Top - farBand : rect.Top, rect.Right + farBand, hasBottomEdge ? rect.Bottom + farBand : rect.Bottom);
+                    break;
+                case Border.Bottom:
+                    g.DrawLine(outerPen, hasLeftEdge ? rect.Left - nearBand : rect.Left, rect.Bottom + nearBand, hasRightEdge ? rect.Right + nearBand : rect.Right, rect.Bottom + nearBand);
+                    g.DrawLine(innerPen, hasLeftEdge ? rect.Left - farBand : rect.Left, rect.Bottom + farBand, hasRightEdge ? rect.Right + farBand : rect.Right, rect.Bottom + farBand);
+                    break;
+                case Border.Left:
+                    g.DrawLine(outerPen, rect.Left - nearBand, hasTopEdge ? rect.Top - nearBand : rect.Top, rect.Left - nearBand, hasBottomEdge ? rect.Bottom + nearBand : rect.Bottom);
+                    g.DrawLine(innerPen, rect.Left - farBand, hasTopEdge ? rect.Top - farBand : rect.Top, rect.Left - farBand, hasBottomEdge ? rect.Bottom + farBand : rect.Bottom);
+                    break;
+            }
+        }
+
+        private static void DrawDottedOrDashedLine(
+            Border side, RGraphics g, RRect rect, RPen pen, double width, double offset,
+            bool hasLeftEdge, bool hasRightEdge, bool hasTopEdge, bool hasBottomEdge)
+        {
+            var mid = offset + width / 2;
+
+            switch (side)
+            {
+                case Border.Top:
+                    g.DrawLine(pen, hasLeftEdge ? rect.Left - mid : rect.Left, rect.Top - mid, hasRightEdge ? rect.Right + mid : rect.Right, rect.Top - mid);
+                    break;
+                case Border.Right:
+                    g.DrawLine(pen, rect.Right + mid, hasTopEdge ? rect.Top - mid : rect.Top, rect.Right + mid, hasBottomEdge ? rect.Bottom + mid : rect.Bottom);
+                    break;
+                case Border.Bottom:
+                    g.DrawLine(pen, hasLeftEdge ? rect.Left - mid : rect.Left, rect.Bottom + mid, hasRightEdge ? rect.Right + mid : rect.Right, rect.Bottom + mid);
+                    break;
+                case Border.Left:
+                    g.DrawLine(pen, rect.Left - mid, hasTopEdge ? rect.Top - mid : rect.Top, rect.Left - mid, hasBottomEdge ? rect.Bottom + mid : rect.Bottom);
+                    break;
+            }
+        }
+
+        private static RPen GetPen(RGraphics g, OutlineStyle style, RColor color, double width)
+        {
+            var p = g.GetPen(color);
+            p.Width = width;
+            p.DashStyle = style switch
+            {
+                OutlineStyle.Dotted => RDashStyle.Dot,
+                OutlineStyle.Dashed => RDashStyle.Dash,
+                _ => RDashStyle.Solid
+            };
+
+            return p;
+        }
+
+        #endregion
+    }
+}

--- a/src/PeachPDF/Html/Core/Paint/FragmentPainter.cs
+++ b/src/PeachPDF/Html/Core/Paint/FragmentPainter.cs
@@ -346,6 +346,14 @@ namespace PeachPDF.Html.Core.Paint
             var lines = fragment.Lines;
             var clip = g.GetClip();
 
+            // Outline is drawn last - CSS Basic User Interface 4 §4: "the outline ... is drawn 'over' a
+            // box, i.e., the outline is always on top" of that box's own content and, per CSS2.1
+            // Appendix E, of its entire stacking context (all its descendants too). So the per-line
+            // geometry this box's outline needs is captured here, alongside border's own (which paints
+            // immediately, unlike outline), and the actual outline draw calls are deferred to their own
+            // pass after this box's text/decorations/descendants have all painted, below.
+            List<(RRect Rect, BoxDecorationGeometry Geometry)>? outlinePaints = null;
+
             for (var i = 0; i < lines.Count; i++)
             {
                 var actualRect = lines[i].Rect;
@@ -410,6 +418,8 @@ namespace PeachPDF.Html.Core.Paint
                     geometry.HasLeftEdge, geometry.HasRightEdge, geometry.HasTopEdge, geometry.HasBottomEdge);
 
                 if (geometry.NeedsClip) g.PopClip();
+
+                (outlinePaints ??= []).Add((rectForBorders, geometry));
             }
 
             if (box.ColumnRuleSegments is { Count: > 0 } && box.ActualColumnRuleWidth > 0)
@@ -484,6 +494,19 @@ namespace PeachPDF.Html.Core.Paint
                 {
                     if (p.Box.IsFixed)
                         PaintStackingParticipant(g, p);
+                }
+            }
+
+            if (outlinePaints is not null)
+            {
+                foreach (var (paintRect, geometry) in outlinePaints)
+                {
+                    if (geometry.NeedsClip) g.PushClip(geometry.ClipRect);
+
+                    OutlineDrawHandler.DrawOutline(g, box, paintRect,
+                        geometry.HasLeftEdge, geometry.HasRightEdge, geometry.HasTopEdge, geometry.HasBottomEdge);
+
+                    if (geometry.NeedsClip) g.PopClip();
                 }
             }
 

--- a/src/PeachPDF/Html/Core/Utils/CssUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/CssUtils.cs
@@ -136,7 +136,8 @@ namespace PeachPDF.Html.Core.Utils
                 "border-left-color",
                 "border-right-color",
                 "background-color",
-                "column-rule-color"
+                "column-rule-color",
+                "outline-color"
             ];
 
             var colorValue = GetPropertyValue(box, "color") ?? Keywords.Initial;

--- a/src/PeachPDF/PdfSharpCore/Drawing/XGraphics.cs
+++ b/src/PeachPDF/PdfSharpCore/Drawing/XGraphics.cs
@@ -1895,6 +1895,16 @@ namespace PeachPDF.PdfSharpCore.Drawing  // #??? aufr�umen
         }
 
         /// <summary>
+        /// Activates a separable/HSL PDF blend mode for subsequent painting - see
+        /// <see cref="XGraphicsPdfRenderer.SetBlendMode"/>. Scope with <see cref="Save()"/>/
+        /// <see cref="Restore(XGraphicsState)"/> so the blend mode is restored to Normal afterward.
+        /// </summary>
+        internal void SetBlendMode(string pdfBlendModeName)
+        {
+            (_renderer as XGraphicsPdfRenderer)?.SetBlendMode(pdfBlendModeName);
+        }
+
+        /// <summary>
         /// Begins a tagged marked-content sequence for the given structure type and marked-content
         /// identifier - see <see cref="XGraphicsPdfRenderer.BeginMarkedContent"/>.
         /// </summary>

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -556,6 +556,64 @@
       }
     },
     {
+      "name": "outline-color",
+      "inherited": false,
+      "initialValue": "currentcolor",
+      "cssDataType": ["color", "current-color", "keyword"],
+      "supportedValues": ["invert"],
+      "keywordComparison": "invariant-ignore-case",
+      "html": {
+        "propertyPath": "OutlineColor",
+        "invalidates": "InvalidateOutlineColor",
+        "csharpDataType": "string",
+        "area": "BorderArea"
+      }
+    },
+    {
+      "name": "outline-style",
+      "inherited": false,
+      "initialValue": "none",
+      "cssDataType": {
+        "type": "enum-keyword",
+        "enumType": "OutlineStyle",
+        "keywordMap": "Map.OutlineStyles",
+        "fallback": "OutlineStyle.None"
+      },
+      "html": {
+        "propertyPath": "OutlineStyle",
+        "csharpDataType": "CssProperty<OutlineStyle>",
+        "area": "BorderArea",
+        "getterExpression": "{box}.OutlineStyle.ToString()"
+      }
+    },
+    {
+      "name": "outline-width",
+      "comment": "thin/medium/thick are real <line-width> keywords (CSS-UI-4 §4). An authored value (e.g. \"outline-width: thin\") never reaches this layer as the literal keyword - the CSS-OM's LineWidthConverter already resolves it to a literal px Length, and Property.Value serializes that resolved length, so Validate_OutlineWidth only ever sees e.g. \"1px\" (which the plain \"length\" clause already accepts). These three keywords are listed here for the *initial-value* defaulting path instead: DomParser.CascadeApplyStyles re-applies each property's literal css-properties.json initialValue (\"medium\" here) via CssUtils.SetPropertyValue every cascade pass, which - unlike the record's own C# default field initializer - does run through this same Validate_OutlineWidth gate.",
+      "inherited": false,
+      "initialValue": "medium",
+      "cssDataType": ["length", "keyword"],
+      "supportedValues": ["thin", "medium", "thick"],
+      "keywordComparison": "invariant-ignore-case",
+      "html": {
+        "propertyPath": "OutlineWidth",
+        "invalidates": "InvalidateOutlineWidth",
+        "csharpDataType": "string",
+        "area": "BorderArea"
+      }
+    },
+    {
+      "name": "outline-offset",
+      "inherited": false,
+      "initialValue": "0",
+      "cssDataType": "length",
+      "html": {
+        "propertyPath": "OutlineOffset",
+        "invalidates": "InvalidateOutlineOffset",
+        "csharpDataType": "string",
+        "area": "BorderArea"
+      }
+    },
+    {
       "name": "transform-origin",
       "inherited": false,
       "initialValue": "50% 50% 0",


### PR DESCRIPTION
## Summary

- Wires up `outline`, `outline-color`, `outline-style`, `outline-width` — previously parsed at the CSS-OM layer but never painted, so an outlined element rendered identically to one without it — and adds the missing `outline-offset` property.
- New `OutlineDrawHandler` paints a real ring outside the border edge, offset by `outline-offset`, in parallel with (but independent from) `BordersDrawHandler`, since outline has a single width/color/style for all four sides rather than border's four independently-configurable ones.
- `outline-style: auto` gets its own dedicated `OutlineStyle` enum/keyword map, kept deliberately separate from the shared `LineStyle` every `border-*-style` property uses, so `auto` never becomes a silently-accepted border value. Renders identically to `solid` (CSS-UI-4 leaves `auto`'s appearance UA-defined).
- `outline-color: invert` performs a true per-pixel color inversion — not an approximation — via a new `RGraphics.PushBlendMode`/`PopBlendMode` primitive backed by PDF's `/Difference` blend mode composited with white.
- Outline paints as the last step for its box: after that box's own text/decorations and its entire stacking-context subtree (all descendants), per CSS2.1 Appendix E — not merely after its own border — since a negative `outline-offset` can pull the ring back over the box's own content.
- `docs/html-css-support.md` gets a new Outline section; a TestHarness showcase demonstrates every style keyword, positive/negative offset, and `invert` over solid and gradient backgrounds.

## Test plan

- [x] Full existing test suite passes unchanged (8502 tests, net8.0)
- [x] New tests: CSS-OM parsing (`OutlineProperty.cs`), cascade/`CssUtils` round-trips (including `currentcolor` resolution and rejecting `auto`/`invert` on border properties), layout-neutrality, and paint-order/geometry integration tests (`OutlineStylePaintIntegrationTests.cs`) — ring geometry, offset (including negative), all style keywords, invert's blend-mode bracket, corner-gap closure for dashed/dotted/double/groove/ridge, and outline-after-content paint ordering
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings solution-wide
- [x] Diff coverage: 99% (only an unreachable defensive fallback uncovered, matching an identical pre-existing pattern in `BordersDrawHandler`)
- [x] TestHarness showcase rasterized through both PDFium and MuPDF and visually verified — all style keywords, offset, and `invert`'s color inversion render correctly in both renderers
- [x] Independent code review pass; two real bugs it found (corner gaps in dashed/dotted/double/groove/ridge, outline painting before rather than after the box's own content) are fixed and now regression-tested

Fixes #697