### PR TITLE
Add support for the caption-side CSS property

### DIFF
--- a/.claude/accepted-gaps/table-caption-painted-inside-the-tables-own-border-background-box.md
+++ b/.claude/accepted-gaps/table-caption-painted-inside-the-tables-own-border-background-box.md
@@ -1,0 +1,26 @@
+# A table's caption is painted inside the table's own border/background box, not a separate wrapper box
+
+[CSS 2.1 §17.4](https://www.w3.org/TR/CSS21/tables.html#caption-position) models a `<table>` and its
+`<caption>` as living inside an anonymous "table wrapper box": the table's own `border`/`background`/
+`padding`/`margin` apply to the *grid* only, and the caption sits outside that box (above or below it,
+per `caption-side`), inside the wrapper instead.
+
+PeachPDF doesn't synthesize a separate wrapper box. `CssLayoutEngineTable` (`LayoutCaptionGroup`,
+called from `LayoutCells` for a top caption and from `LayoutBodyRows`' Step 7 for a bottom one) positions
+each caption inside the same `CssBox` that represents the `<table>` element itself — the one whose
+border/background/`ActualBottom` painting already covers the grid. A table with a visible `border` or
+`background-color` therefore paints that border/background behind the caption's own area too, rather
+than around the grid only. Verified visually (PDFium and MuPDF rasterization, agreeing) as part of the
+`caption-side` implementation: a bordered table's border encloses both the caption and the row grid as
+one rectangle.
+
+Tracked as [#721](https://github.com/jhaygood86/PeachPDF/issues/721).
+
+**Deliberately out of scope** of the `caption-side` positioning fix (top/bottom stacking) this gap was
+found alongside. Closing it properly means giving a `<table>` with a caption an anonymous wrapper
+ancestor that owns the margin box and paints nothing itself, while the existing `CssBox` continues to
+own the grid's border/background/padding exactly as it does today — a structural change (a new anonymous
+box kind, plus updating every place that currently treats "the table's `CssBox`" and "the table's outer
+box" as the same box) well beyond what stacking the caption above or below the grid needed. Most
+real-world tables put borders on cells rather than on `<table>` itself, which is why this reads as
+cosmetic in practice rather than as a correctness bug most documents would hit.

--- a/.claude/migration-notes/2026-08-12-table-caption-now-gets-a-real-position.md
+++ b/.claude/migration-notes/2026-08-12-table-caption-now-gets-a-real-position.md
@@ -1,0 +1,15 @@
+# `<caption>` inside a `<table>` now gets a real position, and `caption-side` now works
+
+Previously: a `<caption>` element inside a `<table>` was never assigned a position by
+`CssLayoutEngineTable` at all — it kept whatever degenerate zero-size geometry an unlaid-out box starts
+with, so it did not reliably appear above the table (or anywhere in particular). The `caption-side`
+CSS property parsed successfully but had no effect on layout.
+
+Now: a `<caption>` is laid out as a full-width block stacked above the table's row grid
+(`caption-side: top`, the initial value — CSS 2.1 §17.4) or below it (`caption-side: bottom`), matching
+the table's own content width. Any existing document with a `<caption>` will now render it in that
+position instead of not rendering it correctly. Both the caption and the row grid are painted inside the
+same box the `<table>` element's own `border`/`background-color` apply to, so a bordered or filled table
+now visually encloses the caption too — see the accepted-gap note on this (tracked as
+[#721](https://github.com/jhaygood86/PeachPDF/issues/721)) for the one respect in which this isn't full
+CSS 2.1 §17.4 conformance (a separate "table wrapper box" that the caption sits outside of).

--- a/.claude/recent-fixes/2026-08-12-caption-side.md
+++ b/.claude/recent-fixes/2026-08-12-caption-side.md
@@ -1,0 +1,49 @@
+# `caption-side` support (issue #705)
+
+`caption-side: top | bottom` (CSS 2.1 §17.4) was fully unimplemented: `CssLayoutEngineTable
+.AssignBoxKinds` had a bare `case Keywords.TableCaption: break;`, so a `<caption>` box was never added
+to any of the engine's row/column bookkeeping and never assigned a position — it kept whatever
+degenerate `Location`/`ActualBottom` it started with. The CSS-OM parsing/converter plumbing for the
+property already existed (`CaptionSideProperty`, `Converters.CaptionSideConverter`,
+`PropertyFactory`), but nothing downstream read it.
+
+**Load-bearing finding, discovered by running it rather than by reading the diff**: giving `<caption>`
+a real position needed two changes, not one. Registering `caption-side` in `css-properties.json` and
+teaching `CssLayoutEngineTable` to position the caption (new `LayoutCaptionGroup`, called from
+`LayoutCells` for a top caption and from `LayoutBodyRows`' Step 7 for a bottom one) produced a caption
+with zero height in every test — `CssBox.PlacesItselfAsBlockBox` gates `LayoutContents`'s real dispatch,
+and `table-caption` wasn't in its list, so the caption fell into the "copy the previous sibling's
+geometry" fallback documented on that property. `table-cell` is in the same list for the identical
+reason (its position is also engine-assigned, not frame-assigned), which is the precedent this fix
+follows — adding `Keywords.TableCaption` alongside it.
+
+**A second bug was caught by a review pass, not by the tests written alongside the feature**: the initial
+`LayoutCaptionGroup` call sites used `_tableBox.ClientLeft` (already inset by the table's own left
+border) as the caption's `x` together with `GetWidthSum()` (which independently adds both border widths
+on top of the column/spacing sum) as its width — double-counting the left border and shifting the
+caption right by exactly that amount. Invisible in the original three tests because none of them put a
+border on the `<table>` element itself (only on `td`), and easy to miss visually at a thin border width
+in a rendered screenshot. Fixed by using `_tableBox.Location.X` (the table's true border-box left edge)
+instead. A fourth test (`TableCaption_TableHasItsOwnBorder_CaptionStillAlignsWithBorderBox`) pins this:
+a table with its own `border` whose caption must still align with `Location.X`/`ActualRight`.
+
+**Deliberately out of scope**: CSS 2.1 §17.4 models the table+caption as living inside an anonymous
+"table wrapper box", with the table's own border/background applying to the grid only. PeachPDF has no
+such wrapper — the caption is laid out inside the same `CssBox` that owns the table's border/background,
+so a bordered/filled `<table>` visually encloses the caption too. Recorded as an accepted gap
+(`.claude/accepted-gaps/table-caption-painted-inside-the-tables-own-border-background-box.md`, tracked
+as [#721](https://github.com/jhaygood86/PeachPDF/issues/721)) rather than fixed here — closing it needs
+a new anonymous-box kind, well beyond what stacking the caption above/below the grid required.
+
+Whole-table page-break relocation (the two pre-checks in `LayoutBodyRows` that move `_tableBox.Location`
+when the first row wouldn't otherwise fit) now also calls `caption.OffsetTop(pageBreakOffset)` for
+already-laid-out top captions, mirroring the existing `_headerBox.OffsetTop(pageBreakOffset)` call —
+verified visually (PDFium rasterization) with a table pushed to a second page: the caption and table
+relocated together, nothing stranded on the first page.
+
+**Evidence**: 4 new unit tests in `CssLayoutEngineTableTests.cs` plus a round-trip row in
+`CssUtilsTests.cs`; full suite (8622 tests, net8.0 and net10.0) passes; 100% diff coverage
+(`diff-cover` against `origin/main`); `dotnet build -t:Rebuild` on the whole solution is warning-free;
+all 91 TestHarness showcases (including the new `table_caption` one) regenerate without error; visual
+verification via both PDFium and MuPDF rasterization for top/bottom captions, a table with its own
+border, and cross-page relocation.

--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -766,6 +766,7 @@ Limitations:
 | Property | MDN Reference | Notes |
 |----------|--------------|-------|
 | `empty-cells` | [empty-cells](https://developer.mozilla.org/en-US/docs/Web/CSS/empty-cells) | `show`, `hide` |
+| `caption-side` | [caption-side](https://developer.mozilla.org/en-US/docs/Web/CSS/caption-side) | `top` (default), `bottom` — a `table-caption` box is stacked above or below the table's row grid and stretched to the table's own content width. Painted inside the `<table>` element's own border/background box rather than a separate outer "table wrapper box", so a bordered or filled table's border/background extends behind the caption too, which [CSS 2.1 §17.4](https://www.w3.org/TR/CSS21/tables.html#caption-position) does not ask for |
 
 ### Generated Content
 

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -7213,6 +7213,52 @@ await SaveShowcaseAsync("table_visibility_collapse", "Layout", "Table Row/Column
     + "unlike visibility: hidden which still reserves the space.",
     visibilityCollapseHtml, pdfConfig);
 
+// --- caption-side showcase (issue #705) ---
+//
+// caption-side was previously unimplemented: a <table>'s <caption> child was never assigned a
+// position at all by CssLayoutEngineTable.AssignBoxKinds, so it painted with degenerate zero-height
+// geometry. This exercises both values (CSS 2.1 §17.4's only two: top, the initial value, and
+// bottom), stacked above or below the row grid and stretched to the table's own content width.
+var tableCaptionHtml = """
+    <!DOCTYPE html><html><head><style>
+    @page { size: a5 landscape; margin: 12mm }
+    body { font: 10pt Helvetica, Arial, sans-serif; margin: 0; color: #1f2937 }
+    h1 { font-size: 14pt; margin: 0 0 0.3em }
+    h2 { font-size: 11pt; margin: 1.2em 0 0.4em }
+    p.intro { color: #6b7280; font-size: 9pt; margin: 0 0 0.6em; max-width: 34em }
+    table { border-collapse: separate; border-spacing: 0; margin-bottom: 0.6em; border: 1.5pt solid #334155 }
+    caption { font-weight: 600; padding: 5pt; background: #eef2ff; text-align: center }
+    td, th { border: 0.75pt solid #94a3b8; padding: 4pt 8pt; text-align: left }
+    th { background: #f8fafc }
+    #bottom-table caption { caption-side: bottom }
+    </style></head><body>
+    <h1>caption-side: Positioning a &lt;caption&gt; Above or Below a Table</h1>
+    <p class="intro">caption-side's only two values (CSS 2.1 §17.4) stack the caption above the row
+    grid (<code>top</code>, the initial value) or below it (<code>bottom</code>) - always spanning the
+    table's own content width.</p>
+
+    <h2>caption-side: top (default)</h2>
+    <table>
+    <caption>Table 1. Quarterly results by region</caption>
+    <tr><th>Region</th><th>Q1</th><th>Q2</th></tr>
+    <tr><td>North</td><td>120</td><td>135</td></tr>
+    <tr><td>South</td><td>98</td><td>110</td></tr>
+    </table>
+
+    <h2>caption-side: bottom</h2>
+    <table id="bottom-table">
+    <caption>Table 2. Same data, caption moved below the table</caption>
+    <tr><th>Region</th><th>Q1</th><th>Q2</th></tr>
+    <tr><td>North</td><td>120</td><td>135</td></tr>
+    <tr><td>South</td><td>98</td><td>110</td></tr>
+    </table>
+    </body></html>
+    """;
+await SaveShowcaseAsync("table_caption", "Layout", "Table Captions (caption-side)",
+    "caption-side: top (the initial value) and bottom (CSS 2.1 §17.4), stacking a <table>'s <caption> "
+    + "above or below its row grid and stretching it to the table's own content width.",
+    tableCaptionHtml, pdfConfig);
+
 // --- interactive PDF forms showcase ---
 //
 // See docs/html-css-support.md#interactive-pdf-forms-support. EnableInteractivePdfForms turns

--- a/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTableTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTableTests.cs
@@ -863,6 +863,151 @@ Assert.NotNull(tbody);
 
         #endregion
 
+        #region Caption Tests
+
+        [Fact]
+        public async Task TableCaption_DefaultCaptionSide_LaysOutAboveRows()
+        {
+            // caption-side's initial value is "top" (CSS 2.1 §17.4) - a <caption> with no explicit
+            // caption-side should land above the row grid, not overlap or follow it.
+            var html = @"
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        table { border-collapse: separate; border-spacing: 0; }
+        td { border: 1px solid black; padding: 4px; }
+    </style>
+</head>
+<body>
+    <table>
+        <caption id='cap'>Table caption</caption>
+        <tr><td id='cell1'>A</td><td>B</td></tr>
+        <tr><td>C</td><td>D</td></tr>
+    </table>
+</body>
+</html>";
+
+            var (rootBox, _) = await BuildCssBoxTree(html);
+            var table = FindTableBox(rootBox);
+            var caption = FindById(rootBox, "cap");
+            var firstCell = FindById(rootBox, "cell1");
+
+            Assert.NotNull(table);
+            Assert.NotNull(caption);
+            Assert.NotNull(firstCell);
+
+            Assert.True(caption!.ActualBottom > caption.Location.Y, "Caption should have height");
+            Assert.Equal(table!.Location.Y, caption.Location.Y, 1);
+            Assert.True(firstCell!.Location.Y >= caption.ActualBottom - 0.01,
+                "First row should be laid out below the caption");
+        }
+
+        [Fact]
+        public async Task TableCaption_CaptionSideBottom_LaysOutBelowRows()
+        {
+            var html = @"
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        table { border-collapse: separate; border-spacing: 0; }
+        td { border: 1px solid black; padding: 4px; }
+        caption { caption-side: bottom; }
+    </style>
+</head>
+<body>
+    <table>
+        <caption id='cap'>Table caption</caption>
+        <tr><td>A</td><td>B</td></tr>
+        <tr><td id='cell2'>C</td><td>D</td></tr>
+    </table>
+</body>
+</html>";
+
+            var (rootBox, _) = await BuildCssBoxTree(html);
+            var table = FindTableBox(rootBox);
+            var caption = FindById(rootBox, "cap");
+            var lastCell = FindById(rootBox, "cell2");
+
+            Assert.NotNull(table);
+            Assert.NotNull(caption);
+            Assert.NotNull(lastCell);
+
+            Assert.True(caption!.ActualBottom > caption.Location.Y, "Caption should have height");
+            Assert.True(caption.Location.Y >= lastCell!.ActualBottom - 0.01,
+                "Caption should be laid out below the last row");
+            Assert.Equal(table!.ActualBottom, caption.ActualBottom, 1);
+        }
+
+        [Fact]
+        public async Task TableCaption_SpansFullTableWidth()
+        {
+            var html = @"
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        table { border-collapse: separate; border-spacing: 0; }
+        td { border: 1px solid black; padding: 4px; }
+    </style>
+</head>
+<body>
+    <table>
+        <caption id='cap'>Short</caption>
+        <tr><td>A longer cell than the caption text</td><td>B</td></tr>
+    </table>
+</body>
+</html>";
+
+            var (rootBox, _) = await BuildCssBoxTree(html);
+            var table = FindTableBox(rootBox);
+            var caption = FindById(rootBox, "cap");
+
+            Assert.NotNull(table);
+            Assert.NotNull(caption);
+
+            Assert.Equal(table!.Location.X, caption!.Location.X, 1);
+            Assert.Equal(table.ActualRight, caption.ActualRight, 1);
+        }
+
+        [Fact]
+        public async Task TableCaption_TableHasItsOwnBorder_CaptionStillAlignsWithBorderBox()
+        {
+            // The table element's own border (as opposed to a border on its cells) contributes to
+            // GetWidthSum() - LayoutCaptionGroup must position the caption from the table's true
+            // border-box left edge (Location.X), not from inside it (ClientLeft), or the caption
+            // drifts right by exactly the table's own left border width.
+            var html = @"
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        table { border-collapse: separate; border-spacing: 0; border: 4px solid black; }
+        td { border: 1px solid black; padding: 4px; }
+    </style>
+</head>
+<body>
+    <table>
+        <caption id='cap'>Short</caption>
+        <tr><td>A longer cell than the caption text</td><td>B</td></tr>
+    </table>
+</body>
+</html>";
+
+            var (rootBox, _) = await BuildCssBoxTree(html);
+            var table = FindTableBox(rootBox);
+            var caption = FindById(rootBox, "cap");
+
+            Assert.NotNull(table);
+            Assert.NotNull(caption);
+
+            Assert.Equal(table!.Location.X, caption!.Location.X, 1);
+            Assert.Equal(table.ActualRight, caption.ActualRight, 1);
+        }
+
+        #endregion
+
    #region Helper Methods
 
         private async Task<(CssBox root, HtmlContainerInt container)> BuildCssBoxTree(

--- a/src/PeachPDF.Tests/Html/Core/Utils/CssUtilsTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Utils/CssUtilsTests.cs
@@ -401,7 +401,7 @@ namespace PeachPDF.Tests.Html.Core.Utils
             ["width", "100px"], ["max-width", "200px"], ["min-width", "50px"], ["height", "120px"], ["max-height", "240px"], ["min-height", "60px"],
             ["background-color", "rgb(4, 5, 6)"], ["background-position", "center"], ["background-size", "cover"], ["background-repeat", "no-repeat"],
             ["background-origin", "border-box"], ["background-clip", "padding-box"], ["background-attachment", "fixed"],
-            ["color", "rgb(7, 8, 9)"], ["content", "normal"], ["display", "block"], ["direction", "rtl"], ["empty-cells", "hide"],
+            ["color", "rgb(7, 8, 9)"], ["content", "normal"], ["display", "block"], ["direction", "rtl"], ["empty-cells", "hide"], ["caption-side", "bottom"],
             ["clear", "both"], ["position", "absolute"], ["line-height", "1.5"], ["vertical-align", "middle"], ["text-indent", "20px"],
             ["text-align", "center"], ["text-decoration-color", "rgb(1, 2, 3)"], ["text-decoration-line", "underline"], ["text-decoration-style", "solid"],
             ["text-transform", "uppercase"], ["white-space", "nowrap"], ["word-break", "break-all"], ["visibility", "hidden"], ["word-spacing", "2px"], ["letter-spacing", "1px"],

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -2618,11 +2618,16 @@ namespace PeachPDF.Html.Core.Dom
         /// <c>display: none</c> box, a <c>table-row</c>, a bare inline. So any later code that measures this
         /// box's own height, or moves it, has to ask this first: for those boxes the coordinates belong to
         /// something else and both the measurement and the move are meaningless.
+        /// <c>table-caption</c> is included alongside <c>table-cell</c> for the same reason: like a cell,
+        /// a caption's position is assigned entirely by <see cref="CssLayoutEngineTable"/>
+        /// (<see cref="CssBox.LayoutContentAtItsAssignedPosition"/>) rather than by the generic
+        /// block-flow frame, so it needs <see cref="LayoutContents"/>'s real dispatch rather than the
+        /// sibling-copying fallback that leaves it at a degenerate zero-height Bounds.
         /// </remarks>
         internal bool PlacesItselfAsBlockBox =>
             IsBlock
             || DerivedStyle.ActualDisplay is Keywords.ListItem or Keywords.Table or Keywords.InlineTable
-                       or Keywords.TableCell or Keywords.Flex or Keywords.InlineFlex
+                       or Keywords.TableCell or Keywords.TableCaption or Keywords.Flex or Keywords.InlineFlex
                        or Keywords.Grid or Keywords.InlineGrid;
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
@@ -66,9 +66,30 @@ namespace PeachPDF.Html.Core.Dom
         private readonly List<CssBox> _columns = [];
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         private readonly List<CssBox> _allRows = [];
+
+        /// <summary>
+        /// Every <c>table-caption</c> box among the table's direct children, in source order -
+        /// populated by <see cref="AssignBoxKinds"/> and split by each box's own <c>caption-side</c>
+        /// into <see cref="_topCaptions"/>/<see cref="_bottomCaptions"/>.
+        /// </summary>
+        private readonly List<CssBox> _captionBoxes = [];
+
+        /// <summary>Captions with <c>caption-side: top</c> (the initial value) - laid out above the row grid.</summary>
+        private readonly List<CssBox> _topCaptions = [];
+
+        /// <summary>Captions with <c>caption-side: bottom</c> - laid out below the row grid.</summary>
+        private readonly List<CssBox> _bottomCaptions = [];
+
+        /// <summary>
+        /// The combined height <see cref="_topCaptions"/> occupies above the row grid - set once by
+        /// <see cref="LayoutCells"/> on the pass that lays them out. Left at 0 on a continuation pass,
+        /// which is harmless: every use of it feeds a <c>Math.Max</c> against the resumed page's own
+        /// top (<see cref="ResumedRowTop"/>), which always wins over a stale/zero caption height.
+        /// </summary>
+        private double _topCaptionsHeight;
 
         private int _columnCount;
 
@@ -415,6 +436,7 @@ namespace PeachPDF.Html.Core.Dom
                 switch (box.DerivedStyle.ActualDisplay)
                 {
                     case Keywords.TableCaption:
+                        _captionBoxes.Add(box);
                         break;
                     case Keywords.TableRow:
                         if (!IsRowCollapsed(box))
@@ -492,6 +514,14 @@ namespace PeachPDF.Html.Core.Dom
 
             if (_footerBox != null)
                 _allRows.AddRange(_footerBox.Boxes.Where(r => !IsRowCollapsed(r)));
+
+            // CSS 2.1 §17.4: caption-side's only two values split the table's caption(s) into a group
+            // stacked above the row grid and a group stacked below it - each caption goes by its own
+            // computed value, not the table's or the first caption's.
+            foreach (var caption in _captionBoxes)
+            {
+                (caption.CaptionSide == Keywords.Bottom ? _bottomCaptions : _topCaptions).Add(caption);
+            }
         }
 
         /// <summary>
@@ -1150,13 +1180,56 @@ namespace PeachPDF.Html.Core.Dom
         }
 
         /// <summary>
+        /// Lays <paramref name="captions"/> out as ordinary full-width blocks, stacked in source order
+        /// starting at (<paramref name="x"/>, <paramref name="y"/>) and sized to <paramref name="width"/>
+        /// - CSS 2.1 §17.4: a caption box takes the full width of the table. Each is placed at its own
+        /// assigned position (<see cref="CssBox.LayoutContentAtItsAssignedPosition"/>) rather than
+        /// through the generic block-flow frame, since this engine - not a block-flow cursor a table box
+        /// does not otherwise keep - owns where it goes.
+        /// </summary>
+        /// <returns><paramref name="y"/> unchanged when <paramref name="captions"/> is empty, otherwise
+        /// the bottom edge after the last caption's own bottom margin.</returns>
+        private static async ValueTask<double> LayoutCaptionGroup(
+            RGraphics g, IReadOnlyList<CssBox> captions, double x, double y, double width)
+        {
+            var currentY = y;
+
+            foreach (var caption in captions)
+            {
+                currentY += caption.ActualMarginTop;
+
+                caption.Location = new RPoint(x, currentY);
+                caption.ActualRight = x + width;
+
+                await caption.LayoutContentAtItsAssignedPosition(g);
+
+                currentY = caption.ActualBottom + caption.ActualMarginBottom;
+            }
+
+            return currentY;
+        }
+
+        /// <summary>
         /// Layout the cells by the calculated table layout
         /// </summary>
         /// <param name="g"></param>
         private async ValueTask LayoutCells(RGraphics g)
         {
             var startX = Math.Max(_tableBox.ClientLeft + GetHorizontalSpacing(), 0);
-            var startY = Math.Max(_tableBox.ClientTop + GetVerticalSpacing(), 0);
+
+            // Lay the top caption(s) out above the row grid before anything else claims this
+            // coordinate - once, on the pass that starts the row loop from the top. A continuation
+            // resumes rows on a later fragmentainer and must not redo this: the caption already sits
+            // where the first pass put it, and _topCaptionsHeight staying 0 on that pass is harmless
+            // (see its own remarks).
+            if (!_continuesAPreviousPass && _topCaptions.Count > 0)
+            {
+                var topCaptionsBottom = await LayoutCaptionGroup(
+                    g, _topCaptions, _tableBox.Location.X, _tableBox.ClientTop, GetWidthSum());
+                _topCaptionsHeight = topCaptionsBottom - _tableBox.ClientTop;
+            }
+
+            var startY = Math.Max(_tableBox.ClientTop + _topCaptionsHeight + GetVerticalSpacing(), 0);
 
             var container = _tableBox.HtmlContainer;
             var pageHeight = container?.PageSize.Height ?? double.MaxValue;
@@ -1516,7 +1589,8 @@ namespace PeachPDF.Html.Core.Dom
                         slot, availableHeight, estimatedBodyHeight);
 
                     _tableBox.Location = _tableBox.Location with { Y = _tableBox.Location.Y + pageBreakOffset };
-                    startY = Math.Max(_tableBox.ClientTop + GetVerticalSpacing(), 0);
+                    foreach (var caption in _topCaptions) caption.OffsetTop(pageBreakOffset);
+                    startY = Math.Max(_tableBox.ClientTop + _topCaptionsHeight + GetVerticalSpacing(), 0);
                     // startY is a fresh restart point at the table's own content-top edge on the new
                     // page, not an arbitrary interior coordinate - the same "top edge flush on a
                     // boundary" case HtmlContainerInt.SlotStartingAt exists for (see the identical fix in
@@ -1557,8 +1631,9 @@ namespace PeachPDF.Html.Core.Dom
 
                     _tableBox.Location = _tableBox.Location with { Y = _tableBox.Location.Y + pageBreakOffset };
                     _headerBox.OffsetTop(pageBreakOffset);
+                    foreach (var caption in _topCaptions) caption.OffsetTop(pageBreakOffset);
 
-                    startY = Math.Max(_tableBox.ClientTop + GetVerticalSpacing(), 0);
+                    startY = Math.Max(_tableBox.ClientTop + _topCaptionsHeight + GetVerticalSpacing(), 0);
                     // startY is a fresh restart point at the table's own content-top edge on the new
                     // page, not an arbitrary interior coordinate - the same "top edge flush on a
                     // boundary" case HtmlContainerInt.SlotStartingAt exists for (see the identical fix in
@@ -1833,7 +1908,21 @@ namespace PeachPDF.Html.Core.Dom
             // Step 7: Set final table dimensions
             var tableRight = Math.Max(cursor.MaxRight, _tableBox.Location.X + _tableBox.ActualWidth);
             _tableBox.ActualRight = tableRight + GetHorizontalSpacing() + _tableBox.ActualBorderRightWidth;
-            _tableBox.ActualBottom = Math.Max(cursor.MaxBottom, startY) + GetVerticalSpacing() + _tableBox.ActualBorderBottomWidth;
+
+            // Computed ahead of ActualBottom rather than only assigned to TableContinuation below,
+            // because a bottom caption's placement depends on it: the caption belongs after the
+            // table's very last row, never stitched into the middle of a table still spanning
+            // fragmentainers, so it may only be laid out on the pass that finishes the row loop.
+            var tableContinuation = cursor.Continuation(_tableBox);
+            var contentBottom = Math.Max(cursor.MaxBottom, startY) + GetVerticalSpacing();
+
+            if (tableContinuation is null && _bottomCaptions.Count > 0)
+            {
+                contentBottom = await LayoutCaptionGroup(
+                    g, _bottomCaptions, _tableBox.Location.X, contentBottom, GetWidthSum());
+            }
+
+            _tableBox.ActualBottom = contentBottom + _tableBox.ActualBorderBottomWidth;
 
             // Publish where the row loop stopped, as a copy of the cursor's own state rather than the
             // cursor: a caller that kept one alive past this point would otherwise mutate what it has
@@ -1848,7 +1937,7 @@ namespace PeachPDF.Html.Core.Dom
             // one field for both: BeginLayoutPass clears PendingBreakToken at the top of the table's next
             // layout, and the record has to survive that in order to be handed back to the run that
             // continues it.
-            _tableBox.TableContinuation = cursor.Continuation(_tableBox);
+            _tableBox.TableContinuation = tableContinuation;
 
             if (_tableBox.TableContinuation is { } stopped)
             {

--- a/src/PeachPDF/css-properties.json
+++ b/src/PeachPDF/css-properties.json
@@ -1722,6 +1722,22 @@
       }
     },
     {
+      "name": "caption-side",
+      "inherited": true,
+      "initialValue": "top",
+      "cssDataType": "keyword",
+      "supportedValues": [
+        "top",
+        "bottom"
+      ],
+      "keywordComparison": "invariant-ignore-case",
+      "html": {
+        "propertyPath": "CaptionSide",
+        "csharpDataType": "string",
+        "area": "TableArea"
+      }
+    },
+    {
       "name": "line-height",
       "comment": "CssKeywordOrValue<NormalKeyword, LengthOrUnitless>-backed (issue #598's follow-up) - the tenth and final keyword-or-value batch. Fixes a real pre-existing bug along the way: a bare unitless multiplier (e.g. 'line-height: 1.5') previously validated but silently collapsed ActualLineHeight to 0 (the old string-based ParseLength had no case for a number with no unit token); LengthOrUnitless's Unitless side now resolves it correctly (CSS2.1 §10.8.1: the number times the element's own font size). 'auto' is deliberately not in supportedValues - CSS Inline Layout 3's grammar is 'normal | <number> | <length-percentage>', auto was never part of it.",
       "inherited": true,


### PR DESCRIPTION
## Summary

- `caption-side: top | bottom` (CSS 2.1 §17.4) was fully unimplemented: `CssLayoutEngineTable.AssignBoxKinds` had a no-op case for `table-caption` boxes, so a `<caption>` was never assigned a real position by the table layout engine.
- Registers `caption-side` in `css-properties.json` (keyword, `top`/`bottom`, initial `top`, inherited) and teaches `CssLayoutEngineTable` to stack a table's caption(s) above (`top`, the default) or below (`bottom`) the row grid, spanning the table's own content width.
- An already-laid-out top caption now travels with the table when the whole-table page-break pre-check relocates it to a later page (mirroring the existing header-relocation handling).
- `CssBox.PlacesItselfAsBlockBox` now includes `table-caption` alongside `table-cell`, since a caption's position is assigned by the table engine rather than the generic block-flow frame — without it, the caption fell into the "copy the previous sibling's geometry" fallback and got zero height.

## Test plan

- [x] 4 new unit tests in `CssLayoutEngineTableTests.cs` (default/top caption, bottom caption, full-width caption, caption alignment on a table with its own border) + a round-trip row in `CssUtilsTests.cs`
- [x] Full test suite passes on both net8.0 and net10.0 (8622 tests)
- [x] 100% diff coverage on the changed lines (`diff-cover` against `origin/main`)
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` is warning-free
- [x] New `table_caption` TestHarness showcase added; all 91 showcases regenerate without error
- [x] Visual verification via both PDFium and MuPDF rasterization: top/bottom captions, a bordered table, and cross-page relocation
- [x] `docs/html-css-support.md` updated with a `caption-side` row
- [x] Recorded a narrow, deliberately out-of-scope accepted gap (caption painted inside the table's own border/background box rather than a separate CSS 2.1 "table wrapper box"), tracked as #721

Fixes #705
