### PR TITLE
Fix td middle alignment with explicit height

### DIFF
--- a/.claude/recent-fixes/2026-08-13-td-vertical-align-middle-with-explicit-height.md
+++ b/.claude/recent-fixes/2026-08-13-td-vertical-align-middle-with-explicit-height.md
@@ -1,0 +1,38 @@
+# `vertical-align: middle`/`bottom` no-op on a `<td>` with an explicit `height`
+
+`CssLayoutEngine.ApplyCellVerticalAlignment` computed the cell's content-bottom via
+`CssBox.GetMaximumBottom(cell, 0f)` — passing the **cell itself** as `startBox`. `GetMaximumBottom`'s
+own-height fallback (`CssBox.cs`, `if (startBox.Height is not Keywords.Auto) currentMaxBottom =
+Math.Max(currentMaxBottom, startBox.ActualBottom);`) exists so a childless box with an explicit height
+still reports a sensible bottom. But by the time `ApplyCellVerticalAlignment` runs, the table row loop
+(`CssLayoutEngineTable.cs`) has already set `cell.ActualBottom = rowMaxBottom` — so for a `<td>` that
+also carries a CSS `height`, that fallback clamped the measured "content bottom" back to the exact same
+row-equalized `ActualBottom` used as `cellBottom`. `(cellBottom - bottom) / 2` (middle) and
+`cellBottom - bottom` (bottom) both collapsed to zero regardless of how much shorter the actual content
+was — `vertical-align: middle`/`bottom` silently did nothing whenever the cell also had an explicit
+`height`, which is exactly the combination most authors reach for (a fixed-height row with centered
+text).
+
+**Fix**: measure over the cell's *children* instead of the cell itself — seed at `cell.ClientTop` and
+call `GetMaximumBottom` per child in `cell.Boxes`, never passing the cell itself as `startBox`. This
+keeps the fallback's original intent (an explicit height still counts for a box with no children
+reaching that far) while no longer letting the cell's own row-stretched `ActualBottom` masquerade as its
+content's bottom.
+
+**Existing coverage had actually documented the gap without closing it**:
+`VerticalAlignIntegrationTests.Bottom_OnATableCell_PushesShortContentLowerThanTopAligned` had a comment
+explicitly avoiding an explicit cell `height` "because it would make `GetMaximumBottom` clamp to the
+cell's own already-row-equalized bottom" — i.e. the test was written *around* this bug rather than
+catching it. New test `Middle_OnATableCellWithExplicitHeight_CentersShortContent` covers the case that
+was actually broken (explicit `height` + `vertical-align: middle`); the stale workaround comment on the
+older test was removed since the underlying limitation it described no longer exists.
+
+`CssLayoutEngineTable.cs`'s own two `GetMaximumBottom(cell, ...)` call sites (line ~2791, and
+`SpanningCellBandGeometry` at ~3142) were left untouched — at those call sites `cell.ActualBottom` has
+not yet been stretched to the row's final height when the call happens, so the same clamp isn't
+observed to misfire there; only `ApplyCellVerticalAlignment`, which runs strictly after the row loop
+sets the final `ActualBottom`, was affected.
+
+**Evidence**: new regression test added; `VerticalAlign`/`Table`/`Rowspan`-filtered suite (530 tests)
+and full `PeachPDF.Tests` suite (6616 tests) pass on net8.0; `dotnet build -t:Rebuild` on the whole
+solution is warning-free.

--- a/src/PeachPDF.Tests/Integration/VerticalAlignIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/VerticalAlignIntegrationTests.cs
@@ -161,15 +161,28 @@ namespace PeachPDF.Tests.Integration
                 + "<td style='height:100pt'>Tall</td>"
                 + "<td id='v' style='height:100pt; vertical-align:middle'>Short</td>"
                 + "</tr></table>");
+            var htmlBottom = Wrap(
+                "<table><tr>"
+                + "<td style='height:100pt'>Tall</td>"
+                + "<td id='v' style='height:100pt; vertical-align:bottom'>Short</td>"
+                + "</tr></table>");
 
             var (rootTop, _) = await BuildAndLayout(htmlTop);
             var (rootMiddle, _) = await BuildAndLayout(htmlMiddle);
+            var (rootBottom, _) = await BuildAndLayout(htmlBottom);
 
             var topY = CssBox.FirstWordOccurence(FindById(rootTop, "v")!, FindById(rootTop, "v")!.LineBoxes[0])!.Top;
             var middleY = CssBox.FirstWordOccurence(FindById(rootMiddle, "v")!, FindById(rootMiddle, "v")!.LineBoxes[0])!.Top;
+            var bottomY = CssBox.FirstWordOccurence(FindById(rootBottom, "v")!, FindById(rootBottom, "v")!.LineBoxes[0])!.Top;
 
-            Assert.True(middleY > topY,
-                $"vertical-align:middle ({middleY}) should push the cell's content lower than vertical-align:top ({topY}) even with an explicit cell height");
+            Assert.True(middleY > topY && middleY < bottomY,
+                $"vertical-align:middle ({middleY}) should land strictly between vertical-align:top ({topY}) and vertical-align:bottom ({bottomY}) even with an explicit cell height");
+
+            // ApplyCellVerticalAlignment splits the leftover room evenly for `middle` (half of what
+            // `bottom` moves it by), so middle must sit at the exact midpoint - not merely somewhere
+            // between top and bottom - or a regression that under/over-shoots the centering offset
+            // would still pass the weaker between-top-and-bottom check above.
+            Assert.Equal((topY + bottomY) / 2, middleY, precision: 2);
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/VerticalAlignIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/VerticalAlignIntegrationTests.cs
@@ -122,9 +122,6 @@ namespace PeachPDF.Tests.Integration
             // from the inline ApplyVerticalAlignment exercised by the other tests in this file) - a
             // short cell in a taller row must be pushed all the way to the row's bottom under
             // vertical-align:bottom, unlike vertical-align:top where it stays put.
-            // "v"'s own height is left auto (an explicit height would make GetMaximumBottom clamp to
-            // the cell's own already-row-equalized bottom, leaving no room for the alignment to move
-            // its content within) - the tall sibling alone is what stretches the shared row.
             var htmlTop = Wrap(
                 "<table><tr>"
                 + "<td style='height:100pt'>Tall</td>"
@@ -144,6 +141,35 @@ namespace PeachPDF.Tests.Integration
 
             Assert.True(bottomY > topY,
                 $"vertical-align:bottom ({bottomY}) should push the cell's content lower than vertical-align:top ({topY})");
+        }
+
+        [Fact]
+        public async Task Middle_OnATableCellWithExplicitHeight_CentersShortContent()
+        {
+            // GetMaximumBottom's own-height fallback used to be applied to the cell itself: once the
+            // row-layout loop stretches the cell's ActualBottom to the row's shared height, a cell that
+            // also carries a CSS `height` had its own explicit height clamp the "content bottom" back to
+            // that same row-equalized ActualBottom, making the (cellBottom - bottom) offset always zero -
+            // vertical-align:middle/bottom were silent no-ops whenever a `<td>` had an explicit height.
+            var htmlTop = Wrap(
+                "<table><tr>"
+                + "<td style='height:100pt'>Tall</td>"
+                + "<td id='v' style='height:100pt; vertical-align:top'>Short</td>"
+                + "</tr></table>");
+            var htmlMiddle = Wrap(
+                "<table><tr>"
+                + "<td style='height:100pt'>Tall</td>"
+                + "<td id='v' style='height:100pt; vertical-align:middle'>Short</td>"
+                + "</tr></table>");
+
+            var (rootTop, _) = await BuildAndLayout(htmlTop);
+            var (rootMiddle, _) = await BuildAndLayout(htmlMiddle);
+
+            var topY = CssBox.FirstWordOccurence(FindById(rootTop, "v")!, FindById(rootTop, "v")!.LineBoxes[0])!.Top;
+            var middleY = CssBox.FirstWordOccurence(FindById(rootMiddle, "v")!, FindById(rootMiddle, "v")!.LineBoxes[0])!.Top;
+
+            Assert.True(middleY > topY,
+                $"vertical-align:middle ({middleY}) should push the cell's content lower than vertical-align:top ({topY}) even with an explicit cell height");
         }
 
         [Fact]

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -539,7 +539,17 @@ namespace PeachPDF.Html.Core.Dom
                 return 0d;
 
             var cellBottom = cell.ClientBottom;
-            var bottom = CssBox.GetMaximumBottom(cell, 0f);
+
+            // Measure over the cell's children, not the cell itself: GetMaximumBottom's own-height
+            // fallback exists for a childless box with an explicit height, but the cell always has an
+            // explicit ActualBottom by this point (the row just stretched it), so passing the cell as
+            // startBox would clamp `bottom` to `cellBottom` and always compute a zero offset whenever the
+            // cell also carries a CSS `height` (issue found via `height` + `vertical-align: middle`).
+            var bottom = cell.ClientTop;
+            foreach (var b in cell.Boxes)
+            {
+                bottom = CssBox.GetMaximumBottom(b, bottom);
+            }
 
             var dist = cellKeyword switch
             {

--- a/src/PeachPDF/PeachPDF.csproj
+++ b/src/PeachPDF/PeachPDF.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<AssemblyName>PeachPDF</AssemblyName>
 		<PackageId>PeachPDF</PackageId>
-		<PackageVersion>0.9.9</PackageVersion>
+		<PackageVersion>0.9.10</PackageVersion>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageIcon>peach.png</PackageIcon>
 		<IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
Update table-cell vertical alignment to measure content bottom from child boxes instead of the cell itself in `ApplyCellVerticalAlignment`. This avoids `GetMaximumBottom` clamping to the row-equalized cell bottom, which made `vertical-align: middle`/`bottom` a no-op when a `<td>` had explicit `height`. Added a regression test for `vertical-align: middle` on an explicit-height cell and removed the old test workaround comment that documented the prior limitation.