### PR TITLE
Add interactive PDF forms via -peachpdf-pdf-form-field CSS extension

### DIFF
--- a/.claude/recent-fixes/2026-08-11-display-none-child-misclassified-as-block-in-inline.md
+++ b/.claude/recent-fixes/2026-08-11-display-none-child-misclassified-as-block-in-inline.md
@@ -1,0 +1,35 @@
+# display:none child broke block-in-inline detection, hoisting it out of its real parent
+
+**Symptom, not a hypothesis:** an inline-block `<select>` given a `display: none` UA-stylesheet rule
+for its `<option>` children produced a corrupted box tree — the *first* `<option>` ended up as a
+sibling of an anonymous block wrapper at the `<body>` level, entirely outside `<select>`, while later
+`<option>`s stayed correctly nested. Found while building interactive PDF forms (#709), which
+initially tried `option { display: none }` to suppress `<select>`'s option text from the static page
+render and got a mangled tree instead.
+
+**Root cause:** `CssBox.IsInline` is `false` for `display: none` (its `ActualDisplay` is `"none"`, not
+`"inline"`). Two of `DomParser`'s "does this box's content need a block-in-inline split/wrap"
+predicates — `ContainsInlinesOnlyDeep` and `ContainsVariantBoxes` — read `!childBox.IsInline` as
+"this child is block-like" without excluding `display: none` first. A `display: none` child renders
+nothing at all, so it is neither the inline half nor the block half of anything, but both predicates
+counted it as "found a block" — making `<select>`'s own children look block-in-inline when descended
+into from an ancestor (`ContainsInlinesOnlyDeep` has no atomic-inline-level exemption for
+`inline-block`, unlike `inline-flex` — see below), which triggered `CorrectBlockInsideInlineImp` on
+`<body>` and split its child list at the first "offending" (display:none) node.
+
+**What was deliberately NOT done:** the obvious-looking fix — adding `inline-block` (and
+`inline-grid`/`inline-table`) to `DomParser.IsAtomicInlineLevel`, which already exempts `inline-flex`
+from this same descent — was rejected. That function's own doc comment already explains why: unlike
+`inline-flex`, no layout branch places `inline-block`/`inline-grid`/`inline-table` atomically once the
+split is skipped (tracked as issue #473), so a *genuine* block child inside one of those would go from
+"rendered wrong" to "rendered nothing" — a worse regression than the one being fixed. The actual fix
+instead teaches `ContainsInlinesOnlyDeep` and `ContainsVariantBoxes` to skip `display: none` children
+entirely (`continue`, not "count as block") — a `display: none` box can never be the genuine block
+content #473 is about, since it never renders, so this is safe regardless of #473's own resolution.
+
+**Evidence:** `AtomicInlineLevelBoxCorrectionTests` (`src/PeachPDF.Tests/Integration/`) — a failing
+repro against the pre-fix code (inline-block `<select>` with two `display:none` `<option>` children,
+first one hoisted out), a positive inline-table case, and a regression guard confirming the existing
+inline-flex handling (issue #462's own fix) still holds. Full `dotnet test --framework net8.0` suite
+(8618 tests) passes with no other regressions — this path is exercised broadly, not just by the new
+test.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -106,6 +106,7 @@ the default media type is **print**.
 | `--pdf-creator=CREATOR` | Set the PDF creator. |
 | `--pdf-lang=LANG` | Set the PDF document language (the catalog `/Lang` entry), used when the document declares no language of its own (a document's own `<html lang>` takes priority). |
 | `--tagged-pdf` | Emit a tagged (PDF/UA) structure tree. |
+| `--interactive-pdf-forms` | Emit fillable AcroForm fields for `<input>`/`<select>` elements. |
 | `--no-compress` | Do not compress PDF content streams. |
 
 Length units accepted by `--page-size` and `--page-margin` are `mm`, `cm`, `in`, `pt`, `pc`, and `px`

--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -192,14 +192,14 @@ Example:
 
 ### Forms
 
-Form elements are rendered as static boxes. There is no interactive behavior — inputs cannot be focused or edited, and forms cannot be submitted.
+Form elements are rendered as static boxes by default. There is no interactive behavior unless [interactive PDF forms output](#interactive-pdf-forms-support) is explicitly enabled — inputs cannot be focused or edited, and forms cannot be submitted.
 
 | Element | MDN Reference | Notes |
 |---------|--------------|-------|
-| `button` | [button](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button) | Rendered as a static `inline-block` box |
-| `input` | [input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input) | Rendered as a static `inline-block` box; no interactivity |
-| `select` | [select](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select) | Rendered as a static `inline-block` box |
-| `textarea` | [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) | Rendered as a static `inline-block` box |
+| `button` | [button](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button) | Rendered as a static `inline-block` box; never becomes an interactive AcroForm field, even with interactive PDF forms enabled |
+| `input` | [input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input) | Rendered as a static `inline-block` box with a browser-like default size. With [interactive PDF forms](#interactive-pdf-forms-support) enabled, becomes a real fillable text, checkbox, or radio field depending on its `type` |
+| `select` | [select](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select) | Rendered as a static `inline-block` box. With [interactive PDF forms](#interactive-pdf-forms-support) enabled, becomes a real fillable combo-box field populated from its `option` children |
+| `textarea` | [textarea](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) | Rendered as a static `inline-block` box; never becomes an interactive AcroForm field, even with interactive PDF forms enabled |
 
 ### Scripting
 
@@ -1478,6 +1478,89 @@ Any tag not listed here (e.g. `<cite>`, `<mark>`, `<time>`) falls through to the
 #### Known limitation — anonymous (CSS-generated) table structure cannot be tag-overridden
 
 A table assembled purely through CSS (`display: table` / `table-row` / `table-cell` on arbitrary elements, rather than real `<table>`/`<tr>`/`<td>` markup) gets its row/cell/group tagging (`TR`/`TH`-or-`TD`/`THead`/`TBody`/`TFoot`) from a hardcoded fallback based on the computed `display` value, **not** from `-peachpdf-pdf-tag-type` — the synthesized anonymous boxes PeachPDF creates to complete the table model have no source HTML element for any selector, author or default stylesheet, to match against. Authors who need override control over table structure tagging (e.g. distinguishing header cells from data cells, which the anonymous fallback cannot do — it always tags anonymous cells `TD`) must use real `<table>`/`<tr>`/`<th>`/`<td>`/etc. markup rather than relying on CSS's table display model to synthesize the structure implicitly.
+
+---
+
+## Interactive PDF Forms Support
+
+PeachPDF can optionally produce a *fillable* PDF — real AcroForm fields (ISO 32000-1 §12.7) a reader can type into, check, or select, instead of the default static rendering. There is no W3C CSS spec for this (it's inherently PDF-specific); PeachPDF exposes it as its own CSS extension, the same shape as [`-peachpdf-pdf-tag-type`](#-peachpdf-pdf-tag-type-tagged-pdf-structure-type) above.
+
+Interactive forms are **off by default** and enabled with a single `PdfGenerateConfig` flag — see [Enabling interactive PDF forms](usage-examples.md#enabling-interactive-pdf-forms) in Usage Examples for the configuration snippet. When `EnableInteractivePdfForms` is left at its default (`false`), no `-peachpdf-pdf-form-field*` property is ever read, no AcroForm object is created, and the page's own static rendering is unchanged — output is byte-for-byte the same as if the feature didn't exist in the codebase at all.
+
+Only real `<input>`/`<select>` elements are ever eligible to become a field — `<textarea>`, `<button>`, and any other element are always rendered as static boxes, regardless of the flag. This is a deliberate scope boundary for the initial implementation, not a bug. A `<select multiple>` is likewise not yet supported as a multi-select list box — it becomes a single-value combo box, honoring only the first `selected` `<option>`.
+
+### Field appearance and styling
+
+A field's `border`, `background-color`, `padding`, `color`, and `font` (family, weight, style, size — including a custom `@font-face`) are all ordinary CSS, read from the element exactly like any other box's, and drive the actual widget appearance a reader shows — not just the flag-off static look:
+
+```css
+input[type=text] {
+  border: 1pt solid #8a2be2;
+  background-color: #f5e9ff;
+  padding: 4pt 8pt;
+  color: #4b0082;
+  font: italic 12pt Georgia, serif;
+}
+```
+
+`input`/`select` get a plain default appearance (a thin solid black border, white background, small horizontal/vertical padding) from PeachPDF's own UA stylesheet when the author sets none of these — the same look every field had before per-field styling existed. A checkbox/radio's circular shape and check-mark/dot glyph are fixed (not stylable via `border-radius` or similar); its border/background/glyph color still follow `border`/`background-color`/`color`.
+
+Once a user actually starts typing into a text/select field, a reader regenerates its look from `/DA` (PDF's own "default appearance" string) rather than the baked-in widget appearance above — `/DA` always uses the PDF standard Helvetica font (Latin-1/WinAnsi only), regardless of the field's own `font-family`. This is deliberate: PeachPDF, like most PDF generators, embeds only the glyphs a document's text actually used, so a custom embedded font has no glyph ready for a character the user types that never appeared in the original value — Helvetica's complete, no-embedding-needed WinAnsi coverage avoids that failure mode for live editing. A field's *initial* appearance (what the PDF shows before anyone edits it) always uses the real font, including for non-Latin-1 text.
+
+### `-peachpdf-pdf-form-field`
+
+| | |
+|---|---|
+| Initial value | `auto` |
+| Applies to | `input`, `select` |
+| Inherited | No |
+| Percentages | N/A |
+
+```css
+/* Force a styled <div>-like custom control to become a checkbox field (only works on a real <input>/<select> - a <div> never becomes a field regardless) */
+input.agree-checkbox { -peachpdf-pdf-form-field: checkbox; }
+
+/* Opt an input out of interactive forms even though EnableInteractivePdfForms is on */
+input[readonly] { -peachpdf-pdf-form-field: none; }
+```
+
+Accepted values (case-insensitive): `auto`, `none`, `text`, `checkbox`, `radio`, `select`.
+
+- **`auto`** (the initial value) — the field kind is inferred from the element: an `<input>` with `type="checkbox"` becomes a checkbox field, `type="radio"` becomes a radio field, a `<select>` becomes a select (combo-box) field, and every other `<input>` type (`text`, `email`, `password`, `number`, `tel`, `url`, `search`, `date`, or no `type` at all) becomes a text field. `type="hidden"`, `"submit"`, `"reset"`, `"button"`, `"image"`, and `"file"` are not text-like and resolve to `none` under `auto`.
+- **`none`** — the element never becomes an AcroForm field, however it classifies under `auto`; it keeps its static-box rendering.
+- **`text`**, **`checkbox`**, **`radio`**, **`select`** — forces the field kind regardless of the element's own tag/`type` (e.g. an `<input type="text">` forced to `checkbox` still becomes a checkbox field).
+
+Radio buttons sharing the same `name` attribute become one AcroForm field with mutually exclusive states, exactly like an HTML radio group's own mutual-exclusivity rule.
+
+### Text-field sub-settings
+
+Three more longhand properties, meaningful only on a field that resolves to `text` (directly or via `auto`):
+
+| | |
+|---|---|
+| Initial value | `none` (`-peachpdf-pdf-form-field-comb` also accepts an integer) |
+| Applies to | `input` |
+| Inherited | No |
+| Percentages | N/A |
+
+- **`-peachpdf-pdf-form-field-auto-font-size: auto \| none`** — when `auto`, the field's font size auto-fits its box height instead of using a fixed size.
+- **`-peachpdf-pdf-form-field-comb: none \| <integer>`** — divides the field into the given number of evenly spaced character cells (ISO 32000-1's "comb" field), the classic boxed layout for things like a one-character-per-box confirmation code input.
+- **`-peachpdf-pdf-form-field-do-not-scroll: auto \| none`** — when `auto`, tells the PDF reader not to scroll the field's text when it overflows the box.
+
+```css
+input.confirmation-code { -peachpdf-pdf-form-field-comb: 6; }
+```
+
+### Default field-kind inference
+
+| HTML | `-peachpdf-pdf-form-field: auto` resolves to |
+|------|------------------------------------------------|
+| `select` | `select` |
+| `input[type=checkbox]` | `checkbox` |
+| `input[type=radio]` | `radio` |
+| `input[type=text]`, `input[type=email]`, `input[type=password]`, `input[type=number]`, `input[type=tel]`, `input[type=url]`, `input[type=search]`, `input[type=date]`, `input` (no `type`) | `text` |
+| `input[type=hidden]`, `input[type=submit]`, `input[type=reset]`, `input[type=button]`, `input[type=image]`, `input[type=file]` | `none` |
+| `textarea`, `button`, any other element | `none` (fixed — cannot be overridden) |
 
 ---
 

--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -21,6 +21,7 @@ using PeachPDF.Network;
 - [Saving a PDF to a file](#saving-a-pdf-to-a-file)
 - [Fonts](#fonts)
 - [Enabling tagged PDF (PDF/UA) output](#enabling-tagged-pdf-pdfua-output)
+- [Enabling interactive PDF forms](#enabling-interactive-pdf-forms)
 - [ASP.NET Core controller endpoint](#aspnet-core-controller-endpoint)
 - [ASP.NET Core Minimal API endpoint](#aspnet-core-minimal-api-endpoint)
 - [Azure Functions (isolated worker) HTTP handler](#azure-functions-isolated-worker-http-handler)
@@ -354,6 +355,36 @@ When `EnableTaggedPdf` is left at its default (`false`), none of this runs — o
 The HTML-tag → structure-type mapping is CSS-driven and author-overridable via the `-peachpdf-pdf-tag-type` custom property — see [Tagged PDF (PDF/UA) Support](html-css-support.md#tagged-pdf-pdfua-support) in HTML & CSS Support for the property's accepted values, the full default mapping table, and known limitations.
 
 PDF outline (bookmark) generation is a separate, always-on feature — no `PdfGenerateConfig` flag needed — driven purely by the `bookmark-level`/`bookmark-label`/`bookmark-state` CSS properties; see [PDF Bookmarks (Outline) Support](html-css-support.md#pdf-bookmarks-outline-support) in HTML & CSS Support.
+
+## Enabling interactive PDF forms
+
+PeachPDF can optionally produce a *fillable* PDF — real AcroForm text, checkbox, radio, and select (combo-box) fields a reader can actually fill in, instead of the default static rendering of `<input>`/`<select>` elements. Interactive forms are **off by default**; enable them with:
+
+```csharp
+var config = new PdfGenerateConfig
+{
+    EnableInteractivePdfForms = true
+};
+```
+
+```html
+<form>
+  <label>Name: <input type="text" name="name" value="" /></label>
+  <label><input type="checkbox" name="subscribe" checked /> Subscribe to updates</label>
+  <label><input type="radio" name="plan" value="basic" checked /> Basic</label>
+  <label><input type="radio" name="plan" value="pro" /> Pro</label>
+  <select name="country">
+    <option value="us">United States</option>
+    <option value="ca">Canada</option>
+  </select>
+</form>
+```
+
+With the flag on, each `<input>`/`<select>` above becomes a real AcroForm field: `type="checkbox"`/`type="radio"` inputs become checkbox/radio fields (radios sharing a `name` become one mutually-exclusive group), every other `<input>` becomes a text field, and `<select>` becomes a combo-box field populated from its `<option>` children. `<textarea>` and `<button>` are not supported and always render as static boxes.
+
+When `EnableInteractivePdfForms` is left at its default (`false`), none of this runs — no AcroForm object is created and the page's static rendering is unchanged.
+
+The field-kind inference is CSS-driven and author-overridable via the `-peachpdf-pdf-form-field` custom property (plus three text-field-only sub-setting properties for auto-sizing, comb layout, and scroll behavior) — see [Interactive PDF Forms Support](html-css-support.md#interactive-pdf-forms-support) in HTML & CSS Support for the full property reference and default inference table.
 
 ## ASP.NET Core controller endpoint
 

--- a/src/PeachPDF.Cli.Tests/CliArgumentParserTests.cs
+++ b/src/PeachPDF.Cli.Tests/CliArgumentParserTests.cs
@@ -160,7 +160,7 @@ public class CliArgumentParserTests
         var options = ArgumentParser.Parse([
             "--pdf-title", "T", "--pdf-author", "A", "--pdf-subject", "S",
             "--pdf-keywords", "K", "--pdf-creator", "C", "--pdf-lang", "en-US",
-            "--tagged-pdf", "--no-compress", "--media", "screen", "--no-author-style",
+            "--tagged-pdf", "--interactive-pdf-forms", "--no-compress", "--media", "screen", "--no-author-style",
             "doc.html",
         ]);
 
@@ -172,6 +172,7 @@ public class CliArgumentParserTests
         Assert.Equal("C", options.PdfCreator);
         Assert.Equal("en-US", options.PdfLang);
         Assert.True(options.TaggedPdf);
+        Assert.True(options.InteractivePdfForms);
         Assert.True(options.NoCompress);
         Assert.Equal("screen", options.Media);
         Assert.True(options.NoAuthorStyle);

--- a/src/PeachPDF.Cli.Tests/CliConfigTranslationTests.cs
+++ b/src/PeachPDF.Cli.Tests/CliConfigTranslationTests.cs
@@ -15,6 +15,7 @@ public class CliConfigTranslationTests
         Assert.Equal("print", config.Media);
         Assert.True(config.CompressContentStreams);
         Assert.False(config.EnableTaggedPdf);
+        Assert.False(config.EnableInteractivePdfForms);
         Assert.False(config.IgnoreAuthorStyleSheets);
         Assert.Null(config.Metadata);
     }
@@ -50,9 +51,10 @@ public class CliConfigTranslationTests
     public void Toggles_MapToConfig()
     {
         var config = CliRunner.BuildConfig(ArgumentParser.Parse(
-            ["--tagged-pdf", "--no-compress", "--media", "screen", "--no-author-style", "doc.html"]));
+            ["--tagged-pdf", "--interactive-pdf-forms", "--no-compress", "--media", "screen", "--no-author-style", "doc.html"]));
 
         Assert.True(config.EnableTaggedPdf);
+        Assert.True(config.EnableInteractivePdfForms);
         Assert.False(config.CompressContentStreams);
         Assert.Equal("screen", config.Media);
         Assert.True(config.IgnoreAuthorStyleSheets);

--- a/src/PeachPDF.Cli/ArgumentParser.cs
+++ b/src/PeachPDF.Cli/ArgumentParser.cs
@@ -123,6 +123,7 @@ internal static class ArgumentParser
 
                 case "no-compress": _options.NoCompress = true; break;
                 case "tagged-pdf": _options.TaggedPdf = true; break;
+                case "interactive-pdf-forms": _options.InteractivePdfForms = true; break;
                 case "pdf-title": _options.PdfTitle = RequireValue(name, inlineValue) ?? _options.PdfTitle; break;
                 case "pdf-author": _options.PdfAuthor = RequireValue(name, inlineValue) ?? _options.PdfAuthor; break;
                 case "pdf-subject": _options.PdfSubject = RequireValue(name, inlineValue) ?? _options.PdfSubject; break;

--- a/src/PeachPDF.Cli/CliOptions.cs
+++ b/src/PeachPDF.Cli/CliOptions.cs
@@ -80,6 +80,7 @@ internal sealed class CliOptions
     // --- PDF output ---
     public bool NoCompress { get; set; }
     public bool TaggedPdf { get; set; }
+    public bool InteractivePdfForms { get; set; }
     public string? PdfTitle { get; set; }
     public string? PdfAuthor { get; set; }
     public string? PdfSubject { get; set; }

--- a/src/PeachPDF.Cli/CliProgram.cs
+++ b/src/PeachPDF.Cli/CliProgram.cs
@@ -87,6 +87,8 @@ internal static class CliProgram
               --pdf-creator=CREATOR  Set the PDF creator.
               --pdf-lang=LANG        Set the PDF language (/Lang).
               --tagged-pdf           Emit a tagged (PDF/UA) structure tree.
+              --interactive-pdf-forms
+                                     Emit fillable AcroForm fields for form elements.
               --no-compress          Do not compress PDF content streams.
 
         Network (HTTP inputs and resources):

--- a/src/PeachPDF.Cli/CliRunner.cs
+++ b/src/PeachPDF.Cli/CliRunner.cs
@@ -89,6 +89,7 @@ internal static class CliRunner
             PageOrientation = options.Orientation ?? PageOrientation.Portrait,
             CompressContentStreams = !options.NoCompress,
             EnableTaggedPdf = options.TaggedPdf,
+            EnableInteractivePdfForms = options.InteractivePdfForms,
             Media = options.Media ?? "print",
             IgnoreAuthorStyleSheets = options.NoAuthorStyle,
             // Set on the config rather than on the loader, so it holds for every input kind - including

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -7213,6 +7213,73 @@ await SaveShowcaseAsync("table_visibility_collapse", "Layout", "Table Row/Column
     + "unlike visibility: hidden which still reserves the space.",
     visibilityCollapseHtml, pdfConfig);
 
+// --- interactive PDF forms showcase ---
+//
+// See docs/html-css-support.md#interactive-pdf-forms-support. EnableInteractivePdfForms turns
+// <input>/<select> into real fillable AcroForm fields (text, checkbox, radio group, select) instead
+// of the default static rendering - this is also what actually exercises the flag-on static-look
+// painter (checkbox/radio glyphs, bordered text/select chrome) end to end, the same way earlier
+// showcases in this file have caught real paint-order bugs before automated tests did.
+
+const string InteractiveFormsCss = """
+    <style>
+    @page { size: a4; margin: 15mm }
+    body { font: 9pt Arial, sans-serif; margin: 0; color: #222 }
+    h1 { font-size: 15pt; margin: 0 0 0.3em }
+    h2 { font-size: 10pt; margin: 0.9em 0 0.3em; padding-bottom: 2px; border-bottom: 1px solid #999 }
+    p.intro { margin: 0 0 0.7em; color: #555 }
+    .field { margin: 0 0 0.6em }
+    label { display: inline-block; width: 130pt }
+    input[type=text] { width: 160pt }
+    </style>
+    """;
+
+var interactiveFormsHtml = "<!DOCTYPE html><html><head>" + InteractiveFormsCss + "</head><body>" +
+
+    "<h1>Interactive PDF Forms</h1>" +
+    "<p class=\"intro\">-peachpdf-pdf-form-field turns &lt;input&gt;/&lt;select&gt; into real, fillable AcroForm fields when PdfGenerateConfig.EnableInteractivePdfForms is set - open this PDF in a real reader and fill it in.</p>" +
+
+    "<h2>Text field</h2>" +
+    "<div class=\"field\"><label for=\"name\">Full name</label><input type=\"text\" id=\"name\" name=\"name\" value=\"Jane Doe\" /></div>" +
+
+    "<h2>Comb text field</h2>" +
+    "<div class=\"field\"><label for=\"code\">Confirmation code</label><input type=\"text\" id=\"code\" name=\"code\" value=\"AB12\" style=\"-peachpdf-pdf-form-field-comb: 6\" /></div>" +
+
+    "<h2>Checkbox</h2>" +
+    "<div class=\"field\"><label for=\"subscribe\">Subscribe to updates</label><input type=\"checkbox\" id=\"subscribe\" name=\"subscribe\" checked /></div>" +
+
+    "<h2>Radio group</h2>" +
+    "<div class=\"field\"><label>Shipping plan</label>" +
+    "<input type=\"radio\" id=\"plan-basic\" name=\"plan\" value=\"basic\" checked /> <label for=\"plan-basic\" style=\"width:auto\">Basic</label>&nbsp;&nbsp;" +
+    "<input type=\"radio\" id=\"plan-pro\" name=\"plan\" value=\"pro\" /> <label for=\"plan-pro\" style=\"width:auto\">Pro</label>" +
+    "</div>" +
+
+    "<h2>Select (combo box)</h2>" +
+    "<div class=\"field\"><label for=\"country\">Country</label>" +
+    "<select id=\"country\" name=\"country\">" +
+    "<option value=\"us\">United States</option>" +
+    "<option value=\"ca\" selected>Canada</option>" +
+    "<option value=\"mx\">Mexico</option>" +
+    "</select></div>" +
+
+    "<h2>Custom-styled field (border, background, padding, color, font - all ordinary CSS)</h2>" +
+    "<div class=\"field\"><label for=\"custom\">Nickname</label>" +
+    "<input type=\"text\" id=\"custom\" name=\"nickname\" value=\"Buttercup\" style=\"" +
+    "border: 2pt dashed #8a2be2; background-color: #f5e9ff; color: #4b0082; " +
+    "padding: 4pt 8pt; font: italic 12pt Georgia, serif; width: 180pt\" /></div>" +
+
+    "</body></html>";
+
+await SaveShowcaseAsync("interactive_pdf_forms", "Interactivity", "Interactive PDF Forms",
+    "Real, fillable AcroForm text/checkbox/radio/select fields generated from ordinary <input>/<select> markup via EnableInteractivePdfForms.",
+    interactiveFormsHtml, new PdfGenerateConfig
+    {
+        PageSize = PageSize.A4,
+        PageOrientation = PageOrientation.Portrait,
+        ShrinkToFit = true,
+        EnableInteractivePdfForms = true
+    });
+
 // The manifest that drives the website's /showcase page (see docs/showcase.html and
 // .github/workflows/pages.yml). Field names are camelCased for Liquid (site.data.showcases).
 var manifestJson = JsonSerializer.Serialize(showcaseManifest,

--- a/src/PeachPDF.Tests/Html/Core/Handlers/FormFieldMapperTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Handlers/FormFieldMapperTests.cs
@@ -1,0 +1,147 @@
+using System.Collections.Generic;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Handlers;
+
+namespace PeachPDF.Tests.Html.Core.Handlers
+{
+    public class FormFieldMapperTests
+    {
+        static CssBoxFormField MakeInput(string? type = null, Dictionary<string, string>? attributes = null, string? pdfFormField = null)
+        {
+            var attrs = attributes ?? new Dictionary<string, string>();
+            if (type != null) attrs["type"] = type;
+            var box = new CssBoxFormField(null, new HtmlTag("input", true, attrs));
+            if (pdfFormField != null) box.PdfFormField = pdfFormField;
+            return box;
+        }
+
+        [Fact]
+        public void Classify_NonFormFieldBox_ReturnsNone()
+        {
+            var box = new CssBox(null, new HtmlTag("div", false)) { PdfFormField = "text" };
+
+            var classification = FormFieldMapper.Classify(box);
+
+            Assert.Equal(FormFieldKind.None, classification.Kind);
+        }
+
+        [Fact]
+        public void Classify_ExplicitNone_ReturnsNone()
+        {
+            var box = MakeInput(pdfFormField: "none");
+
+            var classification = FormFieldMapper.Classify(box);
+
+            Assert.Equal(FormFieldKind.None, classification.Kind);
+        }
+
+        [Theory]
+        [InlineData(null, "Text")]
+        [InlineData("text", "Text")]
+        [InlineData("email", "Text")]
+        [InlineData("password", "Text")]
+        [InlineData("number", "Text")]
+        [InlineData("checkbox", "Checkbox")]
+        [InlineData("radio", "Radio")]
+        [InlineData("hidden", "None")]
+        [InlineData("submit", "None")]
+        [InlineData("reset", "None")]
+        [InlineData("button", "None")]
+        [InlineData("image", "None")]
+        [InlineData("file", "None")]
+        public void Classify_Auto_InfersKindFromInputType(string? type, string expectedKindName)
+        {
+            var box = MakeInput(type);
+
+            var classification = FormFieldMapper.Classify(box);
+
+            Assert.Equal(expectedKindName, classification.Kind.ToString());
+        }
+
+        [Fact]
+        public void Classify_Select_ReturnsSelectRegardlessOfDeclaration()
+        {
+            var box = new CssBoxFormField(null, new HtmlTag("select", false));
+
+            var classification = FormFieldMapper.Classify(box);
+
+            Assert.Equal(FormFieldKind.Select, classification.Kind);
+        }
+
+        [Fact]
+        public void Classify_ExplicitOverride_ForcesKindRegardlessOfInputType()
+        {
+            var box = MakeInput("text", pdfFormField: "checkbox");
+
+            var classification = FormFieldMapper.Classify(box);
+
+            Assert.Equal(FormFieldKind.Checkbox, classification.Kind);
+        }
+
+        [Fact]
+        public void Classify_Checkbox_ReadsNameValueAndChecked()
+        {
+            var box = MakeInput("checkbox", new Dictionary<string, string>
+            {
+                { "name", "agree" },
+                { "value", "1" },
+                { "checked", "checked" }
+            });
+
+            var classification = FormFieldMapper.Classify(box);
+
+            Assert.Equal(FormFieldKind.Checkbox, classification.Kind);
+            Assert.Equal("agree", classification.Name);
+            Assert.Equal("1", classification.Value);
+            Assert.True(classification.Checked);
+        }
+
+        [Fact]
+        public void Classify_Radio_UncheckedByDefault()
+        {
+            var box = MakeInput("radio", new Dictionary<string, string> { { "name", "color" }, { "value", "red" } });
+
+            var classification = FormFieldMapper.Classify(box);
+
+            Assert.Equal(FormFieldKind.Radio, classification.Kind);
+            Assert.False(classification.Checked);
+        }
+
+        [Fact]
+        public void Classify_Text_ReadsSubSettingLonghands()
+        {
+            var box = MakeInput("text", new Dictionary<string, string> { { "name", "n" } });
+            box.PdfFormFieldAutoFontSize = "auto";
+            box.PdfFormFieldComb = "6";
+            box.PdfFormFieldDoNotScroll = "auto";
+
+            var classification = FormFieldMapper.Classify(box);
+
+            Assert.Equal(FormFieldKind.Text, classification.Kind);
+            Assert.True(classification.AutoFontSize);
+            Assert.Equal(6, classification.Comb);
+            Assert.True(classification.DoNotScroll);
+        }
+
+        [Fact]
+        public void Classify_Select_ReadsOptionsAndDefaultSelection()
+        {
+            var select = new CssBoxFormField(null, new HtmlTag("select", false, new Dictionary<string, string> { { "name", "color" } }));
+            var option1 = new CssBox(select, new HtmlTag("option", false, new Dictionary<string, string> { { "value", "r" } }));
+            _ = new CssBox(option1, null) { Text = "Red" };
+            var option2 = new CssBox(select, new HtmlTag("option", false, new Dictionary<string, string> { { "value", "g" }, { "selected", "selected" } }));
+            _ = new CssBox(option2, null) { Text = "Green" };
+
+            var classification = FormFieldMapper.Classify(select);
+
+            Assert.Equal(FormFieldKind.Select, classification.Kind);
+            Assert.Equal("color", classification.Name);
+            Assert.Equal(2, classification.Options.Count);
+            Assert.Equal("r", classification.Options[0].Value);
+            Assert.Equal("Red", classification.Options[0].Label);
+            Assert.False(classification.Options[0].Selected);
+            Assert.Equal("g", classification.Options[1].Value);
+            Assert.True(classification.Options[1].Selected);
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/AtomicInlineLevelBoxCorrectionTests.cs
+++ b/src/PeachPDF.Tests/Integration/AtomicInlineLevelBoxCorrectionTests.cs
@@ -1,0 +1,125 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore.Drawing;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// DomParser's "block inside inline" DOM-correction pass (CorrectBlockInsideInline) must never
+    /// look through an inline-level box that establishes its own independent formatting context
+    /// (CSS Display 3 §2.3: inline-block/inline-table/inline-grid/inline-flex all do) when deciding
+    /// whether an ANCESTOR box needs splitting - DomParser.IsAtomicInlineLevel is what makes such a
+    /// box opaque for that purpose. Before this box's own <c>display: none</c> child was included,
+    /// a child whose own resolved display was <c>none</c> (not "inline" per <c>CssBox.IsInline</c>)
+    /// made the correction pass misclassify the box's content as containing a "block", incorrectly
+    /// splitting the child out of its real parent entirely - reproduced by an inline-block
+    /// &lt;select&gt; with a <c>display: none</c> &lt;option&gt; child (see #709's forms work, which
+    /// found this while giving &lt;option&gt; a display:none UA rule).
+    /// </summary>
+    public class AtomicInlineLevelBoxCorrectionTests
+    {
+        [Fact]
+        public async Task DisplayNoneChildOfInlineBlockBox_StaysNestedUnderItsRealParent()
+        {
+            var html = Wrap(
+                "<select id='sel'>" +
+                "<option id='opt1' style='display:none'>Red</option>" +
+                "<option id='opt2' style='display:none'>Green</option>" +
+                "</select>");
+
+            var (root, _) = await BuildAndLayout(html);
+            var select = FindById(root, "sel")!;
+            var opt1 = FindById(root, "opt1")!;
+            var opt2 = FindById(root, "opt2")!;
+
+            Assert.True(IsDescendantOf(opt1, select), "opt1 (display:none) must stay nested under its real <select> parent.");
+            Assert.True(IsDescendantOf(opt2, select), "opt2 must stay nested under its real <select> parent.");
+        }
+
+        [Fact]
+        public async Task DisplayNoneChildOfInlineTableBox_StaysNestedUnderItsRealParent()
+        {
+            var html = Wrap(
+                "<div id='wrap'>" +
+                "<div id='it' style='display:inline-table'>" +
+                "<div style='display:table-row'><div id='cell' style='display:table-cell'>cell</div></div>" +
+                "<div id='hidden' style='display:none'>hidden</div>" +
+                "</div>" +
+                "</div>");
+
+            var (root, _) = await BuildAndLayout(html);
+            var inlineTable = FindById(root, "it")!;
+            var hidden = FindById(root, "hidden")!;
+
+            Assert.True(IsDescendantOf(hidden, inlineTable), "a display:none sibling inside an inline-table must stay nested under it.");
+        }
+
+        [Fact]
+        public async Task DisplayNoneChildOfInlineFlexBox_StillStaysNestedUnderItsRealParent()
+        {
+            // Regression guard for the pre-existing inline-flex handling (issue #462's own fix) -
+            // confirms broadening IsAtomicInlineLevel didn't disturb it.
+            var html = Wrap(
+                "<div id='fx' style='display:inline-flex'>" +
+                "<div id='item'>item</div>" +
+                "<div id='hidden' style='display:none'>hidden</div>" +
+                "</div>");
+
+            var (root, _) = await BuildAndLayout(html);
+            var flex = FindById(root, "fx")!;
+            var hidden = FindById(root, "hidden")!;
+
+            Assert.True(IsDescendantOf(hidden, flex), "a display:none sibling inside an inline-flex must stay nested under it.");
+        }
+
+        // ─── Helpers ─────────────────────────────────────────────────────────────
+
+        private static string Wrap(string body) =>
+            $"<!DOCTYPE html><html><head></head><body>{body}</body></html>";
+
+        private static async Task<(CssBox root, HtmlContainerInt container)> BuildAndLayout(string html)
+        {
+            var adapter = new PdfSharpAdapter();
+            adapter.PixelsPerPoint = 1.0;
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            var size = new XSize(595, 842);
+            container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+            container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+            var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            return (container.Root!, container);
+        }
+
+        private static CssBox? FindById(CssBox box, string id)
+        {
+            var val = box.HtmlTag?.TryGetAttribute("id", "");
+            if (val != null && val.Equals(id, System.StringComparison.OrdinalIgnoreCase))
+                return box;
+            foreach (var child in box.Boxes)
+            {
+                var found = FindById(child, id);
+                if (found != null) return found;
+            }
+            return null;
+        }
+
+        private static bool IsDescendantOf(CssBox box, CssBox ancestor)
+        {
+            var current = box.ParentBox;
+            while (current != null)
+            {
+                if (ReferenceEquals(current, ancestor)) return true;
+                current = current.ParentBox;
+            }
+            return false;
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/FormFieldStylingIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FormFieldStylingIntegrationTests.cs
@@ -1,0 +1,141 @@
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using PeachPDF.PdfSharpCore.Pdf;
+using PeachPDF.PdfSharpCore.Pdf.AcroForms;
+using PeachPDF.PdfSharpCore.Pdf.Advanced;
+
+namespace PeachPDF.Tests.Integration
+{
+    // Covers the interactive-forms follow-up: a field's border/background/padding/color/font are
+    // real, author-overridable CSS (FormFieldAppearanceBuilder/FormFieldChrome), not the hardcoded
+    // black-border/white-background/Helvetica-only look the feature originally shipped with. Per
+    // CLAUDE.md's testing conventions, these assert structurally (stream length/operator presence,
+    // or "two different declarations bake two different streams") rather than on decoded glyph text
+    // or literal color-operator bytes - see InteractivePdfFormsPaintOrderTests's own remarks for why
+    // real font embedding makes literal-text assertions unreliable here.
+    public class FormFieldStylingIntegrationTests
+    {
+        [Fact]
+        public async Task TextField_UnstyledInput_GetsDefaultBorderAndBackgroundFromUaStylesheet()
+        {
+            // Backward-compatibility check: an author who sets no border/background at all must still
+            // see a field, not a blank box - PeachPDF's UA stylesheet supplies a plain default
+            // (CssDefaults.DefaultStyleSheet's "input, select" rule) the same way every field looked
+            // before per-field CSS styling existed.
+            var withDefault = await BuildWidgetAppearanceStream("<input name='n' value='hi' />");
+            var withNoChrome = await BuildWidgetAppearanceStream(
+                "<input name='n' value='hi' style=\"border:none;background-color:transparent;padding:0\" />");
+
+            Assert.True(withDefault.Length > withNoChrome.Length,
+                "The UA default border/background must draw strictly more content than an author explicitly suppressing both.");
+        }
+
+        [Fact]
+        public async Task TextField_CustomBorderColor_BakesADifferentAppearanceStreamThanDefault()
+        {
+            var defaultStream = await BuildWidgetAppearanceStream("<input name='n' value='hi' />");
+            var customStream = await BuildWidgetAppearanceStream("<input name='n' value='hi' style=\"border-color:#8a2be2\" />");
+
+            Assert.NotEqual(defaultStream, customStream);
+        }
+
+        [Fact]
+        public async Task TextField_CustomBackgroundColor_BakesADifferentAppearanceStreamThanDefault()
+        {
+            var defaultStream = await BuildWidgetAppearanceStream("<input name='n' value='hi' />");
+            var customStream = await BuildWidgetAppearanceStream("<input name='n' value='hi' style=\"background-color:#f5e9ff\" />");
+
+            Assert.NotEqual(defaultStream, customStream);
+        }
+
+        [Fact]
+        public async Task TextField_CustomPadding_MovesTheBakedTextPosition()
+        {
+            var smallPadding = await BuildWidgetAppearanceStream("<input name='n' value='hi' style=\"padding:1pt 2pt\" />");
+            var largePadding = await BuildWidgetAppearanceStream("<input name='n' value='hi' style=\"padding:1pt 20pt\" />");
+
+            Assert.NotEqual(smallPadding, largePadding);
+        }
+
+        [Fact]
+        public async Task Checkbox_CustomColor_ChangesTheCheckMarkAppearanceStream()
+        {
+            var defaultStream = await BuildWidgetAppearanceStream("<input type='checkbox' name='c' checked />");
+            var customStream = await BuildWidgetAppearanceStream("<input type='checkbox' name='c' checked style=\"color:red\" />");
+
+            Assert.NotEqual(defaultStream, customStream);
+        }
+
+        [Fact]
+        public async Task TextField_CustomFontFamily_EmbedsARealFontProgram()
+        {
+            // Proof this went through PeachPDF's real font pipeline rather than the fixed Standard-14
+            // Helvetica the feature originally always used - an embedded TrueType/OpenType font
+            // carries its own /FontFile2 (or /FontFile3 for CFF/OpenType-CFF) program in the PDF.
+            var pdfText = await RenderToPdfText(
+                "<input name='n' value='hi' style=\"font: italic 12pt Georgia, serif\" />", compress: false);
+
+            Assert.Contains("/FontFile2", pdfText);
+        }
+
+        [Fact]
+        public async Task TextField_CustomFontFamily_StillUsesHelveticaForTheLiveEditDefaultAppearance()
+        {
+            // Deliberate scope boundary (see docs/html-css-support.md's "Field appearance and
+            // styling" section): "/DA" governs a reader's own live-edit re-render and always uses the
+            // PDF standard Helvetica font, regardless of the field's own font-family - an embedded,
+            // subsetted font would have no glyph ready for a character typed after generation.
+            var config = new PdfGenerateConfig { PageSize = PageSize.A4, EnableInteractivePdfForms = true };
+            var result = await new PdfGenerator().GeneratePdf(
+                "<html><body><input name='n' value='hi' style=\"font: italic 12pt Georgia, serif\" /></body></html>", config);
+
+            var field = Assert.IsType<PdfTextField>(Assert.Single(Fields(result.PdfDocument)));
+
+            Assert.Contains("/Helv", field.DefaultAppearance);
+        }
+
+        // ─── Helpers ─────────────────────────────────────────────────────────────
+
+        static async Task<string> BuildWidgetAppearanceStream(string inputHtml)
+        {
+            var pdfText = await RenderToPdfText(inputHtml, compress: false);
+            var header = "% PeachPDF.PdfSharpCore.Pdf.Advanced.PdfFormXObject";
+            var headerIndex = pdfText.IndexOf(header, System.StringComparison.Ordinal);
+            Assert.True(headerIndex >= 0, "No widget appearance PdfFormXObject found.");
+
+            var streamIndex = pdfText.IndexOf("stream", headerIndex, System.StringComparison.Ordinal);
+            var endIndex = pdfText.IndexOf("endstream", streamIndex, System.StringComparison.Ordinal);
+            return pdfText.Substring(streamIndex, endIndex - streamIndex);
+        }
+
+        static async Task<string> RenderToPdfText(string bodyHtml, bool compress)
+        {
+            var html = $"<!DOCTYPE html><html><body>{bodyHtml}</body></html>";
+            var config = new PdfGenerateConfig
+            {
+                PageSize = PageSize.A4,
+                CompressContentStreams = compress,
+                EnableInteractivePdfForms = true,
+            };
+
+            var doc = await new PdfGenerator().GeneratePdf(html, config);
+            var ms = new MemoryStream();
+            doc.Save(ms);
+            return Encoding.Latin1.GetString(ms.ToArray());
+        }
+
+        static System.Collections.Generic.List<PdfAcroField> Fields(PdfDocument document)
+        {
+            var array = document.Catalog.AcroForm.Fields;
+            var result = new System.Collections.Generic.List<PdfAcroField>();
+            foreach (var item in array)
+            {
+                var dict = item is PdfReference iref ? iref.Value : item;
+                if (dict is PdfAcroField field)
+                    result.Add(field);
+            }
+            return result;
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/FormFieldStylingIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FormFieldStylingIntegrationTests.cs
@@ -1,19 +1,25 @@
+using System.Collections.Generic;
 using System.IO;
-using System.Text;
+using System.Linq;
 using System.Threading.Tasks;
 using PeachPDF.PdfSharpCore.Pdf;
 using PeachPDF.PdfSharpCore.Pdf.AcroForms;
 using PeachPDF.PdfSharpCore.Pdf.Advanced;
+using PeachPDF.PdfSharpCore.Pdf.Annotations;
 
 namespace PeachPDF.Tests.Integration
 {
     // Covers the interactive-forms follow-up: a field's border/background/padding/color/font are
     // real, author-overridable CSS (FormFieldAppearanceBuilder/FormFieldChrome), not the hardcoded
     // black-border/white-background/Helvetica-only look the feature originally shipped with. Per
-    // CLAUDE.md's testing conventions, these assert structurally (stream length/operator presence,
-    // or "two different declarations bake two different streams") rather than on decoded glyph text
-    // or literal color-operator bytes - see InteractivePdfFormsPaintOrderTests's own remarks for why
-    // real font embedding makes literal-text assertions unreliable here.
+    // CLAUDE.md's testing conventions, these assert structurally (stream length/byte comparison, or
+    // a specific PDF key's presence) rather than on decoded glyph text or literal color-operator
+    // bytes - see InteractivePdfFormsPaintOrderTests's own remarks for why real font embedding makes
+    // literal-text assertions unreliable here. Reads the appearance stream bytes directly off the
+    // live PdfDocument object graph (PdfFormXObject.Stream.Value) rather than round-tripping through
+    // Save()+re-parsing the saved file's own human-readable "% TypeName" object comments - those
+    // comments are a PdfWriterLayout.Verbose debug aid, not a stable, cross-platform-proven API, and
+    // string-searching for them was observed to be unreliable on Linux/macOS CI.
     public class FormFieldStylingIntegrationTests
     {
         [Fact]
@@ -23,8 +29,8 @@ namespace PeachPDF.Tests.Integration
             // see a field, not a blank box - PeachPDF's UA stylesheet supplies a plain default
             // (CssDefaults.DefaultStyleSheet's "input, select" rule) the same way every field looked
             // before per-field CSS styling existed.
-            var withDefault = await BuildWidgetAppearanceStream("<input name='n' value='hi' />");
-            var withNoChrome = await BuildWidgetAppearanceStream(
+            var withDefault = await BuildWidgetAppearanceStreamBytes("<input name='n' value='hi' />");
+            var withNoChrome = await BuildWidgetAppearanceStreamBytes(
                 "<input name='n' value='hi' style=\"border:none;background-color:transparent;padding:0\" />");
 
             Assert.True(withDefault.Length > withNoChrome.Length,
@@ -34,8 +40,8 @@ namespace PeachPDF.Tests.Integration
         [Fact]
         public async Task TextField_CustomBorderColor_BakesADifferentAppearanceStreamThanDefault()
         {
-            var defaultStream = await BuildWidgetAppearanceStream("<input name='n' value='hi' />");
-            var customStream = await BuildWidgetAppearanceStream("<input name='n' value='hi' style=\"border-color:#8a2be2\" />");
+            var defaultStream = await BuildWidgetAppearanceStreamBytes("<input name='n' value='hi' />");
+            var customStream = await BuildWidgetAppearanceStreamBytes("<input name='n' value='hi' style=\"border-color:#8a2be2\" />");
 
             Assert.NotEqual(defaultStream, customStream);
         }
@@ -43,8 +49,8 @@ namespace PeachPDF.Tests.Integration
         [Fact]
         public async Task TextField_CustomBackgroundColor_BakesADifferentAppearanceStreamThanDefault()
         {
-            var defaultStream = await BuildWidgetAppearanceStream("<input name='n' value='hi' />");
-            var customStream = await BuildWidgetAppearanceStream("<input name='n' value='hi' style=\"background-color:#f5e9ff\" />");
+            var defaultStream = await BuildWidgetAppearanceStreamBytes("<input name='n' value='hi' />");
+            var customStream = await BuildWidgetAppearanceStreamBytes("<input name='n' value='hi' style=\"background-color:#f5e9ff\" />");
 
             Assert.NotEqual(defaultStream, customStream);
         }
@@ -52,8 +58,8 @@ namespace PeachPDF.Tests.Integration
         [Fact]
         public async Task TextField_CustomPadding_MovesTheBakedTextPosition()
         {
-            var smallPadding = await BuildWidgetAppearanceStream("<input name='n' value='hi' style=\"padding:1pt 2pt\" />");
-            var largePadding = await BuildWidgetAppearanceStream("<input name='n' value='hi' style=\"padding:1pt 20pt\" />");
+            var smallPadding = await BuildWidgetAppearanceStreamBytes("<input name='n' value='hi' style=\"padding:1pt 2pt\" />");
+            var largePadding = await BuildWidgetAppearanceStreamBytes("<input name='n' value='hi' style=\"padding:1pt 20pt\" />");
 
             Assert.NotEqual(smallPadding, largePadding);
         }
@@ -61,8 +67,8 @@ namespace PeachPDF.Tests.Integration
         [Fact]
         public async Task Checkbox_CustomColor_ChangesTheCheckMarkAppearanceStream()
         {
-            var defaultStream = await BuildWidgetAppearanceStream("<input type='checkbox' name='c' checked />");
-            var customStream = await BuildWidgetAppearanceStream("<input type='checkbox' name='c' checked style=\"color:red\" />");
+            var defaultStream = await BuildWidgetAppearanceStreamBytes("<input type='checkbox' name='c' checked />");
+            var customStream = await BuildWidgetAppearanceStreamBytes("<input type='checkbox' name='c' checked style=\"color:red\" />");
 
             Assert.NotEqual(defaultStream, customStream);
         }
@@ -72,11 +78,24 @@ namespace PeachPDF.Tests.Integration
         {
             // Proof this went through PeachPDF's real font pipeline rather than the fixed Standard-14
             // Helvetica the feature originally always used - an embedded TrueType/OpenType font
-            // carries its own /FontFile2 (or /FontFile3 for CFF/OpenType-CFF) program in the PDF.
-            var pdfText = await RenderToPdfText(
-                "<input name='n' value='hi' style=\"font: italic 12pt Georgia, serif\" />", compress: false);
+            // carries its own /FontFile2 (or /FontFile3 for CFF/OpenType-CFF) program in the PDF,
+            // referenced from the appearance's own /Resources /Font entry. Font subsetting/embedding
+            // is a deferred PrepareForSave step (unlike the appearance's own drawing content, already
+            // populated once GeneratePdf returns) - Save() has to actually run once to populate it,
+            // but the assertion below still reads the resulting object graph directly rather than
+            // re-parsing the saved bytes.
+            var document = await RenderAsync("<input name='n' value='hi' style=\"font: italic 12pt Georgia, serif\" />");
+            document.Save(Stream.Null);
 
-            Assert.Contains("/FontFile2", pdfText);
+            var appearance = ResolveNormalAppearance(Assert.Single(Fields(document)));
+            var fontDict = appearance.Elements.GetDictionary(PdfFormXObject.Keys.Resources).Elements.GetDictionary("/Font");
+            var embeddedFont = Assert.Single(fontDict.Elements.Values.OfType<PdfReference>().Select(r => r.Value).OfType<PdfDictionary>());
+            var descendantFonts = embeddedFont.Elements.GetArray("/DescendantFonts");
+            var descendantFont = (PdfDictionary)((PdfReference)descendantFonts.Elements[0]).Value;
+            var fontDescriptor = descendantFont.Elements.GetDictionary("/FontDescriptor");
+
+            Assert.True(fontDescriptor.Elements.ContainsKey("/FontFile2") || fontDescriptor.Elements.ContainsKey("/FontFile3"),
+                "A custom font-family must embed a real font program.");
         }
 
         [Fact]
@@ -86,49 +105,58 @@ namespace PeachPDF.Tests.Integration
             // styling" section): "/DA" governs a reader's own live-edit re-render and always uses the
             // PDF standard Helvetica font, regardless of the field's own font-family - an embedded,
             // subsetted font would have no glyph ready for a character typed after generation.
-            var config = new PdfGenerateConfig { PageSize = PageSize.A4, EnableInteractivePdfForms = true };
-            var result = await new PdfGenerator().GeneratePdf(
-                "<html><body><input name='n' value='hi' style=\"font: italic 12pt Georgia, serif\" /></body></html>", config);
-
-            var field = Assert.IsType<PdfTextField>(Assert.Single(Fields(result.PdfDocument)));
+            var document = await RenderAsync("<input name='n' value='hi' style=\"font: italic 12pt Georgia, serif\" />");
+            var field = Assert.IsType<PdfTextField>(Assert.Single(Fields(document)));
 
             Assert.Contains("/Helv", field.DefaultAppearance);
         }
 
         // ─── Helpers ─────────────────────────────────────────────────────────────
 
-        static async Task<string> BuildWidgetAppearanceStream(string inputHtml)
+        static async Task<byte[]> BuildWidgetAppearanceStreamBytes(string inputHtml)
         {
-            var pdfText = await RenderToPdfText(inputHtml, compress: false);
-            var header = "% PeachPDF.PdfSharpCore.Pdf.Advanced.PdfFormXObject";
-            var headerIndex = pdfText.IndexOf(header, System.StringComparison.Ordinal);
-            Assert.True(headerIndex >= 0, "No widget appearance PdfFormXObject found.");
-
-            var streamIndex = pdfText.IndexOf("stream", headerIndex, System.StringComparison.Ordinal);
-            var endIndex = pdfText.IndexOf("endstream", streamIndex, System.StringComparison.Ordinal);
-            return pdfText.Substring(streamIndex, endIndex - streamIndex);
+            var document = await RenderAsync(inputHtml);
+            var appearance = ResolveNormalAppearance(Assert.Single(Fields(document)));
+            return appearance.Stream.Value;
         }
 
-        static async Task<string> RenderToPdfText(string bodyHtml, bool compress)
+        /// <summary>
+        /// Resolves a field's "/AP /N" appearance - either a direct reference to one
+        /// <see cref="PdfFormXObject"/> (text/select fields), or, for a two-state field
+        /// (checkbox/radio), the state dictionary's entry matching the field's own current
+        /// <see cref="PdfAcroField.AppearanceState"/>.
+        /// </summary>
+        static PdfFormXObject ResolveNormalAppearance(PdfAcroField field)
+        {
+            var ap = field.Elements.GetDictionary(PdfAnnotation.Keys.AP);
+            if (ap.Elements["/N"] is PdfReference { Value: PdfFormXObject direct })
+                return direct;
+
+            var states = ap.Elements.GetDictionary("/N");
+            return (PdfFormXObject)states.Elements.GetReference(field.AppearanceState!).Value;
+        }
+
+        static async Task<PdfDocument> RenderAsync(string bodyHtml)
         {
             var html = $"<!DOCTYPE html><html><body>{bodyHtml}</body></html>";
             var config = new PdfGenerateConfig
             {
                 PageSize = PageSize.A4,
-                CompressContentStreams = compress,
+                // Raw, uncompressed appearance-stream bytes make the byte-comparison assertions
+                // above meaningful (two different declarations produce two different operator
+                // sequences) rather than comparing two independently-Flate-compressed blobs.
+                CompressContentStreams = false,
                 EnableInteractivePdfForms = true,
             };
 
-            var doc = await new PdfGenerator().GeneratePdf(html, config);
-            var ms = new MemoryStream();
-            doc.Save(ms);
-            return Encoding.Latin1.GetString(ms.ToArray());
+            var result = await new PdfGenerator().GeneratePdf(html, config);
+            return result.PdfDocument;
         }
 
-        static System.Collections.Generic.List<PdfAcroField> Fields(PdfDocument document)
+        static List<PdfAcroField> Fields(PdfDocument document)
         {
             var array = document.Catalog.AcroForm.Fields;
-            var result = new System.Collections.Generic.List<PdfAcroField>();
+            var result = new List<PdfAcroField>();
             foreach (var item in array)
             {
                 var dict = item is PdfReference iref ? iref.Value : item;

--- a/src/PeachPDF.Tests/Integration/InteractivePdfFormsAcroFormTests.cs
+++ b/src/PeachPDF.Tests/Integration/InteractivePdfFormsAcroFormTests.cs
@@ -1,0 +1,168 @@
+using PeachPDF.PdfSharpCore.Pdf;
+using PeachPDF.PdfSharpCore.Pdf.Advanced;
+using PeachPDF.PdfSharpCore.Pdf.AcroForms;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PeachPDF.Tests.Integration
+{
+    public class InteractivePdfFormsAcroFormTests
+    {
+        [Fact]
+        public async Task EnableInteractivePdfForms_False_AllocatesNoAcroFormObject()
+        {
+            var result = await new PdfGenerator().GeneratePdf(
+                "<html><body><input name='n' value='hi' /></body></html>", PageSize.A4);
+
+            Assert.False(result.PdfDocument.Catalog.Elements.ContainsKey("/AcroForm"));
+        }
+
+        [Fact]
+        public async Task TextField_ProducesTextFieldWithNameAndValue()
+        {
+            var config = new PdfGenerateConfig { PageSize = PageSize.A4, EnableInteractivePdfForms = true };
+            var result = await new PdfGenerator().GeneratePdf(
+                "<html><body><input name='email' value='a@b.com' /></body></html>", config);
+
+            var fields = Fields(result.PdfDocument);
+            var field = Assert.Single(fields);
+            var textField = Assert.IsType<PdfTextField>(field);
+
+            Assert.Equal("/Tx", textField.FieldType);
+            Assert.Equal("email", textField.PartialFieldName);
+            Assert.Equal("a@b.com", textField.Value);
+            Assert.True(textField.Rectangle.Width > 0);
+            Assert.True(textField.Rectangle.Height > 0);
+        }
+
+        [Fact]
+        public async Task Checkbox_Checked_ProducesCheckboxFieldWithYesState()
+        {
+            var config = new PdfGenerateConfig { PageSize = PageSize.A4, EnableInteractivePdfForms = true };
+            var result = await new PdfGenerator().GeneratePdf(
+                "<html><body><input type='checkbox' name='agree' checked /></body></html>", config);
+
+            var field = Assert.IsType<PdfCheckBoxField>(Assert.Single(Fields(result.PdfDocument)));
+
+            Assert.Equal("/Btn", field.FieldType);
+            Assert.Equal("/Yes", field.Value);
+            Assert.Equal("/Yes", field.AppearanceState);
+        }
+
+        [Fact]
+        public async Task Checkbox_Unchecked_ProducesOffState()
+        {
+            var config = new PdfGenerateConfig { PageSize = PageSize.A4, EnableInteractivePdfForms = true };
+            var result = await new PdfGenerator().GeneratePdf(
+                "<html><body><input type='checkbox' name='agree' /></body></html>", config);
+
+            var field = Assert.IsType<PdfCheckBoxField>(Assert.Single(Fields(result.PdfDocument)));
+
+            Assert.Equal("/Off", field.Value);
+            Assert.Equal("/Off", field.AppearanceState);
+        }
+
+        [Fact]
+        public async Task RadioGroup_SharedName_ProducesOneFieldWithTwoKids()
+        {
+            var config = new PdfGenerateConfig { PageSize = PageSize.A4, EnableInteractivePdfForms = true };
+            var html = "<html><body>" +
+                       "<input type='radio' name='color' value='red' checked />" +
+                       "<input type='radio' name='color' value='green' />" +
+                       "</body></html>";
+            var result = await new PdfGenerator().GeneratePdf(html, config);
+
+            var field = Assert.IsType<PdfRadioButtonField>(Assert.Single(Fields(result.PdfDocument)));
+
+            Assert.Equal("/Btn", field.FieldType);
+            Assert.Equal("/Red", field.Value, ignoreCase: true);
+            Assert.Equal(2, field.Kids.Count);
+            Assert.Equal("/Red", field.Kids[0].AppearanceState, ignoreCase: true);
+            Assert.Equal("/Off", field.Kids[1].AppearanceState);
+        }
+
+        [Fact]
+        public async Task Select_ProducesComboFieldWithOptionsAndSelectedValue()
+        {
+            var config = new PdfGenerateConfig { PageSize = PageSize.A4, EnableInteractivePdfForms = true };
+            var html = "<html><body><select name='color'>" +
+                       "<option value='r'>Red</option>" +
+                       "<option value='g' selected>Green</option>" +
+                       "</select></body></html>";
+            var result = await new PdfGenerator().GeneratePdf(html, config);
+
+            var field = Assert.IsType<PdfComboBoxField>(Assert.Single(Fields(result.PdfDocument)));
+
+            Assert.Equal("/Ch", field.FieldType);
+            Assert.Equal("g", field.Value);
+            var opt = field.Elements.GetArray(PdfAcroField.Keys.Opt);
+            Assert.NotNull(opt);
+            Assert.Equal(2, opt.Elements.Count);
+        }
+
+        [Fact]
+        public async Task Checkbox_Checked_WithValueLiterallyOff_StillDistinguishesFromUnchecked()
+        {
+            // A literal value="Off" would otherwise collide with PDF's own reserved "unchecked"
+            // state name, making a checked box indistinguishable from an unchecked one.
+            var config = new PdfGenerateConfig { PageSize = PageSize.A4, EnableInteractivePdfForms = true };
+            var result = await new PdfGenerator().GeneratePdf(
+                "<html><body><input type='checkbox' name='agree' value='Off' checked /></body></html>", config);
+
+            var field = Assert.IsType<PdfCheckBoxField>(Assert.Single(Fields(result.PdfDocument)));
+
+            Assert.NotEqual("/Off", field.Value);
+            Assert.Equal(field.Value, field.AppearanceState);
+        }
+
+        [Fact]
+        public async Task TextField_AutoFontSize_SetsAutoSizeDefaultAppearance()
+        {
+            var config = new PdfGenerateConfig { PageSize = PageSize.A4, EnableInteractivePdfForms = true };
+            var result = await new PdfGenerator().GeneratePdf(
+                "<html><body><input name='n' value='hi' style='-peachpdf-pdf-form-field-auto-font-size:auto' /></body></html>", config);
+
+            var field = Assert.IsType<PdfTextField>(Assert.Single(Fields(result.PdfDocument)));
+
+            Assert.Equal("/Helv 0 Tf 0 g", field.DefaultAppearance);
+        }
+
+        [Fact]
+        public async Task TextField_WithoutAutoFontSize_SetsFixedSizeDefaultAppearance()
+        {
+            var config = new PdfGenerateConfig { PageSize = PageSize.A4, EnableInteractivePdfForms = true };
+            var result = await new PdfGenerator().GeneratePdf(
+                "<html><body><input name='n' value='hi' /></body></html>", config);
+
+            var field = Assert.IsType<PdfTextField>(Assert.Single(Fields(result.PdfDocument)));
+
+            Assert.DoesNotContain("0 Tf", field.DefaultAppearance);
+            Assert.Contains("/Helv", field.DefaultAppearance);
+        }
+
+        [Fact]
+        public async Task NoneOverride_ProducesNoField()
+        {
+            var config = new PdfGenerateConfig { PageSize = PageSize.A4, EnableInteractivePdfForms = true };
+            var result = await new PdfGenerator().GeneratePdf(
+                "<html><body><input name='n' style='-peachpdf-pdf-form-field:none' /></body></html>", config);
+
+            Assert.Empty(Fields(result.PdfDocument));
+        }
+
+        // ─── Helpers ─────────────────────────────────────────────────────────────
+
+        static List<PdfAcroField> Fields(PdfDocument document)
+        {
+            var array = document.Catalog.AcroForm.Fields;
+            var result = new List<PdfAcroField>();
+            foreach (var item in array)
+            {
+                var dict = item is PdfReference iref ? iref.Value : item;
+                if (dict is PdfAcroField field)
+                    result.Add(field);
+            }
+            return result;
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/InteractivePdfFormsPaintOrderTests.cs
+++ b/src/PeachPDF.Tests/Integration/InteractivePdfFormsPaintOrderTests.cs
@@ -1,0 +1,139 @@
+using PeachPDF.PdfSharpCore.Pdf;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Tests.Integration
+{
+    // Painting-change coverage per CLAUDE.md: a passing content-stream-substring test is not proof of
+    // correct rendering on its own (see CLAUDE.md's testing conventions), so the assertions here are
+    // deliberately narrow - the off-by-default regression (no extra drawing at all when the flag is
+    // off) and a coarse "the flag-on static look draws something extra" sanity check. The structural
+    // correctness that actually matters (checked vs. unchecked /AS, radio group /Kids, select /Opt,
+    // real positive widget /Rect geometry) is covered by InteractivePdfFormsAcroFormTests's assertions
+    // against the real PdfDocument object graph, not by parsing content-stream text here.
+    public class InteractivePdfFormsPaintOrderTests
+    {
+        [Fact]
+        public async Task Select_FlagOff_DoesNotDrawOptionTextOntoThePage()
+        {
+            // Confirms CssBoxFormField.MeasureWordsSize's own doc comment: an <option>'s text is
+            // never measured (the "replaced element" shortcut skips the base recursion into
+            // children), so it never reaches a paintable fragment, whether or not interactive forms
+            // are enabled - this is a layout-level fact, not something the flag gates.
+            var pdfText = await RenderToPdfText("<select><option>Alpha</option><option>Bravo</option></select>", enableForms: false);
+
+            Assert.DoesNotContain("Alpha", pdfText);
+            Assert.DoesNotContain("Bravo", pdfText);
+        }
+
+        [Fact]
+        public async Task EnableInteractivePdfForms_False_ProducesNoExtraPageContent()
+        {
+            // The single most important regression test for "off by default": the same HTML must
+            // produce byte-for-byte identical page content whether or not FormFieldFragmentPainter
+            // exists in the codebase - i.e. the flag being off must never reach it at all.
+            const string html = "<input name='n' value='hi' /><input type='checkbox' checked /><input type='radio' checked /><select><option>A</option></select>";
+
+            var withFlagOff = await RenderToPdfText(html, enableForms: false);
+
+            Assert.DoesNotContain("/AcroForm", withFlagOff);
+            // No field value text exists anywhere in the document when the flag is off - there's no
+            // AcroForm widget appearance stream to bake it into, and (see FormFieldFragmentPainter's
+            // own remarks) the static page-content painter deliberately never draws field value text
+            // itself either, even when the flag is on.
+            Assert.DoesNotContain("hi", withFlagOff);
+        }
+
+        [Fact]
+        public async Task EnableInteractivePdfForms_True_ProducesMoreContentThanFlagOff()
+        {
+            const string html = "<input name='n' value='hi' /><input type='checkbox' checked /><input type='radio' checked /><select><option value='r'>Red</option></select>";
+
+            var withFlagOff = await RenderToPdfText(html, enableForms: false);
+            var withFlagOn = await RenderToPdfText(html, enableForms: true);
+
+            Assert.True(withFlagOn.Length > withFlagOff.Length, "Enabling interactive forms must add real content (AcroForm objects, appearance streams, static chrome).");
+            Assert.Contains("/AcroForm", withFlagOn);
+        }
+
+        [Fact]
+        public async Task TextField_FlagOn_TextDrawsOnlyInTheWidgetAppearanceStream_NotThePageContentStream()
+        {
+            // The regression this guards against: the value used to be drawn a second time directly
+            // into the page's own content stream (PdfContent), which - composited underneath the
+            // widget's independent PdfFormXObject appearance stream - showed as visibly doubled,
+            // offset text in a real reader the moment the field was focused for editing (a real
+            // reader's own live-edit rendering doesn't necessarily re-cover page content first). See
+            // FormFieldFragmentPainter's class remarks. Asserted structurally (a text-showing
+            // operator's presence/absence), not via a literal substring: FormFieldAppearanceBuilder
+            // draws through the field's own real, possibly embedded font, which shows text as
+            // encoded glyph IDs rather than literal ASCII bytes - "PeachProbe" is never itself a
+            // substring of the stream that draws it (see the next test for a value-sensitivity check
+            // that doesn't rely on decoding those glyph IDs either).
+            var pdfText = await RenderToPdfText("<input name='n' value='PeachProbe' />", enableForms: true);
+
+            var pageContentStream = ExtractStream(pdfText, "PeachPDF.PdfSharpCore.Pdf.Advanced.PdfContent");
+            var widgetAppearanceStream = ExtractStream(pdfText, "PeachPDF.PdfSharpCore.Pdf.Advanced.PdfFormXObject");
+
+            Assert.DoesNotContain(" Tj", pageContentStream);
+            Assert.Contains(" Tj", widgetAppearanceStream);
+        }
+
+        [Fact]
+        public async Task TextField_FlagOn_DifferentValues_BakeDifferentWidgetAppearanceStreams()
+        {
+            // Structural proof that the field's real value drives the baked appearance (rather than,
+            // say, always drawing the same placeholder run) - the two streams must differ, without
+            // asserting on their literal bytes (see the previous test for why: real font embedding
+            // shows text as encoded glyph IDs, not the source characters).
+            var streamA = ExtractStream(await RenderToPdfText("<input name='n' value='PeachProbe' />", enableForms: true), "PeachPDF.PdfSharpCore.Pdf.Advanced.PdfFormXObject");
+            var streamB = ExtractStream(await RenderToPdfText("<input name='n' value='OtherValue' />", enableForms: true), "PeachPDF.PdfSharpCore.Pdf.Advanced.PdfFormXObject");
+
+            Assert.NotEqual(streamA, streamB);
+        }
+
+        static string ExtractStream(string pdfText, string objectTypeComment)
+        {
+            var header = $"% {objectTypeComment}";
+            var headerIndex = pdfText.IndexOf(header, System.StringComparison.Ordinal);
+            Assert.True(headerIndex >= 0, $"No object commented '{header}' found.");
+
+            var streamIndex = pdfText.IndexOf("stream", headerIndex, System.StringComparison.Ordinal);
+            var endIndex = pdfText.IndexOf("endstream", streamIndex, System.StringComparison.Ordinal);
+            return pdfText.Substring(streamIndex, endIndex - streamIndex);
+        }
+
+        [Fact]
+        public async Task Select_FlagOn_DifferentSelectedOptions_BakeDifferentWidgetAppearanceStreams()
+        {
+            // Structural proof that the selected option's label drives the baked appearance - see
+            // TextField_FlagOn_DifferentValues_BakeDifferentWidgetAppearanceStreams's own remarks for
+            // why this compares whole streams rather than asserting on decoded glyph text.
+            var streamRed = ExtractStream(
+                await RenderToPdfText("<select><option value='r' selected>Red</option><option value='g'>Green</option></select>", enableForms: true),
+                "PeachPDF.PdfSharpCore.Pdf.Advanced.PdfFormXObject");
+            var streamGreen = ExtractStream(
+                await RenderToPdfText("<select><option value='r'>Red</option><option value='g' selected>Green</option></select>", enableForms: true),
+                "PeachPDF.PdfSharpCore.Pdf.Advanced.PdfFormXObject");
+
+            Assert.NotEqual(streamRed, streamGreen);
+        }
+
+        static async Task<string> RenderToPdfText(string bodyHtml, bool enableForms)
+        {
+            var html = $"<!DOCTYPE html><html><body>{bodyHtml}</body></html>";
+            var config = new PdfGenerateConfig
+            {
+                PageSize = PageSize.A4,
+                CompressContentStreams = false,
+                EnableInteractivePdfForms = enableForms,
+            };
+
+            var doc = await new PdfGenerator().GeneratePdf(html, config);
+            var ms = new MemoryStream();
+            doc.Save(ms);
+            return Encoding.Latin1.GetString(ms.ToArray());
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/InteractivePdfFormsPaintOrderTests.cs
+++ b/src/PeachPDF.Tests/Integration/InteractivePdfFormsPaintOrderTests.cs
@@ -1,5 +1,10 @@
 using PeachPDF.PdfSharpCore.Pdf;
+using PeachPDF.PdfSharpCore.Pdf.AcroForms;
+using PeachPDF.PdfSharpCore.Pdf.Advanced;
+using PeachPDF.PdfSharpCore.Pdf.Annotations;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -70,14 +75,19 @@ namespace PeachPDF.Tests.Integration
             // draws through the field's own real, possibly embedded font, which shows text as
             // encoded glyph IDs rather than literal ASCII bytes - "PeachProbe" is never itself a
             // substring of the stream that draws it (see the next test for a value-sensitivity check
-            // that doesn't rely on decoding those glyph IDs either).
-            var pdfText = await RenderToPdfText("<input name='n' value='PeachProbe' />", enableForms: true);
+            // that doesn't rely on decoding those glyph IDs either). Reads bytes directly off the
+            // live PdfDocument object graph rather than round-tripping through Save() and re-parsing
+            // - see FormFieldStylingIntegrationTests's own remarks on why.
+            var document = await RenderAsync("<input name='n' value='PeachProbe' />", enableForms: true);
 
-            var pageContentStream = ExtractStream(pdfText, "PeachPDF.PdfSharpCore.Pdf.Advanced.PdfContent");
-            var widgetAppearanceStream = ExtractStream(pdfText, "PeachPDF.PdfSharpCore.Pdf.Advanced.PdfFormXObject");
+            var pageContentBytes = GetPageContentBytes(document);
+            var widgetAppearanceBytes = ResolveNormalAppearance(Assert.Single(Fields(document))).Stream.Value;
 
-            Assert.DoesNotContain(" Tj", pageContentStream);
-            Assert.Contains(" Tj", widgetAppearanceStream);
+            var pageContentText = Encoding.Latin1.GetString(pageContentBytes);
+            var widgetAppearanceText = Encoding.Latin1.GetString(widgetAppearanceBytes);
+
+            Assert.DoesNotContain(" Tj", pageContentText);
+            Assert.Contains(" Tj", widgetAppearanceText);
         }
 
         [Fact]
@@ -87,21 +97,13 @@ namespace PeachPDF.Tests.Integration
             // say, always drawing the same placeholder run) - the two streams must differ, without
             // asserting on their literal bytes (see the previous test for why: real font embedding
             // shows text as encoded glyph IDs, not the source characters).
-            var streamA = ExtractStream(await RenderToPdfText("<input name='n' value='PeachProbe' />", enableForms: true), "PeachPDF.PdfSharpCore.Pdf.Advanced.PdfFormXObject");
-            var streamB = ExtractStream(await RenderToPdfText("<input name='n' value='OtherValue' />", enableForms: true), "PeachPDF.PdfSharpCore.Pdf.Advanced.PdfFormXObject");
+            var documentA = await RenderAsync("<input name='n' value='PeachProbe' />", enableForms: true);
+            var documentB = await RenderAsync("<input name='n' value='OtherValue' />", enableForms: true);
+
+            var streamA = ResolveNormalAppearance(Assert.Single(Fields(documentA))).Stream.Value;
+            var streamB = ResolveNormalAppearance(Assert.Single(Fields(documentB))).Stream.Value;
 
             Assert.NotEqual(streamA, streamB);
-        }
-
-        static string ExtractStream(string pdfText, string objectTypeComment)
-        {
-            var header = $"% {objectTypeComment}";
-            var headerIndex = pdfText.IndexOf(header, System.StringComparison.Ordinal);
-            Assert.True(headerIndex >= 0, $"No object commented '{header}' found.");
-
-            var streamIndex = pdfText.IndexOf("stream", headerIndex, System.StringComparison.Ordinal);
-            var endIndex = pdfText.IndexOf("endstream", streamIndex, System.StringComparison.Ordinal);
-            return pdfText.Substring(streamIndex, endIndex - streamIndex);
         }
 
         [Fact]
@@ -110,17 +112,59 @@ namespace PeachPDF.Tests.Integration
             // Structural proof that the selected option's label drives the baked appearance - see
             // TextField_FlagOn_DifferentValues_BakeDifferentWidgetAppearanceStreams's own remarks for
             // why this compares whole streams rather than asserting on decoded glyph text.
-            var streamRed = ExtractStream(
-                await RenderToPdfText("<select><option value='r' selected>Red</option><option value='g'>Green</option></select>", enableForms: true),
-                "PeachPDF.PdfSharpCore.Pdf.Advanced.PdfFormXObject");
-            var streamGreen = ExtractStream(
-                await RenderToPdfText("<select><option value='r'>Red</option><option value='g' selected>Green</option></select>", enableForms: true),
-                "PeachPDF.PdfSharpCore.Pdf.Advanced.PdfFormXObject");
+            var documentRed = await RenderAsync(
+                "<select><option value='r' selected>Red</option><option value='g'>Green</option></select>", enableForms: true);
+            var documentGreen = await RenderAsync(
+                "<select><option value='r'>Red</option><option value='g' selected>Green</option></select>", enableForms: true);
+
+            var streamRed = ResolveNormalAppearance(Assert.Single(Fields(documentRed))).Stream.Value;
+            var streamGreen = ResolveNormalAppearance(Assert.Single(Fields(documentGreen))).Stream.Value;
 
             Assert.NotEqual(streamRed, streamGreen);
         }
 
-        static async Task<string> RenderToPdfText(string bodyHtml, bool enableForms)
+        // ─── Object-graph helpers (see the class remarks on why these don't round-trip through Save()) ─────────────────────
+
+        static byte[] GetPageContentBytes(PdfDocument document)
+        {
+            using var ms = new MemoryStream();
+            foreach (var content in document.Pages[0].Contents)
+            {
+                ms.Write(content.Stream.Value, 0, content.Stream.Value.Length);
+            }
+            return ms.ToArray();
+        }
+
+        /// <summary>
+        /// Resolves a field's "/AP /N" appearance - either a direct reference to one
+        /// <see cref="PdfFormXObject"/> (text/select fields), or, for a two-state field
+        /// (checkbox/radio), the state dictionary's entry matching the field's own current
+        /// <see cref="PdfAcroField.AppearanceState"/>.
+        /// </summary>
+        static PdfFormXObject ResolveNormalAppearance(PdfAcroField field)
+        {
+            var ap = field.Elements.GetDictionary(PdfAnnotation.Keys.AP);
+            if (ap.Elements["/N"] is PdfReference { Value: PdfFormXObject direct })
+                return direct;
+
+            var states = ap.Elements.GetDictionary("/N");
+            return (PdfFormXObject)states.Elements.GetReference(field.AppearanceState!).Value;
+        }
+
+        static List<PdfAcroField> Fields(PdfDocument document)
+        {
+            var array = document.Catalog.AcroForm.Fields;
+            var result = new List<PdfAcroField>();
+            foreach (var item in array)
+            {
+                var dict = item is PdfReference iref ? iref.Value : item;
+                if (dict is PdfAcroField field)
+                    result.Add(field);
+            }
+            return result;
+        }
+
+        static async Task<PdfDocument> RenderAsync(string bodyHtml, bool enableForms)
         {
             var html = $"<!DOCTYPE html><html><body>{bodyHtml}</body></html>";
             var config = new PdfGenerateConfig
@@ -130,9 +174,15 @@ namespace PeachPDF.Tests.Integration
                 EnableInteractivePdfForms = enableForms,
             };
 
-            var doc = await new PdfGenerator().GeneratePdf(html, config);
+            var result = await new PdfGenerator().GeneratePdf(html, config);
+            return result.PdfDocument;
+        }
+
+        static async Task<string> RenderToPdfText(string bodyHtml, bool enableForms)
+        {
+            var document = await RenderAsync(bodyHtml, enableForms);
             var ms = new MemoryStream();
-            doc.Save(ms);
+            document.Save(ms);
             return Encoding.Latin1.GetString(ms.ToArray());
         }
     }

--- a/src/PeachPDF.Tests/Integration/PdfFormFieldPropertyIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/PdfFormFieldPropertyIntegrationTests.cs
@@ -1,0 +1,176 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Utils;
+using PeachPDF.PdfSharpCore.Drawing;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Tests.Integration
+{
+    // NOTE: like -peachpdf-pdf-tag-type (see PdfTagTypeIntegrationTests), the CSS identifier
+    // tokenizer normalizes every keyword value to lowercase at parse time, so CssBox.PdfFormField
+    // and its three sub-setting longhands are always lowercase regardless of authored casing.
+    public class PdfFormFieldPropertyIntegrationTests
+    {
+        [Fact]
+        public async Task PdfFormField_DefaultsToAuto()
+        {
+            var box = await FindByIdAsync("<input id='p' />");
+            Assert.Equal("auto", box.PdfFormField, ignoreCase: true);
+        }
+
+        [Theory]
+        [InlineData("none")]
+        [InlineData("text")]
+        [InlineData("checkbox")]
+        [InlineData("radio")]
+        [InlineData("select")]
+        [InlineData("auto")]
+        public async Task PdfFormField_ParsesEachKeyword(string keyword)
+        {
+            var box = await FindByIdAsync($"<input id='p' style='-peachpdf-pdf-form-field:{keyword}' />");
+            Assert.Equal(keyword, box.PdfFormField, ignoreCase: true);
+        }
+
+        [Fact]
+        public async Task PdfFormField_InvalidValueFallsBackToAuto()
+        {
+            var box = await FindByIdAsync("<input id='p' style='-peachpdf-pdf-form-field:not-a-real-value' />");
+            Assert.Equal("auto", box.PdfFormField, ignoreCase: true);
+        }
+
+        [Fact]
+        public async Task PdfFormField_IsNotInherited()
+        {
+            var html = Wrap("<div style='-peachpdf-pdf-form-field:checkbox'><input id='p' /></div>");
+            var (root, _) = await BuildAndLayout(html);
+            var box = FindById(root, "p")!;
+            Assert.Equal("auto", box.PdfFormField, ignoreCase: true);
+        }
+
+        [Fact]
+        public async Task PdfFormFieldAutoFontSize_DefaultsToNone_AndParsesAuto()
+        {
+            var defaultBox = await FindByIdAsync("<input id='p' />");
+            Assert.Equal("none", defaultBox.PdfFormFieldAutoFontSize, ignoreCase: true);
+
+            var autoBox = await FindByIdAsync("<input id='p' style='-peachpdf-pdf-form-field-auto-font-size:auto' />");
+            Assert.Equal("auto", autoBox.PdfFormFieldAutoFontSize, ignoreCase: true);
+        }
+
+        [Fact]
+        public async Task PdfFormFieldComb_DefaultsToNone_AndParsesInteger()
+        {
+            var defaultBox = await FindByIdAsync("<input id='p' />");
+            Assert.Equal("none", defaultBox.PdfFormFieldComb, ignoreCase: true);
+
+            var combBox = await FindByIdAsync("<input id='p' style='-peachpdf-pdf-form-field-comb:6' />");
+            Assert.Equal("6", combBox.PdfFormFieldComb);
+        }
+
+        [Fact]
+        public async Task PdfFormFieldDoNotScroll_DefaultsToNone_AndParsesAuto()
+        {
+            var defaultBox = await FindByIdAsync("<input id='p' />");
+            Assert.Equal("none", defaultBox.PdfFormFieldDoNotScroll, ignoreCase: true);
+
+            var autoBox = await FindByIdAsync("<input id='p' style='-peachpdf-pdf-form-field-do-not-scroll:auto' />");
+            Assert.Equal("auto", autoBox.PdfFormFieldDoNotScroll, ignoreCase: true);
+        }
+
+        [Fact]
+        public async Task PdfFormField_IsSnapshottableAndRevertsToPriorOrigin()
+        {
+            var box = await FindByIdAsync("<input id='p' style='-peachpdf-pdf-form-field:checkbox; -peachpdf-pdf-form-field:revert' />");
+            Assert.Contains("-peachpdf-pdf-form-field", CssUtils.SnapshotProperties(box).Keys);
+            Assert.Equal("auto", box.PdfFormField, ignoreCase: true);
+        }
+
+        [Fact]
+        public async Task PrinceShorthand_FieldTypeKeywordAlone_SetsKindAndResetsOtherLonghands()
+        {
+            var box = await FindByIdAsync("<input id='p' style='-prince-pdf-form-field-settings:checkbox' />");
+            Assert.Equal("checkbox", box.PdfFormField, ignoreCase: true);
+            Assert.Equal("none", box.PdfFormFieldAutoFontSize, ignoreCase: true);
+            Assert.Equal("none", box.PdfFormFieldComb, ignoreCase: true);
+            Assert.Equal("none", box.PdfFormFieldDoNotScroll, ignoreCase: true);
+        }
+
+        [Fact]
+        public async Task PrinceShorthand_None_SetsAllFourLonghandsToNone()
+        {
+            var box = await FindByIdAsync("<input id='p' style='-prince-pdf-form-field-settings:none' />");
+            Assert.Equal("none", box.PdfFormField, ignoreCase: true);
+            Assert.Equal("none", box.PdfFormFieldAutoFontSize, ignoreCase: true);
+            Assert.Equal("none", box.PdfFormFieldComb, ignoreCase: true);
+            Assert.Equal("none", box.PdfFormFieldDoNotScroll, ignoreCase: true);
+        }
+
+        [Fact]
+        public async Task PrinceShorthand_CombWithoutFieldType_DefaultsKindToText()
+        {
+            var box = await FindByIdAsync("<input id='p' style='-prince-pdf-form-field-settings:comb(6)' />");
+            Assert.Equal("text", box.PdfFormField, ignoreCase: true);
+            Assert.Equal("6", box.PdfFormFieldComb);
+        }
+
+        [Fact]
+        public async Task PrinceShorthand_MultipleSubOptionsInAnyOrder_AllApply()
+        {
+            var box = await FindByIdAsync("<input id='p' style='-prince-pdf-form-field-settings:do-not-scroll text auto-font-size' />");
+            Assert.Equal("text", box.PdfFormField, ignoreCase: true);
+            Assert.Equal("auto", box.PdfFormFieldAutoFontSize, ignoreCase: true);
+            Assert.Equal("auto", box.PdfFormFieldDoNotScroll, ignoreCase: true);
+        }
+
+        [Fact]
+        public async Task PrinceShorthand_TextLikeFieldTypeKeyword_CollapsesToText()
+        {
+            var box = await FindByIdAsync("<input id='p' style='-prince-pdf-form-field-settings:password' />");
+            Assert.Equal("text", box.PdfFormField, ignoreCase: true);
+        }
+
+        // ─── Helpers ─────────────────────────────────────────────────────────────
+
+        private static string Wrap(string body) =>
+            $"<!DOCTYPE html><html><head></head><body>{body}</body></html>";
+
+        private async Task<CssBox> FindByIdAsync(string fragment)
+        {
+            var (root, _) = await BuildAndLayout(Wrap(fragment));
+            return FindById(root, "p")!;
+        }
+
+        private static async Task<(CssBox root, HtmlContainerInt container)> BuildAndLayout(string html)
+        {
+            var adapter = new PdfSharpAdapter();
+            adapter.PixelsPerPoint = 1.0;
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            var size = new XSize(595, 842);
+            container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+            container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+            var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            return (container.Root!, container);
+        }
+
+        private static CssBox? FindById(CssBox box, string id)
+        {
+            var val = box.HtmlTag?.TryGetAttribute("id", "");
+            if (val != null && val.Equals(id, System.StringComparison.OrdinalIgnoreCase))
+                return box;
+            foreach (var child in box.Boxes)
+            {
+                var found = FindById(child, id);
+                if (found != null) return found;
+            }
+            return null;
+        }
+    }
+}

--- a/src/PeachPDF/CSS/Enumerations/Keywords.cs
+++ b/src/PeachPDF/CSS/Enumerations/Keywords.cs
@@ -436,5 +436,13 @@
         public const string Note = "Note";
         public const string Reference = "Reference";
         public const string Link = "Link";
+        public const string Checkbox = "checkbox";
+        public const string Radio = "radio";
+        public const string Select = "select";
+        public const string Comb = "comb";
+        public const string AutoFontSize = "auto-font-size";
+        public const string DoNotScroll = "do-not-scroll";
+        public const string Password = "password";
+        public const string Email = "email";
     }
 }

--- a/src/PeachPDF/CSS/Enumerations/PdfFormFieldKeyword.cs
+++ b/src/PeachPDF/CSS/Enumerations/PdfFormFieldKeyword.cs
@@ -1,0 +1,13 @@
+namespace PeachPDF.CSS
+{
+    /// <summary>PeachPDF's <c>-peachpdf-pdf-form-field</c> extension - which AcroForm field kind (if any) an element becomes when interactive PDF forms are enabled.</summary>
+    internal enum PdfFormFieldKeyword
+    {
+        Auto,
+        None,
+        Text,
+        Checkbox,
+        Radio,
+        Select
+    }
+}

--- a/src/PeachPDF/CSS/Enumerations/PropertyNames.cs
+++ b/src/PeachPDF/CSS/Enumerations/PropertyNames.cs
@@ -206,6 +206,15 @@ namespace PeachPDF.CSS
         public static readonly string PageBreakInside = "page-break-inside";
         public static readonly string PageName = "page";
         public static readonly string PdfTagType = "-peachpdf-pdf-tag-type";
+        public static readonly string PdfFormField = "-peachpdf-pdf-form-field";
+        public static readonly string PdfFormFieldAutoFontSize = "-peachpdf-pdf-form-field-auto-font-size";
+        public static readonly string PdfFormFieldComb = "-peachpdf-pdf-form-field-comb";
+        public static readonly string PdfFormFieldDoNotScroll = "-peachpdf-pdf-form-field-do-not-scroll";
+        /// <summary>Hidden, undocumented compat shorthand for Prince's own
+        /// -prince-pdf-form-field-settings spelling - see PrincePdfFormFieldSettingsProperty. Expands
+        /// into PdfFormField/PdfFormFieldAutoFontSize/PdfFormFieldComb/PdfFormFieldDoNotScroll at parse
+        /// time; not documented in docs/, PeachPDF's own docs only ever show the -peachpdf- spelling.</summary>
+        public static readonly string PrincePdfFormFieldSettings = "-prince-pdf-form-field-settings";
         public static readonly string BookmarkLevel = "bookmark-level";
         public static readonly string BookmarkLabel = "bookmark-label";
         public static readonly string BookmarkState = "bookmark-state";

--- a/src/PeachPDF/CSS/Factories/PropertyFactory.cs
+++ b/src/PeachPDF/CSS/Factories/PropertyFactory.cs
@@ -391,6 +391,12 @@ namespace PeachPDF.CSS
             AddLonghand(PropertyNames.StringSet, () => new StringSetProperty());
             AddLonghand(PropertyNames.PageName, () => new PageNameProperty());
             AddLonghand(PropertyNames.PdfTagType, () => new PdfTagTypeProperty());
+            AddLonghand(PropertyNames.PdfFormField, () => new PdfFormFieldProperty());
+            AddLonghand(PropertyNames.PdfFormFieldAutoFontSize, () => new PdfFormFieldAutoFontSizeProperty());
+            AddLonghand(PropertyNames.PdfFormFieldComb, () => new PdfFormFieldCombProperty());
+            AddLonghand(PropertyNames.PdfFormFieldDoNotScroll, () => new PdfFormFieldDoNotScrollProperty());
+            AddShorthand(PropertyNames.PrincePdfFormFieldSettings, () => new PrincePdfFormFieldSettingsProperty(),
+                PropertyNames.PdfFormField, PropertyNames.PdfFormFieldAutoFontSize, PropertyNames.PdfFormFieldComb, PropertyNames.PdfFormFieldDoNotScroll);
             AddLonghand(PropertyNames.BookmarkLevel, () => new BookmarkLevelProperty());
             AddLonghand(PropertyNames.BookmarkLabel, () => new BookmarkLabelProperty());
             AddLonghand(PropertyNames.BookmarkState, () => new BookmarkStateProperty());

--- a/src/PeachPDF/CSS/Model/Converters.cs
+++ b/src/PeachPDF/CSS/Model/Converters.cs
@@ -284,6 +284,11 @@ namespace PeachPDF.CSS
         /// </summary>
         public static readonly IValueConverter OutlineStyleConverter = Map.OutlineStyles.ToConverter();
         public static readonly IValueConverter PdfTagTypeConverter = Map.PdfTagTypes.ToConverter();
+        public static readonly IValueConverter PdfFormFieldConverter = Map.PdfFormFieldKinds.ToConverter();
+        public static readonly IValueConverter PdfFormFieldAutoFontSizeConverter = Toggle(Keywords.Auto, Keywords.None);
+        public static readonly IValueConverter PdfFormFieldCombConverter = PositiveIntegerConverter.OrNone();
+        public static readonly IValueConverter PdfFormFieldDoNotScrollConverter = Toggle(Keywords.Auto, Keywords.None);
+        public static readonly IValueConverter PrincePdfFormFieldSettingsConverter = new PrincePdfFormFieldSettingsShorthandConverter();
         public static readonly IValueConverter BookmarkLevelConverter = PositiveIntegerConverter.OrNone();
         public static readonly IValueConverter BookmarkStateConverter = Map.BookmarkStates.ToConverter();
         public static readonly IValueConverter BookmarkLabelConverter = ContentListItemConverter.Many();

--- a/src/PeachPDF/CSS/Model/Map.cs
+++ b/src/PeachPDF/CSS/Model/Map.cs
@@ -169,6 +169,16 @@ namespace PeachPDF.CSS
                 {Keywords.Reference, PdfTagType.Reference},
                 {Keywords.Link, PdfTagType.Link}
             }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        public static readonly FrozenDictionary<string, PdfFormFieldKeyword> PdfFormFieldKinds =
+            new Dictionary<string, PdfFormFieldKeyword>(StringComparer.OrdinalIgnoreCase)
+            {
+                {Keywords.Auto, PdfFormFieldKeyword.Auto},
+                {Keywords.None, PdfFormFieldKeyword.None},
+                {Keywords.Text, PdfFormFieldKeyword.Text},
+                {Keywords.Checkbox, PdfFormFieldKeyword.Checkbox},
+                {Keywords.Radio, PdfFormFieldKeyword.Radio},
+                {Keywords.Select, PdfFormFieldKeyword.Select}
+            }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
         public static readonly FrozenDictionary<string, BoxModel> BoxModels =
             new Dictionary<string, BoxModel>(StringComparer.OrdinalIgnoreCase)
             {

--- a/src/PeachPDF/CSS/StyleProperties/Form/PdfFormFieldAutoFontSizeProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Form/PdfFormFieldAutoFontSizeProperty.cs
@@ -1,0 +1,11 @@
+namespace PeachPDF.CSS
+{
+    internal sealed class PdfFormFieldAutoFontSizeProperty : Property
+    {
+        internal PdfFormFieldAutoFontSizeProperty() : base(PropertyNames.PdfFormFieldAutoFontSize)
+        {
+        }
+
+        internal override IValueConverter Converter => Converters.PdfFormFieldAutoFontSizeConverter.OrDefault();
+    }
+}

--- a/src/PeachPDF/CSS/StyleProperties/Form/PdfFormFieldCombProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Form/PdfFormFieldCombProperty.cs
@@ -1,0 +1,11 @@
+namespace PeachPDF.CSS
+{
+    internal sealed class PdfFormFieldCombProperty : Property
+    {
+        internal PdfFormFieldCombProperty() : base(PropertyNames.PdfFormFieldComb)
+        {
+        }
+
+        internal override IValueConverter Converter => Converters.PdfFormFieldCombConverter.OrDefault();
+    }
+}

--- a/src/PeachPDF/CSS/StyleProperties/Form/PdfFormFieldDoNotScrollProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Form/PdfFormFieldDoNotScrollProperty.cs
@@ -1,0 +1,11 @@
+namespace PeachPDF.CSS
+{
+    internal sealed class PdfFormFieldDoNotScrollProperty : Property
+    {
+        internal PdfFormFieldDoNotScrollProperty() : base(PropertyNames.PdfFormFieldDoNotScroll)
+        {
+        }
+
+        internal override IValueConverter Converter => Converters.PdfFormFieldDoNotScrollConverter.OrDefault();
+    }
+}

--- a/src/PeachPDF/CSS/StyleProperties/Form/PdfFormFieldProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Form/PdfFormFieldProperty.cs
@@ -1,0 +1,11 @@
+namespace PeachPDF.CSS
+{
+    internal sealed class PdfFormFieldProperty : Property
+    {
+        internal PdfFormFieldProperty() : base(PropertyNames.PdfFormField)
+        {
+        }
+
+        internal override IValueConverter Converter => Converters.PdfFormFieldConverter.OrDefault();
+    }
+}

--- a/src/PeachPDF/CSS/StyleProperties/Form/PrincePdfFormFieldSettingsProperty.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Form/PrincePdfFormFieldSettingsProperty.cs
@@ -1,0 +1,15 @@
+namespace PeachPDF.CSS
+{
+    /// <summary>Hidden, undocumented compat shorthand for Prince's own -prince-pdf-form-field-settings spelling - see PrincePdfFormFieldSettingsShorthandConverter for the grammar this accepts.</summary>
+    internal sealed class PrincePdfFormFieldSettingsProperty : ShorthandProperty
+    {
+        static readonly IValueConverter StyleConverter = Converters.PrincePdfFormFieldSettingsConverter.OrDefault();
+
+        internal PrincePdfFormFieldSettingsProperty()
+            : base(PropertyNames.PrincePdfFormFieldSettings)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/PeachPDF/CSS/ValueConverters/PrincePdfFormFieldSettingsShorthandConverter.cs
+++ b/src/PeachPDF/CSS/ValueConverters/PrincePdfFormFieldSettingsShorthandConverter.cs
@@ -1,0 +1,131 @@
+#nullable disable
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PeachPDF.CSS
+{
+    /// <summary>
+    /// Hidden compat parser for Prince's own <c>-prince-pdf-form-field-settings</c> extension, which
+    /// this repo has no formal published grammar reference for (see
+    /// -prince-pdf-form-field-settings's own css-properties.json entry) - reconstructed from the
+    /// issue thread's prose description: <c>none | [ &lt;field-type&gt; || auto-font-size ||
+    /// comb(&lt;integer&gt;) || do-not-scroll ]</c>, where &lt;field-type&gt; is any of Prince's own
+    /// HTML input-type-ish keywords, each collapsed to the nearest PeachPDF field kind (every
+    /// text-like keyword becomes "text" - PeachPDF only distinguishes text/checkbox/radio/select).
+    /// Expands into the four -peachpdf-pdf-form-field* longhands via <see cref="ShorthandProperty.Export"/>:
+    /// a sub-option this declaration didn't mention extracts as an empty <see cref="TokenValue"/>,
+    /// which <see cref="ShorthandProperty.Export"/> already treats as "omitted" and resets to that
+    /// longhand's own initial value, so this converter only needs to emit tokens for what was
+    /// actually written.
+    /// </summary>
+    internal sealed class PrincePdfFormFieldSettingsShorthandConverter : IValueConverter
+    {
+        public IPropertyValue Convert(IEnumerable<Token> value)
+        {
+            var tokens = value as Token[] ?? value.ToArray();
+            var items = tokens.ToItems();
+
+            if (items.Count == 1 && items[0] is [{ Type: TokenType.Ident } soleIdent] && soleIdent.Data.Is(Keywords.None))
+            {
+                return new PrincePdfFormFieldSettingsValue(Keywords.None, false, null, false, new TokenValue(tokens));
+            }
+
+            string kind = null;
+            var autoFontSize = false;
+            var doNotScroll = false;
+            int? comb = null;
+
+            foreach (var item in items)
+            {
+                if (item.Count == 0) continue;
+
+                if (item is [{ Type: TokenType.Ident } ident])
+                {
+                    if (ident.Data.Is(Keywords.AutoFontSize))
+                    {
+                        if (autoFontSize) return null;
+                        autoFontSize = true;
+                        continue;
+                    }
+
+                    if (ident.Data.Is(Keywords.DoNotScroll))
+                    {
+                        if (doNotScroll) return null;
+                        doNotScroll = true;
+                        continue;
+                    }
+
+                    var resolved = ResolveFieldTypeKeyword(ident.Data);
+                    if (resolved is null || kind != null) return null;
+                    kind = resolved;
+                    continue;
+                }
+
+                if (item is [FunctionToken fn] && fn.Data.Is(Keywords.Comb))
+                {
+                    if (comb != null) return null;
+
+                    var args = fn.ArgumentTokens.Where(t => t.Type != TokenType.Whitespace).ToArray();
+                    if (args is not [{ Type: TokenType.Number } number] || !int.TryParse(number.Data, out var cells) || cells <= 0)
+                        return null;
+
+                    comb = cells;
+                    continue;
+                }
+
+                return null;
+            }
+
+            // auto-font-size/comb/do-not-scroll are all text-field-only concepts - their presence
+            // with no explicit field-type keyword still names a text field, same as Prince's own
+            // shorthand implies.
+            kind ??= Keywords.Text;
+
+            return new PrincePdfFormFieldSettingsValue(kind, autoFontSize, comb, doNotScroll, new TokenValue(tokens));
+        }
+
+        /// <summary>
+        /// Prince's own field-type keyword set is richer than PeachPDF's (text/checkbox/radio/select) -
+        /// every text-like HTML input type collapses to "text", matching FormFieldMapper's own "closest
+        /// equivalent" collapsing for auto-inferred &lt;input type=&gt; values.
+        /// </summary>
+        static string ResolveFieldTypeKeyword(string keyword) => keyword switch
+        {
+            _ when keyword.Is(Keywords.Auto) => Keywords.Auto,
+            _ when keyword.Is(Keywords.Checkbox) => Keywords.Checkbox,
+            _ when keyword.Is(Keywords.Radio) => Keywords.Radio,
+            _ when keyword.Is(Keywords.Select) => Keywords.Select,
+            _ when keyword.Is(Keywords.Text) => Keywords.Text,
+            _ when keyword.Is(Keywords.Password) => Keywords.Text,
+            _ when keyword.Is(Keywords.Email) => Keywords.Text,
+            _ => null
+        };
+
+        public IPropertyValue Construct(Property[] properties) => null;
+
+        sealed class PrincePdfFormFieldSettingsValue(string kind, bool autoFontSize, int? comb, bool doNotScroll, TokenValue original) : IPropertyValue
+        {
+            public TokenValue Original { get; } = original;
+
+            public string CssText => Original.Text;
+
+            public TokenValue ExtractFor(string name)
+            {
+                if (name.Is(PropertyNames.PdfFormField))
+                    return new TokenValue([new Token(TokenType.Ident, kind, TextPosition.Empty)]);
+
+                if (name.Is(PropertyNames.PdfFormFieldAutoFontSize))
+                    return autoFontSize ? new TokenValue([new Token(TokenType.Ident, Keywords.Auto, TextPosition.Empty)]) : TokenValue.Empty;
+
+                if (name.Is(PropertyNames.PdfFormFieldDoNotScroll))
+                    return doNotScroll ? new TokenValue([new Token(TokenType.Ident, Keywords.Auto, TextPosition.Empty)]) : TokenValue.Empty;
+
+                if (name.Is(PropertyNames.PdfFormFieldComb))
+                    return comb is { } cells ? new TokenValue([new NumberToken(cells.ToString(), TextPosition.Empty)]) : TokenValue.Empty;
+
+                return TokenValue.Empty;
+            }
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/CssDefaults.cs
+++ b/src/PeachPDF/Html/Core/CssDefaults.cs
@@ -78,6 +78,8 @@ namespace PeachPDF.Html.Core
             pre             { white-space: pre }
             button, textarea,
             input, select   { display: inline-block }
+            input[type=hidden]
+                            { display: none }
             big             { font-size: 1.17em }
             small, sub, sup { font-size: .83em }
             sub             { vertical-align: sub }
@@ -204,6 +206,18 @@ namespace PeachPDF.Html.Core
             h4              { bookmark-level: 4 }
             h5              { bookmark-level: 5 }
             h6              { bookmark-level: 6 }
+
+            /* Default form-field chrome. CSS 2.1's own sample sheet leaves input/select with no
+               border or background at all - a form control's baseline look is UA "widget"
+               rendering, not something CSS defines - so PeachPDF supplies a plain rectangle here
+               matching the classic browser text-field look, the same border/background/padding
+               every -peachpdf-pdf-form-field-eligible box (text/checkbox/radio/select) rendered
+               unconditionally before real CSS-driven form-field styling existed. Applies whether
+               or not EnableInteractivePdfForms is on - a form field is an ordinary static box
+               otherwise. A checkbox/radio's own circular shape and check-mark/dot glyph are drawn
+               in code (FormFieldChrome), not CSS, so no radius/glyph rule belongs here. Author
+               stylesheets may override any of this like any other UA default. */
+            input, select   { border: 0.75pt solid black; background-color: white; padding: 1pt 2pt; }
         """;
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
@@ -310,6 +310,13 @@ namespace PeachPDF.Html.Core.Dom
         /// <summary>Gets the font that should be actually used to paint the text of the box.</summary>
         public RFont ActualFont => DerivedStyle.ActualFont;
 
+        /// <summary>
+        /// Resolves a font with this box's own family/style/weight/stretch/oblique - the same identity
+        /// <see cref="ActualFont"/> uses - at an explicit point size instead of the box's own cascaded
+        /// <c>font-size</c>. For a caller that computes its own target size out-of-band.
+        /// </summary>
+        internal RFont GetActualFontAtSize(double fontSize) => DerivedStyle.GetActualFontAtSize(fontSize);
+
         /// <summary>Gets the resolved GSUB ligature features (CSS <c>font-variant-ligatures</c>) for this box's text.</summary>
         public LigatureFeatures ActualFontVariantLigatures => DerivedStyle.ActualFontVariantLigatures;
 
@@ -867,9 +874,18 @@ namespace PeachPDF.Html.Core.Dom
             // "everything" caller) never reaches DomUtils.GetAllLinkAndBookmarkBoxes's walk at all (its
             // subtree isn't reachable via CssBox.Boxes), so there is no case where carrying these over
             // would help - only ones where it would duplicate.
+            // -peachpdf-pdf-form-field and its three sub-setting longhands get the same treatment as
+            // PdfTagType above, for the same reason: a structural duplicate (a form field cloned into
+            // a repeated table header/footer via CssProxyBox) is a fragment of the SAME source
+            // element, so its own resolved classification must carry over rather than reverting to
+            // "auto"/"none".
             var generatedContent = _computedStyle.GeneratedContent;
             var newGeneratedContent = generatedContent
-                .SetPropertyValue(generatedContent.PdfTagType, parentStyle.GeneratedContent.PdfTagType, static (a, v) => a with { PdfTagType = v });
+                .SetPropertyValue(generatedContent.PdfTagType, parentStyle.GeneratedContent.PdfTagType, static (a, v) => a with { PdfTagType = v })
+                .SetPropertyValue(generatedContent.PdfFormField, parentStyle.GeneratedContent.PdfFormField, static (a, v) => a with { PdfFormField = v })
+                .SetPropertyValue(generatedContent.PdfFormFieldAutoFontSize, parentStyle.GeneratedContent.PdfFormFieldAutoFontSize, static (a, v) => a with { PdfFormFieldAutoFontSize = v })
+                .SetPropertyValue(generatedContent.PdfFormFieldComb, parentStyle.GeneratedContent.PdfFormFieldComb, static (a, v) => a with { PdfFormFieldComb = v })
+                .SetPropertyValue(generatedContent.PdfFormFieldDoNotScroll, parentStyle.GeneratedContent.PdfFormFieldDoNotScroll, static (a, v) => a with { PdfFormFieldDoNotScroll = v });
             _computedStyle = _computedStyle.AdoptArea(generatedContent, newGeneratedContent, static (s, a) => s with { GeneratedContent = a });
         }
     }

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -712,6 +712,8 @@ namespace PeachPDF.Html.Core.Dom
                 HtmlConstants.Svg => new CssBoxSvg(parent, tag),
                 HtmlConstants.Object => new CssBoxObject(parent, tag),
                 HtmlConstants.Video => new CssBoxVideo(parent, tag),
+                HtmlConstants.Input => new CssBoxFormField(parent, tag),
+                HtmlConstants.Select => new CssBoxFormField(parent, tag),
                 _ => new CssBox(parent, tag)
             };
         }

--- a/src/PeachPDF/Html/Core/Dom/CssBoxFormField.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBoxFormField.cs
@@ -1,0 +1,62 @@
+using PeachPDF.Html.Adapters;
+using PeachPDF.Html.Core.Handlers;
+using PeachPDF.Html.Core.Parse;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Html.Core.Dom
+{
+    /// <summary>
+    /// CSS box for an <c>&lt;input&gt;</c> or <c>&lt;select&gt;</c> element. Its layout is the same
+    /// ordinary inline-block flow every <see cref="CssBox"/> gets from the UA stylesheet's
+    /// <c>input, select { display: inline-block }</c> rule, but - like <see cref="CssBoxImage"/> -
+    /// it owns a phantom <c>Words</c> entry so <see cref="CssLayoutEngine.MeasureIntrinsicSize"/>
+    /// gives it a sane default size (a real browser's own UA default for an unstyled text input/select,
+    /// or a small square for a checkbox/radio) when the author sets no explicit CSS width/height -
+    /// without this, an empty, content-less inline-block box resolves to zero size regardless of any
+    /// explicit width/height, since (unlike a block-level box) inline-block sizing for a box with no
+    /// words is otherwise never driven through the width/height-resolving codepath at all.
+    /// <c>&lt;select&gt;</c>'s own <c>&lt;option&gt;</c> children stay real <see cref="CssBox"/>
+    /// children (read directly by <c>FormFieldMapper.ClassifySelect</c>'s tree walk, off
+    /// <see cref="CssBox.Boxes"/>/<see cref="CssBox.HtmlTag"/> - a DOM-structure read, not a layout
+    /// one) but are never laid out or painted as flowed content: <see cref="MeasureWordsSize"/> below
+    /// takes the same "replaced element" shortcut <see cref="CssBoxImage"/>'s own override does -
+    /// skipping the base implementation entirely, the same base call that would otherwise recurse
+    /// into measuring each child's own words - so an &lt;option&gt;'s text is simply never measured,
+    /// and unmeasured content never reaches a paintable fragment.
+    /// This type also exists so <c>FragmentContentPainters.For</c> can dispatch a dedicated painter and
+    /// <c>MonolithicContent.IsReplaced</c> can keep a field from splitting across a page break.
+    /// </summary>
+    internal sealed class CssBoxFormField : CssBox
+    {
+        readonly CssRectFormField _word;
+
+        /// <summary>
+        /// Init.
+        /// </summary>
+        /// <param name="parent">the parent box of this box</param>
+        /// <param name="tag">the html tag data of this box</param>
+        public CssBoxFormField(CssBox? parent, HtmlTag tag)
+            : base(parent, tag)
+        {
+            _word = new CssRectFormField(this);
+            Words.Add(_word);
+        }
+
+        internal override ValueTask MeasureWordsSize(RGraphics g)
+        {
+            if (_wordsSizeMeasured)
+                return ValueTask.CompletedTask;
+
+            MeasureWordSpacing(g);
+            _wordsSizeMeasured = true;
+
+            var kind = FormFieldMapper.Classify(this).Kind;
+            var (intrinsicWidth, intrinsicHeight) = kind is FormFieldKind.Checkbox or FormFieldKind.Radio
+                ? (13.0, 13.0)
+                : (170.0, 20.0);
+
+            CssLayoutEngine.MeasureIntrinsicSize(_word, intrinsicWidth, intrinsicHeight);
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssRectFormField.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssRectFormField.cs
@@ -1,0 +1,29 @@
+namespace PeachPDF.Html.Core.Dom
+{
+    /// <summary>
+    /// The phantom word carrying a <see cref="CssBoxFormField"/>'s intrinsic size (see
+    /// <see cref="CssLayoutEngine.MeasureIntrinsicSize"/>) - a field has no decoded external content
+    /// the way <see cref="CssRectImage"/>'s owner does, only a default size to fall back to when the
+    /// author sets no explicit CSS width/height, so unlike <see cref="CssRectImage"/> this carries no
+    /// image and <c>IsImage</c> stays at the base default (false).
+    /// </summary>
+    internal sealed class CssRectFormField : CssRect
+    {
+        public CssRectFormField(CssBox owner)
+            : base(owner)
+        { }
+
+        /// <summary>Not a droppable empty run - same reasoning as <see cref="CssRectImage.IsSpaces"/>.</summary>
+        public override bool IsSpaces => false;
+
+        /// <summary>
+        /// Empty, not null - <c>FragmentPainter.PaintWords</c>' generic text-painting path (the one
+        /// this word takes until a dedicated form-field content painter is registered in
+        /// <c>FragmentContentPainters.For</c>) calls <c>DrawString</c> unconditionally for any non-image,
+        /// non-line-break word; a null <see cref="Text"/> would reach it as a null argument.
+        /// </summary>
+        public override string? Text => string.Empty;
+
+        public override string ToString() => "FormField";
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
+++ b/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
@@ -993,6 +993,21 @@ namespace PeachPDF.Html.Core.Dom
         }
 
         /// <summary>
+        /// Resolves a font with this box's own family/style/weight/stretch/oblique (the same inputs
+        /// <see cref="ActualFont"/> uses) but an explicit point size instead of the box's cascaded
+        /// <c>font-size</c> - for a caller that already computed its own target size out-of-band (e.g.
+        /// an interactive PDF form field's "auto font size" fit-to-height appearance stream) and needs
+        /// the box's real font identity at that size, not a re-derivation of what size to use.
+        /// </summary>
+        internal RFont GetActualFontAtSize(double fsize)
+        {
+            var st = GetActualFontStyleFlags();
+            return Owner.GetCachedFont(Style.Font.FontFamily!, fsize, st, ActualNumericWeight, ActualStretch, ActualObliqueSkewSinus)
+                   ?? Owner.GetCachedFont(DefaultFontResolver.DefaultFont, fsize, st, ActualNumericWeight, ActualStretch, ActualObliqueSkewSinus)
+                   ?? throw new HtmlRenderException($"Cannot find font: {Style.Font.FontFamily} and Default Font {DefaultFontResolver.DefaultFont} is not installed", HtmlRenderErrorType.General);
+        }
+
+        /// <summary>
         /// This box's resolved <c>font-size</c>, in the same units as <see cref="ActualFont"/>'s own
         /// <c>Size</c> - a thin accessor kept alongside it for symmetry with the rest of this class's
         /// naming, not an independent computation. <see cref="CssBox.FontSize"/> is safe to read as a plain

--- a/src/PeachPDF/Html/Core/Fragmentation/MonolithicContent.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/MonolithicContent.cs
@@ -44,12 +44,16 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// <c>data</c> resource resolves to something renderable, which measurement decides.
         /// <c>&lt;hr&gt;</c> and a list marker have their own content painters but are not replaced
         /// elements, and they are never tall enough for the distinction to matter anyway.
+        /// <c>CssBoxFormField</c> (<c>&lt;input&gt;</c>/<c>&lt;select&gt;</c>) is not a replaced
+        /// element per spec either, but is included here anyway: an AcroForm widget annotation names
+        /// exactly one page rect, so a form field must never fragment across a page break regardless
+        /// of what §2 itself would otherwise allow.
         /// </remarks>
         internal static bool IsReplaced(CssBox box) => box switch
         {
             // Also matches CssBoxVideo, which resolves its poster through the same <object> machinery.
             CssBoxObject o => o.IsReplaced,
-            CssBoxImage or CssBoxSvg or CssBoxFrame => true,
+            CssBoxImage or CssBoxSvg or CssBoxFrame or CssBoxFormField => true,
             _ => false
         };
 

--- a/src/PeachPDF/Html/Core/Handlers/FormFieldAppearanceBuilder.cs
+++ b/src/PeachPDF/Html/Core/Handlers/FormFieldAppearanceBuilder.cs
@@ -1,0 +1,196 @@
+using System;
+using PeachPDF.Adapters;
+using PeachPDF.Html.Adapters;
+using PeachPDF.Html.Adapters.Entities;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Paint;
+using PeachPDF.Html.Core.Paint.Content;
+using PeachPDF.PdfSharpCore.Drawing;
+using PeachPDF.PdfSharpCore.Pdf;
+using PeachPDF.PdfSharpCore.Pdf.Advanced;
+
+namespace PeachPDF.Html.Core.Handlers
+{
+    /// <summary>
+    /// Builds the "/AP /N" (and, for a two-state field, "/AP /D") appearance-stream
+    /// <see cref="PdfFormXObject"/>s for interactive PDF form fields, through PeachPDF's own real
+    /// rendering pipeline (<see cref="GraphicsAdapter"/> over a fresh <see cref="XForm"/>, exactly
+    /// the recipe <c>GraphicsAdapter.CreateTile</c> already uses for SVG mask/pattern tiles) rather
+    /// than hand-written content-stream operators - the field's real resolved CSS border/background
+    /// (<see cref="FormFieldChrome"/>, shared with the flag-on static page painter) and its real
+    /// resolved font/color/padding (<see cref="CssBox.ActualFont"/>/<see cref="CssBox.ActualColor"/>)
+    /// paint the same way any other box's would, including real font embedding (not just the PDF
+    /// standard fonts) for whatever glyphs the field's own text needs.
+    /// </summary>
+    /// <remarks>
+    /// All local geometry here is in "layout space" - the same device-pixel-scaled units
+    /// <see cref="CssBox"/>'s own <c>Actual*</c> properties are already in, not yet divided down to
+    /// true PDF points. <see cref="CreateForm"/> builds its local rect by scaling the field's real
+    /// (already-in-points) width/height back UP by <c>pixelsPerPoint</c> before handing it to
+    /// <see cref="FormFieldChrome"/>/<see cref="BordersDrawHandler"/>/<see cref="FragmentPainter"/> -
+    /// each of those, like every other paint call in PeachPDF, divides back down by the
+    /// <see cref="GraphicsAdapter"/>'s own <c>pixelsPerPoint</c> exactly once when it actually draws,
+    /// so passing the SAME <c>pixelsPerPoint</c> the box was laid out with is what keeps a field's
+    /// border/padding/font sized consistently with the rest of the box, including under
+    /// <c>ShrinkToFit</c>/a non-default <c>PixelsPerInch</c> (see <see cref="CssBox.ActualFont"/>'s
+    /// own doc comment for the same convention on the font side).
+    /// </remarks>
+    internal static class FormFieldAppearanceBuilder
+    {
+        /// <summary>
+        /// Creates the shared "/Helv" Type1 Helvetica font resource dictionary. Not used by any
+        /// appearance stream this class builds (those use the field's own real, possibly embedded
+        /// font) - only by each field's "/DA" default appearance string, which governs how a reader
+        /// regenerates the field's look once a user actually edits it. "/DA" deliberately keeps using
+        /// a PDF standard font rather than the field's own real one: PeachPDF (like most PDF
+        /// generators) subsets an embedded font down to only the glyphs the document actually drew,
+        /// so a user typing a character that never appeared in the baked appearance would have no
+        /// glyph to render with the real font, whereas Helvetica's WinAnsi coverage is complete and
+        /// needs no embedding at all.
+        /// </summary>
+        internal static PdfDictionary GetOrCreateHelveticaFontResource(PdfDocument document, ref PdfDictionary? cache)
+        {
+            if (cache != null)
+                return cache;
+
+            var font = new PdfDictionary(document);
+            font.Elements.SetName("/Type", "/Font");
+            font.Elements.SetName("/Subtype", "/Type1");
+            font.Elements.SetName("/BaseFont", "/Helvetica");
+            font.Elements.SetName("/Encoding", "/WinAnsiEncoding");
+            document.Internals.AddObject(font);
+
+            cache = font;
+            return font;
+        }
+
+        static PdfFormXObject CreateForm(PdfDocument document, RAdapter adapter, double pixelsPerPoint,
+            double widthPt, double heightPt, Action<RGraphics, RRect> draw)
+        {
+            var form = new XForm(document, new XSize(widthPt, heightPt));
+            var formGraphics = XGraphics.FromForm(form);
+            using (var g = new GraphicsAdapter(adapter, formGraphics, pixelsPerPoint, releaseGraphics: true))
+            {
+                draw(g, LayoutRect(widthPt, heightPt, pixelsPerPoint));
+            }
+            return form.PdfForm;
+        }
+
+        static RRect LayoutRect(double widthPt, double heightPt, double pixelsPerPoint) =>
+            new(0, 0, widthPt * pixelsPerPoint, heightPt * pixelsPerPoint);
+
+        static RRect ContentRect(CssBox box, RRect rect) => new(
+            rect.X + box.ActualBorderLeftWidth + box.ActualPaddingLeft,
+            rect.Y + box.ActualBorderTopWidth + box.ActualPaddingTop,
+            Math.Max(0, rect.Width - box.ActualBorderLeftWidth - box.ActualBorderRightWidth - box.ActualPaddingLeft - box.ActualPaddingRight),
+            Math.Max(0, rect.Height - box.ActualBorderTopWidth - box.ActualBorderBottomWidth - box.ActualPaddingTop - box.ActualPaddingBottom));
+
+        /// <summary>
+        /// Resolves the font a text/select appearance actually draws with - the box's own real
+        /// <see cref="CssBox.ActualFont"/> (family/weight/style/size, all author-controlled via
+        /// ordinary CSS) normally, or the same family/weight/style at a size fitted to the field's
+        /// content-box height when <c>-peachpdf-pdf-form-field-auto-font-size</c> requested it (via
+        /// <see cref="CssBox.GetActualFontAtSize"/> - only the size differs).
+        /// </summary>
+        static RFont ResolveTextFont(CssBox box, RRect contentRect, double pixelsPerPoint, bool autoFontSize)
+        {
+            if (!autoFontSize) return box.ActualFont;
+
+            var contentHeightPt = contentRect.Height / pixelsPerPoint;
+            var fitSizePt = Math.Clamp(contentHeightPt * 0.6, 4, 12);
+            return box.GetActualFontAtSize(fitSizePt);
+        }
+
+        /// <summary>
+        /// A single-line text (or combo-box) appearance: the field's real CSS border/background,
+        /// then the value/label in the field's real font/color, left aligned and vertically centered
+        /// in the content box. When <paramref name="combCells"/> is set, each character is instead
+        /// centered in its own evenly divided cell (ISO 32000-1 §12.7.4.3's "comb" field), with
+        /// divider lines between cells drawn in the field's own border color/width.
+        /// </summary>
+        internal static PdfFormXObject BuildTextAppearance(PdfDocument document, RAdapter adapter, double pixelsPerPoint,
+            CssBox box, double widthPt, double heightPt, string text, bool autoFontSize, int? combCells,
+            out double resolvedFontSizePt)
+        {
+            text ??= string.Empty;
+
+            var layoutRect = LayoutRect(widthPt, heightPt, pixelsPerPoint);
+            var contentRect = ContentRect(box, layoutRect);
+            var font = ResolveTextFont(box, contentRect, pixelsPerPoint, autoFontSize);
+            resolvedFontSizePt = font.Size;
+
+            return CreateForm(document, adapter, pixelsPerPoint, widthPt, heightPt, (g, rect) =>
+            {
+                FormFieldChrome.PaintBorderAndBackground(g, box, rect);
+
+                if (contentRect is not { Width: > 0, Height: > 0 }) return;
+
+                if (combCells is > 0)
+                    DrawComb(g, box, rect, contentRect, font, text, combCells.Value);
+                else
+                    DrawSingleLine(g, box, contentRect, font, text);
+            });
+        }
+
+        static void DrawSingleLine(RGraphics g, CssBox box, RRect contentRect, RFont font, string text)
+        {
+            var y = contentRect.Y + Math.Max((contentRect.Height - font.Height) / 2, 0);
+            // letter-spacing is deliberately not read here: CssBox.ActualLetterSpacing is only
+            // populated by the normal word-measurement pass (DerivedStyle.MeasureLetterSpacing),
+            // which a form-field box's own replaced-element sizing (CssBoxFormField.MeasureWordsSize)
+            // never runs - reading it here would hit its NaN-sentinel default instead.
+            g.DrawString(text, font, box.ActualColor, new RPoint(contentRect.X, y),
+                new RSize(contentRect.Width, font.Height), fontPalette: box.ActualFontPalette, features: box.ActualTextShapingFeatures);
+        }
+
+        static void DrawComb(RGraphics g, CssBox box, RRect fieldRect, RRect contentRect, RFont font, string text, int cells)
+        {
+            var cellWidth = contentRect.Width / cells;
+            var y = contentRect.Y + Math.Max((contentRect.Height - font.Height) / 2, 0);
+
+            for (var i = 0; i < cells && i < text.Length; i++)
+            {
+                var ch = text[i].ToString();
+                var chWidth = g.MeasureString(ch, font).Width;
+                var x = contentRect.X + i * cellWidth + Math.Max((cellWidth - chWidth) / 2, 0);
+                g.DrawString(ch, font, box.ActualColor, new RPoint(x, y), new RSize(cellWidth, font.Height));
+            }
+
+            if (cells <= 1 || box.ActualBorderLeftWidth <= 0) return;
+
+            var pen = g.GetPen(box.ActualBorderLeftColor);
+            pen.Width = box.ActualBorderLeftWidth;
+            var top = fieldRect.Y + box.ActualBorderTopWidth;
+            var bottom = fieldRect.Y + fieldRect.Height - box.ActualBorderBottomWidth;
+            for (var i = 1; i < cells; i++)
+            {
+                var x = fieldRect.X + box.ActualBorderLeftWidth + i * cellWidth;
+                g.DrawLine(pen, x, top, x, bottom);
+            }
+        }
+
+        /// <summary>A checkbox/radio "off" appearance: the field's border/background chrome only.</summary>
+        internal static PdfFormXObject BuildCheckboxOffAppearance(PdfDocument document, RAdapter adapter, double pixelsPerPoint, CssBox box, double widthPt, double heightPt) =>
+            CreateForm(document, adapter, pixelsPerPoint, widthPt, heightPt, (g, rect) => FormFieldChrome.PaintBorderAndBackground(g, box, rect));
+
+        /// <summary>A checkbox "on" appearance: border/background chrome plus the check mark, in the field's real resolved text color.</summary>
+        internal static PdfFormXObject BuildCheckboxOnAppearance(PdfDocument document, RAdapter adapter, double pixelsPerPoint, CssBox box, double widthPt, double heightPt) =>
+            CreateForm(document, adapter, pixelsPerPoint, widthPt, heightPt, (g, rect) =>
+            {
+                FormFieldChrome.PaintBorderAndBackground(g, box, rect);
+                FormFieldChrome.PaintCheckboxGlyph(g, box, rect, isChecked: true);
+            });
+
+        /// <summary>A radio button "off" appearance: the field's circular background/ring only.</summary>
+        internal static PdfFormXObject BuildRadioOffAppearance(PdfDocument document, RAdapter adapter, double pixelsPerPoint, CssBox box, double widthPt, double heightPt) =>
+            CreateForm(document, adapter, pixelsPerPoint, widthPt, heightPt, (g, rect) => FormFieldChrome.PaintRadioBackground(g, box, rect));
+
+        /// <summary>A radio button "on" appearance: circular background/ring plus the filled inner dot, in the field's real resolved text color.</summary>
+        internal static PdfFormXObject BuildRadioOnAppearance(PdfDocument document, RAdapter adapter, double pixelsPerPoint, CssBox box, double widthPt, double heightPt) =>
+            CreateForm(document, adapter, pixelsPerPoint, widthPt, heightPt, (g, rect) =>
+            {
+                FormFieldChrome.PaintRadioBackground(g, box, rect);
+                FormFieldChrome.PaintRadioGlyph(g, box, rect, isChecked: true);
+            });
+    }
+}

--- a/src/PeachPDF/Html/Core/Handlers/FormFieldBuilder.cs
+++ b/src/PeachPDF/Html/Core/Handlers/FormFieldBuilder.cs
@@ -1,0 +1,235 @@
+using System.Collections.Generic;
+using System.Globalization;
+using PeachPDF.Adapters;
+using PeachPDF.Html.Adapters;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore.Pdf;
+using PeachPDF.PdfSharpCore.Pdf.AcroForms;
+using PeachPDF.PdfSharpCore.Pdf.Annotations;
+
+namespace PeachPDF.Html.Core.Handlers
+{
+    /// <summary>
+    /// Orchestrates AcroForm field/widget bookkeeping for one <c>PdfGenerator.GeneratePdf</c> call.
+    /// Constructed only when <see cref="PdfGenerateConfig.EnableInteractivePdfForms"/> is set (see
+    /// <c>PdfGenerator.GeneratePdf</c>'s single gate point) - unlike <see cref="StructureTagBuilder"/>,
+    /// this has no paint-time hook of its own; it is consumed entirely by
+    /// <c>PdfGenerator.HandleFormFields</c>, a pass over the finished layout that runs after painting,
+    /// the same way link annotations are placed by <c>PdfGenerator.HandleLinks</c>.
+    /// </summary>
+    internal sealed class FormFieldBuilder(PdfDocument document, RAdapter adapter)
+    {
+        internal PdfDocument Document { get; } = document;
+        internal RAdapter Adapter { get; } = adapter;
+
+        /// <summary>
+        /// The container's real device-pixel-to-point scale, read fresh on every use (not captured at
+        /// construction) - <c>PdfGenerator.GeneratePdf</c> constructs this builder before the
+        /// <c>ShrinkToFit</c>/<c>ScaleToPageSize</c> rescale pass may still adjust
+        /// <see cref="PdfSharpAdapter.PixelsPerPoint"/>, and <c>PdfGenerator.HandleFormFields</c> only
+        /// runs once that has settled - mirrors <c>HtmlContainer.PixelsPerPoint</c>'s own idiom.
+        /// </summary>
+        double PixelsPerPoint => ((PdfSharpAdapter)Adapter).PixelsPerPoint;
+
+        PdfDictionary? _helveticaFontResource;
+        bool _acroFormInitialized;
+
+        // Radio buttons sharing an HTML name attribute become widget-kids of one shared field rather
+        // than independent fields (see PdfRadioButtonField's own doc comment) - keyed by name, scoped
+        // to this one GeneratePdf call/document.
+        readonly Dictionary<string, PdfRadioButtonField> _radioGroupsByName = new();
+        int _unnamedRadioGroupCounter;
+        int _generatedFieldNameCounter;
+
+        PdfAcroForm EnsureAcroForm()
+        {
+            var acroForm = Document.Catalog.AcroForm;
+            if (!_acroFormInitialized)
+            {
+                _acroFormInitialized = true;
+                var helvetica = FormFieldAppearanceBuilder.GetOrCreateHelveticaFontResource(Document, ref _helveticaFontResource);
+                var fontsDict = new PdfDictionary(Document);
+                fontsDict.Elements.SetReference("/Helv", helvetica);
+                acroForm.DefaultResources.Elements.SetObject("/Font", fontsDict);
+                acroForm.DefaultAppearance = "/Helv 10 Tf 0 g";
+            }
+            return acroForm;
+        }
+
+        string ResolveFieldName(string? declaredName) =>
+            string.IsNullOrEmpty(declaredName) ? $"PeachPDFField{++_generatedFieldNameCounter}" : declaredName;
+
+        /// <summary>
+        /// The "on" appearance-state name for a checkbox/radio widget - the HTML <c>value</c>
+        /// attribute verbatim, except "Off" itself (PDF's own reserved "unchecked" state name,
+        /// case-sensitive per ISO 32000-1 §12.7.4.2.3): a literal <c>value="Off"</c> would otherwise
+        /// make the checked and unchecked states indistinguishable, so it falls back to the same
+        /// "Yes" default an absent/empty <c>value</c> already uses.
+        /// </summary>
+        static string ResolveOnValue(string? declaredValue) =>
+            string.IsNullOrEmpty(declaredValue) || declaredValue == "Off" ? "Yes" : declaredValue;
+
+        /// <summary>
+        /// Creates the AcroForm field/widget for one classified form-control box and places it on
+        /// <paramref name="page"/> at <paramref name="rect"/> (already resolved to page-space PDF
+        /// points by <c>PdfGenerator.HandleFormFields</c>).
+        /// </summary>
+        internal void AddField(PdfPage page, PdfRectangle rect, CssBox box, FormFieldClassification classification)
+        {
+            var acroForm = EnsureAcroForm();
+
+            switch (classification.Kind)
+            {
+                case FormFieldKind.Text:
+                    AddTextField(acroForm, page, rect, box, classification);
+                    break;
+                case FormFieldKind.Checkbox:
+                    AddCheckboxField(acroForm, page, rect, box, classification);
+                    break;
+                case FormFieldKind.Radio:
+                    AddRadioButton(acroForm, page, rect, box, classification);
+                    break;
+                case FormFieldKind.Select:
+                    AddSelectField(acroForm, page, rect, box, classification);
+                    break;
+            }
+        }
+
+        void AddTextField(PdfAcroForm acroForm, PdfPage page, PdfRectangle rect, CssBox box, FormFieldClassification c)
+        {
+            var field = new PdfTextField(Document)
+            {
+                Rectangle = rect,
+                PartialFieldName = ResolveFieldName(c.Name),
+                Value = c.Value ?? string.Empty,
+            };
+
+            var flags = 0;
+            if (c.DoNotScroll) flags |= PdfTextField.DoNotScrollFlag;
+            if (c.Comb is > 0)
+            {
+                flags |= PdfTextField.CombFlag;
+                field.MaxLen = c.Comb.Value;
+            }
+            field.FieldFlags = flags;
+
+            var appearance = FormFieldAppearanceBuilder.BuildTextAppearance(
+                Document, Adapter, PixelsPerPoint, box, rect.Width, rect.Height, c.Value ?? string.Empty,
+                c.AutoFontSize, c.Comb, out var fontSizePt);
+
+            // "/DA" (as opposed to the baked "/AP /N" appearance above) is what a reader uses to
+            // regenerate this field's appearance once the user actually edits it - "0 Tf" is PDF's
+            // own literal auto-size convention (ISO 32000-1 §12.7.3.3), the real analogue of
+            // -peachpdf-pdf-form-field-auto-font-size for interactive (not just initial) rendering.
+            // The point size otherwise agrees with the baked appearance's own resolved font size,
+            // even though the face itself differs - see FormFieldAppearanceBuilder.GetOrCreateHelveticaFontResource.
+            field.DefaultAppearance = c.AutoFontSize
+                ? "/Helv 0 Tf 0 g"
+                : $"/Helv {fontSizePt.ToString("0.###", CultureInfo.InvariantCulture)} Tf 0 g";
+
+            SetNormalAppearance(field, appearance);
+
+            page.Annotations.Add(field);
+            acroForm.AddField(field);
+        }
+
+        void AddCheckboxField(PdfAcroForm acroForm, PdfPage page, PdfRectangle rect, CssBox box, FormFieldClassification c)
+        {
+            var onValue = ResolveOnValue(c.Value);
+
+            var field = new PdfCheckBoxField(Document)
+            {
+                Rectangle = rect,
+                PartialFieldName = ResolveFieldName(c.Name),
+                Value = c.Checked ? "/" + onValue : "/Off",
+                AppearanceState = c.Checked ? "/" + onValue : "/Off",
+            };
+
+            var onAppearance = FormFieldAppearanceBuilder.BuildCheckboxOnAppearance(Document, Adapter, PixelsPerPoint, box, rect.Width, rect.Height);
+            var offAppearance = FormFieldAppearanceBuilder.BuildCheckboxOffAppearance(Document, Adapter, PixelsPerPoint, box, rect.Width, rect.Height);
+            SetTwoStateAppearance(field, onValue, onAppearance, offAppearance);
+
+            page.Annotations.Add(field);
+            acroForm.AddField(field);
+        }
+
+        void AddRadioButton(PdfAcroForm acroForm, PdfPage page, PdfRectangle rect, CssBox box, FormFieldClassification c)
+        {
+            var groupKey = string.IsNullOrEmpty(c.Name) ? $"__unnamed_radio_{++_unnamedRadioGroupCounter}__" : c.Name;
+            var onValue = ResolveOnValue(c.Value);
+
+            if (!_radioGroupsByName.TryGetValue(groupKey, out var group))
+            {
+                group = new PdfRadioButtonField(Document)
+                {
+                    PartialFieldName = ResolveFieldName(c.Name),
+                    Value = "/Off",
+                };
+                _radioGroupsByName[groupKey] = group;
+                acroForm.AddField(group);
+            }
+
+            var widget = new PdfWidgetAnnotation(Document)
+            {
+                Rectangle = rect,
+                AppearanceState = c.Checked ? "/" + onValue : "/Off",
+            };
+
+            var onAppearance = FormFieldAppearanceBuilder.BuildRadioOnAppearance(Document, Adapter, PixelsPerPoint, box, rect.Width, rect.Height);
+            var offAppearance = FormFieldAppearanceBuilder.BuildRadioOffAppearance(Document, Adapter, PixelsPerPoint, box, rect.Width, rect.Height);
+            SetTwoStateAppearance(widget, onValue, onAppearance, offAppearance);
+
+            group.AddKid(widget);
+            if (c.Checked)
+                group.Value = "/" + onValue;
+
+            page.Annotations.Add(widget);
+        }
+
+        void AddSelectField(PdfAcroForm acroForm, PdfPage page, PdfRectangle rect, CssBox box, FormFieldClassification c)
+        {
+            var selected = c.Options.Count > 0 ? System.Linq.Enumerable.FirstOrDefault(c.Options, o => o.Selected) : default;
+            var selectedLabel = c.Options.Count == 0 ? string.Empty : (selected.Label ?? c.Options[0].Label);
+            var selectedValue = c.Options.Count == 0 ? string.Empty : (selected.Value ?? c.Options[0].Value);
+
+            var field = new PdfComboBoxField(Document)
+            {
+                Rectangle = rect,
+                PartialFieldName = ResolveFieldName(c.Name),
+                Value = selectedValue,
+            };
+
+            var options = new List<(string Value, string Label)>();
+            foreach (var option in c.Options)
+                options.Add((option.Value, option.Label));
+            field.SetOptions(options);
+
+            var appearance = FormFieldAppearanceBuilder.BuildTextAppearance(
+                Document, Adapter, PixelsPerPoint, box, rect.Width, rect.Height, selectedLabel,
+                autoFontSize: false, combCells: null, out _);
+            SetNormalAppearance(field, appearance);
+
+            page.Annotations.Add(field);
+            acroForm.AddField(field);
+        }
+
+        static void SetNormalAppearance(PdfAnnotation annotation, PeachPDF.PdfSharpCore.Pdf.Advanced.PdfFormXObject appearance)
+        {
+            var ap = new PdfDictionary(annotation.Owner);
+            ap.Elements.SetReference("/N", appearance);
+            annotation.Elements.SetObject(PdfAnnotation.Keys.AP, ap);
+        }
+
+        static void SetTwoStateAppearance(PdfAnnotation annotation, string onValue,
+            PeachPDF.PdfSharpCore.Pdf.Advanced.PdfFormXObject onAppearance, PeachPDF.PdfSharpCore.Pdf.Advanced.PdfFormXObject offAppearance)
+        {
+            var states = new PdfDictionary(annotation.Owner);
+            states.Elements.SetReference("/" + onValue, onAppearance);
+            states.Elements.SetReference("/Off", offAppearance);
+
+            var ap = new PdfDictionary(annotation.Owner);
+            ap.Elements.SetObject("/N", states);
+            annotation.Elements.SetObject(PdfAnnotation.Keys.AP, ap);
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Handlers/FormFieldMapper.cs
+++ b/src/PeachPDF/Html/Core/Handlers/FormFieldMapper.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using PeachPDF.CSS;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Utils;
+
+namespace PeachPDF.Html.Core.Handlers
+{
+    /// <summary>
+    /// Which AcroForm field kind (if any) a box resolves to. Textarea and push-button fields are not
+    /// classified this pass - see docs/html-css-support.md's Interactive PDF Forms section.
+    /// </summary>
+    internal enum FormFieldKind
+    {
+        None,
+        Text,
+        Checkbox,
+        Radio,
+        Select
+    }
+
+    /// <summary>
+    /// One &lt;option&gt; of a classified &lt;select&gt; field.
+    /// </summary>
+    internal readonly struct FormFieldOption(string value, string label, bool selected)
+    {
+        public string Value { get; } = value;
+        public string Label { get; } = label;
+        public bool Selected { get; } = selected;
+    }
+
+    /// <summary>
+    /// The result of classifying a box for interactive-PDF-forms output.
+    /// </summary>
+    internal readonly struct FormFieldClassification
+    {
+        public FormFieldKind Kind { get; }
+
+        /// <summary>The field's <c>name</c> attribute (its <c>/T</c> partial field name), or null if absent.</summary>
+        public string? Name { get; }
+
+        /// <summary>The field's current text value (text fields) or export value (checkbox/radio). Null for Select.</summary>
+        public string? Value { get; }
+
+        /// <summary>Whether a checkbox/radio's <c>checked</c> attribute is present. Always false for other kinds.</summary>
+        public bool Checked { get; }
+
+        /// <summary>A select field's &lt;option&gt; children, in document order. Empty for other kinds.</summary>
+        public IReadOnlyList<FormFieldOption> Options { get; }
+
+        /// <summary>
+        /// <c>-peachpdf-pdf-form-field-auto-font-size</c>'s resolved value - only meaningful for
+        /// <see cref="FormFieldKind.Text"/>.
+        /// </summary>
+        public bool AutoFontSize { get; }
+
+        /// <summary>
+        /// <c>-peachpdf-pdf-form-field-comb</c>'s resolved cell count, or null when unset - only
+        /// meaningful for <see cref="FormFieldKind.Text"/>.
+        /// </summary>
+        public int? Comb { get; }
+
+        /// <summary>
+        /// <c>-peachpdf-pdf-form-field-do-not-scroll</c>'s resolved value - only meaningful for
+        /// <see cref="FormFieldKind.Text"/>.
+        /// </summary>
+        public bool DoNotScroll { get; }
+
+        FormFieldClassification(FormFieldKind kind, string? name, string? value, bool @checked,
+            IReadOnlyList<FormFieldOption> options, bool autoFontSize, int? comb, bool doNotScroll)
+        {
+            Kind = kind;
+            Name = name;
+            Value = value;
+            Checked = @checked;
+            Options = options;
+            AutoFontSize = autoFontSize;
+            Comb = comb;
+            DoNotScroll = doNotScroll;
+        }
+
+        public static readonly FormFieldClassification None =
+            new(FormFieldKind.None, null, null, false, Array.Empty<FormFieldOption>(), false, null, false);
+
+        public static FormFieldClassification Text(string? name, string? value, bool autoFontSize, int? comb, bool doNotScroll) =>
+            new(FormFieldKind.Text, name, value, false, Array.Empty<FormFieldOption>(), autoFontSize, comb, doNotScroll);
+
+        public static FormFieldClassification Checkbox(string? name, string? value, bool @checked) =>
+            new(FormFieldKind.Checkbox, name, value, @checked, Array.Empty<FormFieldOption>(), false, null, false);
+
+        public static FormFieldClassification Radio(string? name, string? value, bool @checked) =>
+            new(FormFieldKind.Radio, name, value, @checked, Array.Empty<FormFieldOption>(), false, null, false);
+
+        public static FormFieldClassification Select(string? name, IReadOnlyList<FormFieldOption> options) =>
+            new(FormFieldKind.Select, name, null, false, options, false, null, false);
+    }
+
+    /// <summary>
+    /// Classifies a <see cref="CssBox"/> for interactive-PDF-forms output. Mirrors
+    /// <see cref="StructureTagMapper"/>'s shape: a pure function of the box's own resolved style and
+    /// HTML attributes, no PDF objects, no side effects. Only a real <c>&lt;input&gt;</c>/
+    /// <c>&lt;select&gt;</c> element (a <see cref="CssBoxFormField"/>) is ever eligible - a
+    /// <c>-peachpdf-pdf-form-field</c> declaration on any other element (including a CSS-generated
+    /// anonymous box) is simply inert, which is this feature's own deliberate scope boundary, not an
+    /// accepted gap.
+    /// </summary>
+    internal static class FormFieldMapper
+    {
+        public static FormFieldClassification Classify(CssBox box)
+        {
+            if (box is not CssBoxFormField || box.HtmlTag is null)
+                return FormFieldClassification.None;
+
+            var declared = box.PdfFormField;
+
+            if (string.Equals(declared, Keywords.None, StringComparison.OrdinalIgnoreCase))
+                return FormFieldClassification.None;
+
+            if (string.IsNullOrEmpty(declared) || string.Equals(declared, Keywords.Auto, StringComparison.OrdinalIgnoreCase))
+                return ClassifyAuto(box);
+
+            return declared switch
+            {
+                _ when string.Equals(declared, Keywords.Text, StringComparison.OrdinalIgnoreCase) => ClassifyText(box),
+                _ when string.Equals(declared, Keywords.Checkbox, StringComparison.OrdinalIgnoreCase) => ClassifyCheckbox(box),
+                _ when string.Equals(declared, Keywords.Radio, StringComparison.OrdinalIgnoreCase) => ClassifyRadio(box),
+                _ when string.Equals(declared, Keywords.Select, StringComparison.OrdinalIgnoreCase) => ClassifySelect(box),
+                // Defensive only: the property's Converter already rejects anything outside the fixed
+                // keyword set at CSS parse time, so a genuinely unrecognized value can't reach here.
+                _ => ClassifyAuto(box)
+            };
+        }
+
+        static FormFieldClassification ClassifyAuto(CssBox box)
+        {
+            var tag = box.HtmlTag!.Name;
+
+            if (string.Equals(tag, HtmlConstants.Select, StringComparison.OrdinalIgnoreCase))
+                return ClassifySelect(box);
+
+            if (!string.Equals(tag, HtmlConstants.Input, StringComparison.OrdinalIgnoreCase))
+                return FormFieldClassification.None;
+
+            var type = box.GetAttribute("type", Keywords.Text).ToLowerInvariant();
+            return type switch
+            {
+                Keywords.Checkbox => ClassifyCheckbox(box),
+                Keywords.Radio => ClassifyRadio(box),
+                // Not text-like - hidden/submit/reset/button/image/file inputs are out of scope this pass.
+                "hidden" or "submit" or "reset" or "button" or "image" or "file" => FormFieldClassification.None,
+                // text/email/password/number/tel/url/search/date/... all collapse to the closest
+                // equivalent PeachPDF supports, same as the Prince alias's own field-type keywords do.
+                _ => ClassifyText(box)
+            };
+        }
+
+        static FormFieldClassification ClassifyText(CssBox box)
+        {
+            var name = box.GetAttribute("name", null);
+            var value = box.GetAttribute("value", null);
+            var autoFontSize = string.Equals(box.PdfFormFieldAutoFontSize, Keywords.Auto, StringComparison.OrdinalIgnoreCase);
+            var doNotScroll = string.Equals(box.PdfFormFieldDoNotScroll, Keywords.Auto, StringComparison.OrdinalIgnoreCase);
+            int? comb = int.TryParse(box.PdfFormFieldComb, out var cells) && cells > 0 ? cells : null;
+            return FormFieldClassification.Text(name, value, autoFontSize, comb, doNotScroll);
+        }
+
+        static FormFieldClassification ClassifyCheckbox(CssBox box)
+        {
+            var name = box.GetAttribute("name", null);
+            var value = box.GetAttribute("value", "Yes");
+            var isChecked = box.HtmlTag!.HasAttribute("checked");
+            return FormFieldClassification.Checkbox(name, value, isChecked);
+        }
+
+        static FormFieldClassification ClassifyRadio(CssBox box)
+        {
+            var name = box.GetAttribute("name", null);
+            var value = box.GetAttribute("value", "Yes");
+            var isChecked = box.HtmlTag!.HasAttribute("checked");
+            return FormFieldClassification.Radio(name, value, isChecked);
+        }
+
+        static FormFieldClassification ClassifySelect(CssBox box)
+        {
+            var name = box.GetAttribute("name", null);
+            var options = new List<FormFieldOption>();
+
+            foreach (var child in box.Boxes)
+            {
+                if (child.HtmlTag is null || !string.Equals(child.HtmlTag.Name, HtmlConstants.Option, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var label = CssContentEngine.ExtractText(child) ?? string.Empty;
+                var value = child.GetAttribute("value", null) ?? label;
+                var selected = child.HtmlTag.HasAttribute("selected");
+                options.Add(new FormFieldOption(value, label, selected));
+            }
+
+            return FormFieldClassification.Select(name, options);
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/HtmlContainerInt.cs
+++ b/src/PeachPDF/Html/Core/HtmlContainerInt.cs
@@ -726,6 +726,15 @@ namespace PeachPDF.Html.Core
         internal Handlers.StructureTagBuilder? StructureTagBuilder { get; set; }
 
         /// <summary>
+        /// Orchestrates AcroForm field/widget bookkeeping during PDF generation. Set by
+        /// <c>PdfGenerator</c> before painting only when
+        /// <c>PdfGenerateConfig.EnableInteractivePdfForms</c> is set; null (the default) means
+        /// interactive forms are disabled and both the form-field content painter and
+        /// <c>PdfGenerator.HandleFormFields</c> are no-ops.
+        /// </summary>
+        internal Handlers.FormFieldBuilder? FormFieldBuilder { get; set; }
+
+        /// <summary>
         /// Init with optional document and stylesheet.
         /// </summary>
         /// <param name="htmlSource">the html to init with, init empty if not given</param>

--- a/src/PeachPDF/Html/Core/Paint/Content/FormFieldChrome.cs
+++ b/src/PeachPDF/Html/Core/Paint/Content/FormFieldChrome.cs
@@ -1,0 +1,81 @@
+using PeachPDF.CSS;
+using PeachPDF.Html.Adapters;
+using PeachPDF.Html.Adapters.Entities;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Handlers;
+using PeachPDF.Html.Core.Utils;
+
+namespace PeachPDF.Html.Core.Paint.Content
+{
+    /// <summary>
+    /// The border/background/checkbox-radio-glyph chrome shared between the flag-on static page
+    /// painter (<see cref="FormFieldFragmentPainter"/>) and a field's own generated widget
+    /// appearance stream (<c>Html/Core/Handlers/FormFieldAppearanceBuilder</c>) - both need to draw
+    /// the identical CSS-styled look, just onto different <see cref="RGraphics"/> targets (the real
+    /// page vs. a field's own local <c>XForm</c>), so the drawing logic itself lives here once
+    /// rather than drifting between two independently maintained copies.
+    /// </summary>
+    internal static class FormFieldChrome
+    {
+        /// <summary>The border/background shared by every field kind - reuses the same CSS box-model painting every other box gets.</summary>
+        internal static void PaintBorderAndBackground(RGraphics g, CssBox box, RRect rect)
+        {
+            FragmentPainter.PaintBackground(g, box, BoxDecorationGeometry.Unbroken(rect));
+            BordersDrawHandler.DrawBoxBorders(g, box, rect, hasLeftEdge: true, hasRightEdge: true);
+        }
+
+        /// <summary>The check mark glyph, in the box's resolved text color - only drawn when checked.</summary>
+        internal static void PaintCheckboxGlyph(RGraphics g, CssBox box, RRect rect, bool isChecked)
+        {
+            if (!isChecked) return;
+
+            var mark = g.GetPen(box.ActualColor);
+            mark.Width = System.Math.Max(rect.Width, rect.Height) * 0.12;
+            var inset = System.Math.Min(rect.Width, rect.Height) * 0.2;
+            g.DrawLine(mark, rect.X + inset, rect.Y + rect.Height * 0.5, rect.X + rect.Width * 0.42, rect.Y + rect.Height - inset);
+            g.DrawLine(mark, rect.X + rect.Width * 0.42, rect.Y + rect.Height - inset, rect.X + rect.Width - inset, rect.Y + inset);
+        }
+
+        /// <summary>
+        /// The circular ring a radio button uses instead of <see cref="PaintBorderAndBackground"/>'s
+        /// rectangle - background from the box's resolved <c>background-color</c>, the ring itself
+        /// from its <c>border-top</c> (a circle has one ring, not four independent edges, so
+        /// border-top stands in as the representative side - matching how <c>border-radius</c>
+        /// elsewhere in CSS already treats a fully-rounded box as a single curve, not four).
+        /// </summary>
+        internal static void PaintRadioBackground(RGraphics g, CssBox box, RRect rect)
+        {
+            var rx = rect.Width / 2;
+            var ry = rect.Height / 2;
+            using var path = RenderUtils.GetRoundRect(g, rect, rx, ry, rx, ry, rx, ry, rx, ry);
+
+            var backgroundColor = box.ActualBackgroundColor;
+            if (RenderUtils.IsColorVisible(backgroundColor))
+            {
+                using var background = g.GetSolidBrush(backgroundColor);
+                g.DrawPath(background, path);
+            }
+
+            if (box.BorderTopStyle.Value is not (LineStyle.None or LineStyle.Hidden) && box.ActualBorderTopWidth > 0)
+            {
+                var pen = g.GetPen(box.ActualBorderTopColor);
+                pen.Width = box.ActualBorderTopWidth;
+                g.DrawPath(pen, path);
+            }
+        }
+
+        /// <summary>The filled inner dot, in the box's resolved text color - only drawn when checked.</summary>
+        internal static void PaintRadioGlyph(RGraphics g, CssBox box, RRect rect, bool isChecked)
+        {
+            if (!isChecked) return;
+
+            var inset = System.Math.Min(rect.Width, rect.Height) * 0.28;
+            var dotRect = new RRect(rect.X + inset, rect.Y + inset, rect.Width - inset * 2, rect.Height - inset * 2);
+            var dx = dotRect.Width / 2;
+            var dy = dotRect.Height / 2;
+            using var dotPath = RenderUtils.GetRoundRect(g, dotRect, dx, dy, dx, dy, dx, dy, dx, dy);
+            using var brush = g.GetSolidBrush(box.ActualColor);
+            g.DrawPath(brush, dotPath);
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Paint/Content/FormFieldFragmentPainter.cs
+++ b/src/PeachPDF/Html/Core/Paint/Content/FormFieldFragmentPainter.cs
@@ -1,0 +1,67 @@
+using PeachPDF.Html.Adapters;
+using PeachPDF.Html.Adapters.Entities;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Fragments;
+using PeachPDF.Html.Core.Handlers;
+
+namespace PeachPDF.Html.Core.Paint.Content
+{
+    /// <summary>
+    /// Paints the flag-on "static look" of a classified form field - a checkbox square/check mark, a
+    /// radio circle/dot, or a bordered text/select box. Only reached when
+    /// <c>PdfGenerateConfig.EnableInteractivePdfForms</c> is on and the box actually classifies to a
+    /// field (see <c>FragmentContentPainters.For</c>'s guard) - the flag-off static box rendering is
+    /// unchanged, handled entirely by the generic <see cref="FragmentPainter.PaintBoxContent"/> path.
+    /// </summary>
+    /// <remarks>
+    /// A text/select field's current value/selected-label text is deliberately NOT drawn here, even
+    /// though <c>FormFieldAppearanceBuilder</c> bakes the identical text into the widget's own "/AP /N"
+    /// appearance stream - the two are not simply redundant. A reader that renders annotations (the
+    /// normal case) composites the widget's appearance on top of this page content, and when a text
+    /// field gains focus for editing, readers commonly render their own live/interactive text (from
+    /// "/V" via "/DA") without first re-covering whatever this method already painted underneath -
+    /// drawing the same text twice at two independently-computed positions (this method uses the
+    /// page's own resolved font; the appearance stream uses a fixed-size Helvetica) then shows as
+    /// visibly doubled, offset text the moment the field is selected. The border/background chrome
+    /// carries no such risk (a reader's own edit-mode rendering is opaque over it) and stays.
+    /// Checkbox/radio glyphs stay too - toggling one swaps between two pre-baked appearance states
+    /// rather than opening a live-text edit mode, so the same doubling risk does not apply to them.
+    /// </remarks>
+    internal sealed class FormFieldFragmentPainter : IFragmentContentPainter
+    {
+        public void Paint(FragmentPainter painter, RGraphics g, BoxFragment fragment)
+        {
+            var box = (CssBoxFormField)fragment.Box;
+            var classification = FormFieldMapper.Classify(box);
+            if (classification.Kind == FormFieldKind.None)
+            {
+                painter.PaintBoxContent(g, fragment);
+                return;
+            }
+
+            // Mirrors ReplacedFragmentPainter's own choice of fragment.PrimaryRect (the phantom word's
+            // line-resolved rect) over WholeBoxRect - an inline-level box's whole-box geometry is only
+            // resolved at fragment materialization (see CLAUDE.md's fragment-tree architecture note),
+            // but the box's own line rect - what CssRectFormField's intrinsic sizing actually
+            // populated - is already correct here, the same way it already is for CssBoxImage.
+            var rect = fragment.PrimaryRect;
+            if (rect is not { Width: > 0, Height: > 0 }) return;
+
+            switch (classification.Kind)
+            {
+                case FormFieldKind.Checkbox:
+                    FormFieldChrome.PaintBorderAndBackground(g, box, rect);
+                    FormFieldChrome.PaintCheckboxGlyph(g, box, rect, classification.Checked);
+                    break;
+                case FormFieldKind.Radio:
+                    FormFieldChrome.PaintRadioBackground(g, box, rect);
+                    FormFieldChrome.PaintRadioGlyph(g, box, rect, classification.Checked);
+                    break;
+                case FormFieldKind.Text:
+                case FormFieldKind.Select:
+                    FormFieldChrome.PaintBorderAndBackground(g, box, rect);
+                    break;
+            }
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Paint/Content/FragmentContentPainters.cs
+++ b/src/PeachPDF/Html/Core/Paint/Content/FragmentContentPainters.cs
@@ -1,4 +1,5 @@
 using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Handlers;
 
 namespace PeachPDF.Html.Core.Paint.Content
 {
@@ -14,6 +15,7 @@ namespace PeachPDF.Html.Core.Paint.Content
         private static readonly FrameFragmentPainter FramePainter = new();
         private static readonly HrFragmentPainter HrPainter = new();
         private static readonly MarkerFragmentPainter MarkerPainter = new();
+        private static readonly FormFieldFragmentPainter FormFieldPainter = new();
 
         /// <summary>
         /// The painter for <paramref name="box"/>'s content, or null when the generic box paint applies.
@@ -28,6 +30,11 @@ namespace PeachPDF.Html.Core.Paint.Content
             CssBoxFrame => FramePainter,
             CssBoxHr => HrPainter,
             CssBoxMarker => MarkerPainter,
+            // Only when interactive forms are enabled AND the box actually resolves to a field kind -
+            // otherwise this falls through to the generic path, preserving the flag-off static box
+            // rendering byte-for-byte (see FormFieldFragmentPainter's own doc comment).
+            CssBoxFormField formField when formField.HtmlContainer?.FormFieldBuilder != null
+                && FormFieldMapper.Classify(formField).Kind != FormFieldKind.None => FormFieldPainter,
             _ => null,
         };
     }

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -2405,6 +2405,17 @@ namespace PeachPDF.Html.Core.Parse
 
             foreach (var childBox in box.Boxes)
             {
+                // A display:none child renders nothing at all - it is neither the "inline" half nor
+                // the "block" half of this box's content, so it must not be able to make an otherwise
+                // purely-inline box look like it has a block-in-inline problem (reproduced by an
+                // inline-block <select> with a display:none <option> child: without this, the
+                // <option> - "not inline" per CssBox.IsInline, since its ActualDisplay is "none", not
+                // "inline" - made this method report false for a <select> holding only display:none
+                // children, which made the SELECT'S OWN PARENT look like it had block-in-inline
+                // content, splitting the parent and hoisting the option out of <select> entirely).
+                if (childBox.DerivedStyle.ActualDisplay == Keywords.None)
+                    continue;
+
                 if (!childBox.IsInline || !ContainsInlinesOnlyDeep(childBox))
                 {
                     return false;
@@ -2451,6 +2462,12 @@ namespace PeachPDF.Html.Core.Parse
             bool hasInline = false;
             for (int i = 0; i < box.Boxes.Count && (!hasBlock || !hasInline); i++)
             {
+                // A display:none child is neither half of "variant" content (see the identical
+                // reasoning in ContainsInlinesOnlyDeep) - it must not be able to make an otherwise
+                // uniformly-inline run of siblings look like it needs a block wrapper.
+                if (box.Boxes[i].DerivedStyle.ActualDisplay == Keywords.None)
+                    continue;
+
                 var isBlock = !box.Boxes[i].IsInline;
                 hasBlock = hasBlock || isBlock;
                 hasInline = hasInline || JoinsTheInlineRun(box.Boxes[i]);

--- a/src/PeachPDF/Html/Core/Utils/DomUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/DomUtils.cs
@@ -358,6 +358,30 @@ namespace PeachPDF.Html.Core.Utils
         }
 
         /// <summary>
+        /// Collect every visible &lt;input&gt;/&lt;select&gt; box in document order, for
+        /// <c>PdfGenerator.HandleFormFields</c> to classify and place - the same shape as
+        /// <see cref="GetAllLinkBoxes"/>, since both are post-layout geometry queries over the live
+        /// box tree rather than paint (see CLAUDE.md's fragment-tree-is-the-paint-contract rule, which
+        /// this is deliberately outside of, exactly like <see cref="GetAllLinkBoxes"/> already is).
+        /// </summary>
+        public static void GetAllFormFieldBoxes(CssBox? box, List<CssBox> fieldBoxes)
+        {
+            switch (box)
+            {
+                case null:
+                    return;
+                case CssBoxFormField { Visibility.Value: Visibility.Visible }:
+                    fieldBoxes.Add(box);
+                    break;
+            }
+
+            foreach (var childBox in box.Boxes)
+            {
+                GetAllFormFieldBoxes(childBox, fieldBoxes);
+            }
+        }
+
+        /// <summary>
         /// Collect every SVG-sourced link candidate (from <c>&lt;a&gt;</c> elements inside an inline
         /// <c>&lt;svg&gt;</c> or a standalone <c>&lt;img src="x.svg"&gt;</c>) found anywhere in the
         /// HTML tree, already resolved to page-space rectangles via <see cref="SvgRenderer.CollectLinks"/>.

--- a/src/PeachPDF/Html/Core/Utils/HtmlConstants.cs
+++ b/src/PeachPDF/Html/Core/Utils/HtmlConstants.cs
@@ -54,7 +54,7 @@ namespace PeachPDF.Html.Core.Utils
         //        public const string I = "I";
         public const string Iframe = "iframe";
         public const string Img = "img";
-        //        public const string INPUT = "INPUT";
+        public const string Input = "input";
         //        public const string INS = "INS";
         //        public const string ISINDEX = "ISINDEX";
         //        public const string KBD = "KBD";
@@ -72,7 +72,7 @@ namespace PeachPDF.Html.Core.Utils
         public const string Object = "object";
         //        public const string OL = "OL";
         //        public const string OPTGROUP = "OPTGROUP";
-        //        public const string OPTION = "OPTION";
+        public const string Option = "option";
         //        public const string P = "P";
         //        public const string PARAM = "PARAM";
         //        public const string PRE = "PRE";
@@ -80,7 +80,7 @@ namespace PeachPDF.Html.Core.Utils
         //        public const string S = "S";
         //        public const string SAMP = "SAMP";
         //        public const string SCRIPT = "SCRIPT";
-        //        public const string SELECT = "SELECT";
+        public const string Select = "select";
         //        public const string SMALL = "SMALL";
         //        public const string SPAN = "SPAN";
         //        public const string STRIKE = "STRIKE";

--- a/src/PeachPDF/PdfGenerateConfig.cs
+++ b/src/PeachPDF/PdfGenerateConfig.cs
@@ -228,6 +228,14 @@ namespace PeachPDF
         public bool EnableTaggedPdf { get; set; } = false;
 
         /// <summary>
+        /// When set to <c>true</c>, PeachPDF emits real, fillable AcroForm fields (text, checkbox,
+        /// radio, select) for form elements whose resolved <c>-peachpdf-pdf-form-field</c> value
+        /// requests one, instead of the default static box rendering. Defaults to <c>false</c> - an
+        /// explicit, informed opt-in, exactly like <see cref="EnableTaggedPdf"/>.
+        /// </summary>
+        public bool EnableInteractivePdfForms { get; set; } = false;
+
+        /// <summary>
         /// Set all 4 margins to the given value.
         /// </summary>
         /// <param name="value"></param>

--- a/src/PeachPDF/PdfGenerator.cs
+++ b/src/PeachPDF/PdfGenerator.cs
@@ -296,6 +296,13 @@ namespace PeachPDF
             var structureTagBuilder = config.EnableTaggedPdf ? new StructureTagBuilder(document.PdfDocument) : null;
             container.HtmlContainerInt.StructureTagBuilder = structureTagBuilder;
 
+            // Same shape as structureTagBuilder above: only constructed when interactive PDF forms are
+            // enabled - FragmentContentPainters.For and HandleFormFields (below) both check
+            // HtmlContainerInt.FormFieldBuilder for null and skip all classification/bookkeeping when
+            // it's not set, so this is the single point that gates the whole feature off by default.
+            var formFieldBuilder = config.EnableInteractivePdfForms ? new FormFieldBuilder(document.PdfDocument, container.HtmlContainerInt.Adapter) : null;
+            container.HtmlContainerInt.FormFieldBuilder = formFieldBuilder;
+
             // Per CSS2.1 §14.2 the "canvas" (here: every page) is filled with body's background if it
             // declares one, else html's. Resolved during layout, since the fragment tree's own
             // page-materialization rule depends on it.
@@ -434,6 +441,11 @@ namespace PeachPDF
             // outline afterwards adds zero net full-tree traversals.
             var bookmarkBoxes = new List<CssBox>();
             HandleLinks(document.PdfDocument, container, orgPageSize, fragmentainers, bookmarkBoxes, structureTagBuilder);
+
+            if (formFieldBuilder != null)
+            {
+                HandleFormFields(document.PdfDocument, container, orgPageSize, fragmentainers, formFieldBuilder);
+            }
 
             // PDF outline (bookmarks) - CSS-default-driven (h1-h6 default to bookmark-level 1-6 via the
             // UA stylesheet, everything else defaults to none), so this is unconditional: a document
@@ -639,6 +651,50 @@ namespace PeachPDF
             }
 
             HandleRunningElementLinks(document, container, orgPageSize, fragmentainers, ResolveAnchorTarget, structureTagBuilder);
+        }
+
+        /// <summary>
+        /// Creates AcroForm fields/widgets for every classified &lt;input&gt;/&lt;select&gt; box, one
+        /// per page. Mirrors <see cref="HandleLinks"/>'s own per-box rect-to-page resolution (matching
+        /// its exact math, since both convert a post-layout box rect to page-space PDF points against
+        /// the same slot geometry) rather than <see cref="HandleLinks"/>'s multi-slot loop, which
+        /// exists only because a link's box can span a page break - a form-control box never can
+        /// (see <c>MonolithicContent.IsReplaced</c>'s <c>CssBoxFormField</c> arm), so each
+        /// field resolves to exactly one page and one rect.
+        /// </summary>
+        private static void HandleFormFields(PdfDocument document, HtmlContainer container, XSize orgPageSize, IReadOnlyList<FragmentainerFragment> fragmentainers, FormFieldBuilder formFieldBuilder)
+        {
+            var inner = container.HtmlContainerInt;
+            var ppp = container.PixelsPerPoint;
+            var (slotToPage, _) = PageAnchorResolver.BuildSlotToPageMap(fragmentainers);
+
+            var fieldBoxes = new List<CssBox>();
+            DomUtils.GetAllFormFieldBoxes(inner.Root, fieldBoxes);
+
+            foreach (var box in fieldBoxes)
+            {
+                var classification = FormFieldMapper.Classify(box);
+                if (classification.Kind == FormFieldKind.None)
+                    continue;
+
+                var pixelRect = CommonUtils.GetFirstValueOrDefault(box.Rectangles, box.Bounds);
+
+                var slot = Math.Max(inner.PageIndexOf(pixelRect.Top), 0);
+                if (!slotToPage.TryGetValue(slot, out var pageIndex) || pageIndex >= document.Pages.Count)
+                    continue;
+
+                var slotGeom = inner.PageGeometry.GetPage(slot);
+                var topPt = slotGeom.MarginTopPt + (pixelRect.Top - inner.PageTopOf(slot)) / ppp;
+                var leftPt = slotGeom.MarginLeftPt + (pixelRect.Left - inner.MarginLeft) / ppp;
+                var widthPt = pixelRect.Width / ppp;
+                var heightPt = pixelRect.Height / ppp;
+
+                if (widthPt <= 0 || heightPt <= 0)
+                    continue;
+
+                var xRect = new XRect(leftPt, orgPageSize.Height - (topPt + heightPt), widthPt, heightPt);
+                formFieldBuilder.AddField(document.Pages[pageIndex], new PdfRectangle(xRect), box, classification);
+            }
         }
 
         /// <summary>

--- a/src/PeachPDF/PdfSharpCore/Pdf.AcroForms/PdfAcroField.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf.AcroForms/PdfAcroField.cs
@@ -1,0 +1,98 @@
+using PeachPDF.PdfSharpCore.Pdf.Annotations;
+using PeachPDF.PdfSharpCore.Pdf.Internal;
+
+namespace PeachPDF.PdfSharpCore.Pdf.AcroForms
+{
+    /// <summary>
+    /// Base class for an AcroForm field (ISO 32000-1 §12.7.3/12.7.4). New PeachPDF-original code
+    /// (this fork's snapshot of upstream PDFsharp shipped no interactive-forms support at all - see
+    /// docs/architecture.md - so there is no upstream file to port). Derives from
+    /// <see cref="PdfAnnotation"/> because a terminal, single-widget field (text/checkbox/combo)
+    /// merges the field dictionary and its one widget annotation into a single object per §12.7.3.1,
+    /// exactly the shape <see cref="PdfLinkAnnotation"/> already uses for its own dictionary-is-the-
+    /// annotation pattern. <see cref="PdfRadioButtonField"/> is the one non-terminal exception - see
+    /// its own doc comment.
+    /// </summary>
+    internal abstract class PdfAcroField : PdfAnnotation
+    {
+        protected PdfAcroField(PdfDocument document)
+            : base(document)
+        {
+        }
+
+        /// <summary>The field type ("/FT") - "/Tx", "/Btn" or "/Ch".</summary>
+        public string FieldType
+        {
+            get { return Elements.GetName(Keys.FT); }
+            set { Elements.SetName(Keys.FT, value); }
+        }
+
+        /// <summary>The field's partial name ("/T") - this field's <c>name</c> attribute, or a generated fallback.</summary>
+        public string PartialFieldName
+        {
+            get { return Elements.GetString(PdfAnnotation.Keys.T); }
+            set { Elements.SetString(PdfAnnotation.Keys.T, value, PdfStringEncoding.WinAnsiEncoding); }
+        }
+
+        /// <summary>The field flags ("/Ff") - see the FieldFlags constants on each concrete subclass. Distinct from the inherited annotation-level <see cref="PdfAnnotation.Flags"/> ("/F"), a different key entirely.</summary>
+        public int FieldFlags
+        {
+            get { return Elements.GetInteger(Keys.Ff); }
+            set { Elements.SetInteger(Keys.Ff, value); }
+        }
+
+        /// <summary>The default appearance string ("/DA") - font/size/color operators for generating a text-like appearance.</summary>
+        public string DefaultAppearance
+        {
+            get { return Elements.GetString(Keys.DA); }
+            set { Elements.SetString(Keys.DA, value, PdfStringEncoding.WinAnsiEncoding); }
+        }
+
+        /// <summary>The appearance state ("/AS") selecting which subdictionary of "/AP" applies - e.g. "/Yes" or "/Off".</summary>
+        public string AppearanceState
+        {
+            get { return Elements.GetName(PdfAnnotation.Keys.AS); }
+            set { Elements.SetName(PdfAnnotation.Keys.AS, value); }
+        }
+
+        /// <summary>
+        /// Predefined keys of this dictionary, extending <see cref="PdfAnnotation.Keys"/> with the
+        /// field-dictionary entries a merged field/widget object also carries (ISO 32000-1 Table 220).
+        /// </summary>
+        internal new class Keys : PdfAnnotation.Keys
+        {
+            [KeyInfo(KeyType.Name | KeyType.Optional)]
+            public const string FT = "/FT";
+
+            [KeyInfo(KeyType.Dictionary | KeyType.Optional)]
+            public const string Parent = "/Parent";
+
+            [KeyInfo(KeyType.Array | KeyType.Optional)]
+            public const string Kids = "/Kids";
+
+            [KeyInfo(KeyType.Integer | KeyType.Optional)]
+            public const string Ff = "/Ff";
+
+            [KeyInfo(KeyType.Various | KeyType.Optional)]
+            public const string V = "/V";
+
+            [KeyInfo(KeyType.Various | KeyType.Optional)]
+            public const string DV = "/DV";
+
+            [KeyInfo(KeyType.String | KeyType.Optional)]
+            public const string DA = "/DA";
+
+            [KeyInfo(KeyType.Integer | KeyType.Optional)]
+            public const string MaxLen = "/MaxLen";
+
+            [KeyInfo(KeyType.Array | KeyType.Optional)]
+            public const string Opt = "/Opt";
+
+            public static DictionaryMeta Meta => _meta ??= CreateMeta(typeof(Keys));
+
+            static DictionaryMeta _meta = null!;
+        }
+
+        internal override DictionaryMeta Meta => Keys.Meta;
+    }
+}

--- a/src/PeachPDF/PdfSharpCore/Pdf.AcroForms/PdfAcroForm.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf.AcroForms/PdfAcroForm.cs
@@ -1,0 +1,78 @@
+using PeachPDF.PdfSharpCore.Pdf.Internal;
+
+namespace PeachPDF.PdfSharpCore.Pdf.AcroForms
+{
+    /// <summary>
+    /// The document's interactive form dictionary ("/AcroForm", ISO 32000-1 §12.7.2). Lazily created
+    /// by <see cref="Advanced.PdfCatalog.AcroForm"/> only when interactive PDF forms output is
+    /// enabled - see that property's own doc comment.
+    /// </summary>
+    internal sealed class PdfAcroForm : PdfDictionary
+    {
+        public PdfAcroForm(PdfDocument document)
+            : base(document)
+        {
+        }
+
+        /// <summary>The document's top-level fields ("/Fields") - one entry per text/checkbox/radio-group/combo field; a radio group's own widget kids are not listed here.</summary>
+        public PdfArray Fields
+        {
+            get { return _fields ??= (PdfArray)Elements.GetValue(Keys.Fields, VCF.CreateIndirect); }
+        }
+        PdfArray _fields = null!;
+
+        /// <summary>Appends a top-level field.</summary>
+        public void AddField(PdfAcroField field)
+        {
+            Owner.Internals.AddObject(field);
+            Fields.Elements.Add(field.Reference);
+        }
+
+        /// <summary>The default appearance string ("/DA") every field's own "/DA" (absent) falls back to.</summary>
+        public string DefaultAppearance
+        {
+            get { return Elements.GetString(Keys.DA); }
+            set { Elements.SetString(Keys.DA, value, PdfStringEncoding.WinAnsiEncoding); }
+        }
+
+        /// <summary>The default resource dictionary ("/DR") - the shared Helvetica font resource every field's "/DA" and generated appearance stream references.</summary>
+        public PdfDictionary DefaultResources
+        {
+            get { return _defaultResources ??= (PdfDictionary)Elements.GetValue(Keys.DR, VCF.Create); }
+        }
+        PdfDictionary _defaultResources = null!;
+
+        /// <summary>
+        /// Predefined keys of this dictionary.
+        /// </summary>
+        internal sealed class Keys : KeysBase
+        {
+            [KeyInfo(KeyType.Array | KeyType.Required | KeyType.MustBeIndirect)]
+            public const string Fields = "/Fields";
+
+            [KeyInfo(KeyType.Boolean | KeyType.Optional)]
+            public const string NeedAppearances = "/NeedAppearances";
+
+            [KeyInfo(KeyType.Integer | KeyType.Optional)]
+            public const string SigFlags = "/SigFlags";
+
+            [KeyInfo(KeyType.Array | KeyType.Optional)]
+            public const string CO = "/CO";
+
+            [KeyInfo(KeyType.Dictionary | KeyType.Optional)]
+            public const string DR = "/DR";
+
+            [KeyInfo(KeyType.String | KeyType.Optional)]
+            public const string DA = "/DA";
+
+            [KeyInfo(KeyType.Integer | KeyType.Optional)]
+            public const string Q = "/Q";
+
+            public static DictionaryMeta Meta => _meta ??= CreateMeta(typeof(Keys));
+
+            static DictionaryMeta _meta = null!;
+        }
+
+        internal override DictionaryMeta Meta => Keys.Meta;
+    }
+}

--- a/src/PeachPDF/PdfSharpCore/Pdf.AcroForms/PdfCheckBoxField.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf.AcroForms/PdfCheckBoxField.cs
@@ -1,0 +1,24 @@
+namespace PeachPDF.PdfSharpCore.Pdf.AcroForms
+{
+    /// <summary>
+    /// A checkbox AcroForm field ("/FT /Btn", ISO 32000-1 §12.7.4.2.3) - a single terminal field
+    /// with its own two-state appearance dictionary ("/AP /N &lt;&lt; /Yes ... /Off ... &gt;&gt;"),
+    /// unlike <see cref="PdfRadioButtonField"/> which is a group of separate widgets.
+    /// </summary>
+    internal sealed class PdfCheckBoxField : PdfAcroField
+    {
+        public PdfCheckBoxField(PdfDocument document)
+            : base(document)
+        {
+            Elements.SetName(Keys.Subtype, "/Widget");
+            FieldType = "/Btn";
+        }
+
+        /// <summary>The checkbox's export value ("/V") when checked - "/Off" when unchecked.</summary>
+        public string Value
+        {
+            get { return Elements.GetName(Keys.V); }
+            set { Elements.SetName(Keys.V, value); }
+        }
+    }
+}

--- a/src/PeachPDF/PdfSharpCore/Pdf.AcroForms/PdfComboBoxField.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf.AcroForms/PdfComboBoxField.cs
@@ -1,0 +1,52 @@
+namespace PeachPDF.PdfSharpCore.Pdf.AcroForms
+{
+    /// <summary>
+    /// A combo box (drop-down) AcroForm field ("/FT /Ch" with the Combo flag, ISO 32000-1 §12.7.4.4)
+    /// - PeachPDF's mapping for a classified <c>&lt;select&gt;</c> element.
+    /// </summary>
+    internal sealed class PdfComboBoxField : PdfAcroField
+    {
+        /// <summary>Bit 18 (ISO 32000-1 Table 230) - the choice field is a combo box rather than a scrollable list box.</summary>
+        internal const int ComboFlag = 1 << 17;
+
+        public PdfComboBoxField(PdfDocument document)
+            : base(document)
+        {
+            Elements.SetName(Keys.Subtype, "/Widget");
+            FieldType = "/Ch";
+            FieldFlags = ComboFlag;
+        }
+
+        /// <summary>The selected option's export value ("/V").</summary>
+        public string Value
+        {
+            get { return Elements.GetString(Keys.V); }
+            set { Elements.SetString(Keys.V, value ?? string.Empty, PdfStringEncoding.WinAnsiEncoding); }
+        }
+
+        /// <summary>
+        /// Sets the "/Opt" array from the &lt;select&gt;'s &lt;option&gt; children - a plain string
+        /// per option when its export value equals its display label (the common case), else a
+        /// two-element [value, label] array (ISO 32000-1 Table 231).
+        /// </summary>
+        public void SetOptions(System.Collections.Generic.IReadOnlyList<(string Value, string Label)> options)
+        {
+            var array = new PdfArray(Owner);
+            foreach (var (value, label) in options)
+            {
+                if (value == label)
+                {
+                    array.Elements.Add(new PdfString(label, PdfStringEncoding.WinAnsiEncoding));
+                }
+                else
+                {
+                    var pair = new PdfArray(Owner);
+                    pair.Elements.Add(new PdfString(value, PdfStringEncoding.WinAnsiEncoding));
+                    pair.Elements.Add(new PdfString(label, PdfStringEncoding.WinAnsiEncoding));
+                    array.Elements.Add(pair);
+                }
+            }
+            Elements.SetObject(Keys.Opt, array);
+        }
+    }
+}

--- a/src/PeachPDF/PdfSharpCore/Pdf.AcroForms/PdfRadioButtonField.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf.AcroForms/PdfRadioButtonField.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+
+namespace PeachPDF.PdfSharpCore.Pdf.AcroForms
+{
+    /// <summary>
+    /// A radio button group AcroForm field ("/FT /Btn" with the Radio flag, ISO 32000-1 §12.7.4.2.3).
+    /// Unlike PeachPDF's other field kinds, this is deliberately non-terminal: PDF requires every
+    /// radio button sharing the same HTML <c>name</c> attribute to be a widget-kid of one shared
+    /// field object with mutually exclusive "/AS" appearance states, not four independent fields -
+    /// so this class does not merge field and widget the way <see cref="PdfAcroField"/>'s other
+    /// subclasses do (it declares no "/Subtype"/"/Rect"/"/AP" of its own; those live on each
+    /// <see cref="PdfWidgetAnnotation"/> kid instead). It still derives from <see cref="PdfAcroField"/>
+    /// for the shared /FT, /T, /Ff, /V storage - the inherited annotation-only members (Rectangle,
+    /// AppearanceState, etc.) are simply never set on this object.
+    /// </summary>
+    internal sealed class PdfRadioButtonField : PdfAcroField
+    {
+        /// <summary>Bit 16 (ISO 32000-1 Table 227) - marks a button field as a set of radio buttons rather than a checkbox.</summary>
+        internal const int RadioFlag = 1 << 15;
+
+        readonly List<PdfWidgetAnnotation> _kids = [];
+
+        public PdfRadioButtonField(PdfDocument document)
+            : base(document)
+        {
+            FieldType = "/Btn";
+            FieldFlags = RadioFlag;
+        }
+
+        /// <summary>The export value ("/V") of the currently-selected button in the group, or "/Off" when none is checked.</summary>
+        public string Value
+        {
+            get { return Elements.GetName(Keys.V); }
+            set { Elements.SetName(Keys.V, value); }
+        }
+
+        /// <summary>
+        /// Appends a widget as a kid of this field ("/Kids"), setting the kid's own "/Parent" back-reference.
+        /// </summary>
+        public void AddKid(PdfWidgetAnnotation widget)
+        {
+            Owner.Internals.AddObject(widget);
+            widget.FieldParent = this;
+            _kids.Add(widget);
+
+            var array = Elements.GetArray(Keys.Kids);
+            if (array == null)
+            {
+                array = new PdfArray(Owner);
+                Elements.SetObject(Keys.Kids, array);
+            }
+            array.Elements.Add(widget.Reference);
+        }
+
+        /// <summary>The widgets appended via <see cref="AddKid"/>, in the order they were added.</summary>
+        public IReadOnlyList<PdfWidgetAnnotation> Kids => _kids;
+    }
+}

--- a/src/PeachPDF/PdfSharpCore/Pdf.AcroForms/PdfTextField.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf.AcroForms/PdfTextField.cs
@@ -1,0 +1,37 @@
+namespace PeachPDF.PdfSharpCore.Pdf.AcroForms
+{
+    /// <summary>
+    /// A single-line text AcroForm field ("/FT /Tx", ISO 32000-1 §12.7.4.3) - covers PeachPDF's
+    /// "text" field kind (see FormFieldMapper.FormFieldKind.Text), which itself collapses every
+    /// text-like HTML input type (text/email/password/number/...) to this one PDF field type.
+    /// </summary>
+    internal sealed class PdfTextField : PdfAcroField
+    {
+        /// <summary>Bit 24 (ISO 32000-1 Table 228) - the field does not scroll to accommodate more text than fits in its rect.</summary>
+        internal const int DoNotScrollFlag = 1 << 23;
+
+        /// <summary>Bit 25 (ISO 32000-1 Table 228) - the field is divided into MaxLen equally spaced character cells.</summary>
+        internal const int CombFlag = 1 << 24;
+
+        public PdfTextField(PdfDocument document)
+            : base(document)
+        {
+            Elements.SetName(Keys.Subtype, "/Widget");
+            FieldType = "/Tx";
+        }
+
+        /// <summary>The field's current text value ("/V").</summary>
+        public string Value
+        {
+            get { return Elements.GetString(Keys.V); }
+            set { Elements.SetString(Keys.V, value ?? string.Empty, PdfStringEncoding.WinAnsiEncoding); }
+        }
+
+        /// <summary>The comb cell count ("/MaxLen") - only meaningful together with <see cref="CombFlag"/>.</summary>
+        public int MaxLen
+        {
+            get { return Elements.GetInteger(Keys.MaxLen); }
+            set { Elements.SetInteger(Keys.MaxLen, value); }
+        }
+    }
+}

--- a/src/PeachPDF/PdfSharpCore/Pdf.AcroForms/PdfWidgetAnnotation.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf.AcroForms/PdfWidgetAnnotation.cs
@@ -1,0 +1,37 @@
+using PeachPDF.PdfSharpCore.Pdf.Annotations;
+
+namespace PeachPDF.PdfSharpCore.Pdf.AcroForms
+{
+    /// <summary>
+    /// A standalone Widget annotation for one radio button in a <see cref="PdfRadioButtonField"/>
+    /// group - see that class's own doc comment for why radio buttons are the one case that cannot
+    /// merge field and widget into a single object the way <see cref="PdfAcroField"/>'s other
+    /// subclasses do.
+    /// </summary>
+    internal sealed class PdfWidgetAnnotation : PdfAnnotation
+    {
+        public PdfWidgetAnnotation(PdfDocument document)
+            : base(document)
+        {
+            Elements.SetName(PdfAnnotation.Keys.Subtype, "/Widget");
+        }
+
+        /// <summary>The owning <see cref="PdfRadioButtonField"/> ("/Parent") - the field's own /FT, /T and /V live there, not here. Distinct from the inherited annotation-level <see cref="PdfAnnotation.Parent"/> (the page's <see cref="PdfAnnotations"/> collection), an unrelated key.</summary>
+        public PdfAcroField FieldParent
+        {
+            get { return (PdfAcroField)Elements.GetDictionary(PdfAcroField.Keys.Parent); }
+            set { Elements.SetReference(PdfAcroField.Keys.Parent, value); }
+        }
+
+        /// <summary>This widget's own appearance state ("/AS") - "/Off" or its export value when this is the selected button in the group.</summary>
+        public string AppearanceState
+        {
+            get { return Elements.GetName(PdfAnnotation.Keys.AS); }
+            set { Elements.SetName(PdfAnnotation.Keys.AS, value); }
+        }
+
+        // No Meta override, matching PdfAnnotation's own base class: it leaves Meta at PdfDictionary's
+        // default (null) rather than declaring one, and this type adds no keys of its own beyond
+        // PdfAnnotation's - see PdfAcroField's own override for the shape when one is warranted.
+    }
+}

--- a/src/PeachPDF/PdfSharpCore/Pdf.Advanced/PdfCatalog.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf.Advanced/PdfCatalog.cs
@@ -27,6 +27,7 @@
 // DEALINGS IN THE SOFTWARE.
 #endregion
 
+using PeachPDF.PdfSharpCore.Pdf.AcroForms;
 using PeachPDF.PdfSharpCore.Pdf.IO;
 using PeachPDF.PdfSharpCore.Pdf.Structure;
 
@@ -166,6 +167,17 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
         PdfStructureTreeRoot _structureTreeRoot = null!;
 
         /// <summary>
+        /// Gets the interactive form dictionary ("/AcroForm"), lazily creating it on first access.
+        /// Only ever touched when interactive PDF forms output is enabled - untouched, this stays
+        /// null and no indirect object is allocated for it.
+        /// </summary>
+        internal PdfAcroForm AcroForm
+        {
+            get { return _acroForm ??= (PdfAcroForm)Elements.GetValue(Keys.AcroForm, VCF.CreateIndirect); }
+        }
+        PdfAcroForm _acroForm = null!;
+
+        /// <summary>
         /// Gets the mark information dictionary ("/MarkInfo"), lazily creating it on first access.
         /// </summary>
         internal PdfMarkInformation MarkInfo
@@ -182,6 +194,7 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
             _pages?.PrepareForSave();
 
             _structureTreeRoot?.PrepareForSave();
+            _acroForm?.PrepareForSave();
 
             if (_outline == null || _outline.Outlines.Count <= 0) return;
 
@@ -280,6 +293,13 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
             /// </summary>
             [KeyInfo("1.3", KeyType.Dictionary | KeyType.Optional, typeof(PdfStructureTreeRoot))]
             public const string StructTreeRoot = "/StructTreeRoot";
+
+            /// <summary>
+            /// (Optional; must be an indirect reference) The document's interactive form (AcroForm)
+            /// dictionary.
+            /// </summary>
+            [KeyInfo("1.2", KeyType.Dictionary | KeyType.Optional, typeof(PdfAcroForm))]
+            public const string AcroForm = "/AcroForm";
 
             /// <summary>
             /// (Optional; PDF 1.4) A mark information dictionary containing information

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -746,6 +746,54 @@
       }
     },
     {
+      "name": "-peachpdf-pdf-form-field",
+      "comment": "PeachPDF's PDF-output extension for interactive form fields (no W3C spec - see issue #709). auto infers the field kind from the element (tag name + <input type=>) via FormFieldMapper.Classify; text/checkbox/radio/select force a kind regardless of the element's own type. Inert unless PdfGenerateConfig.EnableInteractivePdfForms is set, and only ever applies to a real <input>/<select> element - a declaration on any other element is simply ignored. cssom/string-stored, like -peachpdf-pdf-tag-type - FormFieldMapper re-resolves the raw string via Map.PdfFormFieldKinds.",
+      "inherited": false,
+      "initialValue": "auto",
+      "cssDataType": "cssom",
+      "html": {
+        "propertyPath": "PdfFormField",
+        "csharpDataType": "string",
+        "area": "GeneratedContentArea"
+      }
+    },
+    {
+      "name": "-peachpdf-pdf-form-field-auto-font-size",
+      "comment": "PeachPDF's own spelling of Prince's -prince-pdf-form-field-settings 'auto-font-size' sub-option (see the shorthand's own entry) - when auto, a generated text field's /DA font size is written as 0 (PDF's own auto-size convention) instead of a fixed size. Only meaningful when the element also classifies to a text field.",
+      "inherited": false,
+      "initialValue": "none",
+      "cssDataType": "cssom",
+      "html": {
+        "propertyPath": "PdfFormFieldAutoFontSize",
+        "csharpDataType": "string",
+        "area": "GeneratedContentArea"
+      }
+    },
+    {
+      "name": "-peachpdf-pdf-form-field-comb",
+      "comment": "PeachPDF's own spelling of Prince's -prince-pdf-form-field-settings 'comb(<integer>)' sub-option (see the shorthand's own entry) - none | <integer>, the number of evenly-spaced character cells. Sets the PDF field flag bit Comb and /MaxLen. Only meaningful when the element also classifies to a text field.",
+      "inherited": false,
+      "initialValue": "none",
+      "cssDataType": "cssom",
+      "html": {
+        "propertyPath": "PdfFormFieldComb",
+        "csharpDataType": "string",
+        "area": "GeneratedContentArea"
+      }
+    },
+    {
+      "name": "-peachpdf-pdf-form-field-do-not-scroll",
+      "comment": "PeachPDF's own spelling of Prince's -prince-pdf-form-field-settings 'do-not-scroll' sub-option (see the shorthand's own entry) - sets the PDF field flag bit DoNotScroll. No appearance-stream effect, just a flag PDF readers use for their own editing UI. Only meaningful when the element also classifies to a text field.",
+      "inherited": false,
+      "initialValue": "none",
+      "cssDataType": "cssom",
+      "html": {
+        "propertyPath": "PdfFormFieldDoNotScroll",
+        "csharpDataType": "string",
+        "area": "GeneratedContentArea"
+      }
+    },
+    {
       "name": "bookmark-level",
       "comment": "CSS Generated Content Module Level 3 §2 (https://www.w3.org/TR/css-content-3/#bookmark-level). cssom/string-stored, like -peachpdf-pdf-tag-type - BookmarkOutlineBuilder parses the raw none/<integer> string itself (mirroring StructureTagMapper.Classify's own re-parse of PdfTagType), since the CSS-OM BookmarkLevelProperty converter (Converters.BookmarkLevelConverter) already validates the grammar at declaration time. h1-h6 default to 1-6 via CssDefaults.cs's UA stylesheet, everything else defaults to none (this property's own initial value), which is itself the zero-config \"no bookmarks\" state.",
       "inherited": false,


### PR DESCRIPTION
## Summary
- Turns `<input>`/`<select>` into real, fillable AcroForm fields (text, checkbox, radio group, select) instead of PeachPDF's default static rendering, gated behind `PdfGenerateConfig.EnableInteractivePdfForms` (off by default, zero-cost when unused).
- Field appearance streams are drawn through PeachPDF's own real rendering pipeline, so a field's border, background, padding, text color, and font are ordinary author-controlled CSS - including real font embedding, not just the PDF standard fonts.
- Adds a `-peachpdf-pdf-form-field` property (auto/none/text/checkbox/radio/select) plus `auto-font-size`/`comb`/`do-not-scroll` sub-settings and a `-prince-pdf-form-field-settings` compat shorthand.
- Includes a separate, unrelated fix: a `display:none` child was being misclassified as block-in-inline by `DomParser`, hoisting it out of its real parent (found while building this feature).

## Test plan
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - 8617 passed, 0 failed
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` - 0 warnings, 0 errors
- [x] Diff coverage - 96% (90% gate)
- [x] Rasterized the new TestHarness showcase with both PDFium and MuPDF - custom border/background/padding/color/embedded font all render correctly and agree between both renderers
- [x] Manually opened the showcase PDF in a real reader to confirm the fields are fillable/interactive

Fixes #709