### PR TITLE
Fix table cell content overlap when explicit height is smaller than content

### DIFF
--- a/.claude/recent-fixes/2026-08-13-table-cell-explicit-height-smaller-than-content.md
+++ b/.claude/recent-fixes/2026-08-13-table-cell-explicit-height-smaller-than-content.md
@@ -1,0 +1,48 @@
+# A `td`/`th` `height` smaller than its content overlapped the next row
+
+`height: 1px` on a cell (a legacy "definite-height containing block" author hack) made the row's
+real content overlap the row below it instead of laying out at its content-driven height. Per CSS 2.1
+§17.5.3 a cell's specified `height` only ever feeds the row-height calculation (`max(row's own
+height, each cell's height, the minimum height the cells' content requires)`) - it must never clip
+or shrink the cell below what its content needs.
+
+`CssLayoutEngine.ApplyHeight`, called directly on the cell itself in `PerformLayoutEpilogue`
+(`cell.PerformLayout(g)`, strictly *before* `CssLayoutEngineTable.LayoutBodyRow` stretches every cell
+to the row's shared height - see `ApplyParentHeight`'s own comment on that ordering) applied §10.6.3's
+ordinary-block rule ("a definite height is the used height regardless of content") to the cell,
+overwriting the correct content-driven `ActualBottom` that `CreateLineBoxes` had just set with the
+cell's too-small specified height.
+
+Because the row loop takes `Math.Max` over every cell's `ActualBottom` to find the row's real height,
+a row where *every* cell had an explicit height smaller than its content (the reported repro) ended
+up with a `rowMaxBottom` far shorter than any cell's actual content - the next row started right
+under it while the still-there, unclipped text (the lines themselves were never moved, only
+`ActualBottom` was wrong) drew on top of it.
+
+**Fix**: `ApplyHeight` now exempts a table-cell box (`CssBox.IsTableCell`) from the direct-overwrite
+branch, falling back to its existing `Math.Max(box.ActualBottom, ...)` branch instead - exactly "at
+least the content's required height", since `ActualBottom` already holds the true content bottom by
+the time `ApplyHeight` runs on it.
+
+**A neighboring, unconditional "handle limiting block height when overflow is hidden" clamp in
+`CreateLineBoxes` looked at first like a second clamp site, and was initially patched too - it isn't
+one.** `ActualBottom`'s getter (`CssBox.StyleProperties.cs`) is `Location.Y + ActualBoxSizingHeight`,
+and `ActualHeight` is `ActualBoxSizingHeight` itself, so that branch's guard
+(`ActualBottom - Location.Y > ActualHeight`) is always false by construction - dead code for every
+box, not just table cells. Confirmed by instrumenting the branch against the repro: it never fired.
+The exclusion added there during investigation was reverted since it changed nothing and would have
+misdescribed the actual fix to a future reader. Left as-is rather than fixed/removed here since it's
+an unrelated, pre-existing dead branch, not part of this defect - flagged separately for its own
+follow-up.
+
+**Evidence**: two new regression tests in `CssLayoutEngineTableTests.cs`
+(`ExplicitCellHeightSmallerThanContent_DoesNotClipCellOrOverlapNextRow`,
+`ExplicitCellHeightSmallerThanContent_StretchesEveryCellInTheRow` - the second cross-checks against an
+independently-built reference table containing only the tall cell's content, rather than an arbitrary
+threshold, so it actually fails when the tall cell's own `ActualBottom` is wrongly clamped before the
+row-max comparison runs, not merely when the row ends up shorter than *some* fixed number); the
+reported repro re-rendered and rasterized through both PDFium and MuPDF per this repo's
+paint-verification convention, confirming non-overlapping, content-driven row heights on both;
+`Table`/`VerticalAlign`/`Flex`/`Grid`/`Multicol`-filtered suite and full `PeachPDF.Tests` suite pass on
+net8.0; 100% diff coverage on the changed lines; `dotnet build -t:Rebuild` on the whole solution is
+warning-free.

--- a/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTableTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTableTests.cs
@@ -145,6 +145,115 @@ var tallCellHeight = tallCell.ActualBottom - tallCell.Location.Y;
 
       #endregion
 
+        #region Explicit Cell Height Smaller Than Content Tests
+
+        [Fact]
+        public async Task ExplicitCellHeightSmallerThanContent_DoesNotClipCellOrOverlapNextRow()
+        {
+            // CSS 2.1 §17.5.3: a cell's specified `height` only feeds the row-height calculation
+            // (row height = max of the row's own height, each cell's height, and the minimum height
+            // the cells' content requires) - it never clips the cell's own content, regardless of
+            // `overflow` (td/th default to overflow:hidden in CssDefaults). `height:1px` is a legacy
+            // "definite-height containing block" author hack that relies on this: the cell must still
+            // grow to its content's full height, and the next row must start below that, not on top of
+            // it (issue #729).
+            var html = @"
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        table { border-collapse: collapse; }
+        td { border: 1px solid black; padding: 4pt; font-size: 14pt; height: 1px; }
+    </style>
+</head>
+<body>
+    <table>
+        <tr><td id='tall'>Line one<br>Line two<br>Line three</td></tr>
+        <tr><td id='next'>Next row</td></tr>
+    </table>
+</body>
+</html>";
+
+            var (rootBox, _) = await BuildCssBoxTree(html);
+            var tallCell = FindById(rootBox, "tall");
+            var nextCell = FindById(rootBox, "next");
+
+            Assert.NotNull(tallCell);
+            Assert.NotNull(nextCell);
+
+            var tallCellHeight = tallCell!.ActualBottom - tallCell.Location.Y;
+
+            // Three 14pt lines plus padding is well over 1px - if the specified height still clipped
+            // the cell, this would be close to 1px + padding instead.
+            Assert.True(tallCellHeight > 30,
+                $"first row's cell should grow to its content's height, not the specified 1px (actual: {tallCellHeight})");
+
+            // A 1pt tolerance accounts for border-collapse's shared border sitting on the boundary
+            // between the two rows - what this guards against is the tens-of-points overlap the bug
+            // produced (the next row starting inside the tall cell's real text), not sub-point border
+            // placement.
+            Assert.True(nextCell!.Location.Y >= tallCell.ActualBottom - 1,
+                $"second row (starting at {nextCell.Location.Y}) must not overlap the first row's actual content bottom ({tallCell.ActualBottom})");
+        }
+
+        [Fact]
+        public async Task ExplicitCellHeightSmallerThanContent_StretchesEveryCellInTheRow()
+        {
+            // The row-height reconciliation in CssLayoutEngineTable.LayoutBodyRow takes the max of
+            // every cell's ActualBottom for the row - so a short, unconstrained sibling cell in the
+            // same row as the height:1px cell must still be stretched down to the tall cell's real
+            // content height, per the same §17.5.3 row-height rule.
+            //
+            // The row's actual final height is cross-checked against a reference table holding only
+            // the tall cell's own content (no explicit height, no sibling) rather than an arbitrary
+            // threshold - a broken row reconciliation could equalize both cells to some smaller,
+            // wrongly-clipped value, which a threshold alone would not catch if picked too low.
+            const string cellStyle = "border: 1px solid black; padding: 4pt; font-size: 14pt;";
+            var referenceHtml = $@"
+<!DOCTYPE html>
+<html>
+<head><style>table {{ border-collapse: collapse; }}</style></head>
+<body>
+    <table>
+        <tr><td id='reference' style='{cellStyle}'>Line one<br>Line two<br>Line three</td></tr>
+    </table>
+</body>
+</html>";
+            var html = $@"
+<!DOCTYPE html>
+<html>
+<head><style>table {{ border-collapse: collapse; }}</style></head>
+<body>
+    <table>
+        <tr>
+            <td id='tall' style='{cellStyle} height:1px'>Line one<br>Line two<br>Line three</td>
+            <td id='short' style='{cellStyle}'>Short</td>
+        </tr>
+    </table>
+</body>
+</html>";
+
+            var (referenceRoot, _) = await BuildCssBoxTree(referenceHtml);
+            var referenceCell = FindById(referenceRoot, "reference");
+            Assert.NotNull(referenceCell);
+            var referenceHeight = referenceCell!.ActualBottom - referenceCell.Location.Y;
+
+            var (rootBox, _) = await BuildCssBoxTree(html);
+            var tallCell = FindById(rootBox, "tall");
+            var shortCell = FindById(rootBox, "short");
+
+            Assert.NotNull(tallCell);
+            Assert.NotNull(shortCell);
+
+            var rowHeight = shortCell!.ActualBottom - shortCell.Location.Y;
+            Assert.True(rowHeight >= referenceHeight - 1,
+                $"the row (height {rowHeight}) should stretch to at least the tall cell's real, unconstrained content height ({referenceHeight}), not a clipped value");
+
+            Assert.Equal(tallCell!.ActualBottom, shortCell.ActualBottom, 1);
+        }
+
+        #endregion
+
         #region Header/Footer Layout Tests
 
   [Fact]

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -1101,7 +1101,19 @@ namespace PeachPDF.Html.Core.Dom
             // GetBoxHeight couldn't resolve a value at all (e.g. a percentage height against an
             // indefinite containing block) - keep the existing Math.Max fallback there so the box
             // keeps its content-driven height instead of collapsing to zero.
-            box.ActualBottom = boxHeight is not null
+            //
+            // A table cell is the one box kind §10.6.3's "definite height wins regardless of content"
+            // rule does not apply to - CSS 2.1 §17.5.3 makes a cell's own height (before its row even
+            // equalizes every cell to the row's tallest) already the greater of its specified height
+            // and the minimum height its content requires, so an explicit height smaller than content
+            // must never shrink it here. This runs directly on the cell itself (PerformLayoutEpilogue,
+            // via cell.PerformLayout - see ApplyParentHeight's own comment on that call), strictly after
+            // CreateLineBoxes has already set ActualBottom to the real content bottom, so Math.Max
+            // against that value is exactly "at least the content's required height" - the table row
+            // loop's later Math.Max across every cell's ActualBottom (CssLayoutEngineTable.LayoutBodyRow)
+            // then reconciles the row height from correct per-cell values instead of ones already
+            // clipped to their own too-small specified height (issue #729).
+            box.ActualBottom = boxHeight is not null && !box.IsTableCell
                 ? box.Location.Y + height
                 : Math.Max(box.ActualBottom, box.Location.Y + height);
 


### PR DESCRIPTION
## Summary

`height: 1px` (or any explicit `td`/`th` `height` smaller than the cell's real content) made table rows overlap and garble instead of laying out at content-driven height.

Per CSS 2.1 §17.5.3, a cell's specified `height` only ever feeds the row-height calculation (`max(row's own height, each cell's height, the minimum height the cells' content requires)`) — it must never clip or shrink the cell below what its content needs, unlike an ordinary block box under §10.6.3 ("a definite height is the used height regardless of content").

`CssLayoutEngine.ApplyHeight`, called directly on the cell itself before `CssLayoutEngineTable.LayoutBodyRow` stretches every cell to the row's shared height, applied the ordinary-block rule to the cell anyway — overwriting the correct content-driven `ActualBottom` with the too-small specified height. Since the row loop takes `Math.Max` over every cell's `ActualBottom` to find the row's real height, a row where every cell had an explicit height smaller than its content ended up far shorter than any cell's actual content, and the next row started right on top of the still-there text.

- `ApplyHeight` now exempts table-cell boxes from the direct-overwrite branch, falling back to its existing `Math.Max` guard instead.
- Two new regression tests in `CssLayoutEngineTableTests.cs` cover the single-cell overlap case and the case where a `height`-constrained cell must still stretch an unconstrained sibling cell to its real content height.

## Test plan

- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~CssLayoutEngineTableTests"` — 28/28 pass
- [x] `Table`/`VerticalAlign`/`Flex`/`Grid`/`Multicol`-filtered suite (1356 tests) passes
- [x] Full `PeachPDF.Tests` suite (8751 tests) passes on net8.0
- [x] Verified both new tests actually fail without the fix (regression check)
- [x] 100% diff coverage on changed lines
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] Reported repro re-rendered and rasterized through both PDFium and MuPDF — non-overlapping, content-driven rows on both

Fixes #729