### PR TITLE
Compute PDF outline /Count from tree shape instead of incremental accumulation

### DIFF
--- a/.claude/recent-fixes/2026-08-11-outline-count-excludes-closed-item-descendants.md
+++ b/.claude/recent-fixes/2026-08-11-outline-count-excludes-closed-item-descendants.md
@@ -1,0 +1,47 @@
+# PDF outline `/Count` no longer leaks a closed item's descendants into its ancestors
+
+## The load-bearing idea
+
+`PdfOutlineCollection.Add` incremented every ancestor's `OpenCount` whenever the *newly added*
+outline had `Opened == true`, walking straight up the `Parent` chain regardless of whether an
+intermediate ancestor was itself closed. Per PDF 32000-1 Table 152/153, an outline dictionary's or
+item's `/Count` must equal the number of *visible* items — and a closed item hides everything below
+it from the outline panel, so its descendants must not contribute to any ancestor's `/Count` above
+it. Because `Add` only looked at the item being inserted and blindly walked to the root, a closed
+item with open children still let those children's `+1`s propagate past it. The same accumulation
+also never wrote `/Count` at all for an item whose descendants were *all* closed (`OpenCount` stayed
+0), even though the entry is required whenever the item has any descendants, open or not.
+
+The fix drops the incremental accumulation entirely and computes `/Count` from the actual tree shape
+once per save. `PdfOutline.ComputeVisibleDescendantCount` walks bottom-up from the root (the only
+place `PrepareForSave` is ever entered — `PdfCatalog.PrepareForSave` → root `PdfOutline`): for each
+item, its `_visibleDescendantCount` is the number of immediate children (each always counts, since a
+child is visible whenever its parent is open) plus, for each child that is itself `Opened`, that
+child's own `_visibleDescendantCount` recursively. Because the walk starts at the root and touches
+every node exactly once, each item's count is available by the time its own `PrepareForSave` branch
+reads it — no need to recompute per node. `/Count` on an item is then `(_opened ? 1 : -1) *
+_visibleDescendantCount`, written whenever the item `HasChildren`, not only when the count is
+positive.
+
+## What was deliberately not touched
+
+`PdfOutline.CountOpen()`/`PdfOutlineCollection.CountOpen()` are a separate, already-known-broken stub
+(`CountOpen_DoesNotDescendIntoChildren` documents it) — unrelated to `/Count` written to the PDF and
+left alone.
+
+## Evidence
+
+- New `PrepareForSave_ClosedIntermediateItem_ExcludesHiddenDescendantsFromAncestorCounts`
+  (`PdfOutlineSaveTests.cs`): reproduces the issue's exact repro tree (`Top` open → `Closed mid`
+  closed → two open `H3` children) and asserts root=2, `Top`=1, `Closed mid`=-2 — all three were
+  wrong before the fix (root and `Top` over-counted to 3 and 2 respectively).
+- New `PrepareForSave_ClosedItemWithClosedChildren_StillWritesCount`: an item with only closed
+  descendants (no open items anywhere in its subtree) now still gets `/Count = -2` instead of no
+  `/Count` entry at all.
+- Full `net8.0` suite (8552 passed) and `dotnet build PeachPDF.slnx -t:Rebuild` (0 warnings) both
+  green after the change. Diff coverage confirmed via `coverage.cobertura.xml` — every changed line
+  in `PdfOutline.cs`/`PdfOutlineCollection.cs` hit.
+- Found while implementing #711/#716 (PDF bookmark/outline generation), which was the first thing in
+  PeachPDF to actually populate `document.Outlines` and made this pre-existing `PdfSharpCore` bug
+  observable; #716 has landed on `main` but not yet been released (post-`v0.9.9`), so this is folded
+  in as a fix rather than a migration note against a shipped release.

--- a/src/PeachPDF.Tests/PdfSharpCore/Pdf/PdfOutlineSaveTests.cs
+++ b/src/PeachPDF.Tests/PdfSharpCore/Pdf/PdfOutlineSaveTests.cs
@@ -111,5 +111,44 @@ namespace PeachPDF.Tests.PdfSharpCoreTests.Pdf
 
             Assert.Equal(1, parent.CountOpen());
         }
+
+        [Fact]
+        public void PrepareForSave_ClosedIntermediateItem_ExcludesHiddenDescendantsFromAncestorCounts()
+        {
+            // Regression test for #715: a closed intermediate item must not let its own
+            // descendants leak into an ancestor's /Count, and must itself carry the negative
+            // count of what would appear if it were reopened (PDF 32000-1 Table 152/153).
+            var doc = new PdfDocument();
+            var page = doc.AddPage();
+            var top = doc.Outlines.Add("Top", page, opened: true);
+            var closedMid = top.Outlines.Add("Closed mid", page, opened: false);
+            closedMid.Outlines.Add("H3 A", page, opened: true);
+            closedMid.Outlines.Add("H3 B", page, opened: true);
+
+            var root = top.Parent;
+            root.PrepareForSave();
+
+            Assert.Equal(2, root.Elements.GetInteger(PdfOutline.Keys.Count));
+            Assert.Equal(1, top.Elements.GetInteger(PdfOutline.Keys.Count));
+            Assert.Equal(-2, closedMid.Elements.GetInteger(PdfOutline.Keys.Count));
+        }
+
+        [Fact]
+        public void PrepareForSave_ClosedItemWithClosedChildren_StillWritesCount()
+        {
+            // An item with descendants must always carry a /Count entry, even when none of its
+            // children (or their descendants) are open -- the PDF spec requires it whenever the
+            // item has any descendants at all, not only when some are open.
+            var doc = new PdfDocument();
+            var page = doc.AddPage();
+            var closedParent = doc.Outlines.Add("Closed parent", page, opened: false);
+            closedParent.Outlines.Add("Closed child A", page, opened: false);
+            closedParent.Outlines.Add("Closed child B", page, opened: false);
+
+            var root = closedParent.Parent;
+            root.PrepareForSave();
+
+            Assert.Equal(-2, closedParent.Elements.GetInteger(PdfOutline.Keys.Count));
+        }
     }
 }

--- a/src/PeachPDF/PdfSharpCore/Pdf/PdfOutline.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf/PdfOutline.cs
@@ -131,9 +131,35 @@ namespace PeachPDF.PdfSharpCore.Pdf
         int _count;
 
         /// <summary>
-        /// The total number of open descendants at all lower levels.
+        /// The number of descendants that would be visible in the outline panel if this item
+        /// were open, i.e. immediate children plus (recursively) the visible descendants of
+        /// whichever of those children are themselves open. Computed bottom-up by
+        /// <see cref="ComputeVisibleDescendantCount"/> before it is used to write /Count
+        /// (PDF 32000-1 Table 152/153) -- a closed intermediate item hides its own descendants
+        /// from every ancestor's count, so this cannot be accumulated incrementally as items are
+        /// added (see issue #715).
         /// </summary>
-        internal int OpenCount;
+        int _visibleDescendantCount;
+
+        /// <summary>
+        /// Computes <see cref="_visibleDescendantCount"/> for this item and every descendant,
+        /// bottom-up, in a single pass.
+        /// </summary>
+        internal void ComputeVisibleDescendantCount()
+        {
+            int total = 0;
+            if (_outlines != null)
+            {
+                foreach (PdfOutline child in _outlines)
+                {
+                    child.ComputeVisibleDescendantCount();
+                    total++;
+                    if (child.Opened)
+                        total += child._visibleDescendantCount;
+                }
+            }
+            _visibleDescendantCount = total;
+        }
 
         /// <summary>
         /// Counts the open outline items. Not yet used.
@@ -321,10 +347,12 @@ namespace PeachPDF.PdfSharpCore.Pdf
                     Elements[Keys.First] = _outlines[0].Reference;
                     Elements[Keys.Last] = _outlines[_outlines.Count - 1].Reference;
 
-                    // TODO: /Count - the meaning is not completely clear to me.
-                    // Get PDFs created with Acrobat and analyse what to implement.
-                    if (OpenCount > 0)
-                        Elements[Keys.Count] = new PdfInteger(OpenCount);
+                    // The root has no Opened flag of its own -- its top-level items are always
+                    // visible, so /Count is simply the number of items that would show up in the
+                    // outline panel across the whole tree (PDF 32000-1 Table 152).
+                    ComputeVisibleDescendantCount();
+                    if (_visibleDescendantCount > 0)
+                        Elements[Keys.Count] = new PdfInteger(_visibleDescendantCount);
                 }
                 else
                 {
@@ -358,9 +386,13 @@ namespace PeachPDF.PdfSharpCore.Pdf
                         Elements[Keys.First] = _outlines[0].Reference;
                         Elements[Keys.Last] = _outlines[_outlines.Count - 1].Reference;
                     }
-                    // TODO: /Count - the meaning is not completely clear to me
-                    if (OpenCount > 0)
-                        Elements[Keys.Count] = new PdfInteger((_opened ? 1 : -1) * OpenCount);
+                    // If this item is open, /Count is the number of its own descendants that are
+                    // visible; if closed, a negative number whose absolute value is how many
+                    // descendants would become visible if it were reopened (PDF 32000-1 Table 153).
+                    // Either way that is _visibleDescendantCount, computed for the whole tree from
+                    // the root's ComputeVisibleDescendantCount() call above.
+                    if (hasKids)
+                        Elements[Keys.Count] = new PdfInteger((_opened ? 1 : -1) * _visibleDescendantCount);
 
                     if (_textColor != XColor.Empty && Owner.HasVersion("1.4"))
                         Elements[Keys.C] = new PdfLiteral("[{0}]", PdfEncoders.ToString(_textColor, PdfColorMode.Rgb));

--- a/src/PeachPDF/PdfSharpCore/Pdf/PdfOutlineCollection.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf/PdfOutlineCollection.cs
@@ -95,16 +95,6 @@ namespace PeachPDF.PdfSharpCore.Pdf
 
             AddToOutlinesTree(outline);
             _outlines.Add(outline);
-
-            if (outline.Opened)
-            {
-                outline = _parent;
-                while (outline != null)
-                {
-                    outline.OpenCount++;
-                    outline = outline.Parent;
-                }
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- `PdfOutlineCollection.Add` walked every ancestor of a newly-opened outline item and incremented its open-descendant count, regardless of whether an intermediate ancestor was itself closed, so a closed item's descendants leaked into ancestor `/Count` entries above it.
- A closed item with only closed descendants (no open items anywhere in its subtree) also got no `/Count` entry at all, even though PDF 32000-1 Table 152/153 requires one whenever an item has any descendants.
- Replaced the incremental accumulation with `PdfOutline.ComputeVisibleDescendantCount`, a single bottom-up pass run once from the root outline during `PrepareForSave`, so `/Count` reflects the actual visible-descendant shape of the tree.

## Test plan
- [x] New `PrepareForSave_ClosedIntermediateItem_ExcludesHiddenDescendantsFromAncestorCounts` reproduces the issue's exact repro tree and asserts correct counts (root=2, Top=1, Closed mid=-2)
- [x] New `PrepareForSave_ClosedItemWithClosedChildren_StillWritesCount` covers the all-closed-descendants case
- [x] Full `net8.0` suite passes (8552 passed, 0 failed)
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings

Fixes #715