### PR TITLE
Add automatic PDF bookmarks from bookmark-level/bookmark-label/bookmark-state

### DIFF
--- a/.claude/accepted-gaps/bookmark-outline-running-element-content-not-collected.md
+++ b/.claude/accepted-gaps/bookmark-outline-running-element-content-not-collected.md
@@ -1,0 +1,12 @@
+# PDF bookmarks: headings inside repeated running/margin-box content or repeated table headers/footers are not collected
+
+`BookmarkOutlineBuilder` collects bookmark candidates (`bookmark-level != none`) by walking only the
+main document box tree (`DomUtils.GetAllLinkAndBookmarkBoxes`), mirroring the existing `GetAllLinkBoxes`
+walk `PdfGenerator.HandleLinks` already used for `<a>` links. An element that only ever appears as a
+GCPM running element inside an `@page` margin box — repeated per page, with no single canonical document
+position — is never visited by this walk, so it never generates a bookmark even with a non-`none`
+`bookmark-level`. The same applies to a `<thead>`/`<tfoot>` repeated across page breaks via `CssProxyBox`
+(its repeated-header/footer subtree isn't reachable through `CssBox.Boxes`, the same walk `<a>` links
+already don't reach either) — a reader will likely hit this case sooner than the margin-box one. See
+[PDF Bookmarks (Outline) Support](docs/html-css-support.md#pdf-bookmarks-outline-support).
+Tracked in [#714](https://github.com/jhaygood86/PeachPDF/issues/714).

--- a/.claude/migration-notes/2026-08-11-automatic-pdf-bookmarks-and-anchor-link-position-fix.md
+++ b/.claude/migration-notes/2026-08-11-automatic-pdf-bookmarks-and-anchor-link-position-fix.md
@@ -1,0 +1,16 @@
+# PDFs now get automatic bookmarks from headings, and `<a href="#id">` links land on the right spot
+
+Previously: PeachPDF never populated a PDF's outline (`/Outlines`) at all — no document produced a
+bookmark sidebar, regardless of heading structure, and there was no CSS-level control over one. Separately,
+an `<a href="#id">` anchor link's named destination was computed with a Y coordinate in the wrong axis
+(passed as a `/FitV` action's horizontal `left` parameter instead of `/FitH`'s vertical `top`), so clicking
+an anchor link routed a reader to the correct page but not reliably to the correct position on it.
+
+Now: `h1`–`h6` automatically generate a nested PDF outline (via the new `bookmark-level`/`bookmark-label`/
+`bookmark-state` CSS properties — see [PDF Bookmarks (Outline) Support](../../docs/html-css-support.md#pdf-bookmarks-outline-support)),
+with zero configuration required — a document with no headings produces no outline and no `/PageMode`
+change, exactly as before. Any existing document containing at least one heading will now open with a
+populated bookmark panel (PDF readers set `/PageMode /UseOutlines` automatically once an outline exists) —
+authors who don't want this can set `bookmark-level: none` on `h1`–`h6` (or any subset) to suppress it.
+`<a href="#id">` anchor links (and running-element links inside `@page` margin boxes) now land at the
+correct vertical position on their target page, fixing what was previously an unreliable jump.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Peach PDF is a pure .NET HTML -> PDF rendering library. This library does not de
 - CSS Paged Media: `@page` rules, named pages, margin boxes, and running headers/footers via `string-set`/`string()` and `position: running()`/`element()`
 - Automatic [PDF metadata extraction](https://peachpdf.net/html-css-support.html#pdf-metadata-extraction) from HTML `<title>` and `<meta>` elements
 - Optional Tagged PDF (PDF/UA) output — logical structure tree, automatic document language, CSS-driven tag mapping via `-peachpdf-pdf-tag-type` (see `PdfGenerateConfig.EnableTaggedPdf`)
+- Automatic PDF outline (bookmark sidebar) generation from headings, with full CSS control via `bookmark-level`/`bookmark-label`/`bookmark-state` (CSS Generated Content Module Level 3) — no configuration required
 - Web fonts (`@font-face`), custom fonts loaded from a stream, and system font discovery — with per-character font matching (`@font-face` `unicode-range` and coverage-based fallback across the `font-family` stack) and monochrome emoji / supplementary-plane (astral) text via `cmap` format-12 (outlines only; color-emoji tables are not embedded)
 
 See [HTML & CSS Support](https://peachpdf.net/html-css-support.html) for the full compatibility matrix, and [Supported SVG Features](https://peachpdf.net/supported-svg-features.html) for the full SVG compatibility matrix.

--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -1481,6 +1481,104 @@ A table assembled purely through CSS (`display: table` / `table-row` / `table-ce
 
 ---
 
+## PDF Bookmarks (Outline) Support
+
+PeachPDF automatically generates a PDF outline (the navigable bookmark sidebar most PDF readers show) from a document's headings, per [CSS Generated Content Module Level 3's bookmark properties](https://www.w3.org/TR/css-content-3/#bookmarks). This needs no configuration: `h1`–`h6` get a bookmark by default, and a document with no headings simply produces no outline at all.
+
+### `bookmark-level`
+
+Determines whether an element generates a bookmark, and its nesting depth (`1` is shallowest).
+
+| | |
+|---|---|
+| Initial value | `none` |
+| Applies to | All elements |
+| Inherited | No |
+| Percentages | N/A |
+
+```css
+/* Give every top-level <section>'s heading a bookmark of its own, one level deeper than its
+   parent section's heading */
+section h1 { bookmark-level: 1; }
+section section h1 { bookmark-level: 2; }
+
+/* Exclude a heading from the outline entirely */
+h2.no-bookmark { bookmark-level: none; }
+```
+
+Accepted values: `none`, or a positive `<integer>` (`1` and up). Nesting is not required to follow a strict hierarchy — a bookmark's parent is the nearest *preceding* bookmark (in document order) with a shallower level, or the outline root if none exists; a level with no shallower ancestor ever declared still generates a valid, root-level bookmark.
+
+### `bookmark-label`
+
+The bookmark's text, as a `<content-list>` — the same string/`counter()`/`attr()`/`content()`/`string()` grammar the [`content`](#generated-content) property accepts (`url()`, gradients, and the quote/`element()` functions are not accepted here, since none of them produce text).
+
+| | |
+|---|---|
+| Initial value | `content(text)` |
+| Applies to | All elements |
+| Inherited | No |
+| Percentages | N/A |
+
+```css
+/* Default: the heading's own rendered text becomes the bookmark label */
+h1 { /* bookmark-label: content(text) is the initial value - no rule needed */ }
+
+/* A generated label combining a counter, a literal string and an attribute */
+h1 { counter-increment: chapter; bookmark-label: "Chapter " counter(chapter) ": " attr(data-title); }
+```
+
+### `bookmark-state`
+
+The bookmark's initial expansion state in the reader's outline panel.
+
+| | |
+|---|---|
+| Initial value | `open` |
+| Applies to | Block-level elements |
+| Inherited | No |
+| Percentages | N/A |
+
+```css
+/* Collapse deep subsection bookmarks by default */
+h3 { bookmark-state: closed; }
+```
+
+Accepted values: `open`, `closed`.
+
+### `-peachpdf-bookmark-target` (bookmark link target)
+
+By default a bookmark links to the element that generated it. `-peachpdf-bookmark-target` overrides that — this is PeachPDF's own extension (not part of css-content-3, which defines no such property); it follows the same naming convention as [`-peachpdf-pdf-tag-type`](#-peachpdf-pdf-tag-type-tagged-pdf-structure-type) for a PDF-output feature with no real spec-track name.
+
+| | |
+|---|---|
+| Initial value | `self` |
+| Applies to | All elements |
+| Inherited | No |
+| Percentages | N/A |
+
+```css
+/* Point a table-of-contents entry's bookmark at the chapter it lists, not the ToC row itself */
+.toc-entry { -peachpdf-bookmark-target: attr(href); }
+
+/* Link straight to an external URL instead of anywhere in this document */
+h1.appendix-ref { -peachpdf-bookmark-target: url(https://example.com/appendix); }
+```
+
+Accepted values: `self`, `url(<url>)`, or `attr(<attribute-name>)`. A value resolving to `#fragment` targets the element with that `id` in the same document; any other resolved value is treated as an external URL. A target that can't be resolved (e.g. a missing `id`) leaves that bookmark without a destination rather than removing the bookmark itself.
+
+### Default `bookmark-level` mapping
+
+| HTML | `bookmark-level` |
+|------|-------------------|
+| `h1`–`h6` | `1`–`6` |
+| Everything else | `none` (this property's own initial value) |
+
+### Known limitation — bookmarks inside repeated running/margin-box content or repeated table headers/footers are not collected
+
+A heading that only ever appears as [running element](usage-examples.md) content in an `@page` margin box (repeated per page, with no single canonical position) does not get a bookmark, even if it would otherwise have a non-`none` `bookmark-level` — only the main document content tree is walked for bookmark candidates. The same applies to a `<thead>`/`<tfoot>` repeated across a page break: a heading placed there produces no bookmark either.
+
+---
+
 ## Unsupported CSS Features
 
 The following CSS features are not supported:

--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -353,6 +353,8 @@ When `EnableTaggedPdf` is left at its default (`false`), none of this runs — o
 
 The HTML-tag → structure-type mapping is CSS-driven and author-overridable via the `-peachpdf-pdf-tag-type` custom property — see [Tagged PDF (PDF/UA) Support](html-css-support.md#tagged-pdf-pdfua-support) in HTML & CSS Support for the property's accepted values, the full default mapping table, and known limitations.
 
+PDF outline (bookmark) generation is a separate, always-on feature — no `PdfGenerateConfig` flag needed — driven purely by the `bookmark-level`/`bookmark-label`/`bookmark-state` CSS properties; see [PDF Bookmarks (Outline) Support](html-css-support.md#pdf-bookmarks-outline-support) in HTML & CSS Support.
+
 ## ASP.NET Core controller endpoint
 
 Render to a `MemoryStream`, rewind it, and return it with `File()` so ASP.NET Core streams it to the client with the right content type. `BuildInvoiceHtml` below stands in for whatever HTML-generation logic you use (a Razor template, a string builder, etc.) — the PDF-specific part is everything after `var html = ...`.

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -4527,6 +4527,45 @@ await SaveShowcaseAsync("tagged_pdf", "Standards & Accessibility", "Tagged PDF (
     "Accessible, tagged PDF output: a logical structure tree with headings, lists, tables, alt text, links, and tag-type overrides.",
     taggedPdfHtml, taggedPdfConfig);
 
+// --- PDF Bookmarks (Outline) showcase ---
+// Like tagged PDF above, the outline is invisible in a normal page render - its value is manual
+// inspection of the reader's bookmark/outline sidebar (e.g. Acrobat's or a browser PDF viewer's
+// panel) rather than visual comparison, but included anyway per this repo's showcase convention.
+
+const string BookmarksCss = """
+    <style>
+    @page { size: a4; margin: 15mm }
+    body { counter-reset: chapter; font: 10pt Arial, sans-serif; margin: 0 }
+    h1.chapter { counter-increment: chapter; font-size: 16pt; break-before: page }
+    h1.chapter:first-of-type { break-before: avoid }
+    h1.cover { font-size: 20pt; break-before: avoid }
+    h2 { font-size: 12pt; margin-top: 1.2em }
+    p.intro { color: #555 }
+    .toc-entry { display: block; margin: 0.2em 0 }
+    </style>
+    """;
+
+var bookmarksHtml = "<!DOCTYPE html><html><head>" + BookmarksCss + "</head><body>" +
+
+    "<h1 class=\"cover\" style=\"bookmark-level: none\">Cover Page</h1>" +
+    "<p class=\"intro\">This heading is excluded from the outline (bookmark-level: none) even though h1 defaults to bookmark-level: 1 - it's just a cover page, not a real chapter.</p>" +
+    "<a class=\"toc-entry\" href=\"#chapter2\" style=\"bookmark-level: 1; bookmark-label: '→ Jump straight to Chapter 2'; -peachpdf-bookmark-target: attr(href)\">Jump straight to Chapter 2</a>" +
+
+    "<h1 class=\"chapter\" style=\"bookmark-label: 'Chapter ' counter(chapter) ': Introduction'\">Introduction</h1>" +
+    "<p class=\"intro\">This chapter's bookmark label is generated from a counter, not its own heading text (bookmark-label: 'Chapter ' counter(chapter) ': Introduction').</p>" +
+    "<h2>Background</h2><p>Ordinary h2 bookmark (default bookmark-level: 2, label defaults to content(text) - the heading's own rendered text).</p>" +
+    "<h2 style=\"bookmark-state: closed\">Appendix Notes (collapsed by default)</h2><p>This h2's bookmark starts collapsed in the reader's outline panel (bookmark-state: closed) - expand it to see its own nested sub-bookmark.</p>" +
+    "<h3>Appendix Note A</h3><p>Nested under the collapsed Appendix Notes bookmark - stays hidden until that entry is expanded.</p>" +
+
+    "<h1 class=\"chapter\" id=\"chapter2\">Chapter Two</h1>" +
+    "<p class=\"intro\">This is where the \"Jump straight to Chapter 2\" bookmark on the cover page actually points, via -peachpdf-bookmark-target: attr(href) reading its own href.</p>" +
+
+    "</body></html>";
+
+await SaveShowcaseAsync("bookmarks", "Standards & Accessibility", "PDF Bookmarks (Outline)",
+    "Automatic PDF outline generation from headings, with full CSS control via bookmark-level/bookmark-label/bookmark-state and -peachpdf-bookmark-target.",
+    bookmarksHtml, pdfConfig);
+
 // --- border-style showcase ---
 
 const string BorderStyleCss = """

--- a/src/PeachPDF.Tests/Html/Core/Dom/ComputedStyleTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/ComputedStyleTests.cs
@@ -235,6 +235,32 @@ namespace PeachPDF.Tests.Html.Core.Dom
         }
 
         [Fact]
+        public void InheritStyle_Everything_DoesNotCopyBookmarkProperties()
+        {
+            // Unlike PdfTagType/box-sizing above, bookmark-level/-label/-state/-target deliberately do
+            // NOT carry over on the "everything" path (CssProxyBox's repeated header/footer clone,
+            // DomParser's inline/block split) - a bookmark is per-SOURCE-ELEMENT, not per-box, so an
+            // inline element carrying bookmark-level that gets split into multiple sibling CssBoxes
+            // (e.g. because it wraps a block child) must produce exactly one bookmark, not one per
+            // split fragment. See CssBox.StyleProperties.cs's InheritStyle "everything" branch.
+            var source = new CssBox(null, null)
+            {
+                BookmarkLevel = "2",
+                BookmarkLabel = "\"Custom\"",
+                BookmarkState = "closed",
+                BookmarkTarget = "url(#other)"
+            };
+            var clone = new CssBox(null, null);
+
+            clone.InheritStyle(source, everything: true);
+
+            Assert.Equal("none", clone.BookmarkLevel);
+            Assert.Equal("content(text)", clone.BookmarkLabel);
+            Assert.Equal("open", clone.BookmarkState);
+            Assert.Equal("self", clone.BookmarkTarget);
+        }
+
+        [Fact]
         public void InheritStyle_UnicodeBidi_DoesNotAdoptParentsValue()
         {
             // unicode-bidi is CSS-spec Inherited: no, unlike every other property in the otherwise-100%-

--- a/src/PeachPDF.Tests/Html/Core/Utils/CssUtilsTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Utils/CssUtilsTests.cs
@@ -597,6 +597,118 @@ namespace PeachPDF.Tests.Html.Core.Utils
             Assert.Equal("div", box.PdfTagType);
         }
 
+        // --- bookmark-level / bookmark-label / bookmark-state / -peachpdf-bookmark-target (issue #711) ---
+
+        [Fact]
+        public async Task SetPropertyValue_BookmarkLevel_ParsesIntegerAndNone()
+        {
+            var (box, parser) = await FindDivBoxAndParser("");
+
+            CssUtils.SetPropertyValue(parser, box, "bookmark-level", "3");
+            Assert.Equal("3", CssUtils.GetPropertyValue(box, "bookmark-level"));
+
+            CssUtils.SetPropertyValue(parser, box, "bookmark-level", "none");
+            Assert.Equal("none", CssUtils.GetPropertyValue(box, "bookmark-level"));
+        }
+
+        [Theory]
+        [InlineData("0")]
+        [InlineData("-1")]
+        [InlineData("banana")]
+        public async Task SetPropertyValue_BookmarkLevelInvalid_IsIgnored(string invalidValue)
+        {
+            var (box, parser) = await FindDivBoxAndParser("bookmark-level: 2;");
+
+            CssUtils.SetPropertyValue(parser, box, "bookmark-level", invalidValue);
+
+            Assert.Equal("2", CssUtils.GetPropertyValue(box, "bookmark-level"));
+        }
+
+        [Fact]
+        public async Task SetPropertyValue_BookmarkLabel_AcceptsContentList()
+        {
+            var (box, parser) = await FindDivBoxAndParser("");
+
+            CssUtils.SetPropertyValue(parser, box, "bookmark-label", "\"Chapter \" counter(chapter) \": \" attr(data-title)");
+
+            Assert.Equal("\"Chapter \" counter(chapter) \": \" attr(data-title)", CssUtils.GetPropertyValue(box, "bookmark-label"));
+        }
+
+        [Fact]
+        public async Task SetPropertyValue_BookmarkLabelUrl_IsRejected()
+        {
+            // <content-list> excludes url()/gradients - not text-producing - unlike `content` itself.
+            var (box, parser) = await FindDivBoxAndParser("bookmark-label: \"kept\";");
+
+            CssUtils.SetPropertyValue(parser, box, "bookmark-label", "url(logo.png)");
+
+            Assert.Equal("\"kept\"", CssUtils.GetPropertyValue(box, "bookmark-label"));
+        }
+
+        [Fact]
+        public async Task SetPropertyValue_BookmarkState_ParsesOpenAndClosed()
+        {
+            var (box, parser) = await FindDivBoxAndParser("");
+
+            CssUtils.SetPropertyValue(parser, box, "bookmark-state", "closed");
+            Assert.Equal("closed", CssUtils.GetPropertyValue(box, "bookmark-state"));
+
+            CssUtils.SetPropertyValue(parser, box, "bookmark-state", "open");
+            Assert.Equal("open", CssUtils.GetPropertyValue(box, "bookmark-state"));
+        }
+
+        [Theory]
+        [InlineData("self")]
+        [InlineData("url(#chapter2)")]
+        [InlineData("attr(href)")]
+        public async Task SetPropertyValue_PeachPdfBookmarkTarget_ParsesSelfUrlAttr(string value)
+        {
+            var (box, parser) = await FindDivBoxAndParser("");
+
+            CssUtils.SetPropertyValue(parser, box, "-peachpdf-bookmark-target", value);
+
+            Assert.Equal(value, CssUtils.GetPropertyValue(box, "-peachpdf-bookmark-target"));
+        }
+
+        // -prince-bookmark-level/-label/-state translate to the real spec properties; -prince-bookmark-target
+        // and bare bookmark-target (Prince's own convenience alias) both translate to -peachpdf-bookmark-target,
+        // since bookmark-target itself is not a real css-content-3 property.
+        [Theory]
+        [InlineData("-prince-bookmark-level", "bookmark-level", "4")]
+        [InlineData("-prince-bookmark-label", "bookmark-label", "\"Custom\"")]
+        [InlineData("-prince-bookmark-state", "bookmark-state", "closed")]
+        [InlineData("-prince-bookmark-target", "-peachpdf-bookmark-target", "url(#x)")]
+        [InlineData("bookmark-target", "-peachpdf-bookmark-target", "url(#x)")]
+        public async Task SetPropertyValue_BookmarkAlias_MapsToCanonicalProperty(string aliasName, string canonicalName, string value)
+        {
+            var (box, parser) = await FindDivBoxAndParser("");
+
+            CssUtils.SetPropertyValue(parser, box, aliasName, value);
+
+            Assert.Equal(value, CssUtils.GetPropertyValue(box, canonicalName));
+        }
+
+        [Theory]
+        [InlineData("bookmark-level", "none")]
+        [InlineData("bookmark-label", "content(text)")]
+        [InlineData("bookmark-state", "open")]
+        [InlineData("-peachpdf-bookmark-target", "self")]
+        [InlineData("-prince-bookmark-level", "none")]
+        [InlineData("-prince-bookmark-label", "content(text)")]
+        [InlineData("-prince-bookmark-state", "open")]
+        [InlineData("-prince-bookmark-target", "self")]
+        [InlineData("bookmark-target", "self")]
+        public async Task BookmarkProperties_AreSnapshottableAndHaveAnInitialValue(string name, string? expectedInitial = null)
+        {
+            var (box, _) = await FindDivBoxAndParser("");
+
+            Assert.Contains(name, CssUtils.SnapshotProperties(box).Keys);
+            if (expectedInitial is not null)
+            {
+                Assert.Equal(expectedInitial, CssDefaults.GetInitialValue(name));
+            }
+        }
+
         // Same two prerequisites for box-decoration-break (css-break-3 §6.2): without the known-name entry
         // there is no revert snapshot to roll back to, and without the initial-value entry
         // "initial"/"unset"/"revert" resolve to null and the declaration is dropped. The behavioural

--- a/src/PeachPDF.Tests/Html/Core/Utils/DomUtilsTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Utils/DomUtilsTests.cs
@@ -164,6 +164,32 @@ namespace PeachPDF.Tests.Html.Core.Utils
         }
 
         [Fact]
+        public async Task GetAllLinkAndBookmarkBoxes_CollectsBothIndependently()
+        {
+            var root = await Render("<div><a href='#'>Link</a><h1>Heading</h1><span>Neither</span></div>");
+
+            var links = new System.Collections.Generic.List<CssBox>();
+            var bookmarks = new System.Collections.Generic.List<CssBox>();
+            DomUtils.GetAllLinkAndBookmarkBoxes(root, links, bookmarks);
+
+            Assert.Contains(links, b => b.HtmlTag?.Name == "a");
+            Assert.Contains(bookmarks, b => b.HtmlTag?.Name == "h1");
+            Assert.DoesNotContain(bookmarks, b => b.HtmlTag?.Name == "a");
+        }
+
+        [Fact]
+        public void GetAllLinkAndBookmarkBoxes_NullBox_IsANoOp()
+        {
+            var links = new System.Collections.Generic.List<CssBox>();
+            var bookmarks = new System.Collections.Generic.List<CssBox>();
+
+            DomUtils.GetAllLinkAndBookmarkBoxes(null, links, bookmarks);
+
+            Assert.Empty(links);
+            Assert.Empty(bookmarks);
+        }
+
+        [Fact]
         public async Task GetCssBox_LocationInsideBounds_ReturnsABox()
         {
             var root = await Render("<div id='outer' style='width:100px;height:50px'><span id='inner'>Text</span></div>");

--- a/src/PeachPDF.Tests/Integration/AnchorLinkDestinationTests.cs
+++ b/src/PeachPDF.Tests/Integration/AnchorLinkDestinationTests.cs
@@ -1,0 +1,83 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.PdfSharpCore;
+using PeachPDF.PdfSharpCore.Drawing;
+using PeachPDF.PdfSharpCore.Pdf;
+using System.Text.RegularExpressions;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Regression coverage for the pre-existing HandleLinks bug found while implementing PDF bookmarks
+    /// (issue #711): an anchor link's (`&lt;a href="#id"&gt;`) named destination was written as a
+    /// `/FitV left` action with the target's Y offset passed as `left` (a horizontal parameter) instead
+    /// of `/FitH top` (fits page width, positions vertically at `top`) - the correct pairing for
+    /// "jump down to this Y". Fixed alongside the bookmark work since the new PdfOutline destinations
+    /// use the same (now-corrected) PageAnchorResolver-driven math.
+    /// </summary>
+    public class AnchorLinkDestinationTests
+    {
+        [Fact]
+        public async Task AnchorLink_NamedDestination_UsesFitHNotFitV()
+        {
+            var html = "<html><body><a href='#target'>go</a>" +
+                       "<div style='height:2000px'></div>" +
+                       "<h1 id='target'>Target</h1></body></html>";
+            var result = await new PdfGenerator().GeneratePdf(html, PageSize.A4);
+
+            var array = Assert.IsType<PdfArray>(result.PdfDocument.Catalog.Names.NameTree!.GetValue("target"));
+            var literal = Assert.IsType<PdfLiteral>(array.Elements[0]);
+
+            Assert.Contains("/FitH", literal.Value);
+            Assert.DoesNotContain("/FitV", literal.Value);
+        }
+
+        // Regression test for a coordinate-space bug found post-implementation: the fix above (FitV ->
+        // FitH) alone was not sufficient - the Y value passed to CreateFitHorizontally was still the
+        // top-down (0-at-top, increasing downward) offset PageAnchorResolver computes, written directly
+        // as /FitH's own "top" parameter, which PDF 32000-1 defines in bottom-up default user space (0 at
+        // the page's bottom edge). A target near the top of its page therefore needs a Top value near the
+        // FULL page height, not near 0 - verified against real PDF viewers (not just this repo's own
+        // code), which is what caught this.
+        [Fact]
+        public async Task AnchorLink_NamedDestination_TopIsBottomUp_NearPageHeightForATargetNearThePageTop()
+        {
+            var html = "<html><body><a href='#target'>go</a>" +
+                       "<div style='height:1200px'></div>" +
+                       "<h1 id='target' style='break-before:page'>Target</h1></body></html>";
+            var result = await new PdfGenerator().GeneratePdf(html, PageSize.A4);
+
+            var array = Assert.IsType<PdfArray>(result.PdfDocument.Catalog.Names.NameTree!.GetValue("target"));
+            var literal = Assert.IsType<PdfLiteral>(array.Elements[0]);
+
+            var match = Regex.Match(literal.Value, @"/FitH\s+([\d.]+)");
+            Assert.True(match.Success, $"Expected a /FitH value in '{literal.Value}'");
+            var top = double.Parse(match.Groups[1].Value);
+
+            var pageHeight = (double)result.PdfDocument.Pages[result.PdfDocument.Pages.Count - 1].Height;
+            Assert.True(top > pageHeight * 0.8,
+                $"Target starts its own fresh page (break-before:page), so its bottom-up Top ({top}) should be near the full page height ({pageHeight}), not near 0.");
+        }
+
+        // PdfGenerator.HandleLinks always calls the internal HtmlContainer.GetLinks(bookmarkBoxes)
+        // overload now (so bookmark collection rides along on the same walk, see
+        // DomUtils.GetAllLinkAndBookmarkBoxes), leaving the public no-arg GetLinks() only reachable by
+        // a caller using HtmlContainer directly (outside PdfGenerator) - covered here directly since
+        // no generator-level test exercises it anymore.
+        [Fact]
+        public async Task PublicGetLinksNoArgOverload_StillReturnsLinkData()
+        {
+            var adapter = new PdfSharpAdapter();
+            var container = new HtmlContainer(adapter);
+            await container.SetHtml("<html><body><a href='https://example.com'>go</a></body></html>");
+            container.MaxSize = new XSize(600, 0);
+            using var measure = XGraphics.CreateMeasureContext(new XSize(600, 800), XGraphicsUnit.Point, XPageDirection.Downwards);
+            await container.PerformLayout(measure);
+
+            var links = container.GetLinks();
+
+            var link = Assert.Single(links);
+            Assert.Equal("https://example.com/", link.Href);
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/BookmarkOutlineTests.cs
+++ b/src/PeachPDF.Tests/Integration/BookmarkOutlineTests.cs
@@ -1,0 +1,239 @@
+using PeachPDF.PdfSharpCore.Pdf;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Integration coverage for CSS Generated Content Module Level 3's bookmark properties (issue
+    /// #711) - asserts directly on the built <see cref="PdfOutline"/>/<see cref="PdfOutlineCollection"/>
+    /// tree (title/nesting/open-state/destination), not a content-stream substring, per this repo's
+    /// testing convention for anything touching PDF-writing internals.
+    /// </summary>
+    public class BookmarkOutlineTests
+    {
+        [Fact]
+        public async Task NoHeadings_ProducesNoOutline_AndNoUseOutlinesPageMode()
+        {
+            var result = await new PdfGenerator().GeneratePdf("<html><body><p>Hello</p></body></html>", PageSize.A4);
+
+            Assert.Empty(result.PdfDocument.Outlines);
+
+            using var stream = new MemoryStream();
+            result.Save(stream);
+            var bytes = Encoding.Latin1.GetString(stream.ToArray());
+            Assert.DoesNotContain("/UseOutlines", bytes);
+        }
+
+        [Fact]
+        public async Task DefaultHeadings_NestByLevel_InDocumentOrder()
+        {
+            var html = "<html><body>" +
+                       "<h1>Chapter 1</h1><h2>Section 1.1</h2><h2>Section 1.2</h2>" +
+                       "<h1>Chapter 2</h1>" +
+                       "</body></html>";
+            var result = await new PdfGenerator().GeneratePdf(html, PageSize.A4);
+
+            var top = result.PdfDocument.Outlines.ToList();
+            Assert.Equal(new[] { "Chapter 1", "Chapter 2" }, top.Select(o => o.Title));
+
+            var chapter1Children = top[0].Outlines.ToList();
+            Assert.Equal(new[] { "Section 1.1", "Section 1.2" }, chapter1Children.Select(o => o.Title));
+            Assert.Empty(top[1].Outlines);
+        }
+
+        [Fact]
+        public async Task BookmarkLevelNone_SuppressesHeading()
+        {
+            var html = "<html><body>" +
+                       "<h1 style='bookmark-level:none'>Skip</h1><h1>Keep</h1>" +
+                       "</body></html>";
+            var result = await new PdfGenerator().GeneratePdf(html, PageSize.A4);
+
+            var top = result.PdfDocument.Outlines.ToList();
+            Assert.Equal(new[] { "Keep" }, top.Select(o => o.Title));
+        }
+
+        [Fact]
+        public async Task CustomBookmarkLevel_OverridesDefaultNesting()
+        {
+            // h3's own default (level 3) is overridden down to 2, so it nests directly under the h1
+            // even though no h2 ever appeared - the level stack, not DOM nesting, drives the tree.
+            var html = "<html><body>" +
+                       "<h1>A</h1><h3 style='bookmark-level:2'>B</h3>" +
+                       "</body></html>";
+            var result = await new PdfGenerator().GeneratePdf(html, PageSize.A4);
+
+            var top = result.PdfDocument.Outlines.ToList();
+            var a = Assert.Single(top);
+            Assert.Equal("A", a.Title);
+            var b = Assert.Single(a.Outlines);
+            Assert.Equal("B", b.Title);
+        }
+
+        [Fact]
+        public async Task BookmarkLabel_DefaultsToElementOwnText()
+        {
+            var result = await new PdfGenerator().GeneratePdf("<html><body><h1>Hello World</h1></body></html>", PageSize.A4);
+
+            Assert.Equal("Hello World", result.PdfDocument.Outlines.Single().Title);
+        }
+
+        [Fact]
+        public async Task BookmarkLabel_LiteralAndAttr_AreConcatenated()
+        {
+            var html = "<html><body>" +
+                       "<h1 data-title='Intro' style='bookmark-label:\"Custom: \" attr(data-title)'>Ignored text</h1>" +
+                       "</body></html>";
+            var result = await new PdfGenerator().GeneratePdf(html, PageSize.A4);
+
+            Assert.Equal("Custom: Intro", result.PdfDocument.Outlines.Single().Title);
+        }
+
+        [Fact]
+        public async Task BookmarkLabel_Counter_IsFormatted()
+        {
+            var html = "<html><body style='counter-reset:ch'>" +
+                       "<h1 style='counter-increment:ch;bookmark-label:\"Ch. \" counter(ch)'>Ignored</h1>" +
+                       "</body></html>";
+            var result = await new PdfGenerator().GeneratePdf(html, PageSize.A4);
+
+            Assert.Equal("Ch. 1", result.PdfDocument.Outlines.Single().Title);
+        }
+
+        [Fact]
+        public async Task BookmarkState_DefaultsOpen_ClosedIsRespected()
+        {
+            var html = "<html><body>" +
+                       "<h1>Open by default</h1><h1 style='bookmark-state:closed'>Closed</h1>" +
+                       "</body></html>";
+            var result = await new PdfGenerator().GeneratePdf(html, PageSize.A4);
+
+            var top = result.PdfDocument.Outlines.ToList();
+            Assert.True(top[0].Opened);
+            Assert.False(top[1].Opened);
+        }
+
+        // Regression test for a coordinate-space bug found post-implementation: BookmarkOutlineBuilder
+        // wrote the top-down (0-at-top, increasing downward) Y PageAnchorResolver computes directly into
+        // /FitH's own "top" parameter, which PDF 32000-1 defines in bottom-up default user space (0 at
+        // the page's bottom edge) - landing every destination far from its heading (verified against real
+        // PDF viewers, not just this repo's own code). The fix flips via the destination page's own
+        // height. This test would have caught it: with the bug, an EARLIER (visually higher) heading's
+        // unflipped Top was numerically SMALLER than a LATER (visually lower) heading's - the wrong way
+        // around for bottom-up space, where "higher on the page" must mean a LARGER Y.
+        [Fact]
+        public async Task BookmarkTarget_Self_TopIsBottomUp_EarlierHeadingHasLargerTopThanLaterHeadingOnSamePage()
+        {
+            var html = "<html><body>" +
+                       "<h1>First</h1><p style='height:400px'></p><h1>Second</h1>" +
+                       "</body></html>";
+            var result = await new PdfGenerator().GeneratePdf(html, PageSize.A4);
+
+            var top = result.PdfDocument.Outlines.ToList();
+            var first = top.Single(o => o.Title == "First");
+            var second = top.Single(o => o.Title == "Second");
+
+            Assert.Same(first.DestinationPage, second.DestinationPage);
+            Assert.True(first.Top > second.Top,
+                $"First (visually higher) should have a larger bottom-up Top than Second (visually lower), got First.Top={first.Top}, Second.Top={second.Top}");
+            Assert.InRange(first.Top, 0, (double)first.DestinationPage!.Height);
+            Assert.InRange(second.Top, 0, (double)second.DestinationPage!.Height);
+        }
+
+        // Regression test for a second bug the coordinate-flip fix above uncovered: a display:none
+        // heading still has a CssBox (just never painted), so its default self target would otherwise
+        // resolve via CommonUtils.GetFirstValueOrDefault's Bounds fallback to a nonsense page-0/Y-0
+        // destination rather than the documented "leave the outline with neither" behavior. An earlier
+        // attempt at this check (`box.Rectangles.Count == 0`) was itself wrong - Rectangles is commonly
+        // empty for perfectly ordinary, visible block boxes too, not just unrendered ones - so this test
+        // exists specifically to keep the real fix (an ActualDisplay check) from regressing back to that.
+        [Fact]
+        public async Task BookmarkTarget_Self_DisplayNoneHeading_LeavesDestinationUnset()
+        {
+            var html = "<html><body><h1 style='display:none'>Hidden</h1></body></html>";
+            var result = await new PdfGenerator().GeneratePdf(html, PageSize.A4);
+
+            var outline = result.PdfDocument.Outlines.Single();
+            Assert.Equal("Hidden", outline.Title);
+            Assert.Null(outline.DestinationPage);
+            Assert.Null(outline.Url);
+        }
+
+        [Fact]
+        public async Task BookmarkTarget_Self_PointsAtOwnPage()
+        {
+            var result = await new PdfGenerator().GeneratePdf("<html><body><h1>Title</h1></body></html>", PageSize.A4);
+
+            var outline = result.PdfDocument.Outlines.Single();
+            Assert.Same(result.PdfDocument.Pages[0], outline.DestinationPage);
+            Assert.Null(outline.Url);
+        }
+
+        [Fact]
+        public async Task BookmarkTarget_UrlFragment_PointsAtInDocumentElement()
+        {
+            var html = "<html><body>" +
+                       "<h1 style='-peachpdf-bookmark-target:url(#other)'>Title</h1>" +
+                       "<div id='other'>Target</div>" +
+                       "</body></html>";
+            var result = await new PdfGenerator().GeneratePdf(html, PageSize.A4);
+
+            var outline = result.PdfDocument.Outlines.Single();
+            Assert.NotNull(outline.DestinationPage);
+            Assert.Null(outline.Url);
+        }
+
+        [Fact]
+        public async Task BookmarkTarget_AttrHrefExternalUrl_SetsOutlineUrl()
+        {
+            var html = "<html><body>" +
+                       "<h1 data-href='https://example.com' style='-peachpdf-bookmark-target:attr(data-href)'>Title</h1>" +
+                       "</body></html>";
+            var result = await new PdfGenerator().GeneratePdf(html, PageSize.A4);
+
+            var outline = result.PdfDocument.Outlines.Single();
+            // Resolved via HtmlContainer.ResolveHref, same as an equivalent <a href> - which normalizes
+            // a bare-authority URL with an added trailing slash.
+            Assert.Equal("https://example.com/", outline.Url);
+            Assert.Null(outline.DestinationPage);
+        }
+
+        [Fact]
+        public async Task BookmarkTarget_RelativeExternalUrl_IsResolvedAgainstBaseUri()
+        {
+            // -peachpdf-bookmark-target's external-URL branch resolves through HtmlContainer.ResolveHref
+            // - the same base-URI resolution an equivalent <a href="other.html"> already gets - rather
+            // than being written raw and unresolvable by a reader for anything but an already-absolute URL.
+            var html = "<html><head><base href='https://example.com/docs/'></head><body>" +
+                       "<h1 style='-peachpdf-bookmark-target:url(other.html)'>Title</h1>" +
+                       "</body></html>";
+            var result = await new PdfGenerator().GeneratePdf(html, PageSize.A4);
+
+            Assert.Equal("https://example.com/docs/other.html", result.PdfDocument.Outlines.Single().Url);
+        }
+
+        [Theory]
+        [InlineData("-prince-bookmark-level:1")]
+        [InlineData("bookmark-level:1")]
+        public async Task PrinceAliasSpelling_ProducesSameOutlineAsCanonical(string levelDeclaration)
+        {
+            var html = $"<html><body><p style='{levelDeclaration}'>Aliased</p></body></html>";
+            var result = await new PdfGenerator().GeneratePdf(html, PageSize.A4);
+
+            Assert.Equal("Aliased", result.PdfDocument.Outlines.Single().Title);
+        }
+
+        [Fact]
+        public async Task BareBookmarkTargetAlias_BehavesLikePeachPdfBookmarkTarget()
+        {
+            var html = "<html><body>" +
+                       "<h1 data-href='https://example.com' style='bookmark-target:attr(data-href)'>Title</h1>" +
+                       "</body></html>";
+            var result = await new PdfGenerator().GeneratePdf(html, PageSize.A4);
+
+            Assert.Equal("https://example.com/", result.PdfDocument.Outlines.Single().Url);
+        }
+    }
+}

--- a/src/PeachPDF.Tests/PdfSharpCore/Pdf/PdfOutlineSaveTests.cs
+++ b/src/PeachPDF.Tests/PdfSharpCore/Pdf/PdfOutlineSaveTests.cs
@@ -64,6 +64,25 @@ namespace PeachPDF.Tests.PdfSharpCoreTests.Pdf
         }
 
         [Fact]
+        public void Save_WithOutlineUrl_WritesUriActionNotDest()
+        {
+            // An outline with a Url and no DestinationPage writes an /A URI action instead of /Dest
+            // (mutually exclusive per PDF 32000-1:2008 Table 153/176) - see PdfOutline.PrepareForSave.
+            var doc = new PdfDocument();
+            doc.AddPage();
+            var outline = new PeachPDF.PdfSharpCore.Pdf.PdfOutline { Title = "External", Url = "https://example.com" };
+            doc.Outlines.Add(outline);
+
+            using var stream = new MemoryStream();
+            doc.Save(stream);
+
+            var text = System.Text.Encoding.ASCII.GetString(stream.ToArray());
+            Assert.Contains("/S/URI", text);
+            Assert.Contains("https://example.com", text);
+            Assert.DoesNotContain("/Dest", text);
+        }
+
+        [Fact]
         public void Save_WithDefaultTextColor_OmitsColorEntry()
         {
             var doc = new PdfDocument();

--- a/src/PeachPDF/CSS/Enumerations/BookmarkState.cs
+++ b/src/PeachPDF/CSS/Enumerations/BookmarkState.cs
@@ -1,0 +1,9 @@
+namespace PeachPDF.CSS
+{
+    /// <summary>CSS Generated Content Module Level 3 <c>bookmark-state</c> - the PDF outline entry's initial expansion state.</summary>
+    internal enum BookmarkState
+    {
+        Open,
+        Closed
+    }
+}

--- a/src/PeachPDF/CSS/Enumerations/Keywords.cs
+++ b/src/PeachPDF/CSS/Enumerations/Keywords.cs
@@ -211,6 +211,8 @@
         public const string Devanagari = "devanagari";
         public const string DisclosureOpen = "disclosure-open";
         public const string DisclosureClosed = "disclosure-closed";
+        public const string Open = "open";
+        public const string Closed = "closed";
         public const string EthiopicNumeric = "ethiopic-numeric";
         public const string Gujarati = "gujarati";
         public const string Gurmukhi = "gurmukhi";
@@ -387,6 +389,7 @@
         public const string Last = "last";
         public const string SelfStart = "self-start";
         public const string SelfEnd = "self-end";
+        public const string Self = "self";
         public const string Size = "size";
         public const string InlineSize = "inline-size";
 

--- a/src/PeachPDF/CSS/Enumerations/PropertyNames.cs
+++ b/src/PeachPDF/CSS/Enumerations/PropertyNames.cs
@@ -206,6 +206,21 @@ namespace PeachPDF.CSS
         public static readonly string PageBreakInside = "page-break-inside";
         public static readonly string PageName = "page";
         public static readonly string PdfTagType = "-peachpdf-pdf-tag-type";
+        public static readonly string BookmarkLevel = "bookmark-level";
+        public static readonly string BookmarkLabel = "bookmark-label";
+        public static readonly string BookmarkState = "bookmark-state";
+        public static readonly string PeachPdfBookmarkTarget = "-peachpdf-bookmark-target";
+        /// <summary>Hidden, undocumented compat aliases for Prince's own bookmark property spellings -
+        /// see css-properties.json's aliasOf entries for these names. Prince documents both an
+        /// unprefixed and a -prince- prefixed spelling for all four bookmark-* properties; only
+        /// bookmark-target/-prince-bookmark-target need aliasing to -peachpdf-bookmark-target (a
+        /// PeachPDF extension, not a real css-content-3 property) since level/label/state's
+        /// unprefixed spelling already matches the real spec name.</summary>
+        public static readonly string PrinceBookmarkLevel = "-prince-bookmark-level";
+        public static readonly string PrinceBookmarkLabel = "-prince-bookmark-label";
+        public static readonly string PrinceBookmarkState = "-prince-bookmark-state";
+        public static readonly string PrinceBookmarkTarget = "-prince-bookmark-target";
+        public static readonly string BookmarkTarget = "bookmark-target";
         public static readonly string Perspective = "perspective";
         public static readonly string PerspectiveOrigin = "perspective-origin";
         public static readonly string PointerEvents = "pointer-events";

--- a/src/PeachPDF/CSS/Factories/PropertyFactory.cs
+++ b/src/PeachPDF/CSS/Factories/PropertyFactory.cs
@@ -391,6 +391,15 @@ namespace PeachPDF.CSS
             AddLonghand(PropertyNames.StringSet, () => new StringSetProperty());
             AddLonghand(PropertyNames.PageName, () => new PageNameProperty());
             AddLonghand(PropertyNames.PdfTagType, () => new PdfTagTypeProperty());
+            AddLonghand(PropertyNames.BookmarkLevel, () => new BookmarkLevelProperty());
+            AddLonghand(PropertyNames.BookmarkLabel, () => new BookmarkLabelProperty());
+            AddLonghand(PropertyNames.BookmarkState, () => new BookmarkStateProperty());
+            AddLonghand(PropertyNames.PeachPdfBookmarkTarget, () => new BookmarkTargetProperty());
+            AddLonghand(PropertyNames.PrinceBookmarkLevel, () => new PrinceBookmarkLevelProperty());
+            AddLonghand(PropertyNames.PrinceBookmarkLabel, () => new PrinceBookmarkLabelProperty());
+            AddLonghand(PropertyNames.PrinceBookmarkState, () => new PrinceBookmarkStateProperty());
+            AddLonghand(PropertyNames.PrinceBookmarkTarget, () => new PrinceBookmarkTargetProperty());
+            AddLonghand(PropertyNames.BookmarkTarget, () => new BookmarkTargetAliasProperty());
             AddLonghand(PropertyNames.TableLayout, () => new TableLayoutProperty());
             AddLonghand(PropertyNames.TextAlign, () => new TextAlignProperty());
             AddLonghand(PropertyNames.TextAlignLast, () => new TextAlignLastProperty());

--- a/src/PeachPDF/CSS/Model/Converters.cs
+++ b/src/PeachPDF/CSS/Model/Converters.cs
@@ -119,6 +119,18 @@ namespace PeachPDF.CSS
                 .Or(new FunctionValueConverter(FunctionNames.Counters, WithArgs(name, def, kind))));
         });
 
+        // The subset of the <content-list> grammar (CSS Generated Content 3 §2) shared between `content`
+        // (ContentProperty, which additionally allows url()/gradients - image content, not applicable to
+        // a bookmark label - plus the quote-modes and element(), both meaningful only within flowing
+        // generated content, not a standalone label string) and `bookmark-label` (BookmarkLabelProperty,
+        // whose value IS a <content-list> and nothing else) - kept in one place per this repo's "don't
+        // write two independent parsers for the same CSS value grammar" convention rather than
+        // duplicating the combinator chain.
+        public static readonly IValueConverter ContentListItemConverter =
+            StringConverter.Or(AttrConverter).Or(CounterConverter).Or(
+                new ContentFunctionConverter()).Or(
+                new StringFunctionConverter());
+
         public static readonly IValueConverter ShapeConverter = Construct(() =>
         {
             var length = LengthConverter.Required();
@@ -272,6 +284,14 @@ namespace PeachPDF.CSS
         /// </summary>
         public static readonly IValueConverter OutlineStyleConverter = Map.OutlineStyles.ToConverter();
         public static readonly IValueConverter PdfTagTypeConverter = Map.PdfTagTypes.ToConverter();
+        public static readonly IValueConverter BookmarkLevelConverter = PositiveIntegerConverter.OrNone();
+        public static readonly IValueConverter BookmarkStateConverter = Map.BookmarkStates.ToConverter();
+        public static readonly IValueConverter BookmarkLabelConverter = ContentListItemConverter.Many();
+
+        // Prince's own grammar for its bookmark-target extension (self | url() | attr()) - not a real
+        // css-content-3 property, see -peachpdf-bookmark-target's css-properties.json entry.
+        public static readonly IValueConverter BookmarkTargetConverter =
+            Assign(Keywords.Self, Keywords.Self).Or(UrlConverter).Or(AttrConverter);
         public static readonly IValueConverter BackgroundAttachmentConverter = Map.BackgroundAttachments.ToConverter();
         public static readonly IValueConverter BackgroundRepeatConverter = Map.BackgroundRepeats.ToConverter();
         public static readonly IValueConverter BoxModelConverter = Map.BoxModels.ToConverter();

--- a/src/PeachPDF/CSS/Model/Map.cs
+++ b/src/PeachPDF/CSS/Model/Map.cs
@@ -294,6 +294,12 @@ namespace PeachPDF.CSS
             {
                 {Keywords.Auto, AutoKeyword.Auto}
             }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        public static readonly FrozenDictionary<string, BookmarkState> BookmarkStates =
+            new Dictionary<string, BookmarkState>(StringComparer.OrdinalIgnoreCase)
+            {
+                {Keywords.Open, BookmarkState.Open},
+                {Keywords.Closed, BookmarkState.Closed}
+            }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
         public static readonly FrozenDictionary<string, NormalKeyword> NormalKeywords =
             new Dictionary<string, NormalKeyword>(StringComparer.OrdinalIgnoreCase)
             {

--- a/src/PeachPDF/CSS/StyleProperties/Bookmark/BookmarkLabelProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Bookmark/BookmarkLabelProperty.cs
@@ -1,0 +1,13 @@
+namespace PeachPDF.CSS
+{
+    internal sealed class BookmarkLabelProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter = Converters.BookmarkLabelConverter.OrDefault();
+
+        internal BookmarkLabelProperty() : base(PropertyNames.BookmarkLabel)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/PeachPDF/CSS/StyleProperties/Bookmark/BookmarkLevelProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Bookmark/BookmarkLevelProperty.cs
@@ -1,0 +1,11 @@
+namespace PeachPDF.CSS
+{
+    internal sealed class BookmarkLevelProperty : Property
+    {
+        internal BookmarkLevelProperty() : base(PropertyNames.BookmarkLevel)
+        {
+        }
+
+        internal override IValueConverter Converter => Converters.BookmarkLevelConverter.OrDefault();
+    }
+}

--- a/src/PeachPDF/CSS/StyleProperties/Bookmark/BookmarkStateProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Bookmark/BookmarkStateProperty.cs
@@ -1,0 +1,11 @@
+namespace PeachPDF.CSS
+{
+    internal sealed class BookmarkStateProperty : Property
+    {
+        internal BookmarkStateProperty() : base(PropertyNames.BookmarkState)
+        {
+        }
+
+        internal override IValueConverter Converter => Converters.BookmarkStateConverter.OrDefault();
+    }
+}

--- a/src/PeachPDF/CSS/StyleProperties/Bookmark/BookmarkTargetAliasProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Bookmark/BookmarkTargetAliasProperty.cs
@@ -1,0 +1,17 @@
+namespace PeachPDF.CSS
+{
+    /// <summary>
+    /// Hidden, undocumented compat alias for Prince's own bare bookmark-target spelling (Prince's own
+    /// convenience alias for its prince-bookmark-target extension) - see -peachpdf-bookmark-target's
+    /// css-properties.json entry. Not css-content-3's bookmark-target, since that property doesn't
+    /// exist in the real spec.
+    /// </summary>
+    internal sealed class BookmarkTargetAliasProperty : Property
+    {
+        internal BookmarkTargetAliasProperty() : base(PropertyNames.BookmarkTarget)
+        {
+        }
+
+        internal override IValueConverter Converter => Converters.BookmarkTargetConverter.OrDefault();
+    }
+}

--- a/src/PeachPDF/CSS/StyleProperties/Bookmark/BookmarkTargetProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Bookmark/BookmarkTargetProperty.cs
@@ -1,0 +1,11 @@
+namespace PeachPDF.CSS
+{
+    internal sealed class BookmarkTargetProperty : Property
+    {
+        internal BookmarkTargetProperty() : base(PropertyNames.PeachPdfBookmarkTarget)
+        {
+        }
+
+        internal override IValueConverter Converter => Converters.BookmarkTargetConverter.OrDefault();
+    }
+}

--- a/src/PeachPDF/CSS/StyleProperties/Bookmark/PrinceBookmarkLabelProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Bookmark/PrinceBookmarkLabelProperty.cs
@@ -1,0 +1,14 @@
+namespace PeachPDF.CSS
+{
+    /// <summary>Hidden, undocumented compat alias for Prince's own -prince-bookmark-label spelling - see bookmark-label's css-properties.json entry.</summary>
+    internal sealed class PrinceBookmarkLabelProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter = Converters.BookmarkLabelConverter.OrDefault();
+
+        internal PrinceBookmarkLabelProperty() : base(PropertyNames.PrinceBookmarkLabel)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/PeachPDF/CSS/StyleProperties/Bookmark/PrinceBookmarkLevelProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Bookmark/PrinceBookmarkLevelProperty.cs
@@ -1,0 +1,12 @@
+namespace PeachPDF.CSS
+{
+    /// <summary>Hidden, undocumented compat alias for Prince's own -prince-bookmark-level spelling - see bookmark-level's css-properties.json entry.</summary>
+    internal sealed class PrinceBookmarkLevelProperty : Property
+    {
+        internal PrinceBookmarkLevelProperty() : base(PropertyNames.PrinceBookmarkLevel)
+        {
+        }
+
+        internal override IValueConverter Converter => Converters.BookmarkLevelConverter.OrDefault();
+    }
+}

--- a/src/PeachPDF/CSS/StyleProperties/Bookmark/PrinceBookmarkStateProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Bookmark/PrinceBookmarkStateProperty.cs
@@ -1,0 +1,12 @@
+namespace PeachPDF.CSS
+{
+    /// <summary>Hidden, undocumented compat alias for Prince's own -prince-bookmark-state spelling - see bookmark-state's css-properties.json entry.</summary>
+    internal sealed class PrinceBookmarkStateProperty : Property
+    {
+        internal PrinceBookmarkStateProperty() : base(PropertyNames.PrinceBookmarkState)
+        {
+        }
+
+        internal override IValueConverter Converter => Converters.BookmarkStateConverter.OrDefault();
+    }
+}

--- a/src/PeachPDF/CSS/StyleProperties/Bookmark/PrinceBookmarkTargetProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Bookmark/PrinceBookmarkTargetProperty.cs
@@ -1,0 +1,12 @@
+namespace PeachPDF.CSS
+{
+    /// <summary>Hidden, undocumented compat alias for Prince's own -prince-bookmark-target spelling - see -peachpdf-bookmark-target's css-properties.json entry.</summary>
+    internal sealed class PrinceBookmarkTargetProperty : Property
+    {
+        internal PrinceBookmarkTargetProperty() : base(PropertyNames.PrinceBookmarkTarget)
+        {
+        }
+
+        internal override IValueConverter Converter => Converters.BookmarkTargetConverter.OrDefault();
+    }
+}

--- a/src/PeachPDF/CSS/StyleProperties/ContentProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/ContentProperty.cs
@@ -29,11 +29,7 @@ namespace PeachPDF.CSS
             ContentModes.ToConverter().Or(
                 UrlConverter).Or(
                 Converters.GradientConverter).Or(
-                StringConverter).Or(
-                AttrConverter).Or(
-                CounterConverter).Or(
-                new ContentFunctionConverter()).Or(
-                new StringFunctionConverter()).Or(
+                Converters.ContentListItemConverter).Or(
                 new GcpmElementFunctionConverter()).Many()).OrDefault();
 
         private abstract class ContentMode

--- a/src/PeachPDF/Html/Core/CssDefaults.cs
+++ b/src/PeachPDF/Html/Core/CssDefaults.cs
@@ -192,6 +192,18 @@ namespace PeachPDF.Html.Core
             code, kbd,
             samp, var       { -peachpdf-pdf-tag-type: Code }
             a[href]         { -peachpdf-pdf-tag-type: Link }
+
+            /* Default bookmark-level mapping (css-content-3 §2) - author stylesheets may override
+               any of these, or set bookmark-level: none to exclude a heading from the generated PDF
+               outline. Every other element defaults to bookmark-level: none (this property's own
+               initial value), which is also PeachPDF's zero-config "no bookmarks" state for a
+               document with no headings - see BookmarkOutlineBuilder. */
+            h1              { bookmark-level: 1 }
+            h2              { bookmark-level: 2 }
+            h3              { bookmark-level: 3 }
+            h4              { bookmark-level: 4 }
+            h5              { bookmark-level: 5 }
+            h6              { bookmark-level: 6 }
         """;
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
@@ -856,8 +856,20 @@ namespace PeachPDF.Html.Core.Dom
             // box-splitting) represents a structural duplicate of the SAME source box's own
             // resolved content, not real ancestor->descendant inheritance, so its own resolved
             // tag type must carry over too.
+            //
+            // bookmark-level/-label/-state/-target deliberately do NOT get the same treatment: a
+            // bookmark is per-SOURCE-ELEMENT (one outline entry per element), not per-box like a
+            // structure-tree tag. DomParser's inline/block box-splitting produces multiple sibling
+            // CssBoxes for the SAME element (e.g. bookmark-level on a <span> that wraps a block child) -
+            // carrying bookmark metadata into "everything" would give every split fragment its own
+            // bookmark, each with only its own fragment's content(text), instead of the one bookmark the
+            // whole element should produce. CssProxyBox's repeated header/footer clone (the other
+            // "everything" caller) never reaches DomUtils.GetAllLinkAndBookmarkBoxes's walk at all (its
+            // subtree isn't reachable via CssBox.Boxes), so there is no case where carrying these over
+            // would help - only ones where it would duplicate.
             var generatedContent = _computedStyle.GeneratedContent;
-            var newGeneratedContent = generatedContent.SetPropertyValue(generatedContent.PdfTagType, parentStyle.GeneratedContent.PdfTagType, static (a, v) => a with { PdfTagType = v });
+            var newGeneratedContent = generatedContent
+                .SetPropertyValue(generatedContent.PdfTagType, parentStyle.GeneratedContent.PdfTagType, static (a, v) => a with { PdfTagType = v });
             _computedStyle = _computedStyle.AdoptArea(generatedContent, newGeneratedContent, static (s, a) => s with { GeneratedContent = a });
         }
     }

--- a/src/PeachPDF/Html/Core/Dom/CssContentEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssContentEngine.cs
@@ -3,6 +3,7 @@ using PeachPDF.Html.Adapters;
 using PeachPDF.Html.Core.Entities;
 using PeachPDF.Html.Core.Parse;
 using PeachPDF.Html.Core.Utils;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -35,6 +36,19 @@ namespace PeachPDF.Html.Core.Dom
                 }
             }
 
+            cssBox.Text = ResolveContentTokens(cssBox, tokens);
+        }
+
+        /// <summary>
+        /// Resolves a tokenized <c>&lt;content-list&gt;</c> (strings, <c>counter()</c>, <c>attr()</c>,
+        /// <c>content()</c>, <c>string()</c>) against <paramref name="cssBox"/> into its text value.
+        /// Shared by <see cref="ApplyContent"/> (the <c>content</c> property) and
+        /// <see cref="ResolveBookmarkLabel"/> (<c>bookmark-label</c>, whose value IS a
+        /// <c>&lt;content-list&gt;</c> and nothing else) so both consume one resolver for the same
+        /// grammar rather than each re-walking it independently.
+        /// </summary>
+        internal static string ResolveContentTokens(CssBox cssBox, List<Token> tokens)
+        {
             var contentText = new StringBuilder();
 
             foreach (var token in tokens)
@@ -92,7 +106,20 @@ namespace PeachPDF.Html.Core.Dom
                 }
             }
 
-            cssBox.Text = contentText.ToString();
+            return contentText.ToString();
+        }
+
+        /// <summary>
+        /// Resolves <c>bookmark-label</c> (CSS Generated Content Module Level 3 §2) for a PDF outline
+        /// entry's title. The property's initial value is the raw text <c>content(text)</c>, which the
+        /// shared <see cref="ResolveContentTokens"/> switch already handles via its existing
+        /// <c>content()</c>/<c>"text"</c> branch (<see cref="ExtractContentValue"/> -&gt;
+        /// <see cref="ExtractText"/>) - so the default case needs no special-casing here.
+        /// </summary>
+        public static string ResolveBookmarkLabel(CssBox cssBox)
+        {
+            var tokens = CssValueParser.GetCssTokens(cssBox.BookmarkLabel);
+            return ResolveContentTokens(cssBox, tokens);
         }
 
         /// <summary>
@@ -245,7 +272,7 @@ namespace PeachPDF.Html.Core.Dom
             };
         }
 
-        private static string? ExtractText(CssBox cssBox)
+        internal static string? ExtractText(CssBox cssBox)
         {
             // Get the text content of the element (normalized whitespace)
             // If this is a pseudo-element, get the parent's text

--- a/src/PeachPDF/Html/Core/Handlers/BookmarkOutlineBuilder.cs
+++ b/src/PeachPDF/Html/Core/Handlers/BookmarkOutlineBuilder.cs
@@ -1,0 +1,183 @@
+using PeachPDF.CSS;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Fragments;
+using PeachPDF.Html.Core.Parse;
+using PeachPDF.Html.Core.Utils;
+using PeachPDF.PdfSharpCore.Drawing;
+using PeachPDF.PdfSharpCore.Pdf;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PeachPDF.Html.Core.Handlers
+{
+    /// <summary>
+    /// Builds a PDF outline (bookmark sidebar) from every box the document's <c>bookmark-level</c>
+    /// cascade resolved to something other than <c>none</c> (CSS Generated Content Module Level 3 §2).
+    /// Unlike <see cref="StructureTagBuilder"/>, this never hooks into <see cref="Paint.FragmentPainter"/>'s
+    /// paint walk - a PDF outline (<see cref="PdfOutline"/>/<see cref="PdfOutlineCollection"/>) is a
+    /// free-standing dictionary tree independent of the content stream, so it only needs
+    /// <c>bookmarkBoxes</c> in document order (already collected alongside link boxes by
+    /// <see cref="Utils.DomUtils.GetAllLinkAndBookmarkBoxes"/> - see the call site in <c>PdfGenerator</c>)
+    /// and the finished page objects to resolve destinations against. Unconditional - no
+    /// <see cref="PdfGenerateConfig"/> gate, since the UA default stylesheet's own
+    /// <c>bookmark-level: none</c> default is itself the "no bookmarks" state for a document with no
+    /// headings.
+    /// </summary>
+    internal static class BookmarkOutlineBuilder
+    {
+        public static void Build(PdfDocument document, HtmlContainer container,
+            IReadOnlyList<FragmentainerFragment> fragmentainers, IReadOnlyList<CssBox> bookmarkBoxes)
+        {
+            if (bookmarkBoxes.Count == 0) return;
+
+            var (slotToPage, maxMappedSlot) = PageAnchorResolver.BuildSlotToPageMap(fragmentainers);
+
+            // Bookmarks do not need to create a strict hierarchy of levels (css-content-3 §2, note) -
+            // no algorithm is mandated. This is the conventional heading-outline shape (also Prince's
+            // and every browser print-to-PDF's own behavior): a level-N bookmark nests under the
+            // nearest preceding bookmark with a shallower level, or the root if none exists.
+            var stack = new Stack<(int Level, PdfOutline Outline)>();
+
+            foreach (var box in bookmarkBoxes)
+            {
+                var level = ResolveLevel(box);
+                if (level is not { } n) continue;
+
+                while (stack.Count > 0 && stack.Peek().Level >= n)
+                    stack.Pop();
+
+                var outline = new PdfOutline
+                {
+                    Title = CssContentEngine.ResolveBookmarkLabel(box),
+                    Opened = ResolveState(box) != BookmarkState.Closed
+                };
+
+                ApplyDestination(document, outline, box, container, slotToPage, maxMappedSlot, fragmentainers.Count);
+
+                if (stack.Count > 0)
+                    stack.Peek().Outline.Outlines.Add(outline);
+                else
+                    document.Outlines.Add(outline);
+
+                stack.Push((n, outline));
+            }
+        }
+
+        /// <summary>
+        /// Re-parses the raw <c>none | &lt;integer&gt;</c> string (mirroring <see cref="StructureTagMapper.Classify"/>'s
+        /// own re-parse of <c>PdfTagType</c>) - the CSS-OM <c>BookmarkLevelProperty</c> converter
+        /// (<see cref="Converters.BookmarkLevelConverter"/>) already validated the grammar at
+        /// declaration time, so an invalid/unparseable string here can only be a global-keyword
+        /// spelling (e.g. <c>inherit</c> resolved to its cascade-computed text) or genuinely absent.
+        /// </summary>
+        private static int? ResolveLevel(CssBox box)
+        {
+            var raw = box.BookmarkLevel;
+            return !string.IsNullOrWhiteSpace(raw) && int.TryParse(raw.Trim(), out var n) && n >= 1 ? n : null;
+        }
+
+        private static BookmarkState ResolveState(CssBox box) =>
+            !string.IsNullOrWhiteSpace(box.BookmarkState) && Map.BookmarkStates.TryGetValue(box.BookmarkState.Trim(), out var state)
+                ? state
+                : BookmarkState.Open;
+
+        /// <summary>
+        /// Resolves <c>-peachpdf-bookmark-target</c> (self by default) into either a page destination
+        /// (self, or an in-document <c>url(#id)</c>/<c>attr()</c> fragment) or an external-URL <c>/A</c>
+        /// action (see <see cref="PdfOutline.Url"/>). A destination that can't be resolved (e.g. a
+        /// <c>display: none</c> heading) leaves the outline with neither - a supported, harmless state
+        /// (proven by <c>PdfOutlineSaveTests.Save_WithOutlineWithoutDestinationPage_Succeeds</c>) chosen
+        /// over dropping the entry, since dropping it would perturb sibling/descendant nesting.
+        /// </summary>
+        private static void ApplyDestination(PdfDocument document, PdfOutline outline, CssBox box,
+            HtmlContainer container, IReadOnlyDictionary<int, int> slotToPage, int maxMappedSlot, int fallbackPageCount)
+        {
+            var inner = container.HtmlContainerInt;
+            var ppp = container.PixelsPerPoint;
+
+            // Resolved (not the raw declared value) so a relative external target - e.g.
+            // -peachpdf-bookmark-target: attr(href) reading a plain "other.html" - is followed the same
+            // way an equivalent <a href> link would be, rather than being written raw and unresolvable
+            // by a reader for anything but an already-absolute URL. ResolveHref leaves a #-prefixed
+            // fragment untouched, so the classification below still sees it.
+            var target = ResolveTargetValue(box) is { } raw ? container.ResolveHref(raw) : null;
+
+            XRect? rect;
+            if (target is null)
+            {
+                // A display:none (or otherwise unrendered) box was never actually painted -
+                // CommonUtils.GetFirstValueOrDefault would silently fall back to Bounds (typically
+                // all-zero/default), producing a nonsense page-0/Y-0 destination instead of the
+                // documented "leave the outline with neither" behavior. Same ActualDisplay check
+                // FragmentPainter itself uses to skip painting a box entirely.
+                if (box.DerivedStyle.ActualDisplay == Keywords.None) return;
+
+                var ownRect = CommonUtils.GetFirstValueOrDefault(box.Rectangles, box.Bounds);
+                rect = PeachPDF.Utilities.Utils.Convert(ownRect, ppp);
+            }
+            else if (target.Length > 1 && target[0] == '#')
+            {
+                rect = container.GetElementRectangle(target[1..]);
+            }
+            else if (target.Length > 0)
+            {
+                outline.Url = target;
+                return;
+            }
+            else
+            {
+                return;
+            }
+
+            if (rect is not { } r) return;
+
+            var (pageIndex, topPt) = PageAnchorResolver.ResolveRectToPage(inner, ppp, slotToPage, maxMappedSlot, fallbackPageCount, r);
+            if (pageIndex < 0 || pageIndex >= document.Pages.Count) return;
+
+            outline.DestinationPage = document.Pages[pageIndex];
+            // /FitH top fits page width and positions vertically at top - the outline-entry analog of
+            // the anchor-link destination fix in PdfGenerator.HandleLinks, not /FitV's horizontal left.
+            // topPt is top-down (0 at the page's own top margin, increasing downward, matching every
+            // other rect PageAnchorResolver works with), but /FitH's own top parameter is PDF default
+            // user space, which is bottom-up (0 at the page's bottom edge) - flip via the destination
+            // page's own height before writing it, exactly like PdfGenerator.HandleLinks' matching fix.
+            outline.PageDestinationType = PdfPageDestinationType.FitH;
+            outline.Top = outline.DestinationPage.Height - topPt;
+        }
+
+        /// <summary>
+        /// Evaluates <c>-peachpdf-bookmark-target</c>'s <c>self | url() | attr()</c> grammar (Prince's
+        /// own extension, not a real css-content-3 property - see the property's css-properties.json
+        /// entry) to a raw target string, or null for <c>self</c>. The caller classifies the result by
+        /// <c>#</c>-prefix, mirroring <see cref="Entities.LinkElementData{T}.IsAnchor"/>'s identical
+        /// check for <c>&lt;a href="#id"&gt;</c>.
+        /// </summary>
+        private static string? ResolveTargetValue(CssBox box)
+        {
+            var raw = box.BookmarkTarget;
+            if (string.IsNullOrWhiteSpace(raw)) return null;
+
+            var tokens = CssValueParser.GetCssTokens(raw);
+            if (tokens.Count == 0) return null;
+
+            return tokens[0] switch
+            {
+                KeywordToken { Data: Keywords.Self } => null,
+                UrlToken urlToken => string.IsNullOrEmpty(urlToken.Data) ? null : urlToken.Data,
+                FunctionToken { Data: "attr" } attrToken => ResolveAttrTarget(box, attrToken),
+                _ => null
+            };
+        }
+
+        private static string? ResolveAttrTarget(CssBox box, FunctionToken attrToken)
+        {
+            if (attrToken.ArgumentTokens.FirstOrDefault() is not KeywordToken nameToken) return null;
+
+            // Same pseudo-element -> parent redirect CssContentEngine's own attr() handling uses - a
+            // pseudo-element's own attributes don't exist, so it must read the real source element's.
+            var sourceBox = box.IsPseudoElement && box.ParentBox != null ? box.ParentBox : box;
+            var value = sourceBox.GetAttribute(nameToken.Data, "");
+            return string.IsNullOrEmpty(value) ? null : value;
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Handlers/PageAnchorResolver.cs
+++ b/src/PeachPDF/Html/Core/Handlers/PageAnchorResolver.cs
@@ -1,0 +1,60 @@
+using PeachPDF.Html.Core.Fragments;
+using PeachPDF.PdfSharpCore.Drawing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PeachPDF.Html.Core.Handlers
+{
+    /// <summary>
+    /// Shared rect-to-page/Y resolution used by both <c>PdfGenerator.HandleLinks</c>'s anchor-link
+    /// destinations and <see cref="BookmarkOutlineBuilder"/>'s PDF outline destinations, so the two
+    /// don't each re-derive the fragmentainer-slot -&gt; <c>document.Pages</c> mapping and per-slot Y
+    /// math independently.
+    /// </summary>
+    internal static class PageAnchorResolver
+    {
+        /// <summary>
+        /// Materialized pages are the fragmentainers, which may skip content-empty grid slots entirely
+        /// - so a document-space slot index and a <c>document.Pages</c> index are NOT interchangeable.
+        /// Builds that mapping once for a whole generation pass.
+        /// </summary>
+        public static (Dictionary<int, int> SlotToPage, int MaxMappedSlot) BuildSlotToPageMap(
+            IReadOnlyList<FragmentainerFragment> fragmentainers)
+        {
+            var slotToPage = new Dictionary<int, int>(fragmentainers.Count);
+            for (var p = 0; p < fragmentainers.Count; p++)
+                slotToPage[fragmentainers[p].SlotIndex] = p;
+
+            var maxMappedSlot = slotToPage.Count > 0 ? slotToPage.Keys.Max() : -1;
+            return (slotToPage, maxMappedSlot);
+        }
+
+        /// <summary>
+        /// Resolves a true-point rect (see <see cref="HtmlContainer.GetElementRectangle"/>, or a live
+        /// <see cref="Dom.CssBox"/> rect converted via <see cref="Utilities.Utils.Convert(Html.Adapters.Entities.RRect, double)"/>) to the PDF
+        /// page it lands on and its true-point Y offset on that page - <paramref name="ppp"/> converts
+        /// it back to the internal pixel space <paramref name="inner"/>'s slot geometry operates in,
+        /// mirroring how the rest of this pass round-trips point-space rects for slot attribution. A
+        /// rect inside a skipped (content-empty) slot attributes to the next materialized page - the
+        /// nearest place a reader can actually land - falling back to the last mapped page if nothing
+        /// was mapped past it.
+        /// </summary>
+        public static (int PageIndex, double TopPt) ResolveRectToPage(
+            HtmlContainerInt inner, double ppp, IReadOnlyDictionary<int, int> slotToPage, int maxMappedSlot,
+            int fallbackPageCount, XRect rect)
+        {
+            var slot = inner.SlotStartingAt(rect.Top * ppp);
+            var page = -1;
+            for (var s = Math.Max(slot, 0); page < 0 && s <= maxMappedSlot; s++)
+                if (slotToPage.TryGetValue(s, out var found))
+                    page = found;
+            if (page < 0) page = fallbackPageCount - 1;
+
+            var topPt = inner.PageGeometry.GetPage(slot).MarginTopPt
+                + (rect.Top * ppp - inner.PageTopOf(slot)) / ppp;
+
+            return (page, topPt);
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/HtmlContainerInt.cs
+++ b/src/PeachPDF/Html/Core/HtmlContainerInt.cs
@@ -777,13 +777,20 @@ namespace PeachPDF.Html.Core
         }
 
         /// <summary>
-        /// Get all the links in the HTML with the element rectangle and href data.
+        /// Get all the links in the HTML with the element rectangle and href data, additionally
+        /// collecting every bookmark-candidate box (<c>bookmark-level != none</c>) into
+        /// <paramref name="bookmarkBoxes"/> from the same tree walk when non-null (see
+        /// <see cref="Utils.DomUtils.GetAllLinkAndBookmarkBoxes"/>) - the only caller is
+        /// <see cref="HtmlContainer.GetLinks(List{CssBox}?)"/>, which is where the public,
+        /// bookmark-agnostic <see cref="HtmlContainer.GetLinks()"/> contract lives.
         /// </summary>
-        /// <returns>collection of all the links in the HTML</returns>
-        public List<LinkElementData<RRect>> GetLinks()
+        internal List<LinkElementData<RRect>> GetLinks(List<CssBox>? bookmarkBoxes)
         {
             var linkBoxes = new List<CssBox>();
-            DomUtils.GetAllLinkBoxes(Root, linkBoxes);
+            if (bookmarkBoxes is null)
+                DomUtils.GetAllLinkBoxes(Root, linkBoxes);
+            else
+                DomUtils.GetAllLinkAndBookmarkBoxes(Root, linkBoxes, bookmarkBoxes);
 
             var linkElements = new List<LinkElementData<RRect>>();
             foreach (var box in linkBoxes)

--- a/src/PeachPDF/Html/Core/Utils/DomUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/DomUtils.cs
@@ -326,6 +326,38 @@ namespace PeachPDF.Html.Core.Utils
         }
 
         /// <summary>
+        /// Same walk as <see cref="GetAllLinkBoxes"/>, additionally collecting every box whose resolved
+        /// <c>bookmark-level</c> is not <c>none</c> into <paramref name="bookmarkBoxes"/> (in document
+        /// order, for free, since this is a pre-order walk) - so <c>PdfGenerator</c> can build its PDF
+        /// outline from a single full-tree traversal instead of a second, independent one. Link and
+        /// bookmark candidacy are independent conditions; a box can be both (a linked heading).
+        /// </summary>
+        public static void GetAllLinkAndBookmarkBoxes(CssBox? box, List<CssBox> linkBoxes, List<CssBox> bookmarkBoxes)
+        {
+            switch (box)
+            {
+                case null:
+                    return;
+                case { IsClickable: true, Visibility.Value: Visibility.Visible }:
+                    linkBoxes.Add(box);
+                    break;
+            }
+
+            // BookmarkLevel is stored as its raw, already-validated none|<integer> string (see
+            // bookmark-level's css-properties.json entry) - any non-"none" value is a candidate;
+            // BookmarkOutlineBuilder.ResolveLevel does the actual int parse.
+            if (box.BookmarkLevel is { Length: > 0 } level && level != Keywords.None)
+            {
+                bookmarkBoxes.Add(box);
+            }
+
+            foreach (var childBox in box.Boxes)
+            {
+                GetAllLinkAndBookmarkBoxes(childBox, linkBoxes, bookmarkBoxes);
+            }
+        }
+
+        /// <summary>
         /// Collect every SVG-sourced link candidate (from <c>&lt;a&gt;</c> elements inside an inline
         /// <c>&lt;svg&gt;</c> or a standalone <c>&lt;img src="x.svg"&gt;</c>) found anywhere in the
         /// HTML tree, already resolved to page-space rectangles via <see cref="SvgRenderer.CollectLinks"/>.

--- a/src/PeachPDF/HtmlContainer.cs
+++ b/src/PeachPDF/HtmlContainer.cs
@@ -171,27 +171,41 @@ namespace PeachPDF
         /// Get all the links in the HTML with the element rectangle and href data.
         /// </summary>
         /// <returns>collection of all the links in the HTML</returns>
-        public List<LinkElementData<XRect>> GetLinks()
+        public List<LinkElementData<XRect>> GetLinks() => GetLinks(null);
+
+        /// <summary>
+        /// Same as <see cref="GetLinks()"/>, additionally collecting every bookmark-candidate box
+        /// (<c>bookmark-level != none</c>) into <paramref name="bookmarkBoxes"/> from the same tree
+        /// walk (see <see cref="Html.Core.HtmlContainerInt.GetLinks(List{CssBox}?)"/>), when a caller
+        /// needs both - internal only, since the parameter type is internal.
+        /// </summary>
+        internal List<LinkElementData<XRect>> GetLinks(List<CssBox>? bookmarkBoxes)
         {
             var linkElements = new List<LinkElementData<XRect>>();
 
-            var baseElement = DomUtils.GetBoxByTagName(HtmlContainerInt.Root, "base");
-            var baseUrl = "";
-
-            if (baseElement is not null)
+            foreach (var link in HtmlContainerInt.GetLinks(bookmarkBoxes))
             {
-                baseUrl = baseElement.HtmlTag?.TryGetAttribute("href", "");
-            }
-
-            var baseUri = string.IsNullOrWhiteSpace(baseUrl) ? HtmlContainerInt.Adapter.BaseUri : new RUri(baseUrl);
-
-            foreach (var link in HtmlContainerInt.GetLinks())
-            {
-                var href = link.Href.StartsWith('#') || baseUri is null ? link.Href : new RUri(baseUri, link.Href).AbsoluteUri;
+                var href = ResolveHref(link.Href);
                 linkElements.Add(new LinkElementData<XRect>(link.Id, href, Utils.Convert(link.Rectangle, PixelsPerPoint), link.SourceBox));
             }
 
             return linkElements;
+        }
+
+        /// <summary>
+        /// Resolves a relative href (from an <c>&lt;a href&gt;</c> or a <c>-peachpdf-bookmark-target:
+        /// attr()/url()</c> value) against the document's <c>&lt;base&gt;</c> element/adapter base URI -
+        /// shared by <see cref="GetLinks(List{CssBox}?)"/> and <c>BookmarkOutlineBuilder</c> so an
+        /// external bookmark target resolves exactly like an equivalent link would, rather than being
+        /// written raw (unresolvable by a reader for anything but an already-absolute URL).
+        /// </summary>
+        internal string ResolveHref(string href)
+        {
+            var baseElement = DomUtils.GetBoxByTagName(HtmlContainerInt.Root, "base");
+            var baseUrl = baseElement?.HtmlTag?.TryGetAttribute("href", "") ?? "";
+            var baseUri = string.IsNullOrWhiteSpace(baseUrl) ? HtmlContainerInt.Adapter.BaseUri : new RUri(baseUrl);
+
+            return href.StartsWith('#') || baseUri is null ? href : new RUri(baseUri, href).AbsoluteUri;
         }
 
         /// <summary>

--- a/src/PeachPDF/PdfGenerator.cs
+++ b/src/PeachPDF/PdfGenerator.cs
@@ -429,8 +429,16 @@ namespace PeachPDF
             // StructureTagBuilder.Finish and HandleLinks's own tagging-aware section below).
             structureTagBuilder?.Finish();
 
-            // add web links and anchors
-            HandleLinks(document.PdfDocument, container, orgPageSize, fragmentainers, structureTagBuilder);
+            // add web links and anchors. bookmarkBoxes rides along on the same full-tree walk
+            // GetLinks() already performs (DomUtils.GetAllLinkAndBookmarkBoxes), so building the PDF
+            // outline afterwards adds zero net full-tree traversals.
+            var bookmarkBoxes = new List<CssBox>();
+            HandleLinks(document.PdfDocument, container, orgPageSize, fragmentainers, bookmarkBoxes, structureTagBuilder);
+
+            // PDF outline (bookmarks) - CSS-default-driven (h1-h6 default to bookmark-level 1-6 via the
+            // UA stylesheet, everything else defaults to none), so this is unconditional: a document
+            // with no headings simply collects zero bookmark boxes above and adds no outline.
+            BookmarkOutlineBuilder.Build(document.PdfDocument, container, fragmentainers, bookmarkBoxes);
 
             measure?.Dispose();
         }
@@ -547,24 +555,20 @@ namespace PeachPDF
 
         /// <summary>
         /// Handle HTML links by create PDF Documents link either to external URL or to another page in the document.
+        /// <paramref name="bookmarkBoxes"/> collects every bookmark-candidate box found along the way
+        /// (see <see cref="Html.Core.Utils.DomUtils.GetAllLinkAndBookmarkBoxes"/>), for
+        /// <see cref="BookmarkOutlineBuilder"/> to consume afterwards without a second full-tree walk.
         /// <paramref name="structureTagBuilder"/> is non-null only when tagged PDF output is enabled -
         /// used to attach each created Link annotation's "/OBJR" back to its owning "/Link" structure
         /// element (see the tagging-aware section below), completing the bidirectional PDF/UA
         /// linkage between the annotation and the structure tree.
         /// </summary>
-        private static void HandleLinks(PdfDocument document, HtmlContainer container, XSize orgPageSize, IReadOnlyList<FragmentainerFragment> fragmentainers, StructureTagBuilder? structureTagBuilder = null)
+        private static void HandleLinks(PdfDocument document, HtmlContainer container, XSize orgPageSize, IReadOnlyList<FragmentainerFragment> fragmentainers, List<CssBox> bookmarkBoxes, StructureTagBuilder? structureTagBuilder = null)
         {
             var inner = container.HtmlContainerInt;
             var ppp = container.PixelsPerPoint;
 
-            // Materialized pages are the fragmentainers, which may skip content-empty grid slots
-            // entirely - so a document-space slot index and a document.Pages index are NOT
-            // interchangeable. Build the slot -> page mapping once.
-            var slotToPage = new Dictionary<int, int>(fragmentainers.Count);
-            for (var p = 0; p < fragmentainers.Count; p++)
-                slotToPage[fragmentainers[p].SlotIndex] = p;
-
-            var maxMappedSlot = slotToPage.Count > 0 ? slotToPage.Keys.Max() : -1;
+            var (slotToPage, maxMappedSlot) = PageAnchorResolver.BuildSlotToPageMap(fragmentainers);
 
             // An anchor inside a skipped (content-empty) slot attributes to the next materialized
             // page - the nearest place a reader can actually land. Shared by both link sources below
@@ -573,22 +577,12 @@ namespace PeachPDF
             (int PageIndex, double TopPt)? ResolveAnchorTarget(string anchorId)
             {
                 var anchorRect = container.GetElementRectangle(anchorId);
-                if (!anchorRect.HasValue) return null;
-
-                var anchorSlot = inner.SlotStartingAt(anchorRect.Value.Top * ppp);
-                var anchorPage = -1;
-                for (var s = Math.Max(anchorSlot, 0); anchorPage < 0 && s <= maxMappedSlot; s++)
-                    if (slotToPage.TryGetValue(s, out var found))
-                        anchorPage = found;
-                if (anchorPage < 0) anchorPage = fragmentainers.Count - 1;
-
-                var anchorTopPt = inner.PageGeometry.GetPage(anchorSlot).MarginTopPt
-                    + (anchorRect.Value.Top * ppp - inner.PageTopOf(anchorSlot)) / ppp;
-
-                return (anchorPage, anchorTopPt);
+                return anchorRect.HasValue
+                    ? PageAnchorResolver.ResolveRectToPage(inner, ppp, slotToPage, maxMappedSlot, fragmentainers.Count, anchorRect.Value)
+                    : null;
             }
 
-            foreach (var link in container.GetLinks())
+            foreach (var link in container.GetLinks(bookmarkBoxes))
             {
                 // Link rects are true points (the public GetLinks wrapper divides by PixelsPerPoint
                 // and resolves relative hrefs against the document base URI); slot attribution runs
@@ -620,7 +614,15 @@ namespace PeachPDF
                         var target = ResolveAnchorTarget(link.AnchorId);
                         if (target is not { } t) continue;
 
-                        document.AddNamedDestination(link.AnchorId, t.PageIndex + 1, PdfNamedDestinationParameters.CreateFitVertically(t.TopPt));
+                        // /FitH top fits page width and positions vertically at top - the "jump down
+                        // to this Y" behavior an anchor link destination actually wants; CreateFitVertically
+                        // would instead pass TopPt as /FitV's horizontal left parameter. TopPt itself is
+                        // top-down (0 at the page's own top margin, increasing downward, matching every
+                        // other rect this pass works with - see the xRect construction below), but /FitH's
+                        // own "top" parameter is PDF default user space, which is bottom-up (0 at the page's
+                        // bottom edge) - flipping via orgPageSize.Height is required, exactly like the xRect
+                        // construction below already does for the same reason.
+                        document.AddNamedDestination(link.AnchorId, t.PageIndex + 1, PdfNamedDestinationParameters.CreateFitHorizontally(orgPageSize.Height - t.TopPt));
                         annotation = document.Pages[pageIndex].AddDocumentLink(new PdfRectangle(xRect), link.AnchorId);
                     }
                     else
@@ -686,7 +688,9 @@ namespace PeachPDF
                             var target = resolveAnchorTarget(anchorId);
                             if (target is not { } t) continue;
 
-                            document.AddNamedDestination(anchorId, t.PageIndex + 1, PdfNamedDestinationParameters.CreateFitVertically(t.TopPt));
+                            // See the same flip's comment in HandleLinks above - TopPt is top-down, /FitH's
+                            // own top parameter needs bottom-up PDF default user space.
+                            document.AddNamedDestination(anchorId, t.PageIndex + 1, PdfNamedDestinationParameters.CreateFitHorizontally(orgPageSize.Height - t.TopPt));
                             annotation = document.Pages[pageIndex].AddDocumentLink(new PdfRectangle(xRect), anchorId);
                         }
                         else

--- a/src/PeachPDF/PdfSharpCore/Pdf/PdfOutline.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf/PdfOutline.cs
@@ -180,6 +180,19 @@ namespace PeachPDF.PdfSharpCore.Pdf
         PdfPage _destinationPage = null!;
 
         /// <summary>
+        /// Gets or sets an external URL this outline item links to instead of a page in this
+        /// document, written as a <c>/A</c> URI action (mutually exclusive with <see cref="DestinationPage"/>'s
+        /// <c>/Dest</c> per PDF 32000-1:2008 Table 153/Table 176). Ignored when <see cref="DestinationPage"/>
+        /// is also set.
+        /// </summary>
+        public string? Url
+        {
+            get { return _url; }
+            set { _url = value; }
+        }
+        string? _url;
+
+        /// <summary>
         /// Gets or sets the left position of the page positioned at the left side of the window.
         /// Applies only if PageDestinationType is Xyz, FitV, FitR, or FitBV.
         /// </summary>
@@ -323,10 +336,14 @@ namespace PeachPDF.PdfSharpCore.Pdf
                     int index = _parent._outlines.IndexOf(this);
                     Debug.Assert(index != -1);
 
-                    // Has destination?
+                    // Has destination? Mutually exclusive with an /A action - a page destination always
+                    // wins if both happen to be set.
                     if (DestinationPage != null)
                         //Elements[Keys.Dest] = new PdfArray(Owner, DestinationPage.Reference, new PdfLiteral("/XYZ null null 0"));
                         Elements[Keys.Dest] = CreateDestArray();
+                    else if (!string.IsNullOrEmpty(Url))
+                        Elements[Keys.A] = new PdfLiteral("<</S/URI/URI{0}>>",
+                            PdfEncoders.ToStringLiteral(Url, PdfStringEncoding.WinAnsiEncoding));
 
                     // Not the first element?
                     if (index > 0)

--- a/src/PeachPDF/PdfSharpCore/Pdf/PdfOutlineCollection.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf/PdfOutlineCollection.cs
@@ -83,7 +83,8 @@ namespace PeachPDF.PdfSharpCore.Pdf
             if (outline == null)
                 throw new ArgumentNullException(nameof(outline));
 
-            // DestinationPage is optional. PDFsharp does not yet support outlines with action ("/A") instead of destination page ("/DEST")
+            // DestinationPage is optional - an outline may instead carry a Url (written as an /A URI
+            // action, see PdfOutline.PrepareForSave), or neither (no destination at all).
             if (outline.DestinationPage != null && !ReferenceEquals(Owner, outline.DestinationPage.Owner))
                 throw new ArgumentException("Destination page must belong to this document.");
 
@@ -272,7 +273,8 @@ namespace PeachPDF.PdfSharpCore.Pdf
             if (outline == null)
                 throw new ArgumentNullException(nameof(outline));
 
-            // DestinationPage is optional. PDFsharp does not yet support outlines with action ("/A") instead of destination page ("/DEST")
+            // DestinationPage is optional - an outline may instead carry a Url (written as an /A URI
+            // action, see PdfOutline.PrepareForSave), or neither (no destination at all).
             if (outline.DestinationPage != null && !ReferenceEquals(Owner, outline.DestinationPage.Owner))
                 throw new ArgumentException("Destination page must belong to this document.");
 

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -746,6 +746,119 @@
       }
     },
     {
+      "name": "bookmark-level",
+      "comment": "CSS Generated Content Module Level 3 §2 (https://www.w3.org/TR/css-content-3/#bookmark-level). cssom/string-stored, like -peachpdf-pdf-tag-type - BookmarkOutlineBuilder parses the raw none/<integer> string itself (mirroring StructureTagMapper.Classify's own re-parse of PdfTagType), since the CSS-OM BookmarkLevelProperty converter (Converters.BookmarkLevelConverter) already validates the grammar at declaration time. h1-h6 default to 1-6 via CssDefaults.cs's UA stylesheet, everything else defaults to none (this property's own initial value), which is itself the zero-config \"no bookmarks\" state.",
+      "inherited": false,
+      "initialValue": "none",
+      "cssDataType": "cssom",
+      "html": {
+        "propertyPath": "BookmarkLevel",
+        "csharpDataType": "string",
+        "area": "GeneratedContentArea"
+      }
+    },
+    {
+      "name": "bookmark-label",
+      "comment": "CSS Generated Content Module Level 3 §2 (https://www.w3.org/TR/css-content-3/#bookmark-label). A <content-list> - the same string/counter()/attr()/content()/string() grammar `content` accepts, minus url()/gradients (image content, not applicable to a label) and the quote-modes/element() (meaningful only within flowing generated content, not a standalone label string) - see the shared Converters.ContentListItemConverter both properties' CSS-OM converters reference, and CssContentEngine.ResolveContentTokens/ResolveBookmarkLabel for the shared resolver. Initial value content(text) means \"the element's own rendered text\", resolved via the same content()/\"text\" branch content() itself uses.",
+      "inherited": false,
+      "initialValue": "content(text)",
+      "cssDataType": "cssom",
+      "html": {
+        "propertyPath": "BookmarkLabel",
+        "csharpDataType": "string",
+        "area": "GeneratedContentArea"
+      }
+    },
+    {
+      "name": "bookmark-state",
+      "comment": "CSS Generated Content Module Level 3 §2 (https://www.w3.org/TR/css-content-3/#bookmark-state). cssom/string-stored, like bookmark-level - BookmarkOutlineBuilder parses the raw open/closed string itself via Map.BookmarkStates.",
+      "inherited": false,
+      "initialValue": "open",
+      "cssDataType": "cssom",
+      "html": {
+        "propertyPath": "BookmarkState",
+        "csharpDataType": "string",
+        "area": "GeneratedContentArea"
+      }
+    },
+    {
+      "name": "-peachpdf-bookmark-target",
+      "comment": "NOT a css-content-3 property - css-content-3 defines only bookmark-level/-label/-state (verified against the spec source directly; an earlier draft of this issue assumed bookmark-target was part of the same spec and it is not). This is Prince's own extension (prince-bookmark-target, self | url() | attr(), default self) - PeachPDF's own documented spelling follows the -peachpdf-pdf-tag-type precedent for a PDF-output feature with no real spec-track name, rather than the unprefixed spelling Prince itself uses. See BookmarkOutlineBuilder.ResolveTargetValue for self/url()/attr() resolution and the in-document-fragment-vs-external-URL split.",
+      "inherited": false,
+      "initialValue": "self",
+      "cssDataType": "cssom",
+      "html": {
+        "propertyPath": "BookmarkTarget",
+        "csharpDataType": "string",
+        "area": "GeneratedContentArea"
+      }
+    },
+    {
+      "name": "-prince-bookmark-level",
+      "comment": "Hidden, undocumented compat alias for Prince's own -prince-bookmark-level spelling (Prince documents both an unprefixed and a -prince- prefixed form for all four bookmark-* properties) - translates to the real spec property bookmark-level at parse time. Not documented in docs/, same pattern as the other PDF-output extensions' Prince/prefixed compat shims.",
+      "inherited": false,
+      "initialValue": "none",
+      "cssDataType": "cssom",
+      "aliasOf": "bookmark-level",
+      "html": {
+        "propertyPath": "BookmarkLevel",
+        "csharpDataType": "string",
+        "area": "GeneratedContentArea"
+      }
+    },
+    {
+      "name": "-prince-bookmark-label",
+      "comment": "Hidden, undocumented compat alias for Prince's own -prince-bookmark-label spelling - translates to the real spec property bookmark-label at parse time.",
+      "inherited": false,
+      "initialValue": "content(text)",
+      "cssDataType": "cssom",
+      "aliasOf": "bookmark-label",
+      "html": {
+        "propertyPath": "BookmarkLabel",
+        "csharpDataType": "string",
+        "area": "GeneratedContentArea"
+      }
+    },
+    {
+      "name": "-prince-bookmark-state",
+      "comment": "Hidden, undocumented compat alias for Prince's own -prince-bookmark-state spelling - translates to the real spec property bookmark-state at parse time.",
+      "inherited": false,
+      "initialValue": "open",
+      "cssDataType": "cssom",
+      "aliasOf": "bookmark-state",
+      "html": {
+        "propertyPath": "BookmarkState",
+        "csharpDataType": "string",
+        "area": "GeneratedContentArea"
+      }
+    },
+    {
+      "name": "-prince-bookmark-target",
+      "comment": "Hidden, undocumented compat alias for Prince's own -prince-bookmark-target spelling - translates to -peachpdf-bookmark-target (a PeachPDF extension, not a real spec property - see that entry) at parse time.",
+      "inherited": false,
+      "initialValue": "self",
+      "cssDataType": "cssom",
+      "aliasOf": "-peachpdf-bookmark-target",
+      "html": {
+        "propertyPath": "BookmarkTarget",
+        "csharpDataType": "string",
+        "area": "GeneratedContentArea"
+      }
+    },
+    {
+      "name": "bookmark-target",
+      "comment": "Hidden, undocumented compat alias for Prince's own bookmark-target spelling (Prince's convenience alias for its prince-bookmark-target extension) - translates to -peachpdf-bookmark-target at parse time. The one place in this file an unprefixed name is NOT a real spec property: css-content-3 defines no bookmark-target at all (see -peachpdf-bookmark-target's own comment).",
+      "inherited": false,
+      "initialValue": "self",
+      "cssDataType": "cssom",
+      "aliasOf": "-peachpdf-bookmark-target",
+      "html": {
+        "propertyPath": "BookmarkTarget",
+        "csharpDataType": "string",
+        "area": "GeneratedContentArea"
+      }
+    },
+    {
       "name": "margin-bottom",
       "comment": "CssKeywordOrValue<AutoKeyword, LengthOrCalc>-backed (issue #598's follow-up: typed union storage instead of a raw string) — see CssKeywordOrValueParser.FromCssText.",
       "inherited": false,


### PR DESCRIPTION
## Summary

- Implements CSS Generated Content Module Level 3's bookmark properties (`bookmark-level`, `bookmark-label`, `bookmark-state`) to auto-generate a PDF outline (bookmark sidebar) from a document's headings — `h1`–`h6` default to levels 1–6 via the UA stylesheet, so this is zero-configuration for the common case.
- `bookmark-target` is **not** actually part of css-content-3 (verified directly against the spec source — only the three properties above are defined there). It's implemented as PeachPDF's own `-peachpdf-bookmark-target` extension, following the `-peachpdf-pdf-tag-type` precedent for a PDF-output feature with no real spec-track name, supporting `self | url() | attr()` including external URLs (resolved against the document's base URI) and in-document fragments.
- Hidden, undocumented compat aliases translate Prince's own spellings (`-prince-bookmark-*`, and bare `bookmark-target`) to the canonical properties at parse time.
- New `PdfOutline.Url`/`/A` URI-action support (mirroring the existing `PdfLinkAnnotation` web-link pattern) lets a bookmark point at an external URL, not just a page in the document.

## Bundled fix

While building this, found and fixed a pre-existing bug: `<a href="#id">` anchor link destinations were computed in the wrong PDF coordinate space (a top-down layout offset written directly into `/FitH`'s bottom-up "top" parameter — after an earlier, insufficient `/FitV`-to-`/FitH` axis-only fix), so clicking an anchor link routed a reader to the correct page but landed far from the actual target position on it. The new bookmark destinations share the corrected math via a new `PageAnchorResolver`. Verified against the raw PDF bytes (not just a single PDF library's own interpretation) after two independent real-world PDF viewers surfaced the discrepancy during manual testing.

## Test plan

- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 8550 passed, 0 failed
- [x] 100% diff coverage on changed lines (`diff-cover` against `origin/main`)
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings
- [x] New integration tests assert directly on the built `PdfOutline` tree (title/nesting/open-state/destination) and on raw PDF bytes for the anchor-link coordinate fix, not content-stream substrings
- [x] Manually verified destination coordinates against real heading positions in generated PDFs using two independent libraries (PyMuPDF, pikepdf) at the raw-byte level, and against real-world viewer behavior (FoxIt, Edge)
- [x] New TestHarness showcase (`bookmarks`) demonstrating default nesting, `bookmark-level: none` suppression, a generated `bookmark-label` (counter + literal text), `bookmark-state: closed`, and `-peachpdf-bookmark-target` pointing at a different element

## Follow-ups tracked separately

- #714 — headings inside repeated running/margin-box content or repeated table headers/footers aren't collected (documented accepted-gap)
- #715 — pre-existing `PdfOutlineCollection`/`PdfSharpCore` `/Count` non-conformance when a closed outline item has children (unrelated to this change, newly exposed since this PR is the first thing to populate `document.Outlines` at all)