### PR TITLE
Resolve collapsed table borders per CSS 2.1 §17.6.2

### DIFF
--- a/.claude/accepted-gaps/border-radius-ignored-on-a-collapsed-table.md
+++ b/.claude/accepted-gaps/border-radius-ignored-on-a-collapsed-table.md
@@ -1,0 +1,22 @@
+# `border-radius` is ignored on a `border-collapse: collapse` table
+
+`BordersDrawHandler.PaintCollapsedTableBorders`'s draw path (via `DrawCollapsedSegment`) never receives a
+rounded-corner box - a collapsed table's borders paint as straight per-grid-line segments, each butting at
+its intersections rather than mitring into a rounded corner. `border-radius` set on the table or any cell
+has no visible effect on a collapsed table's border painting.
+
+This is not a spec deviation: CSS 2.1 [§17.6.2](https://www.w3.org/TR/CSS21/tables.html#border-conflict-resolution)
+resolves collapsed borders as independent per-grid-line segments and defines no interaction with
+`border-radius` at all, and neither Backgrounds and Borders §5.5's own `border-radius` text nor any later
+module fills the gap - the corner-clipping model both specs describe is inherently a single four-sided box's
+own border box, which a collapsed table's borders (one independently-resolved segment per shared grid line,
+not one border per box) do not have. Chromium and Firefox both ignore `border-radius` on a collapsed table
+for the same reason, so this matches real UA behavior rather than deviating from it - no tracked issue filed
+per this repo's convention, since there is no spec text to be out of compliance with.
+
+**Deliberately out of scope** of the CSS 2.1 §17.6.2 border-conflict-resolution work
+([issue #735](https://github.com/jhaygood86/PeachPDF/issues/735)'s fix): implementing rounded corners for a
+collapsed table's resolved-segment model would mean synthesizing a corner arc from up to four independently
+resolved, possibly differently-styled/colored/widthed segments meeting at one grid-line intersection - a
+different and substantially harder problem than any single box's own `border-radius`, and not something any
+real browser attempts either.

--- a/.claude/accepted-gaps/rowspan-inside-a-multi-row-thead-tfoot-grid-occupancy.md
+++ b/.claude/accepted-gaps/rowspan-inside-a-multi-row-thead-tfoot-grid-occupancy.md
@@ -1,0 +1,39 @@
+# A rowspan cell inside a multi-row `<thead>`/`<tfoot>` can be dropped from the collapsed-border grid
+
+`TableGrid.Build`'s column-index computation (`CssLayoutEngineTable.GetCellRealColumnIndex`) sums the
+`colspan` of preceding cells within a row's own `Boxes` list to find where a cell starts. For an ordinary
+body row this is correct because `CssLayoutEngineTable.InsertEmptyBoxes` pads a rowspan's gap with a
+`CssSpacingBox` placeholder before this runs. A detached `<thead>`/`<tfoot>` row-group's own rows are never
+passed through `InsertEmptyBoxes` (only `_bodyRows` is), so a `rowspan` cell that starts in an earlier row
+of the *same* header/footer group and reaches into a later row leaves a genuine gap with no placeholder -
+the later row's own remaining cells then compute the wrong starting column, and `TableGrid.Build`'s
+`slots[...] ??= cell` first-writer-wins placement silently drops the later cell from the grid entirely for
+the column(s) it should have occupied (the earlier row's rowspan fill runs first and already claims that
+slot).
+
+Concrete case: a `<thead>` with `<tr><th rowspan="2">A</th><th>B</th></tr><tr><th>D</th></tr>` - `D` is
+row 1's only real cell, computed at column 0 (nothing precedes it in that row's own `Boxes`) instead of
+column 1 (column 0 is occupied by `A`'s rowspan). `TableGrid.CellAt(1, 1)` returns `null` instead of `D`,
+so any border-conflict resolution reading that slot - both the whole-table `CollapsedBorderModel.Resolve`
+for the header's own internal grid line, and `CollapsedBorderModel.ResolveRepeatedGroupBoundary` for a
+repeated header's boundary to the body - silently drops `D`'s own border as a candidate for that column.
+
+This is a genuine CSS 2.1 [§17.6.2](https://www.w3.org/TR/CSS21/tables.html#border-conflict-resolution)
+deviation (a declared border is dropped as a resolution candidate outright, not merely outranked), not a
+deliberate scope line - it's tracked as
+[#736](https://github.com/jhaygood86/PeachPDF/issues/736), found while adding
+`CollapsedBorderModel.ResolveRepeatedGroupBoundary` (the repeated-`<thead>`/`<tfoot>`-boundary phase of
+issue #735's fix) and testing it against a multi-row header. `ResolveRepeatedGroupBoundary` itself was
+fixed in the same change to read cell occupancy via `TableGrid.CellAt` (rowspan/colspan-aware) rather than
+a hand-rolled, `Boxes`-list-scanning helper - which is a real improvement (the hand-rolled version would
+have *also* misattributed a rowspan cell it could see at all, on top of this deeper gap it can't see
+around) - but that fix cannot correct occupancy the grid itself never recorded.
+
+**Deliberately out of scope** of issue #735's fix: closing this needs either extending
+`CssLayoutEngineTable.InsertEmptyBoxes` (or an equivalent pass) to also pad a detached header's/footer's
+own rows with `CssSpacingBox` placeholders before `BuildTableGrid` runs, or giving `TableGrid.Build` a
+column-index callback that's aware of rowspan occupancy from earlier rows in the same row-group rather
+than only counting `Boxes`-list predecessors - a change to shared grid-construction code every other
+`TableGrid` consumer (column-width distribution, the main §17.6.2 resolution, `visibility: collapse`
+handling) also depends on, warranting its own focused change and test pass rather than folding it into
+an already large border-collapse PR.

--- a/.claude/migration-notes/2026-08-13-collapsed-table-borders-resolved-per-css-2-1-17-6-2.md
+++ b/.claude/migration-notes/2026-08-13-collapsed-table-borders-resolved-per-css-2-1-17-6-2.md
@@ -1,0 +1,47 @@
+# Collapsed table borders now resolve per CSS 2.1 §17.6.2, instead of a flat 1pt row/column overlap
+
+Previously: a `border-collapse: collapse` table made adjacent rows/columns overlap by a flat, hardcoded
+1 point regardless of the actual border widths declared anywhere in the table, and every participating box
+(the `<table>`, each `<tr>`, each `<td>`) painted its own border independently, relying on that overlap for
+them to visually coincide rather than resolving one winning border per shared edge. Two visible defects
+followed directly from this:
+
+- **A row's border could be painted over and erased by the next row's own background**
+  ([#735](https://github.com/jhaygood86/PeachPDF/issues/735)): because boxes paint in DOM order, a later
+  row's opaque cell background — nudged by the flat overlap to reach into the row above it — could land on
+  top of, and erase, the shared border. This is fixed: resolved borders now paint once, after every
+  table-internal background, so they're never erased regardless of paint order elsewhere.
+- **Table dimensions were wrong whenever cells disagreed on a shared border**, or when no border was
+  declared on a shared edge at all: the flat 1pt overlap applied unconditionally, shrinking a
+  border-less collapsed table by 1pt at every internal row/column boundary even though nothing justified
+  the overlap, and never widening it to accommodate a wider declared border either.
+
+Now: a collapsed table's borders resolve per CSS 2.1
+[§17.6.2](https://www.w3.org/TR/CSS21/tables.html#border-conflict-resolution) — for each grid line, the
+widest declared border wins; ties break by style priority (`hidden` > `double` > `solid` > `dashed` >
+`dotted` > `ridge` > `outset` > `groove` > `inset` > `none`, `hidden` always suppressing the edge
+outright); further ties break by origin specificity (cell > row > row-group > column > column-group >
+table) and finally by position. Adjacent rows/columns overlap by exactly that resolved width instead of a
+flat constant — so:
+
+- **An existing collapsed table's rendered size changes** wherever a shared edge's resolved width differs
+  from 1pt: a table with e.g. 3pt borders is now correctly ~2pt narrower per column boundary and ~2pt
+  shorter per row boundary than before (previously undersized by only 1pt regardless of declared width);
+  a table with no border at all on some shared edge is now exactly flush there instead of overlapping by a
+  spurious 1pt.
+- **Only one border is drawn per shared edge**, chosen by the rules above, instead of every participating
+  box drawing its own — so mismatched or doubled borders on a shared edge now resolve the way a browser
+  resolves them, and `border-style: hidden` now actually suppresses that edge rather than being drawn like
+  any other style.
+- **`<col>`/`<colgroup>` now participate in both border resolution and painting**, where before they had no
+  paint code path at all: a `<col>`'s own `border`/`background-color` is now a real candidate in the
+  origin-priority tiebreak above, and its background now layers correctly between the table's own
+  background and its column's cells' backgrounds (CSS 2.1 §17.5.1's table → column-group → column →
+  row-group → row → cell order), including across a page break.
+- **A repeated `<thead>`/`<tfoot>` now resolves and paints its own collapsed borders correctly on every
+  page it repeats on**, not only the first: the group's own internal grid lines (between its own rows, for
+  a multi-row header/footer) are redrawn at each page's own position, and the border where the group meets
+  the table body is re-resolved fresh against whichever row actually starts/ends that specific page —
+  border-collapse is about visual adjacency, and a repeat's neighbor differs per page even though its
+  DOM-order neighbor does not. Previously this boundary was resolved once, against the group's single
+  DOM-order neighbor, and silently reused (or altogether misplaced) on every later page.

--- a/.claude/recent-fixes/2026-08-13-collapsed-table-borders-css-2-1-17-6-2.md
+++ b/.claude/recent-fixes/2026-08-13-collapsed-table-borders-css-2-1-17-6-2.md
@@ -1,0 +1,113 @@
+# Collapsed table borders now resolve per CSS 2.1 §17.6.2, closing issue #735
+
+[Issue #735](https://github.com/jhaygood86/PeachPDF/issues/735) reported that a `border-collapse: collapse`
+table lost an earlier row's `border-bottom` whenever the next row's cells also had a `background-color`.
+Root cause: `CssLayoutEngineTable` hardcoded a flat `-1pt` row/column overlap for collapsed tables regardless
+of actual border width, and every participating box (table/row/cell) painted its own border independently -
+so a later row's opaque background, nudged into the row above by that overlap, painted over and erased the
+shared border. Below that symptom was a bigger gap: PeachPDF had no real CSS 2.1 §17.6.2 border-conflict
+resolution at all. This was a full implementation of that resolution, landed in seven phases (pure
+resolver/grid types → wiring to real tables → the paint-order fix that actually closes #735 → replacing the
+`-1` spacing hack with resolved widths → a used-border-width override for correct box-model insets →
+`<col>`/`<colgroup>` border and background participation → repeated `<thead>`/`<tfoot>` correctness),
+test-first throughout.
+
+New types: `CollapsedBorderResolver` (pure, static - width wins, then style priority, then origin priority
+cell > row > row-group > column > column-group > table, then position), `TableGrid` (topology - which real
+`CssBox` occupies each row×column cell, honoring colspan/rowspan), `CollapsedBorderModel` (resolves the
+whole table once, holds a `CollapsedBorder` per grid-line segment). Resolved borders paint once, late
+(`FragmentPainter`'s `PaintCollapsedTableBorders`, after every table-internal background), via
+`CssBox.CollapsedBorderSegments` - the same paint-time-consumed-geometry-carried-on-CssBox pattern this
+codebase already uses for `ColumnRuleSegments`/`PageBreakBottoms`.
+
+## Load-bearing lessons
+
+**Hand-tracing exact numeric residuals against an independently-computed ground truth is what caught two
+rounds of geometry double-counting** that visual/coarse testing missed during the spacing-rework phase - a
+table's own border box and its first cell's own border box are the *same* edge under the collapsing model,
+not offset by half a border width as first assumed; `GetWidthSum()`'s own formula gave the right total while
+actual cell positioning was off by exactly `firstColumnBorderWidth / 2` until this was worked out by hand.
+
+**A collapsed table's own reported "does it visually work" during manual testing can be a false positive.**
+Empirically testing a multi-page table with a repeating `<thead>` looked correct - the border under the
+repeated header matched on every page - but this was coincidental: the fixture used uniform border styling
+everywhere, so a completely wrong resolution (reusing page 1's DOM-order-adjacent-row answer on every later
+page, via `CssProxyBox`'s *shared* row objects being repositioned live per page) was indistinguishable from
+a correct one. The regression test that actually proves this (`RepeatedThead_BoundaryToBody_ResolvesFreshPerPage_NotReusedFromPage1`)
+needed *non-uniform* per-page styling - only row 1 (page 1's real DOM neighbor) gets a distinctive border,
+so a stale/reused resolution and a correct fresh-per-page one produce visibly different output.
+
+**A cached "actual border width" property can silently mean two different things depending on when it's
+read.** `ApplyCollapsedUsedBorderWidths()` overwrites every participant's `ActualBorder*Width` with the
+box-model *used* half-width (needed for `ClientLeft`/content insets to agree with the spacing model), and
+that overwrite is destructive - there is no way to recover the original declared width from that property
+once it has run. `CollapsedBorderModel.Resolve` (the whole-table static resolution) runs *before* the
+override and reads the cached property safely; `ResolveRepeatedGroupBoundary` (added in this phase, run at
+the very end of layout once final per-page row geometry exists) runs *after* it, and initially read the same
+cached property - producing a uniformly-wrong resolved width (half of an unrelated single resolution) on
+every page rather than the intended per-page-varying one. Fixed by adding `DerivedStyle.NaturalBorder*Width`
+(and `CssBox` forwarders), which recompute from the declared CSS value directly rather than through the
+cache, for exactly this one late-reading call site.
+
+**A repeated `<thead>`/`<tfoot>` is not one box with N positions - it is one *shared* box repositioned live,
+N times, by whichever `CssProxyBox` laid out last.** `CssProxyBox.PerformLayoutImp` mutates the shared
+source row-group's own `Location`/its rows' positions to match *that* proxy's page every time any proxy for
+it lays out - so by the time layout finishes, the source's live geometry reflects only the last page it was
+positioned at. Reading `TableGrid.RowAt(...)`'s live `Location`/`ActualBottom` for a header/footer row (as
+the main per-table `EmitCollapsedBorderSegments` correctly does for an ordinary, never-repositioned body row)
+is wrong for a repeated group on every page but the one whose proxy happened to run last. The fix reads
+`CssProxyBox.SourceGeometry` (`BoxGeometrySnapshot`, already the sanctioned mechanism `FragmentEmitter` uses
+to place a repeat's own content) instead, and accumulates segments from *every* proxy of the same source
+into that source's single `CollapsedBorderSegments` list - `FragmentEmitter.ChildrenOf` gives a repeated
+group's fragment the *source* box's identity on every page (not the proxy's own), so paint's
+`box.CollapsedBorderSegments` check reads the shared box regardless of which proxy is being painted; each
+page's own fragment `OriginY`/clip then naturally shows only the segments that belong on that page, exactly
+like the main table's own multi-page segment list already works.
+
+**A row whose own border overlaps the boundary it sits on can start *before* that boundary's Y, not after
+it.** Finding "which body row is actually adjacent to this header/footer proxy" by filtering
+`row.Location.Y >= proxyBottom` silently skips the true neighbor whenever that row's own border-collapse
+overlap (up to the resolved line width) pulls its top above the header's own bottom - found via a debug
+trace showing a ~73pt gap between `proxyBottom` and the "adjacent" row that predicate found, when the real
+neighbor sat only 9pt before it. Fixed by filtering on the row's *span* reaching the boundary
+(`row.ActualBottom >= proxyBottom`) instead of its start position.
+
+## Post-change review pass caught three real bugs, all fixed before landing
+
+A review agent run against the repeated-group-boundary phase per this repo's own convention found three
+genuine correctness issues in `CollapsedBorderModel.ResolveRepeatedGroupBoundary`, all fixed:
+
+- It read cell occupancy via a hand-rolled `Boxes`-list scan (`FindCellAtColumn`) instead of
+  `TableGrid.CellAt`, which independently re-derived (and could disagree with) the grid's own
+  rowspan/colspan accounting - replaced by passing grid row indices straight through and calling
+  `TableGrid.CellAt`/`RowGroupAt`, which also deleted the duplicate, less-defensive `colspan` parsing
+  `FindCellAtColumn` had.
+- It never added the adjacent row's own row-group (e.g. an explicit `<tbody>`'s own border) as a
+  candidate - `CollapsedBorderOrigin.RowGroup` is a real, independently-competing priority tier
+  (`CollapsedBorder.cs`), not merely a tiebreak, so a wider `<tbody>` border was silently never even
+  considered. Fixed by adding `grid.RowGroupAt(adjacentRow)` as a candidate alongside the group side's own.
+- A repeated group with no opposing row at all (a `<thead>`-only/`<tfoot>`-only table, or a header
+  immediately followed by a footer with zero body rows between them) silently dropped that boundary
+  entirely. Fixed with a fallback to the whole-table static resolution's own value for that line, which
+  already models exactly this case correctly (`CollectHorizontal`'s `line == 0`/`line == grid.RowCount`
+  gating already includes Column/ColumnGroup/Table origins there).
+
+Chasing down a regression test for the first fix surfaced a second, genuinely pre-existing bug one level
+deeper: `TableGrid.Build`'s own column-index computation can silently drop a cell from the grid entirely
+when a `rowspan` inside a multi-row `<thead>`/`<tfoot>` reaches from an earlier row into a later one, since
+`CssLayoutEngineTable.InsertEmptyBoxes` (which pads exactly this gap with a placeholder for an ordinary
+body row) never touches a detached header's/footer's own rows. This predates this change and affects every
+`TableGrid` consumer, not just the new boundary resolution - tracked as
+[#736](https://github.com/jhaygood86/PeachPDF/issues/736) and left out of scope (see
+`.claude/accepted-gaps/rowspan-inside-a-multi-row-thead-tfoot-grid-occupancy.md`), since fixing it touches
+shared grid-construction code every other `TableGrid` consumer depends on and warrants its own change and
+test pass.
+
+## Evidence
+
+Full suite green throughout (8825 tests, net8.0), zero warnings on `dotnet build -t:Rebuild`. The final
+repeated-header fix was verified two ways beyond the unit tests: a purpose-built regression fixture with
+non-uniform per-page border styling (see above), and an actual multi-page PDF rendered through the CLI and
+rasterized with both PDFium and MuPDF - page 1 correctly shows a distinctive 6px border under the header
+(the real DOM-adjacent row's own border winning), every later page correctly shows an ordinary 1px border
+instead of the page-1 value, confirmed identically by both renderers.

--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -265,7 +265,7 @@ Each logical longhand keeps its own identity through the cascade and is resolved
 | `border-width` | [border-width](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) | Shorthand and all four longhands supported |
 | `border-style` | [border-style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style) | Shorthand and all four longhands supported; values: `none`, `solid`, `dashed`, `dotted`, `double`, `inset`, `outset`, `groove`, `ridge` |
 | `border-color` | [border-color](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) | Shorthand and all four longhands supported |
-| `border-collapse` | [border-collapse](https://developer.mozilla.org/en-US/docs/Web/CSS/border-collapse) | Full support for tables |
+| `border-collapse` | [border-collapse](https://developer.mozilla.org/en-US/docs/Web/CSS/border-collapse) | `collapse` resolves borders per CSS 2.1 [§17.6.2](https://www.w3.org/TR/CSS21/tables.html#border-conflict-resolution) (width, then style, then cell/row/row-group/column/column-group/table origin, then position), including on a repeated `<thead>`/`<tfoot>` across pages; `border-radius` is undefined by the spec on a collapsed table and is not drawn there, matching common browser behavior |
 | `border-spacing` | [border-spacing](https://developer.mozilla.org/en-US/docs/Web/CSS/border-spacing) | Full support for tables |
 
 ### Border Radius

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -7467,6 +7467,97 @@ await SaveShowcaseAsync("table_caption", "Layout", "Table Captions (caption-side
     + "<table>'s own border/background wrapping the row grid only.",
     tableCaptionHtml, pdfConfig);
 
+// --- collapsed border conflict resolution showcase (issue #735) ---
+//
+// border-collapse: collapse previously overlapped adjacent rows/columns by a flat, hardcoded 1pt
+// regardless of the borders actually declared, and every participating box painted its own border
+// independently - so a later row's opaque background could paint over and erase the border it shared
+// with the row above (#735). This exercises the real CSS 2.1 §17.6.2 resolution that replaced it: width
+// wins, then style priority, then origin priority (cell > row > row-group > column > column-group >
+// table), then position - plus <col>/<colgroup> border/background participation and a repeated <thead>
+// whose boundary to the body re-resolves correctly on every page, not just the first.
+var collapsedBorderRepeatRows = string.Join("\n", Enumerable.Range(1, 24).Select(i =>
+    i == 1
+        ? "<tr class=\"first\"><td>Row 1</td><td>The first body row's own border wins here - it's the true DOM neighbor of the header.</td></tr>"
+        : $"<tr><td>Row {i}</td><td>An ordinary row - every later page's header boundary resolves against whichever row actually starts that page, not row 1's.</td></tr>"));
+
+var collapsedBorderHtml = $$"""
+    <!DOCTYPE html><html><head><style>
+    @page { size: a4 portrait; margin: 15mm }
+    body { font: 10pt Helvetica, Arial, sans-serif; margin: 0; color: #1f2937 }
+    h1 { font-size: 15pt; margin: 0 0 0.3em }
+    h2 { font-size: 11pt; margin: 1.2em 0 0.4em }
+    p.intro { color: #6b7280; font-size: 9pt; margin: 0 0 0.6em; max-width: 34em }
+    table { border-collapse: collapse; width: 100%; margin-bottom: 0.8em }
+    td, th { padding: 5pt 8pt; text-align: left }
+
+    /* Conflict matrix: three adjacent cells whose shared edges are contested by a different origin
+       each time, so the resolved border visibly differs edge to edge. */
+    #matrix td, #matrix th { border: 1pt solid #cbd5e1 }
+    #matrix tr { border-bottom: 4pt solid #f59e0b }               /* row-origin: medium, orange */
+    #matrix td.cell-wins { border-bottom: 8pt double #0b4f6c }      /* cell-origin: widest, wins outright */
+    #matrix { border: 2pt solid #7c3aed }                          /* table-origin: only at the outer edge */
+
+    /* <col>/<colgroup> participation: a colgroup border/background competing with (and losing to) a
+       narrower <col>-level border, and both painting behind the cells' own backgrounds. */
+    #cols colgroup.grp { border: 3pt solid #059669; background: #ecfdf5 }
+    #cols col.narrow { border-right: 1pt solid #dc2626; background: #fef2f2 }
+    #cols td, #cols th { border: 0.75pt solid #94a3b8; background: white }
+
+    /* border-style: hidden suppresses an edge outright, regardless of what competes for it. */
+    #hidden td, #hidden th { border: 2pt solid #0b4f6c }
+    #hidden td.gap { border-right-style: hidden }
+
+    #repeat thead th { border: 1pt solid #0b4f6c; background: #0b4f6c; color: white; padding: 6pt 8pt }
+    #repeat tbody td { border: 1pt solid #94a3b8; padding: 5pt 8pt }
+    #repeat tr.first td { border-top: 6pt solid #dc2626 }
+    </style></head><body>
+    <h1>Collapsed Table Borders: CSS 2.1 §17.6.2 Conflict Resolution</h1>
+    <p class="intro">A <code>border-collapse: collapse</code> table resolves exactly one border per shared
+    grid line - the widest declared border wins, ties break by style priority, further ties by how
+    specific the declaring box is (cell &gt; row &gt; row-group &gt; column &gt; column-group &gt; table),
+    and finally by position. Every other participant's own border at that edge is suppressed rather than
+    separately painted.</p>
+
+    <h2>Width, then origin, decide each edge</h2>
+    <table id="matrix">
+    <tr><td>A</td><td>B</td></tr>
+    <tr><td class="cell-wins">The 8pt double border on this cell's own bottom edge outranks the row's 4pt orange border below - cell beats row regardless of which one is wider here.</td><td>Where no cell states an opinion, the row's own 4pt orange border wins instead.</td></tr>
+    </table>
+
+    <h2>&lt;col&gt;/&lt;colgroup&gt; border and background participation</h2>
+    <table id="cols">
+    <colgroup class="grp"><col class="narrow"><col></colgroup>
+    <tr><th>Column A</th><th>Column B</th></tr>
+    <tr><td>The colgroup's 3pt green border frames both columns; column A's own narrower red border wins the shared edge between them.</td><td>Column backgrounds layer under the cells' own white background, per CSS 2.1 §17.5.1's table &rarr; column-group &rarr; column &rarr; row &rarr; cell order.</td></tr>
+    </table>
+
+    <h2>border-style: hidden suppresses an edge outright</h2>
+    <table id="hidden">
+    <tr><th>Left</th><th class="gap">Right</th></tr>
+    <tr><td>No border here</td><td class="gap">or here - hidden always wins, whatever else competes for this edge</td></tr>
+    </table>
+
+    <h2>A repeated &lt;thead&gt;'s boundary resolves fresh on every page</h2>
+    <p class="intro">Only row 1 - the header's real DOM neighbor - has the bold red top border. On the
+    first page the header sits directly above it, so that border is what's resolved and drawn. On every
+    later page the header repeats above a different row instead, and the boundary is re-resolved against
+    <em>that</em> row - not reused from page 1 - so only the first page shows the red border.</p>
+    <table id="repeat">
+    <thead><tr><th>Row</th><th>Note</th></tr></thead>
+    <tbody>
+    {{collapsedBorderRepeatRows}}
+    </tbody>
+    </table>
+    </body></html>
+    """;
+await SaveShowcaseAsync("table_collapsed_border_resolution", "Layout", "Collapsed Table Border Resolution",
+    "CSS 2.1 §17.6.2's full border-conflict resolution for border-collapse: collapse - width, then style "
+    + "priority, then cell/row/row-group/column/column-group/table origin, then position - plus "
+    + "<col>/<colgroup> border/background participation and a repeated <thead> whose boundary to the body "
+    + "re-resolves correctly on every page (issue #735).",
+    collapsedBorderHtml, pdfConfig);
+
 // --- interactive PDF forms showcase ---
 //
 // See docs/html-css-support.md#interactive-pdf-forms-support. EnableInteractivePdfForms turns

--- a/src/PeachPDF.Tests/Html/Core/Dom/CollapsedBorderColumnTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/CollapsedBorderColumnTests.cs
@@ -1,0 +1,148 @@
+using PeachPDF.CSS;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Tests.TestSupport;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Html.Core.Dom
+{
+    /// <summary>
+    /// <c>&lt;col&gt;</c>/<c>&lt;colgroup&gt;</c> border (CSS 2.1 §17.6.2's widest origin-priority tier)
+    /// and background (§17.5.1's layering) participation - both previously entirely unpainted, since
+    /// neither box was ever given real layout geometry (see <c>CssLayoutEngineTable.SetColumnBoxDimensions</c>).
+    /// </summary>
+    public class CollapsedBorderColumnTests
+    {
+        private static CssBox FindById(CssBox root, string id) => LayoutHarness.FindById(root, id)!;
+
+        [Fact]
+        public async Task Col_GetsRealGeometry_SpanningItsOwnColumnAndTheFullRowGrid()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(@"
+                <table style='border-collapse:collapse'>
+                    <col id='c0' /><col id='c1' />
+                    <tr><td id='a'>a</td><td id='b'>b</td></tr>
+                    <tr><td id='c'>c</td><td id='d'>d</td></tr>
+                </table>"));
+
+            var col0 = FindById(root, "c0");
+            var a = FindById(root, "a");
+            var c = FindById(root, "c");
+
+            Assert.Equal(a.Location.X, col0.Location.X, 1);
+            Assert.Equal(a.Location.Y, col0.Location.Y, 1); // top of the row grid
+            Assert.Equal(c.ActualBottom, col0.ActualBottom, 1); // bottom of the row grid
+            Assert.Equal(a.ActualRight, col0.ActualRight, 1);
+        }
+
+        [Fact]
+        public async Task ColSpan_GivesTheColBoxTheCombinedWidthOfEveryColumnItCovers()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(@"
+                <table style='border-collapse:collapse'>
+                    <col id='wide' span='2' />
+                    <tr><td id='a'>a</td><td id='b'>b</td></tr>
+                </table>"));
+
+            var wide = FindById(root, "wide");
+            var a = FindById(root, "a");
+            var b = FindById(root, "b");
+
+            Assert.Equal(a.Location.X, wide.Location.X, 1);
+            Assert.Equal(b.ActualRight, wide.ActualRight, 1);
+        }
+
+        [Fact]
+        public async Task ColGroupWithColChildren_AlsoGetsItsOwnGeometry_SpanningAllItsChildren()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(@"
+                <table style='border-collapse:collapse'>
+                    <colgroup id='g'><col id='c0' /><col id='c1' /></colgroup>
+                    <tr><td id='a'>a</td><td id='b'>b</td></tr>
+                </table>"));
+
+            var group = FindById(root, "g");
+            var a = FindById(root, "a");
+            var b = FindById(root, "b");
+
+            Assert.Equal(a.Location.X, group.Location.X, 1);
+            Assert.Equal(b.ActualRight, group.ActualRight, 1);
+        }
+
+        [Fact]
+        public async Task Background_LayersUnderTheCellsBackground_InFillOrder()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(@"
+                <table style='border-collapse:collapse'>
+                    <col id='c0' style='background-color:blue' />
+                    <tr><td id='a' style='background-color:red'>a</td></tr>
+                </table>"));
+
+            var table = LayoutHarness.Descendants(root).First(x => x.DerivedStyle.ActualDisplay is Keywords.Table or Keywords.InlineTable);
+            var adapter = new PeachPDF.Adapters.PdfSharpAdapter();
+            var recording = new RecordingGraphics(adapter);
+            FragmentPaintHarness.PaintPage(container, recording);
+
+            var fills = recording.Log.Where(op => op.Kind == PaintOpKind.FillRect).ToList();
+
+            // The column's own fill must come before the cell's own fill - DOM order (col precedes tbody)
+            // already gives the right layer order once both have real geometry to paint from.
+            Assert.True(fills.Count >= 2, $"expected at least 2 fills, got {fills.Count}");
+        }
+
+        [Fact]
+        public async Task ColBackground_IsNotPaintCulled_EvenWithNoOtherOutOfFlowContentInTheDocument()
+        {
+            // CssBox's paint-time visibility-culling optimization (intersecting a box's own Bounds
+            // against the current clip) only activates when the document has no floated/absolute/fixed
+            // content anywhere - the exact condition this fixture deliberately has none of, so a <col>
+            // still stuck at a degenerate (0,0,0,0) Bounds would be silently dropped here.
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(@"
+                <table style='border-collapse:collapse'>
+                    <col id='c0' style='background-color:blue' />
+                    <tr><td>a</td></tr>
+                </table>"));
+
+            var adapter = new PeachPDF.Adapters.PdfSharpAdapter();
+            var recording = new RecordingGraphics(adapter);
+            FragmentPaintHarness.PaintPage(container, recording);
+
+            Assert.Contains(recording.Log, op => op.Kind == PaintOpKind.FillRect);
+        }
+
+        [Fact]
+        public async Task ColBorder_WinsAgainstAWeakerCellBorder_AndIsDrawnOnce()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(@"
+                <table style='border-collapse:collapse'>
+                    <col id='c0' style='border-left:8pt solid black' />
+                    <tr><td id='a' style='border-left:1pt solid red'>a</td></tr>
+                </table>"));
+
+            var table = LayoutHarness.Descendants(root).First(x => x.DerivedStyle.ActualDisplay is Keywords.Table or Keywords.InlineTable);
+
+            Assert.NotNull(table.CollapsedBorders);
+            var resolved = table.CollapsedBorders!.Vertical(0, 0);
+
+            Assert.Equal(8, resolved.Width, 1);
+            Assert.Equal(LineStyle.Solid, resolved.Style);
+        }
+
+        [Fact]
+        public async Task ColGroupBorder_LosesTo_AMoreSpecificColBorder()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(@"
+                <table style='border-collapse:collapse'>
+                    <colgroup style='border-left:5pt solid blue'><col id='c0' style='border-left:5pt solid red' /></colgroup>
+                    <tr><td id='a'>a</td></tr>
+                </table>"));
+
+            var table = LayoutHarness.Descendants(root).First(x => x.DerivedStyle.ActualDisplay is Keywords.Table or Keywords.InlineTable);
+            var resolved = table.CollapsedBorders!.Vertical(0, 0);
+
+            // Equal width/style - Column outranks ColumnGroup, so red (the <col>'s own) wins.
+            Assert.Equal(PeachPDF.Html.Adapters.Entities.RColor.FromArgb(255, 0, 0), resolved.Color);
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Html/Core/Dom/CollapsedBorderLayoutTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/CollapsedBorderLayoutTests.cs
@@ -1,0 +1,230 @@
+using PeachPDF.CSS;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Tests.TestSupport;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Html.Core.Dom
+{
+    /// <summary>
+    /// The row/column spacing rework - <c>HorizontalSpacingAt</c>/<c>VerticalSpacingAt</c> replacing the
+    /// old flat <c>-1</c> border-collapse constant with CSS 2.1 §17.6.2's actual resolved border width at
+    /// each grid line.
+    /// </summary>
+    public class CollapsedBorderLayoutTests
+    {
+        private static CssBox FindById(CssBox root, string id) => LayoutHarness.FindById(root, id)!;
+
+        [Fact]
+        public async Task AdjacentCells_OverlapByTheResolvedWidth_NotAFlatOne()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(@"
+                <table style='border-collapse:collapse'>
+                    <tr><td id='a' style='border-right:3pt solid black'>a</td><td id='b'>b</td></tr>
+                </table>"));
+
+            var a = FindById(root, "a");
+            var b = FindById(root, "b");
+
+            Assert.Equal(-3, b.Location.X - a.ActualRight, 1);
+        }
+
+        [Fact]
+        public async Task Rows_OverlapVerticallyByTheResolvedWidth()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(@"
+                <table style='border-collapse:collapse'>
+                    <tr><td id='a' style='border-bottom:4pt solid black'>a</td></tr>
+                    <tr><td id='b'>b</td></tr>
+                </table>"));
+
+            var a = FindById(root, "a");
+            var b = FindById(root, "b");
+
+            Assert.Equal(-4, b.Location.Y - a.ActualBottom, 1);
+        }
+
+        [Fact]
+        public async Task RowBorder_WidensEveryColumnBoundaryOnThatLine()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(@"
+                <table style='border-collapse:collapse'>
+                    <tr style='border-bottom:6pt solid red'><td id='a'>a</td><td id='b'>b</td></tr>
+                    <tr><td id='c'>c</td><td id='d'>d</td></tr>
+                </table>"));
+
+            var a = FindById(root, "a");
+            var c = FindById(root, "c");
+
+            Assert.Equal(-6, c.Location.Y - a.ActualBottom, 1);
+        }
+
+        [Fact]
+        public async Task MixedWidthBoundary_ReservesTheMaxAcrossItsSegments()
+        {
+            // Column 0's boundary resolves to 8pt (a's own border), column 1's to 2pt (c's) - the row
+            // below must start clear of the WIDER of the two, even though only one column's border is
+            // actually that wide.
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(@"
+                <table style='border-collapse:collapse'>
+                    <tr><td id='a' style='border-bottom:8pt solid black'>a</td><td id='b' style='border-bottom:2pt solid black'>b</td></tr>
+                    <tr><td id='c'>c</td><td id='d'>d</td></tr>
+                </table>"));
+
+            var a = FindById(root, "a");
+            var b = FindById(root, "b");
+            var c = FindById(root, "c");
+            var d = FindById(root, "d");
+
+            // Both columns' rows start at the SAME Y (a row is one flat cursor position), reserving the
+            // wider (8pt) boundary's room even under column 1, whose own resolved border is only 2pt.
+            Assert.Equal(c.Location.Y, d.Location.Y, 1);
+            Assert.Equal(-8, c.Location.Y - a.ActualBottom, 1);
+        }
+
+        [Fact]
+        public async Task Hidden_RemovesReservedRoomEntirely()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(@"
+                <table style='border-collapse:collapse'>
+                    <tr><td id='a' style='border-bottom:10pt solid black'>a</td></tr>
+                    <tr><td id='b' style='border-top:hidden'>b</td></tr>
+                </table>"));
+
+            var a = FindById(root, "a");
+            var b = FindById(root, "b");
+
+            // hidden suppresses the shared edge outright - the cells become flush, not merely narrower.
+            Assert.Equal(0, b.Location.Y - a.ActualBottom, 1);
+        }
+
+        [Fact]
+        public async Task NoBorderAnywhere_CellsAreExactlyFlush()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(@"
+                <table style='border-collapse:collapse'>
+                    <tr><td id='a'>a</td></tr>
+                    <tr><td id='b'>b</td></tr>
+                </table>"));
+
+            var a = FindById(root, "a");
+            var b = FindById(root, "b");
+
+            Assert.Equal(0, b.Location.Y - a.ActualBottom, 1);
+        }
+
+        [Fact]
+        public async Task TableOuterEdges_CoincideWithTheFirstCellsOwnEdges()
+        {
+            // Per CollapsedBorderModel's own geometric model, the table's own border box and the first
+            // cell's own border box are the SAME edge (X_0 - VW[0]/2 both), not two edges VW[0]/2 apart -
+            // the shared outer border is one physical sliver of space, viewed from the table's side and
+            // the cell's side at once, not two separate reservations stacked. Verified against
+            // GetWidthSum's own independently-derived total, not just asserted (see StartXSpacing's
+            // remarks in CssLayoutEngineTable for the exact numeric residual this caught).
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(@"
+                <table id='t' style='border-collapse:collapse;border:6pt solid black'>
+                    <tr><td id='a' style='border-top:6pt solid black;border-left:6pt solid black'>a</td></tr>
+                </table>"));
+
+            var table = FindById(root, "t");
+            var a = FindById(root, "a");
+
+            Assert.Equal(0, a.Location.Y - table.Location.Y, 1);
+            Assert.Equal(0, a.Location.X - table.Location.X, 1);
+        }
+
+        [Fact]
+        public async Task TableOuterEdge_WonByACellAlone_StillCoincides()
+        {
+            // The table itself declares no border at all - only the cell touching the outer edge does.
+            // Without DerivedStyle.SetCollapsedUsedBorderWidths, the table's own (still-computed-from-its-
+            // own-declared-style) ActualBorderTopWidth/ActualBorderLeftWidth would stay 0, which happens
+            // to already coincide by accident here - the real point of this test is
+            // TableWidthMatchesGetWidthSum below, which fails without the override regardless of which
+            // box's declared border happens to be nonzero.
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(@"
+                <table id='t' style='border-collapse:collapse'>
+                    <tr><td id='a' style='border-top:6pt solid black;border-left:6pt solid black'>a</td></tr>
+                </table>"));
+
+            var table = FindById(root, "t");
+            var a = FindById(root, "a");
+
+            Assert.Equal(0, a.Location.Y - table.Location.Y, 1);
+            Assert.Equal(0, a.Location.X - table.Location.X, 1);
+        }
+
+        [Fact]
+        public async Task TableWidthMatchesColumnWidthsMinusInteriorGaps_NoOuterEdgeResidual()
+        {
+            // The regression this whole fix was for: a 3-column, uniformly 1px-bordered table's rendered
+            // width must equal its columns' own widths minus the (two) interior overlaps - with no
+            // leftover half-border residual from the outer edges, which independently-but-inconsistently
+            // computed startX/ActualRight formulas produced (200.375 instead of 200.000, for the fixture
+            // this mirrors) before StartXSpacing/StartYSpacing accounted for ClientLeft/ClientTop already
+            // including the table's own outer used-border-width.
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(@"
+                <table id='t' style='border-collapse:collapse;width:200pt'>
+                    <tr>
+                        <td id='a' style='border:1px solid black'>a</td>
+                        <td id='b' style='border:1px solid black'>b</td>
+                        <td id='c' style='border:1px solid black'>c</td>
+                    </tr>
+                </table>"));
+
+            var table = FindById(root, "t");
+
+            Assert.Equal(200, table.ActualRight - table.Location.X, 1);
+        }
+
+        [Fact]
+        public async Task ClientTop_ReflectsTheCellsOwnUsedBorderWidth_NotItsDeclaredOne()
+        {
+            // The cell's own border-top is 10pt, but half the RESOLVED width (also 10pt here, since
+            // nothing else contests this edge) is 5pt - content must be inset by the used (halved) value.
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(@"
+                <table style='border-collapse:collapse'>
+                    <tr><td id='a' style='border-top:10pt solid black;padding-top:2pt'>a</td></tr>
+                </table>"));
+
+            var a = FindById(root, "a");
+
+            Assert.Equal(5 + 2, a.ClientTop - a.Location.Y, 1);
+        }
+
+        [Fact]
+        public async Task SeparateTable_StillUsesRealBorderSpacing_Unaffected()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(@"
+                <table style='border-collapse:separate;border-spacing:5pt'>
+                    <tr><td id='a'>a</td><td id='b'>b</td></tr>
+                </table>"));
+
+            var a = FindById(root, "a");
+            var b = FindById(root, "b");
+
+            Assert.Equal(5, b.Location.X - a.ActualRight, 1);
+        }
+
+        [Fact]
+        public async Task Colspan_InteriorBoundary_ContributesNoSpacing()
+        {
+            // The line "inside" a colspan cell's own span is None (CollapsedBorderModel never registers
+            // a candidate there), so the cell measures as one continuous span with no internal gap.
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(@"
+                <table style='border-collapse:collapse;width:400pt'>
+                    <tr><td id='wide' colspan='2'>wide</td></tr>
+                    <tr><td id='c'>c</td><td id='d'>d</td></tr>
+                </table>"));
+
+            var wide = FindById(root, "wide");
+            var d = FindById(root, "d");
+
+            // The wide cell's own right edge reaches at least as far as column 2's own right edge (d's) -
+            // no interior gap was subtracted out of its span.
+            Assert.True(wide.ActualRight >= d.ActualRight - 1);
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Html/Core/Dom/CollapsedBorderModelIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/CollapsedBorderModelIntegrationTests.cs
@@ -1,0 +1,229 @@
+using PeachPDF.CSS;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Tests.TestSupport;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Html.Core.Dom
+{
+    /// <summary>
+    /// <see cref="CollapsedBorderModel"/> wired into <see cref="CssLayoutEngineTable"/> against real,
+    /// laid-out tables - resolved values only (cell/row/row-group/table origins; the column/column-group
+    /// tier lands separately). No geometry or paint assertions here - <see cref="CssBox.CollapsedBorders"/>
+    /// is set but nothing yet reads it to position or paint anything.
+    /// </summary>
+    public class CollapsedBorderModelIntegrationTests
+    {
+        private static async Task<CssBox> LayoutTable(string bodyHtml)
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(bodyHtml));
+            return LayoutHarness.Descendants(root).First(b => b.DerivedStyle.ActualDisplay is Keywords.Table or Keywords.InlineTable);
+        }
+
+        [Fact]
+        public async Task SeparateTable_BuildsNoGridOrModel()
+        {
+            var table = await LayoutTable(@"
+                <table style='border-collapse:separate'>
+                    <tr><td>a</td><td>b</td></tr>
+                </table>");
+
+            Assert.Null(table.CollapsedBorderGrid);
+            Assert.Null(table.CollapsedBorders);
+        }
+
+        [Fact]
+        public async Task CollapseTable_BuildsGridAndModel()
+        {
+            var table = await LayoutTable(@"
+                <table style='border-collapse:collapse'>
+                    <tr><td>a</td><td>b</td></tr>
+                </table>");
+
+            Assert.NotNull(table.CollapsedBorderGrid);
+            Assert.NotNull(table.CollapsedBorders);
+            Assert.Equal(1, table.CollapsedBorderGrid!.RowCount);
+            Assert.Equal(2, table.CollapsedBorderGrid!.ColumnCount);
+        }
+
+        [Fact]
+        public async Task SharedEdge_OnlyOneSideDeclaresABorder_ThatOneWins()
+        {
+            var table = await LayoutTable(@"
+                <table style='border-collapse:collapse'>
+                    <tr><td id='a' style='border-bottom:2pt solid black'>a</td></tr>
+                    <tr><td id='b'>b</td></tr>
+                </table>");
+
+            var resolved = table.CollapsedBorders!.Horizontal(1, 0); // between row 0 and row 1
+
+            Assert.Equal(LineStyle.Solid, resolved.Style);
+            Assert.Equal(2, resolved.Width);
+        }
+
+        [Fact]
+        public async Task SharedEdge_BothSidesDeclare_WiderWins()
+        {
+            var table = await LayoutTable(@"
+                <table style='border-collapse:collapse'>
+                    <tr><td style='border-bottom:1pt solid black'>a</td></tr>
+                    <tr><td style='border-top:5pt dashed blue'>b</td></tr>
+                </table>");
+
+            var resolved = table.CollapsedBorders!.Horizontal(1, 0);
+
+            Assert.Equal(LineStyle.Dashed, resolved.Style);
+            Assert.Equal(5, resolved.Width);
+        }
+
+        [Fact]
+        public async Task SharedEdge_EqualWidth_HigherStylePriorityWins()
+        {
+            var table = await LayoutTable(@"
+                <table style='border-collapse:collapse'>
+                    <tr><td style='border-bottom:2pt dotted black'>a</td></tr>
+                    <tr><td style='border-top:2pt double black'>b</td></tr>
+                </table>");
+
+            var resolved = table.CollapsedBorders!.Horizontal(1, 0);
+
+            Assert.Equal(LineStyle.Double, resolved.Style); // double outranks dotted
+        }
+
+        [Fact]
+        public async Task Hidden_SuppressesTheSharedEdge_EvenAgainstAWiderSolidBorder()
+        {
+            var table = await LayoutTable(@"
+                <table style='border-collapse:collapse'>
+                    <tr><td style='border-bottom:10pt solid black'>a</td></tr>
+                    <tr><td style='border-top:hidden'>b</td></tr>
+                </table>");
+
+            var resolved = table.CollapsedBorders!.Horizontal(1, 0);
+
+            Assert.Equal(LineStyle.Hidden, resolved.Style);
+            Assert.False(resolved.IsPainted);
+        }
+
+        [Fact]
+        public async Task CellBorder_OutranksRowBorder_AtEqualWidthAndStyle()
+        {
+            var table = await LayoutTable(@"
+                <table style='border-collapse:collapse'>
+                    <tr style='border-bottom:3pt solid red'><td style='border-bottom:3pt solid blue'>a</td></tr>
+                    <tr><td>b</td></tr>
+                </table>");
+
+            var resolved = table.CollapsedBorders!.Horizontal(1, 0);
+
+            // Cell (blue) beats row (red) - both 3pt solid, cell has higher origin priority.
+            Assert.Equal(RColorBlue(), resolved.Color);
+        }
+
+        private static PeachPDF.Html.Adapters.Entities.RColor RColorBlue() =>
+            PeachPDF.Html.Adapters.Entities.RColor.FromArgb(0, 0, 255);
+
+        [Fact]
+        public async Task RowBorder_WinsWhenNoCellDeclaresOne()
+        {
+            var table = await LayoutTable(@"
+                <table style='border-collapse:collapse'>
+                    <tr style='border-bottom:4pt solid green'><td>a</td></tr>
+                    <tr><td>b</td></tr>
+                </table>");
+
+            var resolved = table.CollapsedBorders!.Horizontal(1, 0);
+
+            Assert.Equal(4, resolved.Width);
+            Assert.True(resolved.IsPainted);
+        }
+
+        [Fact]
+        public async Task TableBorder_ParticipatesAtTheOuterTopEdge()
+        {
+            var table = await LayoutTable(@"
+                <table style='border-collapse:collapse;border:6pt solid black'>
+                    <tr><td>a</td></tr>
+                </table>");
+
+            var top = table.CollapsedBorders!.Horizontal(0, 0);
+            var bottom = table.CollapsedBorders!.Horizontal(1, 0);
+            var left = table.CollapsedBorders!.Vertical(0, 0);
+            var right = table.CollapsedBorders!.Vertical(0, 1);
+
+            Assert.Equal(6, top.Width);
+            Assert.Equal(6, bottom.Width);
+            Assert.Equal(6, left.Width);
+            Assert.Equal(6, right.Width);
+        }
+
+        [Fact]
+        public async Task TableBorder_LosesToAWiderCellBorder_AtTheOuterEdge()
+        {
+            var table = await LayoutTable(@"
+                <table style='border-collapse:collapse;border:1pt solid black'>
+                    <tr><td style='border-top:9pt solid red'>a</td></tr>
+                </table>");
+
+            var top = table.CollapsedBorders!.Horizontal(0, 0);
+
+            Assert.Equal(9, top.Width);
+        }
+
+        [Fact]
+        public async Task RowGroupBorder_ParticipatesAtItsOwnBoundary()
+        {
+            var table = await LayoutTable(@"
+                <table style='border-collapse:collapse'>
+                    <tbody style='border-bottom:7pt solid black'>
+                        <tr><td>a</td></tr>
+                    </tbody>
+                    <tbody>
+                        <tr><td>b</td></tr>
+                    </tbody>
+                </table>");
+
+            var resolved = table.CollapsedBorders!.Horizontal(1, 0); // boundary between the two tbodies
+
+            Assert.Equal(7, resolved.Width);
+        }
+
+        [Fact]
+        public async Task NoBordersDeclaredAnywhere_EveryLineResolvesToNone()
+        {
+            var table = await LayoutTable(@"
+                <table style='border-collapse:collapse'>
+                    <tr><td>a</td><td>b</td></tr>
+                </table>");
+
+            for (var line = 0; line <= table.CollapsedBorderGrid!.RowCount; line++)
+            for (var column = 0; column < table.CollapsedBorderGrid!.ColumnCount; column++)
+            {
+                var resolved = table.CollapsedBorders!.Horizontal(line, column);
+                Assert.False(resolved.IsPainted);
+            }
+        }
+
+        [Fact]
+        public async Task Issue735Repro_SharedEdgeBetweenTwoBackgroundColoredRows_ResolvesToAVisibleBorder()
+        {
+            // The reported bug's own shape: two adjacent rows, each cell colored AND carrying the shared
+            // border-bottom - this asserts the RESOLUTION is correct (a real border wins the shared
+            // edge); the paint-order fix that makes it actually render is Phase 3.
+            var td = "style='background-color:#C00000;border-bottom:solid #000 1pt'";
+            var table = await LayoutTable($@"
+                <table style='border-collapse:collapse;width:100%'>
+                    <tr style='border-bottom:solid #000 1pt'><td {td}>!</td><td style='border-bottom:solid #000 1pt'>Missing Emergency Contact</td></tr>
+                    <tr style='border-bottom:solid #000 1pt'><td {td}>!</td><td style='border-bottom:solid #000 1pt'>Missing Emergency Contact</td></tr>
+                </table>");
+
+            var sharedEdgeColumn0 = table.CollapsedBorders!.Horizontal(1, 0);
+            var sharedEdgeColumn1 = table.CollapsedBorders!.Horizontal(1, 1);
+
+            Assert.True(sharedEdgeColumn0.IsPainted);
+            Assert.Equal(LineStyle.Solid, sharedEdgeColumn0.Style);
+            Assert.True(sharedEdgeColumn1.IsPainted);
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Html/Core/Dom/CollapsedBorderResolverTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/CollapsedBorderResolverTests.cs
@@ -1,0 +1,267 @@
+using PeachPDF.CSS;
+using PeachPDF.Html.Adapters.Entities;
+using PeachPDF.Html.Core.Dom;
+using System;
+using Xunit;
+
+namespace PeachPDF.Tests.Html.Core.Dom
+{
+    /// <summary>
+    /// CSS 2.1 §17.6.2 border-conflict resolution, tested in isolation from layout/paint -
+    /// <see cref="CollapsedBorderResolver"/> is a pure function of candidate values.
+    /// </summary>
+    public class CollapsedBorderResolverTests
+    {
+        private static CollapsedBorderCandidate Candidate(
+            LineStyle style,
+            double width,
+            CollapsedBorderOrigin origin = CollapsedBorderOrigin.Cell,
+            int row = 0,
+            int column = 0,
+            byte colorSeed = 0) =>
+            new(style, width, RColor.FromArgb(colorSeed, colorSeed, colorSeed), origin, row, column);
+
+        [Fact]
+        public void StylePriority_MatchesCss21Order()
+        {
+            // §17.6.2's own order - deliberately NOT LineStyle's declaration order.
+            var ordered = new[]
+            {
+                LineStyle.None, LineStyle.Inset, LineStyle.Groove, LineStyle.Outset, LineStyle.Ridge,
+                LineStyle.Dotted, LineStyle.Dashed, LineStyle.Solid, LineStyle.Double, LineStyle.Hidden
+            };
+
+            for (var i = 1; i < ordered.Length; i++)
+            {
+                Assert.True(
+                    CollapsedBorderResolver.StylePriority(ordered[i]) > CollapsedBorderResolver.StylePriority(ordered[i - 1]),
+                    $"{ordered[i]} should outrank {ordered[i - 1]}");
+            }
+        }
+
+        [Fact]
+        public void NoCandidates_ResolvesToNone()
+        {
+            var result = CollapsedBorderResolver.Resolve(ReadOnlySpan<CollapsedBorderCandidate>.Empty, leftToRight: true);
+
+            Assert.Equal(CollapsedBorder.None, result);
+            Assert.False(result.IsPainted);
+        }
+
+        [Fact]
+        public void Hidden_SuppressesEveryOtherCandidate_EvenAWiderMoreSpecificOne()
+        {
+            var candidates = new[]
+            {
+                Candidate(LineStyle.Hidden, 1, CollapsedBorderOrigin.Table),
+                Candidate(LineStyle.Solid, 10, CollapsedBorderOrigin.Cell),
+            };
+
+            var result = CollapsedBorderResolver.Resolve(candidates, leftToRight: true);
+
+            Assert.Equal(LineStyle.Hidden, result.Style);
+            Assert.False(result.IsPainted);
+        }
+
+        [Fact]
+        public void None_NeverParticipates_UnlessEveryCandidateIsNone()
+        {
+            var candidates = new[]
+            {
+                Candidate(LineStyle.None, 5),
+                Candidate(LineStyle.Solid, 1),
+            };
+
+            var result = CollapsedBorderResolver.Resolve(candidates, leftToRight: true);
+
+            Assert.Equal(LineStyle.Solid, result.Style);
+            Assert.Equal(1, result.Width);
+        }
+
+        [Fact]
+        public void AllNone_ResolvesToNone()
+        {
+            var candidates = new[] { Candidate(LineStyle.None, 5), Candidate(LineStyle.None, 3) };
+
+            var result = CollapsedBorderResolver.Resolve(candidates, leftToRight: true);
+
+            Assert.Equal(CollapsedBorder.None, result);
+        }
+
+        [Fact]
+        public void WiderWins_RegardlessOfStyleAndOrigin()
+        {
+            var candidates = new[]
+            {
+                Candidate(LineStyle.Dotted, 5, CollapsedBorderOrigin.Table),
+                Candidate(LineStyle.Double, 3, CollapsedBorderOrigin.Cell),
+            };
+
+            var result = CollapsedBorderResolver.Resolve(candidates, leftToRight: true);
+
+            Assert.Equal(LineStyle.Dotted, result.Style);
+            Assert.Equal(5, result.Width);
+        }
+
+        [Fact]
+        public void EqualWidth_HigherStylePriorityWins()
+        {
+            // §17.6.2 order, adjacent pairs: each earlier style must outrank the one after it.
+            var order = new[]
+            {
+                LineStyle.Double, LineStyle.Solid, LineStyle.Dashed, LineStyle.Dotted,
+                LineStyle.Ridge, LineStyle.Outset, LineStyle.Groove, LineStyle.Inset
+            };
+
+            for (var i = 0; i < order.Length - 1; i++)
+            {
+                var higher = order[i];
+                var lower = order[i + 1];
+
+                var candidates = new[]
+                {
+                    Candidate(lower, 2, CollapsedBorderOrigin.Cell),
+                    Candidate(higher, 2, CollapsedBorderOrigin.Table),
+                };
+
+                var result = CollapsedBorderResolver.Resolve(candidates, leftToRight: true);
+
+                Assert.True(result.Style == higher, $"{higher} should have outranked {lower}, got {result.Style}");
+            }
+        }
+
+        [Fact]
+        public void EqualWidthAndStyle_MoreSpecificOriginWins()
+        {
+            var origins = new[]
+            {
+                CollapsedBorderOrigin.Cell, CollapsedBorderOrigin.Row, CollapsedBorderOrigin.RowGroup,
+                CollapsedBorderOrigin.Column, CollapsedBorderOrigin.ColumnGroup, CollapsedBorderOrigin.Table
+            };
+
+            for (var i = 0; i < origins.Length; i++)
+            {
+                for (var j = i + 1; j < origins.Length; j++)
+                {
+                    var moreSpecific = origins[i];
+                    var lessSpecific = origins[j];
+
+                    var winnerColor = RColor.FromArgb(1, 1, 1);
+                    var loserColor = RColor.FromArgb(2, 2, 2);
+                    var candidates = new[]
+                    {
+                        new CollapsedBorderCandidate(LineStyle.Solid, 2, loserColor, lessSpecific, 0, 0),
+                        new CollapsedBorderCandidate(LineStyle.Solid, 2, winnerColor, moreSpecific, 0, 0),
+                    };
+
+                    var result = CollapsedBorderResolver.Resolve(candidates, leftToRight: true);
+
+                    Assert.True(result.Color == winnerColor,
+                        $"{moreSpecific} should have outranked {lessSpecific}");
+                }
+            }
+        }
+
+        [Fact]
+        public void DifferOnlyInColor_MoreSpecificOriginStillDecides()
+        {
+            var cellColor = RColor.FromArgb(255, 0, 0);
+            var tableColor = RColor.FromArgb(0, 0, 255);
+            var candidates = new[]
+            {
+                new CollapsedBorderCandidate(LineStyle.Solid, 2, tableColor, CollapsedBorderOrigin.Table, 0, 0),
+                new CollapsedBorderCandidate(LineStyle.Solid, 2, cellColor, CollapsedBorderOrigin.Cell, 0, 0),
+            };
+
+            var result = CollapsedBorderResolver.Resolve(candidates, leftToRight: true);
+
+            Assert.Equal(cellColor, result.Color);
+        }
+
+        [Fact]
+        public void SameOrigin_Ltr_PrefersLeftmostColumnThenTopmostRow()
+        {
+            var candidates = new[]
+            {
+                Candidate(LineStyle.Solid, 2, CollapsedBorderOrigin.Cell, row: 5, column: 3),
+                Candidate(LineStyle.Solid, 2, CollapsedBorderOrigin.Cell, row: 1, column: 1),
+            };
+
+            var result = CollapsedBorderResolver.Resolve(candidates, leftToRight: true);
+
+            // Both candidates resolve to the same style/width; assert via a distinguishing color instead.
+            var withColor = new[]
+            {
+                new CollapsedBorderCandidate(LineStyle.Solid, 2, RColor.FromArgb(1, 1, 1), CollapsedBorderOrigin.Cell, 5, 3),
+                new CollapsedBorderCandidate(LineStyle.Solid, 2, RColor.FromArgb(2, 2, 2), CollapsedBorderOrigin.Cell, 1, 1),
+            };
+            var resolved = CollapsedBorderResolver.Resolve(withColor, leftToRight: true);
+
+            Assert.Equal(RColor.FromArgb(2, 2, 2), resolved.Color); // column 1 beats column 3
+        }
+
+        [Fact]
+        public void SameOrigin_Rtl_PrefersRightmostColumn()
+        {
+            var candidates = new[]
+            {
+                new CollapsedBorderCandidate(LineStyle.Solid, 2, RColor.FromArgb(1, 1, 1), CollapsedBorderOrigin.Cell, 0, 3),
+                new CollapsedBorderCandidate(LineStyle.Solid, 2, RColor.FromArgb(2, 2, 2), CollapsedBorderOrigin.Cell, 0, 1),
+            };
+
+            var resolved = CollapsedBorderResolver.Resolve(candidates, leftToRight: false);
+
+            Assert.Equal(RColor.FromArgb(1, 1, 1), resolved.Color); // column 3 beats column 1 under rtl
+        }
+
+        [Fact]
+        public void SameOriginAndColumn_PrefersTopmostRow()
+        {
+            var candidates = new[]
+            {
+                new CollapsedBorderCandidate(LineStyle.Solid, 2, RColor.FromArgb(1, 1, 1), CollapsedBorderOrigin.Cell, 5, 0),
+                new CollapsedBorderCandidate(LineStyle.Solid, 2, RColor.FromArgb(2, 2, 2), CollapsedBorderOrigin.Cell, 1, 0),
+            };
+
+            var resolved = CollapsedBorderResolver.Resolve(candidates, leftToRight: true);
+
+            Assert.Equal(RColor.FromArgb(2, 2, 2), resolved.Color); // row 1 beats row 5
+        }
+
+        [Fact]
+        public void HiddenWithZeroWidth_StillSuppresses()
+        {
+            // A computed border-width is forced to 0 for style "none" but NOT for "hidden" - a
+            // hidden border with an explicit width of 0 must still short-circuit via clause 1, not be
+            // skipped as if it were unpainted.
+            var candidates = new[]
+            {
+                Candidate(LineStyle.Hidden, 0),
+                Candidate(LineStyle.Solid, 5),
+            };
+
+            var result = CollapsedBorderResolver.Resolve(candidates, leftToRight: true);
+
+            Assert.Equal(LineStyle.Hidden, result.Style);
+        }
+
+        [Fact]
+        public void Css21WorkedExample_RowWins()
+        {
+            // CSS 2.1 §17.6.2's own example: "a table cell has a 4px solid red border with a table
+            // that has a 10px double blue border" resolves to... the wider one; here transcribed with
+            // a cell 3px solid vs. a row 5px dashed - the row wins purely on width despite lower style
+            // priority and lower origin priority, exactly clause 3 overriding clauses 4 and 5.
+            var candidates = new[]
+            {
+                Candidate(LineStyle.Solid, 3, CollapsedBorderOrigin.Cell),
+                Candidate(LineStyle.Dashed, 5, CollapsedBorderOrigin.Row),
+            };
+
+            var result = CollapsedBorderResolver.Resolve(candidates, leftToRight: true);
+
+            Assert.Equal(LineStyle.Dashed, result.Style);
+            Assert.Equal(5, result.Width);
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTablePageBreakTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTablePageBreakTests.cs
@@ -497,7 +497,11 @@ namespace PeachPDF.Tests.Html.Core.Dom
             Assert.NotNull(table.PageBreakBottoms);
             Assert.NotEmpty(table.PageBreakBottoms);
 
-            var lastPageIndex = (int)(table.ActualBottom / pageHeight);
+            // The actual fragmentainer count, not a heuristic division of table.ActualBottom by
+            // pageHeight - collapsed-border geometry (issue #735's own fix) shifts exactly how tall the
+            // table measures, and a division-based estimate drifts out of sync with the real page count
+            // as that arithmetic gets more precise, landing on a page index the fragment tree never built.
+            var lastPageIndex = container.FragmentTree!.Fragmentainers.Count - 1;
             Assert.True(lastPageIndex >= 1, "Table should span at least 2 pages for this test to be meaningful.");
 
             var adapter = new PeachPDF.Adapters.PdfSharpAdapter();
@@ -730,6 +734,292 @@ namespace PeachPDF.Tests.Html.Core.Dom
                 $"but found none. All lines: [{string.Join(", ", recording.HorizontalLines.Select(y => $"{y:F1}"))}]");
         }
 
+        [Fact]
+        public async Task RepeatedThead_BoundaryToBody_ResolvesFreshPerPage_NotReusedFromPage1()
+        {
+            // CSS 2.1 §17.6.2 resolves a border against whichever row is *visually* adjacent - for a
+            // repeated <thead>, that is whatever row actually starts each page, not the header's single
+            // DOM-order neighbor (body row 1). Only row 1 (page 1's true neighbor) gets a deliberately
+            // huge, distinctive border; every other row keeps an ordinary thin one. A resolution that
+            // reuses page 1's answer on every later page would wrongly show the huge border repeated at
+            // every page's header boundary too; a per-page-fresh resolution shows it only on page 1.
+            var pageHeight = 400.0;
+
+            var html = @"
+<!DOCTYPE html>
+<html>
+<body>
+    <table style='width:100%;border-collapse:collapse;'>
+        <thead>
+            <tr><th style='border:1px solid black;padding:5px;'>Header</th></tr>
+        </thead>
+        <tbody>
+" + string.Join("", Enumerable.Range(1, 30).Select(i =>
+    i == 1
+        ? "<tr><td style='border:9px solid red;padding:5px;'>Row 1</td></tr>"
+        : $"<tr><td style='border:1px solid black;padding:5px;'>Row {i}</td></tr>")) + @"
+        </tbody>
+    </table>
+</body>
+</html>";
+
+            var (rootBox, container) = await BuildCssBoxTree(html, pageHeight);
+
+            var table = FindTableBox(rootBox);
+            Assert.NotNull(table);
+
+            var lastPageIndex = container.FragmentTree!.Fragmentainers.Count - 1;
+            Assert.True(lastPageIndex >= 2, "Table should span at least 3 pages for this test to be meaningful.");
+
+            var adapter = new PeachPDF.Adapters.PdfSharpAdapter();
+
+            // Page 0: the header's true DOM/visual neighbor (row 1's huge red border) drives the
+            // boundary - a thick (>=8pt) roughly-horizontal segment must appear somewhere on this page.
+            var page0Recording = new RecordingGraphics(adapter);
+            FragmentPaintHarness.PaintPage(container, page0Recording, 0);
+            Assert.Contains(page0Recording.Log, IsThickHorizontalSegment);
+
+            // Every later page: the header repeats above a *different* row (an ordinary 1px border), so
+            // no page after the first should show that same thick segment anywhere.
+            for (var page = 1; page <= lastPageIndex; page++)
+            {
+                var recording = new RecordingGraphics(adapter);
+                FragmentPaintHarness.PaintPage(container, recording, page);
+                Assert.DoesNotContain(recording.Log, IsThickHorizontalSegment);
+            }
+        }
+
+        // 9px resolves to 6.75pt (1px = 0.75pt, see Length.PointsPerPx); an ordinary 1px border resolves
+        // to 0.75pt, so a threshold well between the two distinguishes "row 1's huge border won" from
+        // "an ordinary row's border won" without being sensitive to the exact px-to-pt ratio.
+        private static bool IsThickHorizontalSegment(PaintOp op) =>
+            op.Kind is PaintOpKind.Polygon or PaintOpKind.Line &&
+            op.Bounds.Width > op.Bounds.Height && op.Bounds.Height >= 4;
+
+        [Fact]
+        public async Task RepeatedThead_OwnInternalGridLine_RedrawnTranslatedOnEveryPage()
+        {
+            // A multi-row <thead>'s own internal grid line (between its own rows) is fixed, unlike the
+            // boundary to the body - but a repeated group's *position* still differs per page, since each
+            // CssProxyBox.PerformLayoutImp repositions the same shared header rows to wherever that page's
+            // proxy sits. Reading the live row geometry after the whole table has laid out (as
+            // EmitCollapsedBorderSegments does for an ordinary body row) would only reflect whichever
+            // proxy happened to lay out last - this line must instead come from each proxy's own captured
+            // BoxGeometrySnapshot, so it has to reappear, correctly positioned, on every page.
+            //
+            // Page height (1200) is deliberately generous relative to the two-row header's own height
+            // (~160pt): css-tables-3 §6.2 (SettleWhetherTheGroupsRepeat) only repeats a group under a
+            // quarter of the page's own height, and a too-small page here would silently turn this into a
+            // non-repeating-header test instead of the multi-page one intended.
+            var pageHeight = 1200.0;
+
+            var html = @"
+<!DOCTYPE html>
+<html>
+<body>
+    <table style='width:100%;border-collapse:collapse;'>
+        <thead>
+            <tr><th style='border:1px solid black;border-bottom:5px solid green;padding:5px;'>Header A</th></tr>
+            <tr><th style='border:1px solid black;border-top:5px solid green;padding:5px;'>Header B</th></tr>
+        </thead>
+        <tbody>
+" + string.Join("", Enumerable.Range(1, 90).Select(i =>
+    $"<tr><td style='border:1px solid black;padding:5px;'>Row {i}</td></tr>")) + @"
+        </tbody>
+    </table>
+</body>
+</html>";
+
+            var (rootBox, container) = await BuildCssBoxTree(html, pageHeight);
+
+            var table = FindTableBox(rootBox);
+            Assert.NotNull(table);
+
+            var lastPageIndex = container.FragmentTree!.Fragmentainers.Count - 1;
+            Assert.True(lastPageIndex >= 2, "Table should span at least 3 pages for this test to be meaningful.");
+
+            var adapter = new PeachPDF.Adapters.PdfSharpAdapter();
+
+            // 5px resolves to 3.75pt - between the 0.75pt ordinary borders and the header's own outer
+            // 1px (0.75pt) edges, so this threshold catches only the header's own internal line.
+            static bool IsHeaderInternalLine(PaintOp op) =>
+                op.Kind is PaintOpKind.Polygon or PaintOpKind.Line &&
+                op.Bounds.Width > op.Bounds.Height && op.Bounds.Height is >= 2 and < 4;
+
+            for (var page = 0; page <= lastPageIndex; page++)
+            {
+                var recording = new RecordingGraphics(adapter);
+                FragmentPaintHarness.PaintPage(container, recording, page);
+                Assert.True(recording.Log.Any(IsHeaderInternalLine),
+                    $"Expected the header's own internal grid line on page {page}, but found none.");
+            }
+        }
+
+        [Fact]
+        public async Task RepeatedThead_RowspanInHeadersLastRow_BoundaryColumnsAttributeToTheRightCell()
+        {
+            // CollapsedBorderModel.ResolveRepeatedGroupBoundary reads cell candidates from the header's
+            // own last row at each column via TableGrid.CellAt - which correctly follows a rowspan cell
+            // (here, A, spanning both header rows in the last column) into the boundary line, unlike
+            // scanning the last row's own Boxes list by hand (which held only D, and would either
+            // misattribute column 1 to it or miss it depending on where in the row the span falls).
+            //
+            // The rowspan cell is placed LAST in row 0 (not first) deliberately: a rowspan cell reaching
+            // into a later row from earlier in the *same* row deliberately leaves that later row's own
+            // Boxes list non-dense (CssLayoutEngineTable.InsertEmptyBoxes, which pads exactly this gap
+            // with a CssSpacingBox placeholder, never touches a detached header's own rows - only
+            // _bodyRows) - tracked separately as
+            // https://github.com/jhaygood86/PeachPDF/issues/736, since TableGrid.Build's own column-index
+            // computation mis-places a cell after such a gap regardless of which resolver reads the grid
+            // afterward. Putting the rowspan cell last avoids that unrelated, pre-existing gap: row 1's
+            // only real cell (D) is then genuinely its own first Boxes entry, so its column index is
+            // right either way, and only column 1 depends on rowspan-aware occupancy at all.
+            var pageHeight = 400.0;
+
+            var html = @"
+<!DOCTYPE html>
+<html>
+<body>
+    <table style='width:100%;border-collapse:collapse;'>
+        <thead>
+            <tr><th style='border-bottom:1px solid black'>B</th><th rowspan='2' style='border-bottom:9px solid red'>A</th></tr>
+            <tr><th style='border-bottom:3px solid blue'>D</th></tr>
+        </thead>
+        <tbody>
+" + string.Join("", Enumerable.Range(1, 20).Select(i =>
+    $"<tr><td id='r{i}c0'>{i}x</td><td id='r{i}c1'>{i}y</td></tr>")) + @"
+        </tbody>
+    </table>
+</body>
+</html>";
+
+            var (rootBox, container) = await BuildCssBoxTree(html, pageHeight);
+
+            var table = FindTableBox(rootBox);
+            Assert.NotNull(table);
+
+            var headerProxy = table!.Boxes.OfType<CssProxyBox>()
+                .First(p => p.Display.Value == DisplayMode.TableHeaderGroup);
+            var segments = headerProxy.SourceBox.CollapsedBorderSegments;
+            Assert.NotNull(segments);
+
+            var col0 = LayoutHarness.FindById(rootBox, "r1c0")!;
+            var col1 = LayoutHarness.FindById(rootBox, "r1c1")!;
+
+            // Column 0 also has its own row 0-to-row 1 *internal* line (B's border-bottom, since B - unlike
+            // A - does not span into row 1), so filtering by X alone finds two candidates there; the
+            // boundary is always the group's own last line, i.e. the largest Y among a header's segments.
+            var boundarySegments = segments!.Where(s => s.IsHorizontal).ToList();
+
+            var col0Segment = boundarySegments
+                .Where(s => s.Rect.X + s.Rect.Width / 2 >= col0.Location.X && s.Rect.X + s.Rect.Width / 2 < col0.ActualRight)
+                .OrderByDescending(s => s.Rect.Y)
+                .FirstOrDefault();
+            var col1Segment = boundarySegments
+                .Where(s => s.Rect.X + s.Rect.Width / 2 >= col1.Location.X && s.Rect.X + s.Rect.Width / 2 < col1.ActualRight)
+                .OrderByDescending(s => s.Rect.Y)
+                .FirstOrDefault();
+
+            // 3px/9px resolve to 2.25pt/6.75pt (1px = 0.75pt).
+            Assert.Equal(2.25, col0Segment.Width, 1);
+            Assert.Equal(6.75, col1Segment.Width, 1);
+        }
+
+        [Fact]
+        public async Task RepeatedTfoot_BoundaryToBody_ResolvesFreshPerPage_NotReusedFromTheLastPage()
+        {
+            // The mirror of RepeatedThead_BoundaryToBody_ResolvesFreshPerPage_NotReusedFromPage1 for a
+            // repeating <tfoot>: only the table's actual LAST body row (its true DOM/visual neighbor on
+            // the final page) gets a distinctive border; every earlier row keeps an ordinary one. A
+            // resolution that reused the last page's answer on every earlier page would wrongly show the
+            // huge border repeated at every page's footer boundary too.
+            var pageHeight = 400.0;
+
+            var html = @"
+<!DOCTYPE html>
+<html>
+<body>
+    <table style='width:100%;border-collapse:collapse;'>
+        <tbody>
+" + string.Join("", Enumerable.Range(1, 30).Select(i =>
+    i == 30
+        ? "<tr><td style='border:9px solid red;padding:5px;'>Last row</td></tr>"
+        : $"<tr><td style='border:1px solid black;padding:5px;'>Row {i}</td></tr>")) + @"
+        </tbody>
+        <tfoot>
+            <tr><td style='border:1px solid black;padding:5px;'>Footer</td></tr>
+        </tfoot>
+    </table>
+</body>
+</html>";
+
+            var (rootBox, container) = await BuildCssBoxTree(html, pageHeight);
+
+            var table = FindTableBox(rootBox);
+            Assert.NotNull(table);
+
+            var lastPageIndex = container.FragmentTree!.Fragmentainers.Count - 1;
+            Assert.True(lastPageIndex >= 2, "Table should span at least 3 pages for this test to be meaningful.");
+
+            var adapter = new PeachPDF.Adapters.PdfSharpAdapter();
+
+            // The last page: the footer's true DOM/visual neighbor (the last row's huge red border)
+            // drives the boundary - a thick (>=4pt) roughly-horizontal segment must appear.
+            var lastPageRecording = new RecordingGraphics(adapter);
+            FragmentPaintHarness.PaintPage(container, lastPageRecording, lastPageIndex);
+            Assert.Contains(lastPageRecording.Log, IsThickHorizontalSegment);
+
+            // Every earlier page: the footer repeats below a *different* row (an ordinary 1px border),
+            // so no page before the last should show that same thick segment anywhere.
+            for (var page = 0; page < lastPageIndex; page++)
+            {
+                var recording = new RecordingGraphics(adapter);
+                FragmentPaintHarness.PaintPage(container, recording, page);
+                Assert.DoesNotContain(recording.Log, IsThickHorizontalSegment);
+            }
+        }
+
+        [Fact]
+        public async Task RepeatedThead_BoundaryAgainstABorderedTbody_TbodysOwnBorderCanWin()
+        {
+            // ResolveRepeatedGroupBoundary must weigh the adjacent side's own row-group (an explicit
+            // <tbody>'s border-top), not just its row/cell - CollapsedBorderOrigin.RowGroup is a real,
+            // independently-competing tier (CollapsedBorder.cs), not merely a tiebreak, so a <tbody>
+            // border wider than anything the header or the first row itself declares must still win.
+            var pageHeight = 1200.0;
+
+            var html = @"
+<!DOCTYPE html>
+<html>
+<body>
+    <table style='width:100%;border-collapse:collapse;'>
+        <thead>
+            <tr><th style='border-bottom:1px solid black;padding:5px;'>Header</th></tr>
+        </thead>
+        <tbody style='border-top:8px solid green'>
+" + string.Join("", Enumerable.Range(1, 60).Select(i =>
+    $"<tr><td style='padding:5px;'>Row {i}</td></tr>")) + @"
+        </tbody>
+    </table>
+</body>
+</html>";
+
+            var (rootBox, container) = await BuildCssBoxTree(html, pageHeight);
+
+            var table = FindTableBox(rootBox);
+            Assert.NotNull(table);
+
+            var adapter = new PeachPDF.Adapters.PdfSharpAdapter();
+            var recording = new RecordingGraphics(adapter);
+            FragmentPaintHarness.PaintPage(container, recording, 0);
+
+            // 8px resolves to 6pt - between the 0.75pt header border and page 1's thead test's own 6.75pt
+            // threshold band, so >=5 unambiguously catches only the tbody's own border winning.
+            Assert.Contains(recording.Log, op =>
+                op.Kind is PaintOpKind.Polygon or PaintOpKind.Line &&
+                op.Bounds.Width > op.Bounds.Height && op.Bounds.Height >= 5);
+        }
+
         #endregion
 
         #region Helper Methods
@@ -772,110 +1062,7 @@ namespace PeachPDF.Tests.Html.Core.Dom
 
         #endregion
 
-        #region Recording Graphics Adapter
-
-        /// <summary>
-        /// Minimal RGraphics implementation that records PushClip/PopClip calls and drawn lines
-        /// so tests can verify page-break border behavior without a full PDF rendering stack.
-        /// </summary>
-        private sealed class RecordingGraphics : PeachPDF.Html.Adapters.RGraphics
-        {
-            /// <summary>All rects passed to PushClip during this paint pass.</summary>
-            public List<PeachPDF.Html.Adapters.Entities.RRect> PushedClips { get; } = [];
-            /// <summary>Total PushClip invocations.</summary>
-            public int PushCount { get; private set; }
-            /// <summary>Total PopClip invocations.</summary>
-            public int PopCount { get; private set; }
-            /// <summary>Y-coordinates of horizontal lines drawn (where y1 ≈ y2).</summary>
-            public List<double> HorizontalLines { get; } = [];
-            /// <summary>Every word string passed to DrawString during this paint pass, with the Y it was drawn at.</summary>
-            public List<(string Text, double Y)> DrawnStrings { get; } = [];
-
-            public RecordingGraphics(PeachPDF.Html.Adapters.RAdapter adapter)
-                : base(adapter, new PeachPDF.Html.Adapters.Entities.RRect(0, 0, double.MaxValue, double.MaxValue)) { }
-
-            public override void DrawLine(PeachPDF.Html.Adapters.RPen pen, double x1, double y1, double x2, double y2)
-            {
-                if (Math.Abs(y1 - y2) < 0.5)
-                    HorizontalLines.Add(y1);
-            }
-
-            /// <summary>
-            /// Solid borders paint as a mitered quad (BordersDrawHandler.SetInOutsetRectanglePoints),
-            /// not a DrawLine call - a wide-and-thin quad (wider in X than in Y) is a horizontal border
-            /// stripe; record its vertical center the same way DrawLine's y1/y2 would, so callers don't
-            /// need to know which draw method a given border style happens to use.
-            /// </summary>
-            public override void DrawPolygon(PeachPDF.Html.Adapters.RBrush brush, PeachPDF.Html.Adapters.Entities.RPoint[] points)
-            {
-                if (points.Length == 0) return;
-                var minY = points.Min(p => p.Y);
-                var maxY = points.Max(p => p.Y);
-                var minX = points.Min(p => p.X);
-                var maxX = points.Max(p => p.X);
-                if (maxX - minX > maxY - minY)
-                    HorizontalLines.Add((minY + maxY) / 2);
-            }
-
-            public override void PushClip(PeachPDF.Html.Adapters.Entities.RRect rect)
-            {
-                _clipStack.Push(rect);
-                PushedClips.Add(rect);
-                PushCount++;
-            }
-
-            public override void PopClip()
-            {
-                if (_clipStack.Count > 1)
-                    _clipStack.Pop();
-                PopCount++;
-            }
-
-            public override void PushClip(PeachPDF.Html.Adapters.RGraphicsPath path) => _clipStack.Push(_clipStack.Peek());
-            public override void PushClipExclude(PeachPDF.Html.Adapters.Entities.RRect rect) { }
-            public override void PushTransform(PeachPDF.Html.Adapters.Entities.RMatrix matrix) { }
-            public override void PopTransform() { }
-            public override void PushBlendMode(PeachPDF.Html.Adapters.Entities.RBlendMode mode) { }
-            public override void PopBlendMode() { }
-            public override object SetAntiAliasSmoothingMode() => new object();
-            public override void ReturnPreviousSmoothingMode(object? prevMode) { }
-            public override PeachPDF.Html.Adapters.Entities.RSize MeasureString(string str, PeachPDF.Html.Adapters.RFont font, PeachPDF.Text.TextShapingFeatures? features = null) => new(0, 12);
-            public override int CountShapedGlyphs(string str, PeachPDF.Html.Adapters.RFont font, PeachPDF.Text.TextShapingFeatures? features = null) => str?.Length ?? 0;
-            public override void MeasureString(string str, PeachPDF.Html.Adapters.RFont font, double maxWidth, out int charFit, out double charFitWidth) { charFit = str?.Length ?? 0; charFitWidth = 0; }
-            public override void DrawString(string str, PeachPDF.Html.Adapters.RFont font, PeachPDF.Html.Adapters.Entities.RColor color, PeachPDF.Html.Adapters.Entities.RPoint point, PeachPDF.Html.Adapters.Entities.RSize size, double letterSpacing = 0, PeachPDF.Html.Adapters.Entities.RFontPalette? fontPalette = null, PeachPDF.Text.TextShapingFeatures? features = null) => DrawnStrings.Add((str, point.Y));
-            public override void DrawRectangle(PeachPDF.Html.Adapters.RPen pen, double x, double y, double width, double height) { }
-            public override void DrawRectangle(PeachPDF.Html.Adapters.RBrush brush, double x, double y, double width, double height) { }
-            public override void DrawImage(PeachPDF.Html.Adapters.RImage image, PeachPDF.Html.Adapters.Entities.RRect destRect, PeachPDF.Html.Adapters.Entities.RRect srcRect) { }
-            public override void DrawImage(PeachPDF.Html.Adapters.RImage image, PeachPDF.Html.Adapters.Entities.RRect destRect) { }
-            public override void DrawPath(PeachPDF.Html.Adapters.RPen pen, PeachPDF.Html.Adapters.RGraphicsPath path) { }
-            public override void DrawPath(PeachPDF.Html.Adapters.RBrush brush, PeachPDF.Html.Adapters.RGraphicsPath path) { }
-            public override PeachPDF.Html.Adapters.RGraphicsPath GetGraphicsPath() => new RecordingGraphicsPath();
-
-            public override PeachPDF.Html.Adapters.RGraphicsPath? GetTextOutline(string str, PeachPDF.Html.Adapters.RFont font, PeachPDF.Html.Adapters.Entities.RPoint baselineOrigin, double letterSpacing = 0, PeachPDF.Text.TextShapingFeatures? features = null) => null;
-            public override (PeachPDF.Html.Adapters.RGraphics Graphics, PeachPDF.Html.Adapters.RImage Image)? CreateTile(double width, double height) => null;
-            public override void DrawImageMasked(PeachPDF.Html.Adapters.RImage image, PeachPDF.Html.Adapters.RImage maskImage, PeachPDF.Html.Adapters.Entities.RRect destRect) { }
-            public override void DrawImageWithOpacity(PeachPDF.Html.Adapters.RImage image, PeachPDF.Html.Adapters.Entities.RRect destRect, double opacity) { }
-            public override void BeginMarkedContent(string structureType, int mcid) { }
-            public override void EndMarkedContent() { }
-            public override void BeginArtifact() { }
-            public override void Dispose() { }
-        }
-
-        private sealed class RecordingGraphicsPath : PeachPDF.Html.Adapters.RGraphicsPath
-        {
-            public override void Start(double x, double y) { }
-            public override void LineTo(double x, double y) { }
-            public override void ArcTo(double x, double y, double radiusX, double radiusY, Corner corner) { }
-            public override void AddMove(double x, double y) { }
-            public override void AddBezierTo(double x1, double y1, double x2, double y2, double x3, double y3) { }
-            public override void AddArc(double x, double y, double radiusX, double radiusY, double rotationAngle, bool isLargeArc, bool sweepClockwise) { }
-            public override void CloseFigure() { }
-            public override void Transform(PeachPDF.Html.Adapters.Entities.RMatrix matrix) { }
-            public override void AddPath(PeachPDF.Html.Adapters.RGraphicsPath path) { }
-            public override PeachPDF.Html.Adapters.Entities.RFillMode FillMode { get; set; }
-            public override void Dispose() { }
-        }
-
-        #endregion
+        // RecordingGraphics/RecordingGraphicsPath moved to PeachPDF.Tests.TestSupport (shared with
+        // CollapsedBorderPaintTests.cs) - see that file rather than adding a parallel copy here.
     }
 }

--- a/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTableTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTableTests.cs
@@ -900,14 +900,15 @@ Assert.NotNull(tbody);
         #region Border-collapse Tests
 
         [Theory]
-        [InlineData("collapse", -1)]
+        [InlineData("collapse", -2)]
         [InlineData("separate", 8)]
         public async Task TableLayout_BorderCollapse_ControlsGapBetweenAdjacentCells(string borderCollapse, double expectedGap)
         {
-            // CssLayoutEngineTable.GetHorizontalSpacing() returns -1pt (cells overlap by 1pt, merging
-            // their shared border) under "collapse", or the real border-spacing under "separate" - this
-            // asserts the actual per-cell X gap that value produces, not just that BorderCollapse is
-            // stored on the box.
+            // Under "collapse", CSS 2.1 §17.6.2 resolves the shared edge's border once (both cells
+            // declare an identical 2pt solid black border there, so the resolved width is 2pt) and
+            // adjacent cells overlap by exactly that resolved width, not a flat 1pt - this asserts the
+            // actual per-cell X gap that produces, not just that BorderCollapse is stored on the box.
+            // Under "separate", the real border-spacing applies instead.
             var html = $@"
 <!DOCTYPE html>
 <html>

--- a/src/PeachPDF.Tests/Html/Core/Dom/TableGridTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/TableGridTests.cs
@@ -1,0 +1,329 @@
+using PeachPDF.CSS;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Tests.TestSupport;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Html.Core.Dom
+{
+    /// <summary>
+    /// <see cref="TableGrid.Build"/> tested against real, laid-out box trees (so rowspan placeholders -
+    /// <see cref="CssSpacingBox"/> - already exist, exactly as <see cref="CssLayoutEngineTable"/> would
+    /// hand them in) but with hand-rolled span primitives standing in for
+    /// <see cref="CssLayoutEngineTable"/>'s own (which are private) - simple sum-of-colspan/rowspan
+    /// arithmetic, not the visibility:collapse-aware row remapping <c>GetEffectiveEndRowIndex</c> does,
+    /// which is exercised instead once this is wired into the real engine.
+    /// </summary>
+    public class TableGridTests
+    {
+        private static int GetColSpan(CssBox b)
+        {
+            var att = b.GetAttribute("colspan", "1");
+            return !int.TryParse(att, out var span) ? 1 : span;
+        }
+
+        private static int GetRowSpan(CssBox b)
+        {
+            var att = b.GetAttribute("rowspan", "1");
+            return !int.TryParse(att, out var span) ? 1 : span;
+        }
+
+        private static int GetRealColumnIndex(CssBox row, CssBox cell)
+        {
+            var i = 0;
+            foreach (var b in row.Boxes)
+            {
+                if (ReferenceEquals(b, cell)) break;
+                i += GetColSpan(b);
+            }
+            return i;
+        }
+
+        private static int GetLastRow(int gridRow, CssBox cell, int rowSpan) => gridRow + rowSpan - 1;
+
+        /// <summary>Every &lt;tr&gt; under <paramref name="table"/>, in thead/tbody-in-source-order/tfoot order.</summary>
+        private static List<CssBox> AllRows(CssBox table)
+        {
+            var header = new List<CssBox>();
+            var body = new List<CssBox>();
+            var footer = new List<CssBox>();
+
+            void CollectRows(CssBox groupOrRow, List<CssBox> into)
+            {
+                if (groupOrRow.DerivedStyle.ActualDisplay == Keywords.TableRow)
+                {
+                    into.Add(groupOrRow);
+                    return;
+                }
+                foreach (var child in groupOrRow.Boxes) CollectRows(child, into);
+            }
+
+            foreach (var box in table.Boxes)
+            {
+                switch (box.DerivedStyle.ActualDisplay)
+                {
+                    case Keywords.TableHeaderGroup:
+                        CollectRows(box, header);
+                        break;
+                    case Keywords.TableFooterGroup:
+                        CollectRows(box, footer);
+                        break;
+                    case Keywords.TableRowGroup:
+                    case Keywords.TableRow:
+                        CollectRows(box, body);
+                        break;
+                }
+            }
+
+            return [.. header, .. body, .. footer];
+        }
+
+        /// <summary>One entry per column, repeated across a &lt;col span&gt;/&lt;colgroup span&gt; - mirrors <c>_columns</c>.</summary>
+        private static List<CssBox?> AllColumns(CssBox table)
+        {
+            var columns = new List<CssBox?>();
+
+            foreach (var box in table.Boxes)
+            {
+                if (box.DerivedStyle.ActualDisplay == Keywords.TableColumn)
+                {
+                    var span = box.GetAttribute("span", "1");
+                    var count = int.TryParse(span, out var s) ? s : 1;
+                    for (var i = 0; i < count; i++) columns.Add(box);
+                }
+                else if (box.DerivedStyle.ActualDisplay == Keywords.TableColumnGroup)
+                {
+                    var colChildren = box.Boxes.Where(c => c.DerivedStyle.ActualDisplay == Keywords.TableColumn).ToList();
+                    if (colChildren.Count == 0)
+                    {
+                        var span = box.GetAttribute("span", "1");
+                        var count = int.TryParse(span, out var s) ? s : 1;
+                        for (var i = 0; i < count; i++) columns.Add(box);
+                    }
+                    else
+                    {
+                        foreach (var col in colChildren)
+                        {
+                            var span = col.GetAttribute("span", "1");
+                            var count = int.TryParse(span, out var s) ? s : 1;
+                            for (var i = 0; i < count; i++) columns.Add(col);
+                        }
+                    }
+                }
+            }
+
+            return columns;
+        }
+
+        private static async Task<(CssBox Table, TableGrid Grid)> Build(string html)
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var table = LayoutHarness.Descendants(root).First(b => b.DerivedStyle.ActualDisplay is Keywords.Table or Keywords.InlineTable);
+
+            var grid = TableGrid.Build(
+                AllRows(table), AllColumns(table),
+                GetRealColumnIndex, GetRowSpan, GetColSpan, GetLastRow);
+
+            return (table, grid);
+        }
+
+        [Fact]
+        public async Task PlainGrid_EachCellOccupiesItsOwnSlot()
+        {
+            var (_, grid) = await Build(LayoutHarness.Wrap(@"
+                <table>
+                    <tr><td id='a'>a</td><td id='b'>b</td></tr>
+                    <tr><td id='c'>c</td><td id='d'>d</td></tr>
+                </table>"));
+
+            Assert.Equal(2, grid.RowCount);
+            Assert.Equal(2, grid.ColumnCount);
+            Assert.NotNull(grid.CellAt(0, 0));
+            Assert.NotSame(grid.CellAt(0, 0), grid.CellAt(0, 1));
+            Assert.NotSame(grid.CellAt(0, 0), grid.CellAt(1, 0));
+        }
+
+        [Fact]
+        public async Task Colspan_CellOccupiesEveryColumnItSpans()
+        {
+            var (_, grid) = await Build(LayoutHarness.Wrap(@"
+                <table>
+                    <tr><td colspan='2' id='wide'>wide</td></tr>
+                    <tr><td id='c'>c</td><td id='d'>d</td></tr>
+                </table>"));
+
+            Assert.Equal(2, grid.ColumnCount);
+            var wide = grid.CellAt(0, 0);
+            Assert.NotNull(wide);
+            Assert.Same(wide, grid.CellAt(0, 1));
+            Assert.True(grid.TryGetSpan(wide!, out var span));
+            Assert.Equal(new CellSpan(0, 0, 1, 2), span);
+        }
+
+        [Fact]
+        public async Task Rowspan_CellOccupiesEveryRowItSpans_ViaSpacingBoxPlaceholders()
+        {
+            var (_, grid) = await Build(LayoutHarness.Wrap(@"
+                <table>
+                    <tr><td rowspan='2' id='tall'>tall</td><td id='b'>b</td></tr>
+                    <tr><td id='c'>c</td></tr>
+                </table>"));
+
+            var tall = grid.CellAt(0, 0);
+            Assert.NotNull(tall);
+            Assert.Same(tall, grid.CellAt(1, 0));
+            Assert.True(grid.TryGetSpan(tall!, out var span));
+            Assert.Equal(new CellSpan(0, 0, 2, 1), span);
+        }
+
+        [Fact]
+        public async Task RowspanAndColspan_Combine()
+        {
+            var (_, grid) = await Build(LayoutHarness.Wrap(@"
+                <table>
+                    <tr><td rowspan='2' colspan='2' id='big'>big</td><td id='c'>c</td></tr>
+                    <tr><td id='d'>d</td></tr>
+                </table>"));
+
+            var big = grid.CellAt(0, 0);
+            Assert.NotNull(big);
+            Assert.Same(big, grid.CellAt(0, 1));
+            Assert.Same(big, grid.CellAt(1, 0));
+            Assert.Same(big, grid.CellAt(1, 1));
+            Assert.True(grid.TryGetSpan(big!, out var span));
+            Assert.Equal(new CellSpan(0, 0, 2, 2), span);
+        }
+
+        [Fact]
+        public async Task RaggedRows_ShorterRowLeavesTrailingSlotsEmpty()
+        {
+            var (_, grid) = await Build(LayoutHarness.Wrap(@"
+                <table>
+                    <tr><td id='a'>a</td><td id='b'>b</td><td id='c'>c</td></tr>
+                    <tr><td id='d'>d</td></tr>
+                </table>"));
+
+            Assert.Equal(3, grid.ColumnCount);
+            Assert.NotNull(grid.CellAt(1, 0));
+            Assert.Null(grid.CellAt(1, 1));
+            Assert.Null(grid.CellAt(1, 2));
+        }
+
+        [Fact]
+        public async Task RowspanIntoLastColumn_ResolvesCorrectly()
+        {
+            var (_, grid) = await Build(LayoutHarness.Wrap(@"
+                <table>
+                    <tr><td id='a'>a</td><td id='b'>b</td><td rowspan='2' id='tall'>tall</td></tr>
+                    <tr><td id='d'>d</td><td id='e'>e</td></tr>
+                </table>"));
+
+            Assert.Equal(3, grid.ColumnCount);
+            var tall = grid.CellAt(0, 2);
+            Assert.NotNull(tall);
+            Assert.Same(tall, grid.CellAt(1, 2));
+        }
+
+        [Fact]
+        public async Task TwoRowGroups_IdentifyFirstAndLastRowOfEach()
+        {
+            // <thead>/<tfoot> are detached from the table's own Boxes during layout (they repeat per
+            // page via CssLayoutEngineTable's own _headerBox/_footerBox, not as ordinary children) -
+            // exercised once TableGrid is wired into the real engine (Phase 2), which builds from
+            // _allRows directly rather than re-walking the post-layout DOM the way this test's AllRows
+            // helper does. Two plain <tbody> groups exercise the same row-group boundary logic without
+            // that detachment.
+            var (_, grid) = await Build(LayoutHarness.Wrap(@"
+                <table>
+                    <tbody>
+                        <tr><td id='a1'>a1</td></tr>
+                        <tr><td id='a2'>a2</td></tr>
+                    </tbody>
+                    <tbody>
+                        <tr><td id='b1'>b1</td></tr>
+                    </tbody>
+                </table>"));
+
+            Assert.Equal(3, grid.RowCount);
+            Assert.NotNull(grid.RowGroupAt(0));
+            Assert.True(grid.IsFirstRowOfGroup(0));
+            Assert.False(grid.IsLastRowOfGroup(0));
+            Assert.False(grid.IsFirstRowOfGroup(1));
+            Assert.True(grid.IsLastRowOfGroup(1));
+
+            Assert.NotNull(grid.RowGroupAt(2));
+            Assert.True(grid.IsFirstRowOfGroup(2));
+            Assert.True(grid.IsLastRowOfGroup(2));
+            Assert.NotSame(grid.RowGroupAt(1), grid.RowGroupAt(2));
+        }
+
+        [Fact]
+        public async Task BareRow_HasNoRowGroup()
+        {
+            var (_, grid) = await Build(LayoutHarness.Wrap(@"
+                <table><tr><td id='a'>a</td></tr></table>"));
+
+            Assert.Null(grid.RowGroupAt(0));
+        }
+
+        [Fact]
+        public async Task ColGroupWithSpan_NoColChildren_OneColumnBoxCoversTheWholeSpan()
+        {
+            var (_, grid) = await Build(LayoutHarness.Wrap(@"
+                <table>
+                    <colgroup span='3'></colgroup>
+                    <tr><td>a</td><td>b</td><td>c</td></tr>
+                </table>"));
+
+            Assert.Equal(3, grid.ColumnCount);
+            Assert.True(grid.ColumnGroupStartsAt(0));
+            Assert.False(grid.ColumnGroupStartsAt(1));
+            Assert.False(grid.ColumnGroupStartsAt(2));
+            Assert.True(grid.ColumnGroupEndsAt(2));
+            Assert.Same(grid.ColumnGroupAt(0), grid.ColumnGroupAt(2));
+            // No <col> children, so the group itself stands in as the column - no separate column box.
+            Assert.Null(grid.ColumnAt(0));
+        }
+
+        [Fact]
+        public async Task ColGroupWithColChildren_EachColIsItsOwnColumnBox()
+        {
+            var (_, grid) = await Build(LayoutHarness.Wrap(@"
+                <table>
+                    <colgroup>
+                        <col id='c1' />
+                        <col id='c2' span='2' />
+                    </colgroup>
+                    <tr><td>a</td><td>b</td><td>c</td></tr>
+                </table>"));
+
+            Assert.Equal(3, grid.ColumnCount);
+            Assert.True(grid.ColumnBoxStartsAt(0));
+            Assert.True(grid.ColumnBoxStartsAt(1));
+            Assert.False(grid.ColumnBoxStartsAt(2));
+            Assert.True(grid.ColumnBoxEndsAt(0));
+            Assert.True(grid.ColumnBoxEndsAt(2));
+            Assert.NotSame(grid.ColumnAt(0), grid.ColumnAt(1));
+            Assert.Same(grid.ColumnAt(1), grid.ColumnAt(2));
+            // Every column here shares one enclosing <colgroup>.
+            Assert.Same(grid.ColumnGroupAt(0), grid.ColumnGroupAt(2));
+        }
+
+        [Fact]
+        public async Task BareColsWithNoColgroup_HaveNoColumnGroup()
+        {
+            var (_, grid) = await Build(LayoutHarness.Wrap(@"
+                <table>
+                    <col />
+                    <col />
+                    <tr><td>a</td><td>b</td></tr>
+                </table>"));
+
+            Assert.Equal(2, grid.ColumnCount);
+            Assert.NotNull(grid.ColumnAt(0));
+            Assert.Null(grid.ColumnGroupAt(0));
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Html/Core/Paint/CollapsedBorderPaintTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Paint/CollapsedBorderPaintTests.cs
@@ -1,0 +1,73 @@
+using PeachPDF.Adapters;
+using PeachPDF.CSS;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Tests.TestSupport;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Html.Core.Paint
+{
+    /// <summary>
+    /// The paint-side half of CSS 2.1 §17.6.2's border-conflict resolution - resolved borders paint once,
+    /// after every table-internal background, instead of each participant painting its own border
+    /// independently (which is what let a later row's background erase an earlier row's shared border -
+    /// <see href="https://github.com/jhaygood86/PeachPDF/issues/735">issue #735</see>).
+    /// </summary>
+    public class CollapsedBorderPaintTests
+    {
+        private static CssBox FindTable(CssBox root) =>
+            LayoutHarness.Descendants(root).First(b => b.DerivedStyle.ActualDisplay is Keywords.Table or Keywords.InlineTable);
+
+        [Fact]
+        public async Task Issue735Repro_BorderDrawsAfterBothAdjacentRowsOwnBackgroundFills()
+        {
+            // The issue's own shape: two adjacent rows, each cell colored AND carrying the shared
+            // border-bottom. Before the fix, each row/cell paints its own border independently in DOM
+            // order, so row 2's background fill lands after (and erases) row 1's border. This is the
+            // regression gate - it must fail on unfixed code and pass once resolved borders paint last.
+            var td = "style='background-color:#C00000;border-bottom:solid #000 1pt'";
+            var html = LayoutHarness.Wrap($@"
+                <table style='border-collapse:collapse;width:100%'>
+                    <tr style='border-bottom:solid #000 1pt'><td {td}>!</td><td style='border-bottom:solid #000 1pt'>Missing Emergency Contact</td></tr>
+                    <tr style='border-bottom:solid #000 1pt'><td {td}>!</td><td style='border-bottom:solid #000 1pt'>Missing Emergency Contact</td></tr>
+                </table>");
+
+            var (root, container) = await LayoutHarness.LayoutAsync(html);
+            var table = FindTable(root);
+
+            var adapter = new PdfSharpAdapter();
+            var recording = new RecordingGraphics(adapter);
+            FragmentPaintHarness.PaintPage(container, recording);
+
+            // The shared edge between row 1 and row 2 - both rows' own ActualBottom/Location.Y agree on
+            // it (that's the whole point of the border-collapse overlap), so either row's geometry names
+            // the same Y.
+            var firstRow = table.Boxes.First(b => b.DerivedStyle.ActualDisplay == Keywords.TableRow);
+            var sharedEdgeY = firstRow.ActualBottom;
+
+            var backgroundFillIndices = recording.Log
+                .Select((op, index) => (op, index))
+                .Where(t => t.op.Kind == PaintOpKind.FillRect && Overlaps(t.op.Bounds, sharedEdgeY))
+                .Select(t => t.index)
+                .ToList();
+
+            var borderDrawIndices = recording.Log
+                .Select((op, index) => (op, index))
+                .Where(t => t.op.Kind is PaintOpKind.Polygon or PaintOpKind.Line && Overlaps(t.op.Bounds, sharedEdgeY))
+                .Select(t => t.index)
+                .ToList();
+
+            Assert.NotEmpty(backgroundFillIndices);
+            Assert.NotEmpty(borderDrawIndices);
+            Assert.True(
+                borderDrawIndices.Max() > backgroundFillIndices.Max(),
+                $"border draw (last at log index {borderDrawIndices.Max()}) must paint after every " +
+                $"background fill at the shared edge (last at {backgroundFillIndices.Max()}), or a " +
+                "later row's background erases the earlier row's border.");
+        }
+
+        private static bool Overlaps(PeachPDF.Html.Adapters.Entities.RRect bounds, double y) =>
+            y >= bounds.Y - 1 && y <= bounds.Y + bounds.Height + 1;
+    }
+}

--- a/src/PeachPDF.Tests/Integration/PageBreakTableKeepWithNextIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/PageBreakTableKeepWithNextIntegrationTests.cs
@@ -116,11 +116,14 @@ namespace PeachPDF.Tests.Integration
             // Constructs a case where BOTH fixes fire, in sequence, for the same table in one
             // layout pass. The 10pt spacer + 800pt heading + 40pt margin gives the table a
             // natural top of 850pt, crossing the 842pt page-1 boundary on its own - Gap 1 pulls
-            // the heading along, landing it exactly at the page-2 top (842) and the table just
-            // 2pt short of page 2's own bottom (842 + 840 = 1682, leaving only 2pt of the
-            // 842pt-tall page 2 for the table's header). That's nowhere near enough for even
-            // the thead's own first row, so Gap 2's header-aware pre-check fires a *second* time
-            // and relocates the table (with its already-relocated header) again, onto page 3.
+            // the heading along, landing it exactly at the page-2 top (842) and the table close
+            // to page 2's own bottom, leaving nowhere near enough room for even the thead's own
+            // first row. Gap 2's header-aware pre-check then fires a *second* time and relocates
+            // the table (with its already-relocated header) again, onto page 3 - landing exactly
+            // at its top (2 * 842 = 1684) here since the table declares no border anywhere, so
+            // CSS 2.1 §17.6.2 resolves every collapsed grid line to a real zero rather than the
+            // flat non-zero nudge a border-less collapsed table used to get regardless of whether
+            // it declared a border to justify one.
             // Gap 2's own guard correctly declines to pull the heading a second time - re-pulling
             // it this far would no longer leave room for the header alongside it either - so the
             // heading stays exactly where Gap 1 alone put it while the table moves on without it.
@@ -156,8 +159,8 @@ namespace PeachPDF.Tests.Integration
 
             // Gap 2 fires a second time and pushes the table on to page 3 - past what Gap 1
             // alone would have produced (which stopped just short of page 2's own bottom).
-            Assert.True(table!.Location.Y > 2 * PageHeight,
-                $"Table should be pushed on to page 3 (Y > {2 * PageHeight}) by Gap 2's second pass but Y={table.Location.Y:F1}");
+            Assert.True(table!.Location.Y >= 2 * PageHeight,
+                $"Table should be pushed on to page 3 (Y >= {2 * PageHeight}) by Gap 2's second pass but Y={table.Location.Y:F1}");
 
             // Document order is preserved even though heading and table now sit on different
             // pages - a direct consequence of Gap 2's guard correctly declining to re-pull an

--- a/src/PeachPDF.Tests/TestSupport/RecordingGraphics.cs
+++ b/src/PeachPDF.Tests/TestSupport/RecordingGraphics.cs
@@ -1,0 +1,146 @@
+using PeachPDF.Html.Adapters;
+using PeachPDF.Html.Adapters.Entities;
+using PeachPDF.Text;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PeachPDF.Tests.TestSupport
+{
+    /// <summary>What kind of draw operation a <see cref="PaintOp"/> records.</summary>
+    internal enum PaintOpKind
+    {
+        FillRect,
+        Polygon,
+        Line,
+        PushClip,
+        PopClip
+    }
+
+    /// <summary>One paint call, in the order it happened - the single ordered log <see cref="RecordingGraphics.Log"/> keeps, per this repo's own preference (CLAUDE.md's testing conventions) for one ordered log over parallel per-call-type counts/lists when order across different call types matters.</summary>
+    internal readonly record struct PaintOp(PaintOpKind Kind, RRect Bounds);
+
+    /// <summary>
+    /// Minimal <see cref="RGraphics"/> implementation that records paint calls so tests can verify paint
+    /// order/behavior without a full PDF rendering stack. Shared across test files (originally private to
+    /// <c>CssLayoutEngineTablePageBreakTests</c>) - extend this one rather than adding a parallel copy.
+    /// </summary>
+    internal sealed class RecordingGraphics : RGraphics
+    {
+        /// <summary>Every fill/stroke/clip operation, in the order it was made.</summary>
+        public List<PaintOp> Log { get; } = [];
+
+        /// <summary>All rects passed to PushClip during this paint pass.</summary>
+        public List<RRect> PushedClips { get; } = [];
+
+        /// <summary>Total PushClip invocations.</summary>
+        public int PushCount { get; private set; }
+
+        /// <summary>Total PopClip invocations.</summary>
+        public int PopCount { get; private set; }
+
+        /// <summary>Y-coordinates of horizontal lines drawn (where y1 ≈ y2).</summary>
+        public List<double> HorizontalLines { get; } = [];
+
+        /// <summary>Every word string passed to DrawString during this paint pass, with the Y it was drawn at.</summary>
+        public List<(string Text, double Y)> DrawnStrings { get; } = [];
+
+        public RecordingGraphics(RAdapter adapter)
+            : base(adapter, new RRect(0, 0, double.MaxValue, double.MaxValue)) { }
+
+        public override void DrawLine(RPen pen, double x1, double y1, double x2, double y2)
+        {
+            if (Math.Abs(y1 - y2) < 0.5)
+                HorizontalLines.Add(y1);
+
+            var left = Math.Min(x1, x2);
+            var top = Math.Min(y1, y2);
+            Log.Add(new PaintOp(PaintOpKind.Line, new RRect(left, top, Math.Abs(x2 - x1), Math.Abs(y2 - y1))));
+        }
+
+        /// <summary>
+        /// Solid borders paint as a mitered quad (BordersDrawHandler.SetInOutsetRectanglePoints),
+        /// not a DrawLine call - a wide-and-thin quad (wider in X than in Y) is a horizontal border
+        /// stripe; record its vertical center the same way DrawLine's y1/y2 would, so callers don't
+        /// need to know which draw method a given border style happens to use.
+        /// </summary>
+        public override void DrawPolygon(RBrush brush, RPoint[] points)
+        {
+            if (points.Length == 0) return;
+
+            var minY = points.Min(p => p.Y);
+            var maxY = points.Max(p => p.Y);
+            var minX = points.Min(p => p.X);
+            var maxX = points.Max(p => p.X);
+
+            if (maxX - minX > maxY - minY)
+                HorizontalLines.Add((minY + maxY) / 2);
+
+            Log.Add(new PaintOp(PaintOpKind.Polygon, new RRect(minX, minY, maxX - minX, maxY - minY)));
+        }
+
+        public override void PushClip(RRect rect)
+        {
+            _clipStack.Push(rect);
+            PushedClips.Add(rect);
+            PushCount++;
+            Log.Add(new PaintOp(PaintOpKind.PushClip, rect));
+        }
+
+        public override void PopClip()
+        {
+            if (_clipStack.Count > 1)
+                _clipStack.Pop();
+            PopCount++;
+            Log.Add(new PaintOp(PaintOpKind.PopClip, default));
+        }
+
+        public override void PushClip(RGraphicsPath path) => _clipStack.Push(_clipStack.Peek());
+        public override void PushClipExclude(RRect rect) { }
+        public override void PushTransform(RMatrix matrix) { }
+        public override void PopTransform() { }
+        public override void PushBlendMode(RBlendMode mode) { }
+        public override void PopBlendMode() { }
+        public override object SetAntiAliasSmoothingMode() => new object();
+        public override void ReturnPreviousSmoothingMode(object? prevMode) { }
+        public override RSize MeasureString(string str, RFont font, TextShapingFeatures? features = null) => new(0, 12);
+        public override int CountShapedGlyphs(string str, RFont font, TextShapingFeatures? features = null) => str?.Length ?? 0;
+        public override void MeasureString(string str, RFont font, double maxWidth, out int charFit, out double charFitWidth) { charFit = str?.Length ?? 0; charFitWidth = 0; }
+        public override void DrawString(string str, RFont font, RColor color, RPoint point, RSize size, double letterSpacing = 0, RFontPalette? fontPalette = null, TextShapingFeatures? features = null) => DrawnStrings.Add((str, point.Y));
+
+        public override void DrawRectangle(RPen pen, double x, double y, double width, double height) { }
+
+        public override void DrawRectangle(RBrush brush, double x, double y, double width, double height) =>
+            Log.Add(new PaintOp(PaintOpKind.FillRect, new RRect(x, y, width, height)));
+
+        public override void DrawImage(RImage image, RRect destRect, RRect srcRect) { }
+        public override void DrawImage(RImage image, RRect destRect) { }
+        public override void DrawPath(RPen pen, RGraphicsPath path) { }
+        public override void DrawPath(RBrush brush, RGraphicsPath path) { }
+        public override RGraphicsPath GetGraphicsPath() => new RecordingGraphicsPath();
+
+        public override RGraphicsPath? GetTextOutline(string str, RFont font, RPoint baselineOrigin, double letterSpacing = 0, TextShapingFeatures? features = null) => null;
+        public override (RGraphics Graphics, RImage Image)? CreateTile(double width, double height) => null;
+        public override void DrawImageMasked(RImage image, RImage maskImage, RRect destRect) { }
+        public override void DrawImageWithOpacity(RImage image, RRect destRect, double opacity) { }
+        public override void BeginMarkedContent(string structureType, int mcid) { }
+        public override void EndMarkedContent() { }
+        public override void BeginArtifact() { }
+        public override void Dispose() { }
+    }
+
+    internal sealed class RecordingGraphicsPath : RGraphicsPath
+    {
+        public override void Start(double x, double y) { }
+        public override void LineTo(double x, double y) { }
+        public override void ArcTo(double x, double y, double radiusX, double radiusY, Corner corner) { }
+        public override void AddMove(double x, double y) { }
+        public override void AddBezierTo(double x1, double y1, double x2, double y2, double x3, double y3) { }
+        public override void AddArc(double x, double y, double radiusX, double radiusY, double rotationAngle, bool isLargeArc, bool sweepClockwise) { }
+        public override void CloseFigure() { }
+        public override void Transform(RMatrix matrix) { }
+        public override void AddPath(RGraphicsPath path) { }
+        public override RFillMode FillMode { get; set; }
+        public override void Dispose() { }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/Border.cs
+++ b/src/PeachPDF/Html/Core/Dom/Border.cs
@@ -10,6 +10,8 @@
 // - Sun Tsu,
 // "The Art of War"
 
+using System;
+
 namespace PeachPDF.Html.Core.Dom
 {
     /// <summary>
@@ -21,5 +23,25 @@ namespace PeachPDF.Html.Core.Dom
         Right,
         Bottom,
         Left
+    }
+
+    /// <summary>
+    /// Edges whose own border stroke a box must not paint, because another mechanism paints it instead.
+    /// Set by <see cref="CssLayoutEngineTable"/> on every participant of a <c>border-collapse: collapse</c>
+    /// table (CSS 2.1 §17.6.2): the table, its rows, its row groups and its cells each stop drawing their
+    /// own four edges, and one resolved border per grid-line segment is drawn instead - see
+    /// <see cref="CssBox.CollapsedBorderSegments"/>. Distinct from <see cref="CssBox.SuppressOwnBorderPaint"/>,
+    /// which is whole-box and also suppresses box-shadow (issue #721) - this is edge-granular and touches
+    /// border paint only.
+    /// </summary>
+    [Flags]
+    internal enum BorderEdges
+    {
+        None = 0,
+        Top = 1,
+        Right = 2,
+        Bottom = 4,
+        Left = 8,
+        All = Top | Right | Bottom | Left
     }
 }

--- a/src/PeachPDF/Html/Core/Dom/CollapsedBorder.cs
+++ b/src/PeachPDF/Html/Core/Dom/CollapsedBorder.cs
@@ -1,0 +1,80 @@
+using PeachPDF.CSS;
+using PeachPDF.Html.Adapters.Entities;
+
+namespace PeachPDF.Html.Core.Dom
+{
+    /// <summary>
+    /// CSS 2.1 §17.6.2's border-conflict origin priority, most specific first. A lower value wins a
+    /// tie in <see cref="CollapsedBorderResolver"/> once width and style priority have already tied.
+    /// </summary>
+    internal enum CollapsedBorderOrigin
+    {
+        Cell = 0,
+        Row = 1,
+        RowGroup = 2,
+        Column = 3,
+        ColumnGroup = 4,
+        Table = 5
+    }
+
+    /// <summary>
+    /// One border declaration competing for a single grid-line segment - one box's style/width/color on
+    /// one of its four edges, tagged with where it came from (for the origin-priority tiebreak) and its
+    /// position in the grid (for the final leftmost/topmost tiebreak).
+    /// </summary>
+    /// <param name="Style">The declaring box's border style on this edge.</param>
+    /// <param name="Width">The declaring box's actual border width on this edge.</param>
+    /// <param name="Color">The declaring box's actual border color on this edge.</param>
+    /// <param name="Origin">Where this declaration comes from, for the origin-priority tiebreak.</param>
+    /// <param name="Row">
+    /// The grid row of the declaring element - a cell's own row, a row-group's first row, or 0 for a
+    /// column/column-group/table declaration (which have no row of their own).
+    /// </param>
+    /// <param name="Column">
+    /// The grid column of the declaring element - a cell's own starting column, a column/column-group's
+    /// first column, or 0 for a row/row-group/table declaration.
+    /// </param>
+    internal readonly record struct CollapsedBorderCandidate(
+        LineStyle Style,
+        double Width,
+        RColor Color,
+        CollapsedBorderOrigin Origin,
+        int Row,
+        int Column);
+
+    /// <summary>
+    /// The single border CSS 2.1 §17.6.2 resolved for one grid-line segment.
+    /// </summary>
+    internal readonly record struct CollapsedBorder(LineStyle Style, double Width, RColor Color)
+    {
+        /// <summary>No candidate contributed here, or every candidate was <c>none</c>.</summary>
+        internal static readonly CollapsedBorder None = new(LineStyle.None, 0, RColor.Empty);
+
+        /// <summary>
+        /// The room this border occupies on the grid line - zero for <see cref="LineStyle.None"/> and
+        /// <see cref="LineStyle.Hidden"/> alike, since a suppressed edge reserves no space either.
+        /// </summary>
+        internal double UsedWidth => Style is LineStyle.None or LineStyle.Hidden ? 0 : Width;
+
+        /// <summary>Whether this border actually draws anything.</summary>
+        internal bool IsPainted => UsedWidth > 0;
+    }
+
+    /// <summary>
+    /// One resolved, drawable run along a grid line - the <c>ColumnRuleSegments</c>-style paint-time
+    /// carrier <see cref="CssBox.CollapsedBorderSegments"/> holds, consumed by <c>FragmentPainter</c>
+    /// after every table-internal background has painted (the fix for issue #735: painting late, once,
+    /// is what stops a later row's background from erasing an earlier row's shared border).
+    /// </summary>
+    /// <param name="IsHorizontal">Whether this segment runs along a horizontal (row) grid line rather than a vertical (column) one.</param>
+    /// <param name="Rect">The segment's own bounding rect, in the same fragment-local document space <c>ColumnRuleSegments</c> uses.</param>
+    /// <param name="Style">The resolved border style.</param>
+    /// <param name="Width">The resolved border width.</param>
+    /// <param name="Color">The resolved border color.</param>
+    internal readonly record struct CollapsedBorderSegment(
+        bool IsHorizontal,
+        RRect Rect,
+        LineStyle Style,
+        double Width,
+        RColor Color);
+}

--- a/src/PeachPDF/Html/Core/Dom/CollapsedBorderModel.cs
+++ b/src/PeachPDF/Html/Core/Dom/CollapsedBorderModel.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace PeachPDF.Html.Core.Dom
+{
+    /// <summary>
+    /// The whole table's CSS 2.1 §17.6.2 resolution, one <see cref="CollapsedBorder"/> per unit
+    /// grid-line segment - resolving on the unit grid rather than on abstract whole-table lines is what
+    /// lets a <c>colspan</c>/<c>rowspan</c> cell produce correctly-differing per-segment results with no
+    /// special splitting logic (a horizontal line under a 3-column <c>colspan</c> cell independently
+    /// resolves once per column it crosses, because the cell <i>below</i> it can differ per column).
+    /// </summary>
+    internal sealed class CollapsedBorderModel
+    {
+        // [line, column] for line in 0..RowCount, column in 0..ColumnCount-1.
+        private readonly CollapsedBorder[,] _horizontal;
+
+        // [row, line] for row in 0..RowCount-1, line in 0..ColumnCount.
+        private readonly CollapsedBorder[,] _vertical;
+
+        /// <summary>The room horizontal grid line <c>i</c> reserves - the max resolved width across every column it crosses. Length <c>RowCount + 1</c>.</summary>
+        internal double[] HorizontalLineWidth { get; }
+
+        /// <summary>The room vertical grid line <c>j</c> reserves - the max resolved width across every row it crosses. Length <c>ColumnCount + 1</c>.</summary>
+        internal double[] VerticalLineWidth { get; }
+
+        private CollapsedBorderModel(
+            CollapsedBorder[,] horizontal, CollapsedBorder[,] vertical,
+            double[] horizontalLineWidth, double[] verticalLineWidth)
+        {
+            _horizontal = horizontal;
+            _vertical = vertical;
+            HorizontalLineWidth = horizontalLineWidth;
+            VerticalLineWidth = verticalLineWidth;
+        }
+
+        /// <summary>The resolved border on horizontal grid line <paramref name="line"/> (0..RowCount), over column <paramref name="column"/>.</summary>
+        internal CollapsedBorder Horizontal(int line, int column) => _horizontal[line, column];
+
+        /// <summary>The resolved border on vertical grid line <paramref name="line"/> (0..ColumnCount), over row <paramref name="row"/>.</summary>
+        internal CollapsedBorder Vertical(int row, int line) => _vertical[row, line];
+
+        /// <param name="grid">The table's topology.</param>
+        /// <param name="tableBox">The table's own box - its border participates at the grid's outer edges.</param>
+        /// <param name="isColumnCollapsed">
+        /// Whether the given column index is <c>visibility: collapse</c> (CSS 2.1 §17.6.1) - a collapsed
+        /// column contributes no candidates of its own and reserves no room, matching
+        /// <c>CssLayoutEngineTable.CollapseColumnWidths</c> already zeroing its width.
+        /// </param>
+        /// <param name="leftToRight">The table's own <c>direction</c>, for the resolver's position tiebreak.</param>
+        internal static CollapsedBorderModel Resolve(
+            TableGrid grid, CssBox tableBox, Func<int, bool> isColumnCollapsed, bool leftToRight)
+        {
+            var columnCount = Math.Max(grid.ColumnCount, 1);
+            var horizontal = new CollapsedBorder[grid.RowCount + 1, columnCount];
+            var vertical = new CollapsedBorder[Math.Max(grid.RowCount, 1), grid.ColumnCount + 1];
+            var horizontalLineWidth = new double[grid.RowCount + 1];
+            var verticalLineWidth = new double[grid.ColumnCount + 1];
+
+            var candidates = new List<CollapsedBorderCandidate>(8);
+
+            for (var line = 0; line <= grid.RowCount; line++)
+            {
+                for (var column = 0; column < grid.ColumnCount; column++)
+                {
+                    if (isColumnCollapsed(column))
+                    {
+                        horizontal[line, column] = CollapsedBorder.None;
+                        continue;
+                    }
+
+                    candidates.Clear();
+                    CollectHorizontal(grid, tableBox, line, column, candidates);
+                    var resolved = CollapsedBorderResolver.Resolve(CollectionsMarshal.AsSpan(candidates), leftToRight);
+
+                    horizontal[line, column] = resolved;
+                    horizontalLineWidth[line] = Math.Max(horizontalLineWidth[line], resolved.UsedWidth);
+                }
+            }
+
+            for (var line = 0; line <= grid.ColumnCount; line++)
+            {
+                var leftCollapsed = line > 0 && isColumnCollapsed(line - 1);
+                var rightCollapsed = line < grid.ColumnCount && isColumnCollapsed(line);
+
+                for (var row = 0; row < grid.RowCount; row++)
+                {
+                    if (leftCollapsed && rightCollapsed)
+                    {
+                        vertical[row, line] = CollapsedBorder.None;
+                        continue;
+                    }
+
+                    candidates.Clear();
+                    CollectVertical(grid, tableBox, row, line, candidates, skipLeft: leftCollapsed, skipRight: rightCollapsed);
+                    var resolved = CollapsedBorderResolver.Resolve(CollectionsMarshal.AsSpan(candidates), leftToRight);
+
+                    vertical[row, line] = resolved;
+                    verticalLineWidth[line] = Math.Max(verticalLineWidth[line], resolved.UsedWidth);
+                }
+            }
+
+            return new CollapsedBorderModel(horizontal, vertical, horizontalLineWidth, verticalLineWidth);
+        }
+
+        private static void CollectHorizontal(
+            TableGrid grid, CssBox tableBox, int line, int column, List<CollapsedBorderCandidate> into)
+        {
+            var above = line > 0 ? grid.CellAt(line - 1, column) : null;
+            var below = line < grid.RowCount ? grid.CellAt(line, column) : null;
+
+            // Interior to a rowspanning cell - the same cell occupies both sides, so this line is inside
+            // its own border box, not on its edge. No candidate from anywhere participates here.
+            if (above is not null && ReferenceEquals(above, below)) return;
+
+            // If above/below survived the check above, contiguous spans guarantee this really is that
+            // cell's own top/bottom edge (see CollapsedBorderModel's own remarks for why).
+            Add(into, above, Border.Bottom, CollapsedBorderOrigin.Cell, line - 1, column);
+            Add(into, below, Border.Top, CollapsedBorderOrigin.Cell, line, column);
+
+            if (line > 0) Add(into, grid.RowAt(line - 1), Border.Bottom, CollapsedBorderOrigin.Row, line - 1, 0);
+            if (line < grid.RowCount) Add(into, grid.RowAt(line), Border.Top, CollapsedBorderOrigin.Row, line, 0);
+
+            if (line > 0 && grid.IsLastRowOfGroup(line - 1))
+                Add(into, grid.RowGroupAt(line - 1), Border.Bottom, CollapsedBorderOrigin.RowGroup, line - 1, 0);
+            if (line < grid.RowCount && grid.IsFirstRowOfGroup(line))
+                Add(into, grid.RowGroupAt(line), Border.Top, CollapsedBorderOrigin.RowGroup, line, 0);
+
+            // A column/column-group has no per-row top/bottom boundary of its own - only at the table's
+            // very top/bottom does its own border-top/-bottom compete at all (a column spans every row).
+            if (line == 0)
+            {
+                Add(into, grid.ColumnAt(column), Border.Top, CollapsedBorderOrigin.Column, 0, column);
+                Add(into, grid.ColumnGroupAt(column), Border.Top, CollapsedBorderOrigin.ColumnGroup, 0, column);
+                Add(into, tableBox, Border.Top, CollapsedBorderOrigin.Table, 0, 0);
+            }
+            if (line == grid.RowCount)
+            {
+                Add(into, grid.ColumnAt(column), Border.Bottom, CollapsedBorderOrigin.Column, 0, column);
+                Add(into, grid.ColumnGroupAt(column), Border.Bottom, CollapsedBorderOrigin.ColumnGroup, 0, column);
+                Add(into, tableBox, Border.Bottom, CollapsedBorderOrigin.Table, 0, 0);
+            }
+        }
+
+        private static void CollectVertical(
+            TableGrid grid, CssBox tableBox, int row, int line, List<CollapsedBorderCandidate> into,
+            bool skipLeft, bool skipRight)
+        {
+            var left = !skipLeft && line > 0 ? grid.CellAt(row, line - 1) : null;
+            var right = !skipRight && line < grid.ColumnCount ? grid.CellAt(row, line) : null;
+
+            // Interior to a colspanning cell - same reasoning as CollectHorizontal.
+            if (left is not null && ReferenceEquals(left, right)) return;
+
+            Add(into, left, Border.Right, CollapsedBorderOrigin.Cell, row, line - 1);
+            Add(into, right, Border.Left, CollapsedBorderOrigin.Cell, row, line);
+
+            if (!skipLeft && line == 0) Add(into, grid.RowAt(row), Border.Left, CollapsedBorderOrigin.Row, row, 0);
+            if (!skipRight && line == grid.ColumnCount) Add(into, grid.RowAt(row), Border.Right, CollapsedBorderOrigin.Row, row, 0);
+
+            if (line == 0)
+            {
+                Add(into, grid.RowGroupAt(row), Border.Left, CollapsedBorderOrigin.RowGroup, row, 0);
+                Add(into, tableBox, Border.Left, CollapsedBorderOrigin.Table, 0, 0);
+            }
+            if (line == grid.ColumnCount)
+            {
+                Add(into, grid.RowGroupAt(row), Border.Right, CollapsedBorderOrigin.RowGroup, row, 0);
+                Add(into, tableBox, Border.Right, CollapsedBorderOrigin.Table, 0, 0);
+            }
+
+            // A column/column-group's own border participates at every vertical line its own boundary
+            // falls on - unlike row/row-group/table above, this is not confined to the table's outer
+            // edges, since a column runs the table's full height but only *begins*/*ends* at its own
+            // left/right boundary, which can be any interior line.
+            if (!skipLeft && line > 0 && grid.ColumnBoxEndsAt(line - 1))
+                Add(into, grid.ColumnAt(line - 1), Border.Right, CollapsedBorderOrigin.Column, 0, line - 1);
+            if (!skipRight && line < grid.ColumnCount && grid.ColumnBoxStartsAt(line))
+                Add(into, grid.ColumnAt(line), Border.Left, CollapsedBorderOrigin.Column, 0, line);
+            if (!skipLeft && line > 0 && grid.ColumnGroupEndsAt(line - 1))
+                Add(into, grid.ColumnGroupAt(line - 1), Border.Right, CollapsedBorderOrigin.ColumnGroup, 0, line - 1);
+            if (!skipRight && line < grid.ColumnCount && grid.ColumnGroupStartsAt(line))
+                Add(into, grid.ColumnGroupAt(line), Border.Left, CollapsedBorderOrigin.ColumnGroup, 0, line);
+        }
+
+        /// <summary>
+        /// Resolves the border between a repeated <c>&lt;thead&gt;</c>/<c>&lt;tfoot&gt;</c>'s own last/first
+        /// row and whichever row visually follows/precedes it on one specific page - a horizontal line
+        /// this table's main grid does not itself model, since a repeated group's visual neighbor differs
+        /// per page while its logical (DOM-order) neighbor does not. Border-collapse is about visual
+        /// adjacency, so this is resolved fresh, per call, rather than read off <see cref="Horizontal"/>.
+        /// Column/column-group/table origins never apply here (an interior horizontal line - not the
+        /// table's own outer top/bottom edge - is never a column's own top/bottom boundary or the table's
+        /// own edge, see <c>CollectHorizontal</c>'s identical gating), so this needs only
+        /// cell/row/row-group, on *both* sides of the line.
+        /// </summary>
+        /// <param name="grid">
+        /// The table's topology - <paramref name="groupRow"/>/<paramref name="adjacentRow"/> are grid row
+        /// indices into it, so occupancy (including a <c>rowspan</c> cell reaching into the group's own
+        /// last/first row from an earlier row in the *same* group - <see cref="TableGrid.CellAt"/> resolves
+        /// this correctly via the grid's own rowspan/colspan accounting, unlike scanning a row's own
+        /// <c>Boxes</c> list, which is dense only for a body row (<c>CssLayoutEngineTable.InsertEmptyBoxes</c>
+        /// never touches a detached header/footer's rows) - and row-group lookup both come from the grid
+        /// rather than being passed in separately.
+        /// </param>
+        /// <param name="groupRow">The repeated group's own last row index (for a header) or first row index (for a footer).</param>
+        /// <param name="groupRowGroup">The repeated group's own row-group box (<c>&lt;thead&gt;</c>/<c>&lt;tfoot&gt;</c>).</param>
+        /// <param name="adjacentRow">Whichever row index this page's layout actually places next to the repeated group.</param>
+        /// <param name="groupIsAbove">True for a header's own bottom edge (group above, adjacent row below); false for a footer's own top edge.</param>
+        /// <param name="leftToRight">The table's own <c>direction</c>, for the resolver's position tiebreak.</param>
+        internal static CollapsedBorder[] ResolveRepeatedGroupBoundary(
+            TableGrid grid, int groupRow, CssBox? groupRowGroup, int adjacentRow,
+            bool groupIsAbove, bool leftToRight)
+        {
+            var result = new CollapsedBorder[Math.Max(grid.ColumnCount, 1)];
+            var candidates = new List<CollapsedBorderCandidate>(6);
+
+            var groupSide = groupIsAbove ? Border.Bottom : Border.Top;
+            var adjacentSide = groupIsAbove ? Border.Top : Border.Bottom;
+            var adjacentRowGroup = grid.RowGroupAt(adjacentRow);
+
+            for (var column = 0; column < grid.ColumnCount; column++)
+            {
+                candidates.Clear();
+
+                Add(candidates, grid.CellAt(groupRow, column), groupSide, CollapsedBorderOrigin.Cell, 0, column, natural: true);
+                Add(candidates, grid.CellAt(adjacentRow, column), adjacentSide, CollapsedBorderOrigin.Cell, 0, column, natural: true);
+                Add(candidates, grid.RowAt(groupRow), groupSide, CollapsedBorderOrigin.Row, 0, 0, natural: true);
+                Add(candidates, grid.RowAt(adjacentRow), adjacentSide, CollapsedBorderOrigin.Row, 0, 0, natural: true);
+                Add(candidates, groupRowGroup, groupSide, CollapsedBorderOrigin.RowGroup, 0, 0, natural: true);
+                Add(candidates, adjacentRowGroup, adjacentSide, CollapsedBorderOrigin.RowGroup, 0, 0, natural: true);
+
+                result[column] = CollapsedBorderResolver.Resolve(CollectionsMarshal.AsSpan(candidates), leftToRight);
+            }
+
+            return result;
+        }
+
+        /// <param name="into">The candidate list to append to.</param>
+        /// <param name="box">The box whose edge to read, or null to contribute nothing.</param>
+        /// <param name="side">Which of the box's four edges names this grid line.</param>
+        /// <param name="origin">This candidate's CSS 2.1 §17.6.2 origin-priority tier.</param>
+        /// <param name="row">The candidate's own row, for the resolver's position tiebreak.</param>
+        /// <param name="column">The candidate's own column, for the resolver's position tiebreak.</param>
+        /// <param name="natural">
+        /// True to read <see cref="CssBox.NaturalBorderTopWidth"/>/etc instead of the cached
+        /// <see cref="CssBox.ActualBorderTopWidth"/>/etc - required for any candidate collected after
+        /// <c>CssLayoutEngineTable.ApplyCollapsedUsedBorderWidths</c> has overwritten that cache with the
+        /// box-model *used* half-width (see <see cref="ResolveRepeatedGroupBoundary"/>'s call site).
+        /// <see cref="Resolve"/>'s own candidates run before that override, so they read the cheaper
+        /// cached property.
+        /// </param>
+        private static void Add(
+            List<CollapsedBorderCandidate> into, CssBox? box, Border side,
+            CollapsedBorderOrigin origin, int row, int column, bool natural = false)
+        {
+            if (box is null) return;
+
+            var (style, width, color) = side switch
+            {
+                Border.Top => (box.BorderTopStyle.Value,
+                    natural ? box.NaturalBorderTopWidth : box.ActualBorderTopWidth, box.ActualBorderTopColor),
+                Border.Right => (box.BorderRightStyle.Value,
+                    natural ? box.NaturalBorderRightWidth : box.ActualBorderRightWidth, box.ActualBorderRightColor),
+                Border.Bottom => (box.BorderBottomStyle.Value,
+                    natural ? box.NaturalBorderBottomWidth : box.ActualBorderBottomWidth, box.ActualBorderBottomColor),
+                Border.Left => (box.BorderLeftStyle.Value,
+                    natural ? box.NaturalBorderLeftWidth : box.ActualBorderLeftWidth, box.ActualBorderLeftColor),
+                _ => throw new ArgumentOutOfRangeException(nameof(side)),
+            };
+
+            into.Add(new CollapsedBorderCandidate(style, width, color, origin, row, column));
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CollapsedBorderResolver.cs
+++ b/src/PeachPDF/Html/Core/Dom/CollapsedBorderResolver.cs
@@ -1,0 +1,98 @@
+using PeachPDF.CSS;
+using PeachPDF.Html.Adapters.Entities;
+using System;
+
+namespace PeachPDF.Html.Core.Dom
+{
+    /// <summary>
+    /// CSS 2.1 <see href="https://www.w3.org/TR/CSS21/tables.html#border-conflict-resolution">§17.6.2</see>'s
+    /// border-conflict resolution, transcribed clause by clause. Pure and stateless - every input is a
+    /// <see cref="CollapsedBorderCandidate"/> value, so this has no dependency on <see cref="CssBox"/>,
+    /// layout, or paint and is unit-testable on its own.
+    /// </summary>
+    internal static class CollapsedBorderResolver
+    {
+        /// <summary>
+        /// §17.6.2's own style priority order - "hidden, then double, solid, dashed, dotted, ridge,
+        /// outset, groove, and the lowest: inset" (none never reaches here, see <see cref="Resolve"/>).
+        /// This is deliberately NOT <see cref="LineStyle"/>'s declaration order
+        /// (<c>None, Hidden, Dotted, Dashed, Solid, Double, Groove, Ridge, Inset, Outset</c>), which is
+        /// unrelated - never cast the enum to <c>int</c> for this comparison.
+        /// </summary>
+        internal static int StylePriority(LineStyle style) => style switch
+        {
+            LineStyle.Hidden => 9,
+            LineStyle.Double => 8,
+            LineStyle.Solid => 7,
+            LineStyle.Dashed => 6,
+            LineStyle.Dotted => 5,
+            LineStyle.Ridge => 4,
+            LineStyle.Outset => 3,
+            LineStyle.Groove => 2,
+            LineStyle.Inset => 1,
+            _ => 0, // None
+        };
+
+        /// <summary>
+        /// Resolves the single winning border for one grid-line segment from every candidate that
+        /// touches it.
+        /// </summary>
+        /// <param name="candidates">
+        /// Every border declaration competing for this segment - order does not matter, every tiebreak
+        /// below is explicit.
+        /// </param>
+        /// <param name="leftToRight">
+        /// The table's own <c>direction</c> (not the cell's) - used only for the final position tiebreak,
+        /// clause 6.
+        /// </param>
+        internal static CollapsedBorder Resolve(ReadOnlySpan<CollapsedBorderCandidate> candidates, bool leftToRight)
+        {
+            CollapsedBorderCandidate? best = null;
+
+            foreach (var candidate in candidates)
+            {
+                // Clause 1: "hidden" suppresses the border unconditionally, beating every other
+                // candidate regardless of width - including a wider one from a more specific origin.
+                if (candidate.Style == LineStyle.Hidden)
+                    return new CollapsedBorder(LineStyle.Hidden, 0, RColor.Empty);
+
+                // Clause 2: "none" never participates in the comparison at all.
+                if (candidate.Style == LineStyle.None)
+                    continue;
+
+                if (best is null || Beats(candidate, best.Value, leftToRight))
+                    best = candidate;
+            }
+
+            return best is null
+                ? CollapsedBorder.None
+                : new CollapsedBorder(best.Value.Style, best.Value.Width, best.Value.Color);
+        }
+
+        /// <summary>Whether <paramref name="a"/> wins over the current best, <paramref name="b"/>.</summary>
+        private static bool Beats(CollapsedBorderCandidate a, CollapsedBorderCandidate b, bool leftToRight)
+        {
+            // Clause 3: widest wins, regardless of style or origin.
+            if (a.Width != b.Width)
+                return a.Width > b.Width;
+
+            // Clause 4: equal width, style priority decides.
+            var stylePriorityA = StylePriority(a.Style);
+            var stylePriorityB = StylePriority(b.Style);
+            if (stylePriorityA != stylePriorityB)
+                return stylePriorityA > stylePriorityB;
+
+            // Clause 5: equal width and style, origin priority decides (cell > row > row-group >
+            // column > column-group > table - lower enum value wins, see CollapsedBorderOrigin).
+            if (a.Origin != b.Origin)
+                return a.Origin < b.Origin;
+
+            // Clause 6: same origin (e.g. two adjacent cells' own borders tie exactly) - the one
+            // further to the left (or right, under rtl) wins; failing that, the one further to the top.
+            if (a.Column != b.Column)
+                return leftToRight ? a.Column < b.Column : a.Column > b.Column;
+
+            return a.Row < b.Row;
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
@@ -252,6 +252,11 @@ namespace PeachPDF.Html.Core.Dom
         public double ActualBorderBottomWidth => DerivedStyle.ActualBorderBottomWidth;
         public double ActualBorderLeftWidth => DerivedStyle.ActualBorderLeftWidth;
 
+        internal double NaturalBorderTopWidth => DerivedStyle.NaturalBorderTopWidth;
+        internal double NaturalBorderRightWidth => DerivedStyle.NaturalBorderRightWidth;
+        internal double NaturalBorderBottomWidth => DerivedStyle.NaturalBorderBottomWidth;
+        internal double NaturalBorderLeftWidth => DerivedStyle.NaturalBorderLeftWidth;
+
         /// <summary>Gets the actual column-rule width (the line drawn between columns in a multi-column container).</summary>
         public double ActualColumnRuleWidth => DerivedStyle.ActualColumnRuleWidth;
 

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -430,6 +430,28 @@ namespace PeachPDF.Html.Core.Dom
         internal Dictionary<int, double>? PageBreakBottoms { get; set; }
 
         /// <summary>
+        /// A <c>border-collapse: collapse</c> table's own logical row×column grid. Set on the table box by
+        /// <see cref="CssLayoutEngineTable"/> every pass (deterministic from markup + computed style, so -
+        /// unlike <see cref="TableSetup"/> - never needs carrying across a resumed pass); null for a
+        /// <c>separate</c> table, which builds neither this nor <see cref="CollapsedBorders"/>.
+        /// </summary>
+        internal TableGrid? CollapsedBorderGrid { get; set; }
+
+        /// <summary>CSS 2.1 §17.6.2's resolution of <see cref="CollapsedBorderGrid"/> - see its own remarks.</summary>
+        internal CollapsedBorderModel? CollapsedBorders { get; set; }
+
+        /// <summary>The edges of this box's own border stroke that <c>FragmentPainter</c> must not paint - see <see cref="BorderEdges"/>.</summary>
+        internal BorderEdges SuppressedBorderEdges { get; set; }
+
+        /// <summary>
+        /// Set on a <c>border-collapse: collapse</c> table's own box, mirroring
+        /// <see cref="ColumnRuleSegments"/>'s pattern for cross-fragment paint data carried on the box
+        /// rather than derivable from one box's own geometry - one entry per resolved grid-line run, see
+        /// <see cref="CollapsedBorderSegment"/>.
+        /// </summary>
+        internal List<CollapsedBorderSegment>? CollapsedBorderSegments { get; set; }
+
+        /// <summary>
         /// Where this table's row loop stopped, or null when it reached the end of its body rows. Null on
         /// every box that is not a table.
         /// </summary>

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
@@ -16,6 +16,7 @@ using PeachPDF.Html.Adapters;
 using PeachPDF.Html.Adapters.Entities;
 using PeachPDF.Html.Core.Entities;
 using PeachPDF.Html.Core.Fragmentation;
+using PeachPDF.Html.Core.Fragments;
 using PeachPDF.Html.Core.Parse;
 using PeachPDF.Html.Core.Utils;
 using System;
@@ -102,6 +103,16 @@ namespace PeachPDF.Html.Core.Dom
         /// <summary>Cache for <see cref="CollapsedColumnCount"/>.</summary>
         private int? _collapsedColumnCount;
 
+        /// <summary>
+        /// The table's logical row×column grid, built (and <see cref="_collapsedBorders"/> resolved from
+        /// it) only when <c>border-collapse: collapse</c> is set - null for a <c>separate</c> table,
+        /// which needs neither.
+        /// </summary>
+        private TableGrid? _grid;
+
+        /// <summary>CSS 2.1 §17.6.2's resolution of <see cref="_grid"/> - see <see cref="_grid"/>.</summary>
+        private CollapsedBorderModel? _collapsedBorders;
+
         // Header/Footer repetition fields
         private double _headerHeight;
         private double _footerHeight;
@@ -174,9 +185,9 @@ namespace PeachPDF.Html.Core.Dom
         /// §6.2 declines is still measured, so subtracting the raw height would keep charging every band
         /// for a footer that is not there — which is the whole cost §6.2's conditions exist to remove.
         /// <para>
-        /// Clamped at zero because an empty <c>&lt;tfoot&gt;&lt;/tfoot&gt;</c> measures
-        /// <c>-GetVerticalSpacing()</c>, and a negative reservation would <i>add</i> room to a band rather
-        /// than take it. The expression this replaced carried the same guard.
+        /// Clamped at zero because an empty <c>&lt;tfoot&gt;&lt;/tfoot&gt;</c> measures a negative
+        /// <see cref="VerticalSpacingAt"/>, and a negative reservation would <i>add</i> room to a band
+        /// rather than take it. The expression this replaced carried the same guard.
         /// </para>
         /// </remarks>
         private double RepeatedFooterHeight => _footerRepeats && _footerHeight > 0 ? _footerHeight : 0;
@@ -186,7 +197,7 @@ namespace PeachPDF.Html.Core.Dom
         /// included, or zero where nothing repeats.
         /// </summary>
         private double RepeatedHeaderRoom =>
-            _headerRepeats && _headerHeight > 0 ? _headerHeight + GetVerticalSpacing() : 0;
+            _headerRepeats && _headerHeight > 0 ? _headerHeight + VerticalSpacingAt(HeaderRowCountInGrid) : 0;
 
         /// <summary>
         /// Whether this run continues a table layout an earlier fragmentainer pass began, rather than
@@ -292,8 +303,14 @@ namespace PeachPDF.Html.Core.Dom
                     break;
             }
 
+            // Collapse: no grid exists yet at this pre-layout estimation point (this is a static
+            // estimator with no CssLayoutEngineTable instance to build one), so there is nothing to
+            // resolve against - 0 is a strictly better estimate than a flat per-boundary guess would be,
+            // and every real caller re-derives the true spacing once the engine actually runs.
+            if (tableBox.BorderCollapse == Keywords.Collapse) return 0;
+
             // +1 columns because padding is between the cell and table borders
-            return (columns + 1) * GetHorizontalSpacing(tableBox);
+            return (columns + 1) * tableBox.ActualBorderSpacingHorizontal;
         }
 
         /// <summary>
@@ -353,8 +370,34 @@ namespace PeachPDF.Html.Core.Dom
             // Insert EmptyBoxes for vertical cell spanning.
             InsertEmptyBoxes();
 
-            // Determine Row and Column Count, and ColumnWidths
-            var availCellSpace = CalculateCountAndWidth();
+            // Determine Row and Column Count
+            DetermineColumnCount();
+
+            // CSS 2.1 §17.6.2's border-conflict resolution needs only topology (the grid) and computed
+            // border styles, not geometry - so it can run here, before any width/height math, and its
+            // output (HorizontalLineWidth/VerticalLineWidth) then feeds that math instead of the old
+            // flat border-spacing constant. Table-topology-only cost for a `separate` table: none, since
+            // neither field is ever set.
+            if (_tableBox.BorderCollapse == Keywords.Collapse)
+            {
+                _grid = BuildTableGrid();
+                _collapsedBorders = CollapsedBorderModel.Resolve(_grid, _tableBox, IsColumnCollapsed, IsLeftToRight());
+            }
+            else
+            {
+                _grid = null;
+                _collapsedBorders = null;
+            }
+
+            _tableBox.CollapsedBorderGrid = _grid;
+            _tableBox.CollapsedBorders = _collapsedBorders;
+
+            // Must run before any cell is measured/laid out (CalculateColumnWidths/GetAvailableCellWidth
+            // read the table's own used border widths; cell content insets read each cell's own).
+            ApplyCollapsedUsedBorderWidths();
+
+            // Determine ColumnWidths
+            var availCellSpace = CalculateColumnWidths();
 
             DetermineMissingColumnWidths(availCellSpace);
 
@@ -398,9 +441,467 @@ namespace PeachPDF.Html.Core.Dom
             //Actually layout cells!
             await LayoutCells(g);
 
+            // Issue #735's actual fix: every collapse participant's own border paint is suppressed here,
+            // and CollapsedBorderSegments - built from this pass's real row/cell geometry, after it is
+            // final - is what FragmentPainter draws instead, once, after every table-internal background.
+            // Boxes paint in tree order, so a later row's opaque cell background otherwise lands on top of
+            // (and erases) an earlier row's border - suppressing the independent per-box draws and
+            // painting the resolved borders late is what stops that regardless of paint order elsewhere.
+            SuppressParticipantBorderPaint();
+            EmitCollapsedBorderSegments();
+            EmitHeaderFooterBorderSegments();
+
             // Published only now that the run has finished - see the constructor for what a half-settled
             // setup would cost a later continuation. A continuation re-publishes the instance it inherited.
             _tableBox.TableSetup = _setup;
+        }
+
+        /// <summary>
+        /// States every collapse participant's <i>used</i> border widths - half the resolved grid-line
+        /// width per edge - via <see cref="DerivedStyle.SetCollapsedUsedBorderWidths"/>, so
+        /// <c>ClientLeft</c>/<c>ClientTop</c>/content insets and the width-sum math all agree with the
+        /// spacing model <see cref="HorizontalSpacingAt"/>/<see cref="VerticalSpacingAt"/> implement. A
+        /// row/row-group/column/column-group owns no box-model space of its own under this model - the
+        /// grid line's room is charged entirely to the cells that actually border it - so those get all
+        /// zeros. A cell spanning multiple segments takes the max resolved width across its own span on
+        /// each edge, so its inset clears the thickest segment it touches.
+        /// </summary>
+        private void ApplyCollapsedUsedBorderWidths()
+        {
+            if (_grid is not { } grid || _collapsedBorders is not { } model)
+            {
+                // Not (or no longer) a collapsed table - undo whatever an earlier pass over this same
+                // table (ShrinkToFit, a §4.3 relocation, a per-page-width reflow) may have stated.
+                _tableBox.DerivedStyle.ClearCollapsedUsedBorderWidths();
+                foreach (var box in _tableBox.Boxes)
+                {
+                    if (box.DerivedStyle.ActualDisplay == Keywords.TableRowGroup)
+                        box.DerivedStyle.ClearCollapsedUsedBorderWidths();
+                }
+                _headerBox?.DerivedStyle.ClearCollapsedUsedBorderWidths();
+                _footerBox?.DerivedStyle.ClearCollapsedUsedBorderWidths();
+                foreach (var column in _columns) column.DerivedStyle.ClearCollapsedUsedBorderWidths();
+                foreach (var box in _tableBox.Boxes)
+                {
+                    if (box.DerivedStyle.ActualDisplay == Keywords.TableColumnGroup)
+                        box.DerivedStyle.ClearCollapsedUsedBorderWidths();
+                }
+                foreach (var row in _allRows)
+                {
+                    row.DerivedStyle.ClearCollapsedUsedBorderWidths();
+                    foreach (var cell in row.Boxes) cell.DerivedStyle.ClearCollapsedUsedBorderWidths();
+                }
+                return;
+            }
+
+            var rowCount = grid.RowCount;
+            var columnCount = grid.ColumnCount;
+
+            _tableBox.DerivedStyle.SetCollapsedUsedBorderWidths(
+                top: model.HorizontalLineWidth[0] / 2,
+                right: model.VerticalLineWidth[columnCount] / 2,
+                bottom: model.HorizontalLineWidth[rowCount] / 2,
+                left: model.VerticalLineWidth[0] / 2);
+
+            foreach (var box in _tableBox.Boxes)
+            {
+                if (box.DerivedStyle.ActualDisplay == Keywords.TableRowGroup)
+                    box.DerivedStyle.SetCollapsedUsedBorderWidths(0, 0, 0, 0);
+            }
+            _headerBox?.DerivedStyle.SetCollapsedUsedBorderWidths(0, 0, 0, 0);
+            _footerBox?.DerivedStyle.SetCollapsedUsedBorderWidths(0, 0, 0, 0);
+            foreach (var column in _columns) column.DerivedStyle.SetCollapsedUsedBorderWidths(0, 0, 0, 0);
+            foreach (var box in _tableBox.Boxes)
+            {
+                if (box.DerivedStyle.ActualDisplay == Keywords.TableColumnGroup)
+                    box.DerivedStyle.SetCollapsedUsedBorderWidths(0, 0, 0, 0);
+            }
+
+            var seen = new HashSet<CssBox>(ReferenceEqualityComparer.Instance);
+
+            foreach (var row in _allRows)
+            {
+                row.DerivedStyle.SetCollapsedUsedBorderWidths(0, 0, 0, 0);
+
+                foreach (var cell in row.Boxes)
+                {
+                    if (cell is CssSpacingBox spacer)
+                    {
+                        spacer.DerivedStyle.SetCollapsedUsedBorderWidths(0, 0, 0, 0);
+                        continue;
+                    }
+
+                    if (!seen.Add(cell)) continue;
+                    if (!grid.TryGetSpan(cell, out var span)) continue;
+
+                    double top = 0, right = 0, bottom = 0, left = 0;
+
+                    for (var c = span.Column; c <= span.LastColumn && c < columnCount; c++)
+                    {
+                        top = Math.Max(top, model.Horizontal(span.Row, c).UsedWidth / 2);
+                        bottom = Math.Max(bottom, model.Horizontal(span.LastRow + 1, c).UsedWidth / 2);
+                    }
+                    for (var r = span.Row; r <= span.LastRow && r < rowCount; r++)
+                    {
+                        left = Math.Max(left, model.Vertical(r, span.Column).UsedWidth / 2);
+                        right = Math.Max(right, model.Vertical(r, span.LastColumn + 1).UsedWidth / 2);
+                    }
+
+                    cell.DerivedStyle.SetCollapsedUsedBorderWidths(top, right, bottom, left);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Suppresses every collapse participant's own independent border paint - see the call site's
+        /// own remarks. Idempotent and safe to call unconditionally: a <c>separate</c> table (or one that
+        /// somehow changed collapse mode since a previous pass) is explicitly cleared back to
+        /// <see cref="BorderEdges.None"/> rather than left however an earlier pass set it.
+        /// </summary>
+        private void SuppressParticipantBorderPaint()
+        {
+            var edges = _tableBox.BorderCollapse == Keywords.Collapse ? BorderEdges.All : BorderEdges.None;
+
+            _tableBox.SuppressedBorderEdges = edges;
+
+            foreach (var box in _tableBox.Boxes)
+            {
+                if (box.DerivedStyle.ActualDisplay == Keywords.TableRowGroup)
+                    box.SuppressedBorderEdges = edges;
+            }
+
+            if (_headerBox is not null) _headerBox.SuppressedBorderEdges = edges;
+            if (_footerBox is not null) _footerBox.SuppressedBorderEdges = edges;
+
+            // <col>/<colgroup> - their own border paint (they are never painted at all otherwise; see
+            // SetColumnBoxDimensions) is suppressed the same way once they participate in resolution.
+            foreach (var column in _columns) column.SuppressedBorderEdges = edges;
+            foreach (var box in _tableBox.Boxes)
+            {
+                if (box.DerivedStyle.ActualDisplay == Keywords.TableColumnGroup)
+                    box.SuppressedBorderEdges = edges;
+            }
+
+            foreach (var row in _allRows)
+            {
+                row.SuppressedBorderEdges = edges;
+
+                // Includes CssSpacingBox - harmless, it paints nothing of its own regardless.
+                foreach (var cell in row.Boxes) cell.SuppressedBorderEdges = edges;
+            }
+        }
+
+        /// <summary>
+        /// Builds <see cref="CssBox.CollapsedBorderSegments"/> from this pass's real, final row/cell
+        /// geometry - one merged run per grid line per contiguous stretch of identically-resolved
+        /// segments (a colspan/rowspan cell's own differing per-column/per-row resolution, from
+        /// <see cref="CollapsedBorderModel"/> resolving on the unit grid, is what makes the runs
+        /// naturally split where the resolved border actually changes, with no special-casing here).
+        /// </summary>
+        /// <remarks>
+        /// Excludes every line inside a detached header's/footer's own row range (including its own
+        /// outer edge and its boundary to the body) - a repeated group is shown through one
+        /// <see cref="CssProxyBox"/> per page, each repositioning the <i>same</i> shared row objects
+        /// (<see cref="CssProxyBox.PerformLayoutImp"/>), so by the time this runs those rows' own
+        /// <c>Location</c>/<c>ActualBottom</c> reflect only whichever proxy happened to lay out last -
+        /// not any particular page. <see cref="EmitHeaderFooterBorderSegments"/> is what emits those
+        /// lines instead, once per proxy, from that proxy's own captured
+        /// <see cref="CssProxyBox.SourceGeometry"/> snapshot.
+        /// </remarks>
+        private void EmitCollapsedBorderSegments()
+        {
+            if (_grid is not { } grid || _collapsedBorders is not { } model)
+            {
+                _tableBox.CollapsedBorderSegments = null;
+                return;
+            }
+
+            var segments = new List<CollapsedBorderSegment>();
+
+            var headerRowCount = _headerBox != null ? HeaderRowCountInGrid : 0;
+            var footerRowCount = _footerBox != null ? FooterRowCountInGrid : 0;
+
+            var lineStart = _headerBox != null ? headerRowCount + 1 : 0;
+            var lineEnd = _footerBox != null ? grid.RowCount - footerRowCount - 1 : grid.RowCount;
+
+            for (var line = lineStart; line <= lineEnd; line++)
+            {
+                if (model.HorizontalLineWidth[line] <= 0) continue;
+                var y = GetGridLineY(grid, line);
+
+                EmitRuns(grid.ColumnCount, col => model.Horizontal(line, col), (start, end, border) =>
+                {
+                    var x0 = GetGridLineX(grid, start);
+                    var x1 = GetGridLineX(grid, end);
+                    if (x0 is null || x1 is null) return;
+
+                    segments.Add(new CollapsedBorderSegment(true,
+                        new RRect(x0.Value, y - border.Width / 2, x1.Value - x0.Value, border.Width),
+                        border.Style, border.Width, border.Color));
+                });
+            }
+
+            var rowStart = headerRowCount;
+            var rowEnd = grid.RowCount - footerRowCount;
+
+            for (var line = 0; line <= grid.ColumnCount; line++)
+            {
+                if (model.VerticalLineWidth[line] <= 0) continue;
+                var x = GetGridLineX(grid, line);
+                if (x is null) continue;
+
+                EmitRuns(rowEnd - rowStart, i => model.Vertical(rowStart + i, line), (start, end, border) =>
+                {
+                    var y0 = GetGridLineY(grid, rowStart + start);
+                    var y1 = GetGridLineY(grid, rowStart + end);
+
+                    segments.Add(new CollapsedBorderSegment(false,
+                        new RRect(x.Value - border.Width / 2, y0, border.Width, y1 - y0),
+                        border.Style, border.Width, border.Color));
+                });
+            }
+
+            _tableBox.CollapsedBorderSegments = segments;
+        }
+
+        /// <summary>
+        /// Builds each detached header's/footer's own <see cref="CssBox.CollapsedBorderSegments"/> -
+        /// once per <see cref="CssProxyBox"/>, i.e. once per page it is shown on (every occurrence goes
+        /// through a proxy, including a group's only appearance when it does not repeat - see
+        /// <see cref="CreateHeaderProxy"/>/<see cref="CreateFooterProxy"/>'s call sites). Two things a
+        /// repeated group needs that a plain body row never does:
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Its own internal grid lines translate per page</b>, read from the proxy's own captured
+        /// <see cref="CssProxyBox.SourceGeometry"/> rather than the shared source rows' live geometry -
+        /// see <see cref="EmitCollapsedBorderSegments"/>'s remarks for why the live geometry is not
+        /// trustworthy here. A group's own topology (which cells/rows exist) is page-invariant, so
+        /// <see cref="TableGrid"/>/<see cref="CollapsedBorderModel"/>'s already-resolved values are still
+        /// used for style/width/color - only position is re-read per proxy. X does not need the same
+        /// treatment: a repeat's <c>startX</c> is always <see cref="_tableBox"/>'s own <c>ClientLeft</c>,
+        /// identical on every page, so the existing live-geometry <see cref="GetGridLineX"/> is safe to
+        /// reuse for every segment this method emits, including the boundary one below.
+        /// </para>
+        /// <para>
+        /// <b>The line where the group meets the body is genuinely different per page</b> - CSS 2.1
+        /// §17.6.2 resolves a border against whichever row is visually adjacent, and a repeat's neighbor
+        /// is whatever row starts/ends <i>that page</i>, not the header/footer's original DOM neighbor.
+        /// This is why that one line is excluded from the "own outer edge" loop below and resolved fresh
+        /// via <see cref="CollapsedBorderModel.ResolveRepeatedGroupBoundary"/> against the real adjacent
+        /// row instead of <see cref="_collapsedBorders"/>'s single, DOM-order-based resolution for it.
+        /// </para>
+        /// </remarks>
+        private void EmitHeaderFooterBorderSegments()
+        {
+            if (_headerBox is not null) _headerBox.CollapsedBorderSegments = null;
+            if (_footerBox is not null) _footerBox.CollapsedBorderSegments = null;
+
+            if (_grid is not { } grid || _collapsedBorders is not { } model) return;
+
+            // Accumulated across every proxy of the same source, exactly like _tableBox's own segments
+            // span every page it's on: FragmentEmitter gives a repeated group's fragment the *source*
+            // box's identity on every page (ChildrenOf yields proxy.SourceBox, not the proxy itself), so
+            // paint's box.CollapsedBorderSegments check reads _headerBox/_footerBox - one property, not
+            // one per proxy - and relies on each page's own fragment.OriginY/clip to show only the
+            // segments actually on that page (see PaintCollapsedTableBorders' IsRectVisible culling).
+            var headerSegments = _headerBox is null ? null : new List<CollapsedBorderSegment>();
+            var footerSegments = _footerBox is null ? null : new List<CollapsedBorderSegment>();
+
+            foreach (var proxy in _tableBox.Boxes.OfType<CssProxyBox>())
+            {
+                var isHeader = ReferenceEquals(proxy.SourceBox, _headerBox);
+                var isFooter = !isHeader && ReferenceEquals(proxy.SourceBox, _footerBox);
+                if (!isHeader && !isFooter) continue;
+
+                var snapshot = proxy.SourceGeometry;
+                if (snapshot is null) continue;
+
+                var sourceStart = isHeader ? 0 : grid.RowCount - FooterRowCountInGrid;
+                var sourceCount = isHeader ? HeaderRowCountInGrid : FooterRowCountInGrid;
+                if (sourceCount <= 0) continue;
+
+                var segments = isHeader ? headerSegments! : footerSegments!;
+
+                double? SnapshotLineY(int line)
+                {
+                    if (line <= sourceStart)
+                        return snapshot.TryGetGeometry(grid.RowAt(sourceStart), out var top) ? top.Location.Y : null;
+                    if (line >= sourceStart + sourceCount)
+                        return snapshot.TryGetGeometry(grid.RowAt(sourceStart + sourceCount - 1), out var bottom)
+                            ? bottom.ActualBottom : null;
+                    return snapshot.TryGetGeometry(grid.RowAt(line - 1), out var above) ? above.ActualBottom : null;
+                }
+
+                // The group's own internal lines and whichever of its two outer edges is not the
+                // boundary to the body (the other is resolved fresh, below).
+                var ownLineStart = isHeader ? sourceStart : sourceStart + 1;
+                var ownLineEnd = isHeader ? sourceStart + sourceCount - 1 : sourceStart + sourceCount;
+
+                for (var line = ownLineStart; line <= ownLineEnd; line++)
+                {
+                    if (model.HorizontalLineWidth[line] <= 0) continue;
+                    var y = SnapshotLineY(line);
+                    if (y is null) continue;
+
+                    EmitRuns(grid.ColumnCount, col => model.Horizontal(line, col), (start, end, border) =>
+                    {
+                        var x0 = GetGridLineX(grid, start);
+                        var x1 = GetGridLineX(grid, end);
+                        if (x0 is null || x1 is null) return;
+
+                        segments.Add(new CollapsedBorderSegment(true,
+                            new RRect(x0.Value, y.Value - border.Width / 2, x1.Value - x0.Value, border.Width),
+                            border.Style, border.Width, border.Color));
+                    });
+                }
+
+                for (var line = 0; line <= grid.ColumnCount; line++)
+                {
+                    if (model.VerticalLineWidth[line] <= 0) continue;
+                    var x = GetGridLineX(grid, line);
+                    if (x is null) continue;
+
+                    EmitRuns(sourceCount, i => model.Vertical(sourceStart + i, line), (start, end, border) =>
+                    {
+                        var y0 = SnapshotLineY(sourceStart + start);
+                        var y1 = SnapshotLineY(sourceStart + end);
+                        if (y0 is null || y1 is null) return;
+
+                        segments.Add(new CollapsedBorderSegment(false,
+                            new RRect(x.Value - border.Width / 2, y0.Value, border.Width, y1.Value - y0.Value),
+                            border.Style, border.Width, border.Color));
+                    });
+                }
+
+                var proxyTop = proxy.Location.Y;
+                var proxyBottom = proxy.ActualBottom;
+                var groupRow = isHeader ? sourceStart + sourceCount - 1 : sourceStart;
+                var boundaryLine = isHeader ? sourceStart + sourceCount : sourceStart;
+
+                // The row whose *span* reaches this boundary, not the first one whose own Location.Y is
+                // past it: border-collapse overlaps adjacent boxes by (up to) the resolved line width, so
+                // a row with a thick border-top can legitimately start a little before proxyBottom while
+                // still being the row the header sits directly above - filtering on Location.Y alone would
+                // skip it and wrongly land on the row after.
+                var adjacentRowIndex = isHeader
+                    ? _bodyRows.FindIndex(r => r.ActualBottom >= proxyBottom - 0.5)
+                    : _bodyRows.FindLastIndex(r => r.Location.Y <= proxyTop + 0.5);
+
+                if (adjacentRowIndex >= 0)
+                {
+                    var groupRowGroup = isHeader ? _headerBox : _footerBox;
+
+                    var resolved = CollapsedBorderModel.ResolveRepeatedGroupBoundary(
+                        grid, groupRow, groupRowGroup, HeaderRowCountInGrid + adjacentRowIndex,
+                        groupIsAbove: isHeader, IsLeftToRight());
+
+                    var boundaryY = isHeader ? proxyBottom : proxyTop;
+
+                    EmitRuns(grid.ColumnCount, col => resolved[col], (start, end, border) =>
+                    {
+                        var x0 = GetGridLineX(grid, start);
+                        var x1 = GetGridLineX(grid, end);
+                        if (x0 is null || x1 is null) return;
+
+                        segments.Add(new CollapsedBorderSegment(true,
+                            new RRect(x0.Value, boundaryY - border.Width / 2, x1.Value - x0.Value, border.Width),
+                            border.Style, border.Width, border.Color));
+                    });
+                }
+                else if (model.HorizontalLineWidth[boundaryLine] > 0)
+                {
+                    // No opposing row exists at all on either side of this line (a <thead>-only/<tfoot>-only
+                    // table, or a header immediately followed by a footer with no body rows in between) -
+                    // this boundary is then either the table's own true outer edge or a fixed header/footer
+                    // adjacency that doesn't vary per page either way, both of which the whole-table static
+                    // resolution already models correctly (Column/ColumnGroup/Table origins apply exactly
+                    // at line 0/RowCount - see CollectHorizontal), unlike the fresh per-page resolution
+                    // above, which deliberately excludes those origins because they don't apply to a
+                    // genuinely interior line.
+                    var y = SnapshotLineY(boundaryLine);
+                    if (y is not null)
+                    {
+                        EmitRuns(grid.ColumnCount, col => model.Horizontal(boundaryLine, col), (start, end, border) =>
+                        {
+                            var x0 = GetGridLineX(grid, start);
+                            var x1 = GetGridLineX(grid, end);
+                            if (x0 is null || x1 is null) return;
+
+                            segments.Add(new CollapsedBorderSegment(true,
+                                new RRect(x0.Value, y.Value - border.Width / 2, x1.Value - x0.Value, border.Width),
+                                border.Style, border.Width, border.Color));
+                        });
+                    }
+                }
+            }
+
+            if (_headerBox is not null) _headerBox.CollapsedBorderSegments = headerSegments;
+            if (_footerBox is not null) _footerBox.CollapsedBorderSegments = footerSegments;
+        }
+
+        /// <summary>
+        /// Walks <paramref name="count"/> unit segments (columns for a horizontal line, rows for a
+        /// vertical one), merging consecutive ones with an identical resolved border into one run and
+        /// reporting each run via <paramref name="emit"/> - the [start, end) index range and the shared
+        /// <see cref="CollapsedBorder"/>. A segment that doesn't paint (<see cref="CollapsedBorder.IsPainted"/>
+        /// false) ends whatever run precedes it without starting a new one.
+        /// </summary>
+        private static void EmitRuns(int count, Func<int, CollapsedBorder> resolvedAt, Action<int, int, CollapsedBorder> emit)
+        {
+            var runStart = -1;
+            var current = CollapsedBorder.None;
+
+            for (var i = 0; i <= count; i++)
+            {
+                var resolved = i < count ? resolvedAt(i) : CollapsedBorder.None;
+                var continuesRun = runStart >= 0 && resolved.IsPainted &&
+                    resolved.Style == current.Style && resolved.Width == current.Width && resolved.Color == current.Color;
+
+                if (continuesRun) continue;
+
+                if (runStart >= 0) emit(runStart, i, current);
+
+                if (i < count && resolved.IsPainted)
+                {
+                    runStart = i;
+                    current = resolved;
+                }
+                else
+                {
+                    runStart = -1;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The document-space Y of horizontal grid line <paramref name="line"/> (0..RowCount), read from
+        /// this pass's real, laid-out row geometry rather than derived arithmetically - a boundary's two
+        /// neighboring rows already agree on it exactly (that agreement is the whole point of the
+        /// border-collapse overlap), so the row above's own <c>ActualBottom</c> stands for the shared line.
+        /// </summary>
+        private static double GetGridLineY(TableGrid grid, int line)
+        {
+            if (line <= 0) return grid.RowAt(0).Location.Y;
+            if (line >= grid.RowCount) return grid.RowAt(grid.RowCount - 1).ActualBottom;
+            return grid.RowAt(line - 1).ActualBottom;
+        }
+
+        /// <summary>
+        /// The document-space X of vertical grid line <paramref name="line"/> (0..ColumnCount) - read off
+        /// the first real cell anywhere in the grid whose own edge is that line, since a ragged row can
+        /// leave some rows with no cell there at all. Null only for a column with no real cell in any row
+        /// on either side of it (a fully empty column), which has no geometry to draw a segment at.
+        /// </summary>
+        private static double? GetGridLineX(TableGrid grid, int line)
+        {
+            for (var r = 0; r < grid.RowCount; r++)
+            {
+                if (line < grid.ColumnCount && grid.CellAt(r, line) is { } right) return right.Location.X;
+                if (line > 0 && grid.CellAt(r, line - 1) is { } left) return left.ActualRight;
+            }
+
+            return null;
         }
 
         /// <summary>
@@ -625,13 +1126,49 @@ namespace PeachPDF.Html.Core.Dom
             return endRowIndex;
         }
 
+        /// <summary>How many of <see cref="_allRows"/>'s leading entries are the (filtered) header rows - the offset into it <see cref="_bodyRows"/> starts at.</summary>
+        private int HeaderRowCountInGrid => _headerBox?.Boxes.Count(r => !IsRowCollapsed(r)) ?? 0;
+
+        /// <summary>How many of <see cref="_allRows"/>'s trailing entries are the (filtered) footer rows.</summary>
+        private int FooterRowCountInGrid => _footerBox?.Boxes.Count(r => !IsRowCollapsed(r)) ?? 0;
+
         /// <summary>
-        /// Determine Row and Column Count, and ColumnWidths
+        /// Builds <see cref="_grid"/> from <see cref="_allRows"/>/<see cref="_columns"/>, wiring this
+        /// engine's own span primitives into <see cref="TableGrid.Build"/>'s injected delegates.
         /// </summary>
-        /// <returns></returns>
-        private double CalculateCountAndWidth()
+        private TableGrid BuildTableGrid()
         {
-            //Columns
+            var headerRowCount = HeaderRowCountInGrid;
+            var bodyRowCount = _bodyRows.Count;
+
+            int GetLastRow(int gridRow, CssBox cell, int rowSpan)
+            {
+                // A body row's rowspan counts against the original (pre-visibility-filter) grid -
+                // GetEffectiveEndRowIndex is the one place that mapping happens (issue #665). A
+                // header/footer row's does not (InsertEmptyBoxes never touches them either - see
+                // BuildTableGrid's own remarks), so the raw arithmetic stands for those.
+                if (gridRow >= headerRowCount && gridRow < headerRowCount + bodyRowCount)
+                {
+                    var bodyIndex = gridRow - headerRowCount;
+                    return GetEffectiveEndRowIndex(bodyIndex, rowSpan) + headerRowCount;
+                }
+
+                return gridRow + rowSpan - 1;
+            }
+
+            return TableGrid.Build(_allRows, _columns, GetCellRealColumnIndex, GetRowSpan, GetColSpan, GetLastRow);
+        }
+
+        /// <summary>The table's own <c>direction</c> (not any cell's) - CSS 2.1 §17.6.2's position tiebreak reads this, not the writing direction of whatever happens to be adjacent.</summary>
+        private bool IsLeftToRight() => _tableBox.Direction.Value == DirectionMode.Ltr;
+
+        /// <summary>
+        /// Determines <see cref="_columnCount"/> alone - split out from column-width calculation so the
+        /// column count (and so <see cref="_allRows"/>/<see cref="_columns"/>) is known before
+        /// <see cref="BuildTableGrid"/> needs it, without the width math running first.
+        /// </summary>
+        private void DetermineColumnCount()
+        {
             if (_columns.Count > 0)
             {
                 _columnCount = _columns.Count;
@@ -643,9 +1180,15 @@ namespace PeachPDF.Html.Core.Dom
                     var rowColumnCount = b.Boxes.Sum(GetColSpan);
                     _columnCount = Math.Max(_columnCount, rowColumnCount);
                 }
-
             }
+        }
 
+        /// <summary>
+        /// Determine ColumnWidths, once <see cref="_columnCount"/> is already known.
+        /// </summary>
+        /// <returns></returns>
+        private double CalculateColumnWidths()
+        {
             //Initialize column widths array with NaNs
             _columnWidths = new double[_columnCount];
             for (var i = 0; i < _columnWidths.Length; i++)
@@ -1074,7 +1617,7 @@ namespace PeachPDF.Html.Core.Dom
 
             for (var i = columnIndex; i < columnIndex + colspan - 1; i++)
             {
-                if (!IsColumnCollapsed(i)) spacing += GetHorizontalSpacing();
+                if (!IsColumnCollapsed(i)) spacing += HorizontalSpacingAt(i + 1);
             }
 
             return spacing;
@@ -1166,7 +1709,7 @@ namespace PeachPDF.Html.Core.Dom
                 return null;
 
             var proxy = new CssProxyBox(_tableBox, _headerBox, _headerIndex);
-            var startX = Math.Max(_tableBox.ClientLeft + GetHorizontalSpacing(), 0);
+            var startX = Math.Max(_tableBox.ClientLeft + StartXSpacing(), 0);
             proxy.Location = new RPoint(startX, yPosition);
             return proxy;
         }
@@ -1180,7 +1723,7 @@ namespace PeachPDF.Html.Core.Dom
                 return null;
 
             var proxy = new CssProxyBox(_tableBox, _footerBox, _footerIndex);
-            var startX = Math.Max(_tableBox.ClientLeft + GetHorizontalSpacing(), 0);
+            var startX = Math.Max(_tableBox.ClientLeft + StartXSpacing(), 0);
             proxy.Location = new RPoint(startX, yPosition);
             return proxy;
         }
@@ -1316,7 +1859,7 @@ namespace PeachPDF.Html.Core.Dom
         /// <param name="g"></param>
         private async ValueTask LayoutCells(RGraphics g)
         {
-            var startX = Math.Max(_tableBox.ClientLeft + GetHorizontalSpacing(), 0);
+            var startX = Math.Max(_tableBox.ClientLeft + StartXSpacing(), 0);
 
             // Lay the top caption(s) out above the row grid before anything else claims this
             // coordinate - once, on the pass that starts the row loop from the top. A continuation
@@ -1339,17 +1882,18 @@ namespace PeachPDF.Html.Core.Dom
                 _topCaptionsHeight = topCaptionsBottom - _tableBox.Location.Y;
             }
 
-            var startY = Math.Max(_tableBox.ClientTop + _topCaptionsHeight + GetVerticalSpacing(), 0);
+            var startY = Math.Max(_tableBox.ClientTop + _topCaptionsHeight + StartYSpacing(), 0);
 
             var container = _tableBox.HtmlContainer;
             var pageHeight = container?.PageSize.Height ?? double.MaxValue;
 
             // Which fragmentainer the table begins in is a question about the table's own top edge, not
-            // about startY: startY is a row cursor, and GetVerticalSpacing() is -1 for a collapsed-border
-            // table, so it sits one point *above* the box for exactly the tables whose top lands flush on
-            // a page boundary. Reading it there names the page the table just left, and the pre-check
-            // below then nudges the table one point onto the next one - which is what a table relocated
-            // by CssBox's own §4.3 mover, and so placed exactly at a page top, does every time.
+            // about startY: startY is a row cursor, and VerticalSpacingAt(0) is negative (half the
+            // table's own resolved top border) for a collapsed-border table, so it sits above the box for
+            // exactly the tables whose top lands flush on a page boundary. Reading it there names the
+            // page the table just left, and the pre-check below then nudges the table onto the next one -
+            // which is what a table relocated by CssBox's own §4.3 mover, and so placed exactly at a page
+            // top, does every time.
             //
             // A continuation resumes the cursor the pass before it left; every other run starts one. The
             // two differ in what only the earlier pass knows - which row to re-enter and which of its
@@ -1519,6 +2063,11 @@ namespace PeachPDF.Html.Core.Dom
                 var headerRowsLayoutY = cursor.CurrentY;
                 var headerCursor = cursor.ForRowGroupMeasurement(headerRowsLayoutY);
 
+                // Header rows are always _allRows' own leading entries (AssignBoxKinds), so this loop's
+                // own ordinal is that row's grid row index too - line rowIndex+1 is the boundary right
+                // after it.
+                var rowIndex = 0;
+
                 foreach (var row in _headerBox.Boxes)
                 {
                     if (row.DerivedStyle.ActualDisplay != Keywords.TableRow)
@@ -1530,7 +2079,8 @@ namespace PeachPDF.Html.Core.Dom
                     headerCursor.MaxBottom = headerRowsLayoutY;
 
                     await LayoutBodyRow(g, row, startX, headerCursor);
-                    headerRowsLayoutY = headerCursor.MaxBottom + GetVerticalSpacing();
+                    headerRowsLayoutY = headerCursor.MaxBottom + VerticalSpacingAt(rowIndex + 1);
+                    rowIndex++;
 
                     // Unlike the regular body-row loop below, this never set the row's own
                     // Location/ActualRight/ActualBottom (only each cell's) - left it at a
@@ -1547,7 +2097,7 @@ namespace PeachPDF.Html.Core.Dom
                 // Set header box dimensions
                 _headerBox.Location = new RPoint(startX, cursor.CurrentY);
                 _headerBox.ActualRight = cursor.MaxRight;
-                _headerBox.ActualBottom = headerRowsLayoutY - GetVerticalSpacing();
+                _headerBox.ActualBottom = headerRowsLayoutY - VerticalSpacingAt(rowIndex);
                 _headerHeight = _headerBox.ActualBottom - _headerBox.Location.Y;
             }
 
@@ -1557,6 +2107,10 @@ namespace PeachPDF.Html.Core.Dom
                 // Layout footer rows directly
                 var footerRowsLayoutY = 0d;
                 var footerCursor = cursor.ForRowGroupMeasurement(footerRowsLayoutY);
+
+                // Footer rows are always _allRows' own trailing entries, after every header and body row -
+                // see the header loop above for why the ordinal doubles as the grid row index.
+                var footerRowIndex = HeaderRowCountInGrid + _bodyRows.Count;
 
                 foreach (var row in _footerBox.Boxes)
                 {
@@ -1569,7 +2123,8 @@ namespace PeachPDF.Html.Core.Dom
                     footerCursor.MaxBottom = footerRowsLayoutY;
 
                     await LayoutBodyRow(g, row, startX, footerCursor);
-                    footerRowsLayoutY = footerCursor.MaxBottom + GetVerticalSpacing();
+                    footerRowsLayoutY = footerCursor.MaxBottom + VerticalSpacingAt(footerRowIndex + 1);
+                    footerRowIndex++;
 
                     // See the identical fix in the header-rows loop above for why this is needed.
                     row.Location = new RPoint(row.Boxes.Min(x => x.Location.X), row.Boxes.Min(x => x.Location.Y));
@@ -1590,7 +2145,7 @@ namespace PeachPDF.Html.Core.Dom
                 // assignment above. See GitHub issue #124.
                 _footerBox.Location = new RPoint(startX, 0);
                 _footerBox.ActualRight = cursor.MaxRight;
-                _footerBox.ActualBottom = footerRowsLayoutY - GetVerticalSpacing();
+                _footerBox.ActualBottom = footerRowsLayoutY - VerticalSpacingAt(footerRowIndex);
                 _footerHeight = _footerBox.ActualBottom - _footerBox.Location.Y;
             }
 
@@ -1700,7 +2255,7 @@ namespace PeachPDF.Html.Core.Dom
 
                     _tableBox.Location = _tableBox.Location with { Y = _tableBox.Location.Y + pageBreakOffset };
                     foreach (var caption in _topCaptions) caption.OffsetTop(pageBreakOffset);
-                    startY = Math.Max(_tableBox.ClientTop + _topCaptionsHeight + GetVerticalSpacing(), 0);
+                    startY = Math.Max(_tableBox.ClientTop + _topCaptionsHeight + StartYSpacing(), 0);
                     // startY is a fresh restart point at the table's own content-top edge on the new
                     // page, not an arbitrary interior coordinate - the same "top edge flush on a
                     // boundary" case HtmlContainerInt.SlotStartingAt exists for (see the identical fix in
@@ -1731,7 +2286,7 @@ namespace PeachPDF.Html.Core.Dom
                 var slot = cursor.SlotIndex;
                 var firstRowHeight = EstimateRowHeight(_bodyRows[0]);
                 var availableHeight = container.PageBandHeightOf(slot) - RepeatedFooterHeight;
-                var afterHeaderY = startY + _headerHeight + GetVerticalSpacing();
+                var afterHeaderY = startY + _headerHeight + VerticalSpacingAt(HeaderRowCountInGrid);
 
                 if (WillCrossPageBoundary(container, afterHeaderY + firstRowHeight, availableHeight, slot))
                 {
@@ -1743,7 +2298,7 @@ namespace PeachPDF.Html.Core.Dom
                     _headerBox.OffsetTop(pageBreakOffset);
                     foreach (var caption in _topCaptions) caption.OffsetTop(pageBreakOffset);
 
-                    startY = Math.Max(_tableBox.ClientTop + _topCaptionsHeight + GetVerticalSpacing(), 0);
+                    startY = Math.Max(_tableBox.ClientTop + _topCaptionsHeight + StartYSpacing(), 0);
                     // startY is a fresh restart point at the table's own content-top edge on the new
                     // page, not an arbitrary interior coordinate - the same "top edge flush on a
                     // boundary" case HtmlContainerInt.SlotStartingAt exists for (see the identical fix in
@@ -1776,7 +2331,7 @@ namespace PeachPDF.Html.Core.Dom
                 {
                     await headerProxy.PerformLayout(g);
 
-                    var headerRoom = _headerHeight + GetVerticalSpacing();
+                    var headerRoom = _headerHeight + VerticalSpacingAt(HeaderRowCountInGrid);
                     if (_continuesAPreviousPass) resumedHeaderRoom = headerRoom;
 
                     cursor.CurrentY += headerRoom;
@@ -1908,7 +2463,7 @@ namespace PeachPDF.Html.Core.Dom
                 // correction moved fits the band it was moved to and has nothing to slice.
                 var slicedRowBottom = SliceARowAcrossTheBandsItOverflows(container, row, cursor, rowTop);
 
-                cursor.CurrentY = cursor.MaxBottom + GetVerticalSpacing();
+                cursor.CurrentY = cursor.MaxBottom + VerticalSpacingAt(HeaderRowCountInGrid + i + 1);
 
                 row.Location = new RPoint(row.Boxes.Min(x => x.Location.X), row.Boxes.Min(x => x.Location.Y));
                 row.ActualRight = row.Boxes.Max(x => x.ActualRight);
@@ -1994,7 +2549,7 @@ namespace PeachPDF.Html.Core.Dom
                 if (finalFooterProxy != null)
                 {
                     await finalFooterProxy.PerformLayout(g);
-                    cursor.CurrentY += _footerHeight + GetVerticalSpacing();
+                    cursor.CurrentY += _footerHeight + VerticalSpacingAt(_grid?.RowCount ?? 0);
                     cursor.MaxBottom = Math.Max(cursor.MaxBottom, finalFooterProxy.ActualBottom);
                     cursor.MaxRight = Math.Max(cursor.MaxRight, finalFooterProxy.ActualRight);
                 }
@@ -2014,17 +2569,18 @@ namespace PeachPDF.Html.Core.Dom
             // perfectly valid, already-computed position. Give every row-group box a real bounding
             // rect spanning its own row children so it participates in that check correctly.
             SetRowGroupBoxDimensions(placedRows);
+            SetColumnBoxDimensions();
 
             // Step 7: Set final table dimensions
             var tableRight = Math.Max(cursor.MaxRight, _tableBox.Location.X + _tableBox.ActualWidth);
-            _tableBox.ActualRight = tableRight + GetHorizontalSpacing() + _tableBox.ActualBorderRightWidth;
+            _tableBox.ActualRight = tableRight + HorizontalSpacingAt(_columnCount) + _tableBox.ActualBorderRightWidth;
 
             // Computed ahead of ActualBottom rather than only assigned to TableContinuation below,
             // because a bottom caption's placement depends on it: the caption belongs after the
             // table's very last row, never stitched into the middle of a table still spanning
             // fragmentainers, so it may only be laid out on the pass that finishes the row loop.
             var tableContinuation = cursor.Continuation(_tableBox);
-            var contentBottom = Math.Max(cursor.MaxBottom, startY) + GetVerticalSpacing();
+            var contentBottom = Math.Max(cursor.MaxBottom, startY) + VerticalSpacingAt(_grid?.RowCount ?? 0);
 
             // CSS 2.1 §17.4: the row grid's own border-box bottom - where FinalizeGridDecorationBoxGeometry
             // sizes the grid's own paint rect to (issue #721) - sits here, before any bottom caption is
@@ -2081,6 +2637,104 @@ namespace PeachPDF.Html.Core.Dom
             // recorded no break inside itself, so it did not fragment, and a box that did not fragment
             // is moved whole or left alone. The engine states the fact (PageBreakBottoms) and the
             // epilogue takes the decision - see CssBox.PaginatedItsOwnContentWithoutBreaking.
+        }
+
+        /// <summary>
+        /// Real document-space X of vertical grid line <paramref name="line"/> (0..ColumnCount), read off
+        /// any real cell anywhere in the table whose own edge is that line - independent of
+        /// <see cref="_grid"/> (unlike <see cref="GetGridLineX"/>), so this works for a <c>separate</c>
+        /// table too, since <see cref="SetColumnBoxDimensions"/> - CSS 2.1 §17.5.1 column/column-group
+        /// background layering - is not itself a collapse-only feature. Null only when no row has a real
+        /// cell on either side of the line (every row is shorter than it, a legitimately empty column).
+        /// </summary>
+        /// <param name="line">vertical grid line index, 0..ColumnCount</param>
+        private double? GetColumnLineX(int line)
+        {
+            foreach (var row in _allRows)
+            {
+                foreach (var cell in row.Boxes)
+                {
+                    if (cell is CssSpacingBox) continue;
+
+                    var col = GetCellRealColumnIndex(row, cell);
+                    var span = GetColSpan(cell);
+
+                    if (line == col) return cell.Location.X;
+                    if (line == col + span) return cell.ActualRight;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gives every <c>&lt;col&gt;</c>/<c>&lt;colgroup&gt;</c> box a real
+        /// <c>Location</c>/<c>ActualRight</c>/<c>ActualBottom</c> spanning its own column range's
+        /// X-extent and the full row grid's Y-extent - the exact twin of
+        /// <see cref="SetRowGroupBoxDimensions"/> for the same reason: these boxes are otherwise never
+        /// laid out at all, so <c>CssBox</c>'s paint-time visibility-culling optimization (intersecting a
+        /// still-default <c>(0,0,0,0)</c> <c>Bounds</c> against the current clip) silently drops them from
+        /// painting - which, since neither box has painted anything at all until now, has hidden the fact
+        /// that they never got real geometry in the first place. Once they have it, their own background
+        /// paints through the ordinary <c>FragmentPainter</c> path with no new mechanism (their border
+        /// paint still goes through <see cref="CssBox.CollapsedBorderSegments"/> like every other collapse
+        /// participant, gated on <c>border-collapse: collapse</c> the same way) - CSS 2.1 §17.5.1's
+        /// column-group-then-column-then-row-group-then-row-then-cell background layering falls out of
+        /// DOM tree order for free, since a <c>&lt;colgroup&gt;</c> structurally always precedes its own
+        /// <c>&lt;col&gt;</c> children and both always precede <c>&lt;tbody&gt;</c>/<c>&lt;tr&gt;</c>/
+        /// <c>&lt;td&gt;</c>. Runs for every table, not just <c>collapse</c> ones - unlike border
+        /// participation, background layering is an ordinary CSS 2.1 feature this gap affected regardless
+        /// of <c>border-collapse</c>.
+        /// </summary>
+        private void SetColumnBoxDimensions()
+        {
+            if (_columns.Count == 0 || _allRows.Count == 0) return;
+
+            var top = _allRows[0].Location.Y;
+            var bottom = _allRows[^1].ActualBottom;
+
+            var i = 0;
+            while (i < _columns.Count)
+            {
+                var box = _columns[i];
+                var j = i;
+                while (j < _columns.Count && ReferenceEquals(_columns[j], box)) j++;
+
+                var left = GetColumnLineX(i);
+                var right = GetColumnLineX(j);
+                if (left is { } l && right is { } r)
+                {
+                    box.Location = new RPoint(l, top);
+                    box.ActualRight = r;
+                    box.ActualBottom = bottom;
+                }
+
+                i = j;
+            }
+
+            // A <colgroup> with real <col> children never appears in _columns itself (only its children
+            // do) - it still needs its own geometry, spanning the union of its children's columns, so its
+            // own background paints beneath theirs.
+            foreach (var box in _tableBox.Boxes)
+            {
+                if (box.DerivedStyle.ActualDisplay != Keywords.TableColumnGroup) continue;
+
+                var childCols = box.Boxes.Where(c => c.DerivedStyle.ActualDisplay == Keywords.TableColumn).ToList();
+                if (childCols.Count == 0) continue;
+
+                var firstIndex = _columns.IndexOf(childCols[0]);
+                var lastIndex = _columns.LastIndexOf(childCols[^1]);
+                if (firstIndex < 0 || lastIndex < 0) continue;
+
+                var left = GetColumnLineX(firstIndex);
+                var right = GetColumnLineX(lastIndex + 1);
+                if (left is { } l && right is { } r)
+                {
+                    box.Location = new RPoint(l, top);
+                    box.ActualRight = r;
+                    box.ActualBottom = bottom;
+                }
+            }
         }
 
         /// <summary>
@@ -2210,7 +2864,7 @@ namespace PeachPDF.Html.Core.Dom
                 if (headerProxy != null)
                 {
                     await headerProxy.PerformLayout(g);
-                    cursor.CurrentY += _headerHeight + GetVerticalSpacing();
+                    cursor.CurrentY += _headerHeight + VerticalSpacingAt(HeaderRowCountInGrid);
                     cursor.MaxRight = Math.Max(cursor.MaxRight, headerProxy.ActualRight);
                 }
             }
@@ -2261,7 +2915,7 @@ namespace PeachPDF.Html.Core.Dom
             if (container.CurrentFragmentainer is { HasOwnBand: true }) return;
 
             var slot = cursor.BandReached(container);
-            var room = _footerHeight + GetVerticalSpacing();
+            var room = _footerHeight + VerticalSpacingAt(_grid?.RowCount ?? 0);
 
             if (!HtmlContainerInt.FallsPast(cursor.CurrentY + room, container.BandOfSlot(slot))) return;
             if (room > container.PageBandHeightOf(slot + 1)) return;
@@ -2286,7 +2940,7 @@ namespace PeachPDF.Html.Core.Dom
                 if (headerProxy != null)
                 {
                     await headerProxy.PerformLayout(g);
-                    cursor.CurrentY += _headerHeight + GetVerticalSpacing();
+                    cursor.CurrentY += _headerHeight + VerticalSpacingAt(HeaderRowCountInGrid);
                     cursor.MaxRight = Math.Max(cursor.MaxRight, headerProxy.ActualRight);
                 }
             }
@@ -2817,7 +3471,7 @@ namespace PeachPDF.Html.Core.Dom
                 // the slot is owed only when the cell's own trailing edge lands on a visible column.
                 var spacingAfterCell = IsColumnCollapsed(columnIndex + GetColSpan(cell) - 1)
                     ? 0
-                    : GetHorizontalSpacing();
+                    : HorizontalSpacingAt(columnIndex + GetColSpan(cell));
 
                 // A cell an earlier pass finished has its whole content in the fragment that pass emitted,
                 // so this one places nothing for it: not its position, not its content, not its alignment.
@@ -3597,7 +4251,7 @@ namespace PeachPDF.Html.Core.Dom
         /// </remarks>
         private double GetAvailableCellWidth()
         {
-            return GetAvailableTableWidth() - GetHorizontalSpacing() * (_columnCount + 1) - _tableBox.ActualBorderLeftWidth - _tableBox.ActualBorderRightWidth;
+            return GetAvailableTableWidth() - SumHorizontalSpacing() - _tableBox.ActualBorderLeftWidth - _tableBox.ActualBorderRightWidth;
         }
 
         /// <summary>
@@ -3622,7 +4276,7 @@ namespace PeachPDF.Html.Core.Dom
             // slot of its own, matching LayoutBodyRow's cursor advance not spacing past it either.
             // Without this a table with a collapsed column measured one border-spacing unit wider
             // than a table genuinely built with one fewer column.
-            f += GetHorizontalSpacing() * (_columnWidths.Length + 1 - CollapsedColumnCount());
+            f += SumHorizontalSpacingExcludingCollapsedColumns();
 
             //Take table borders
             f += _tableBox.ActualBorderLeftWidth + _tableBox.ActualBorderRightWidth;
@@ -3687,27 +4341,101 @@ namespace PeachPDF.Html.Core.Dom
         }
 
         /// <summary>
-        /// Gets the actual horizontal spacing of the table
+        /// The gap between <c>ClientLeft</c> and the first column's own start (<c>startX</c>) - zero
+        /// under <c>collapse</c>, unlike every other use of <see cref="HorizontalSpacingAt"/> at line 0:
+        /// <c>ClientLeft</c> already reserves the table's own half of the outer edge via
+        /// <see cref="DerivedStyle.SetCollapsedUsedBorderWidths"/>, so adding
+        /// <c>HorizontalSpacingAt(0)</c> (also half that same width, negative) here would double-count
+        /// it. Every other line-0/line-ColumnCount use pairs the spacing term with a matching border-width
+        /// term that cancels it the same way (<c>_tableBox.ActualRight</c>'s
+        /// <c>tableRight + HorizontalSpacingAt(columnCount) + ActualBorderRightWidth</c>, and
+        /// <c>contentBottom</c>/<c>gridBorderBoxBottom</c>'s two-statement equivalent on the row axis) -
+        /// <c>startX</c>/<c>startY</c> are the one case with no such partner, because <c>ClientLeft</c>/
+        /// <c>ClientTop</c> already folded the border term in directly.
         /// </summary>
-        private double GetHorizontalSpacing()
+        /// <remarks>
+        /// Under <c>collapse</c> this is <c>-ActualBorderLeftWidth</c>, not 0: <c>ClientLeft</c> already
+        /// added that same <c>VW[0]/2</c> once (it is <c>Location.X + ActualBorderLeftWidth</c>, and
+        /// padding is always zero on a table), so this cancels it back to bare <c>Location.X</c>. That is
+        /// deliberate, not a second double-count - per <see cref="CollapsedBorderModel"/>'s own geometric
+        /// model, the table's border box and the first cell's own border box are <i>the same edge</i>
+        /// (<c>X_0 − VW[0]/2</c> both), not two edges VW[0]/2 apart the way a normal (non-collapsed) box's
+        /// border-then-content layering would suggest. Verified by hand against <c>GetWidthSum</c>'s own
+        /// (independently-derived, and already-correct) total: a first cell placed at
+        /// <c>ClientLeft + HorizontalSpacingAt(0)</c> instead - reusing the interior formula's shape -
+        /// measured 200.375pt against 200.000pt of column width for a 3-column, 1px-bordered fixture, an
+        /// exact one-outer-edge (VW[0]/2 = 0.375pt) residual.
+        /// </remarks>
+        private double StartXSpacing() =>
+            _tableBox.BorderCollapse == Keywords.Collapse ? -_tableBox.ActualBorderLeftWidth : _tableBox.ActualBorderSpacingHorizontal;
+
+        /// <summary>The row-axis twin of <see cref="StartXSpacing"/> - see its own remarks.</summary>
+        private double StartYSpacing() =>
+            _tableBox.BorderCollapse == Keywords.Collapse ? -_tableBox.ActualBorderTopWidth : _tableBox.ActualBorderSpacingVertical;
+
+        /// <summary>
+        /// The gap a row/column cursor advances by when it crosses vertical grid line
+        /// <paramref name="line"/> (0..ColumnCount) - negative under <c>collapse</c>, since adjacent
+        /// cells' border boxes overlap there by the resolved border width instead of being held apart by
+        /// <c>border-spacing</c>. Borders are centered on their grid line (see
+        /// <see cref="CollapsedBorderModel"/>'s own remarks), so an <b>interior</b> line's cells overlap
+        /// by the whole resolved width, while the table's own two <b>outer</b> edges (line 0 and
+        /// <see cref="_columnCount"/>) only give up half of it - the other half is the table's own used
+        /// border width, applied separately via the table's own used-border-width override.
+        /// </summary>
+        private double HorizontalSpacingAt(int line)
         {
-            return _tableBox.BorderCollapse == Keywords.Collapse ? -1f : _tableBox.ActualBorderSpacingHorizontal;
+            if (_tableBox.BorderCollapse != Keywords.Collapse) return _tableBox.ActualBorderSpacingHorizontal;
+            if (_collapsedBorders is not { } model || model.VerticalLineWidth.Length == 0) return 0;
+
+            var width = model.VerticalLineWidth[Math.Clamp(line, 0, model.VerticalLineWidth.Length - 1)];
+            return line <= 0 || line >= _columnCount ? -width / 2 : -width;
+        }
+
+        /// <summary>The gap a row cursor advances by when it crosses horizontal grid line <paramref name="line"/> (0..RowCount) - see <see cref="HorizontalSpacingAt"/>'s own remarks, which apply identically on this axis.</summary>
+        private double VerticalSpacingAt(int line)
+        {
+            if (_tableBox.BorderCollapse != Keywords.Collapse) return _tableBox.ActualBorderSpacingVertical;
+            if (_collapsedBorders is not { } model || model.HorizontalLineWidth.Length == 0) return 0;
+
+            var rowCount = _grid?.RowCount ?? 0;
+            var width = model.HorizontalLineWidth[Math.Clamp(line, 0, model.HorizontalLineWidth.Length - 1)];
+            return line <= 0 || line >= rowCount ? -width / 2 : -width;
         }
 
         /// <summary>
-        /// Gets the actual horizontal spacing of the table
+        /// Sums <see cref="HorizontalSpacingAt"/> over every vertical grid line - what
+        /// <see cref="GetAvailableCellWidth"/>'s own pre-existing flat-spacing formula summed without
+        /// ever excluding a collapsed column's own boundary (only <see cref="GetWidthSum"/> did that);
+        /// preserved here rather than reconciling the two, since fixing that asymmetry is unrelated to
+        /// replacing the flat spacing constant with resolved widths.
         /// </summary>
-        private static double GetHorizontalSpacing(CssBox box)
+        private double SumHorizontalSpacing()
         {
-            return box.BorderCollapse == Keywords.Collapse ? -1f : box.ActualBorderSpacingHorizontal;
+            double total = 0;
+            for (var line = 0; line <= _columnCount; line++) total += HorizontalSpacingAt(line);
+            return total;
         }
 
         /// <summary>
-        /// Gets the actual vertical spacing of the table
+        /// <see cref="SumHorizontalSpacing"/>, minus one boundary per collapsed column - the per-line
+        /// translation of <see cref="GetWidthSum"/>'s own pre-existing
+        /// <c>(columnCount + 1 - CollapsedColumnCount())</c> removal: a collapsed column contributes
+        /// neither its own width (already zeroed by <see cref="CollapseColumnWidths"/>) nor a
+        /// border-spacing slot of its own, matching <see cref="LayoutBodyRow"/>'s cursor advance not
+        /// spacing past it either. The boundary immediately after each collapsed column is the one
+        /// skipped, mirroring <see cref="GetInteriorSpacing"/>'s and <c>LayoutBodyRow</c>'s own choice of
+        /// which side of a collapsed column carries no spacing.
         /// </summary>
-        private double GetVerticalSpacing()
+        private double SumHorizontalSpacingExcludingCollapsedColumns()
         {
-            return _tableBox.BorderCollapse == Keywords.Collapse ? -1f : _tableBox.ActualBorderSpacingVertical;
+            double total = 0;
+            for (var line = 0; line <= _columnCount; line++)
+            {
+                if (line > 0 && IsColumnCollapsed(line - 1)) continue;
+                total += HorizontalSpacingAt(line);
+            }
+            return total;
         }
 
         /// <summary>
@@ -3741,6 +4469,16 @@ namespace PeachPDF.Html.Core.Dom
         /// <summary>
         /// Phase 3: Estimates the height a row will need (for page break detection)
         /// </summary>
+        /// <remarks>
+        /// A heuristic, not exact geometry - already known to undershoot a row holding block content by
+        /// roughly 2x (see the pre-check callers' own remarks), with real layout correcting the answer
+        /// afterward. Passed as a method group in one caller (<c>_bodyRows.Sum(EstimateRowHeight)</c>), so
+        /// this deliberately does not take a grid-row index the way the real (non-estimated) row-advance
+        /// call sites do; <see cref="VerticalSpacingAt"/> at an arbitrary interior line (1) stands in for
+        /// "whatever this row's own boundary resolves to", which is exact for the overwhelmingly common
+        /// case of uniform border widths across a table and only approximate otherwise - acceptable for an
+        /// estimate real layout supersedes.
+        /// </remarks>
         private double EstimateRowHeight(CssBox row)
         {
             double maxHeight = 0;
@@ -3756,7 +4494,7 @@ namespace PeachPDF.Html.Core.Dom
                 maxHeight = Math.Max(maxHeight, estimatedHeight);
             }
 
-            return maxHeight + GetVerticalSpacing();
+            return maxHeight + VerticalSpacingAt(1);
         }
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
+++ b/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
@@ -111,10 +111,70 @@ namespace PeachPDF.Html.Core.Dom
             }
         }
 
-        internal void InvalidateBorderTopWidth() => _actualBorderTopWidth = double.NaN;
-        internal void InvalidateBorderRightWidth() => _actualBorderRightWidth = double.NaN;
-        internal void InvalidateBorderBottomWidth() => _actualBorderBottomWidth = double.NaN;
-        internal void InvalidateBorderLeftWidth() => _actualBorderLeftWidth = double.NaN;
+        /// <summary>
+        /// The declared border width CSS 2.1 §17.6.2 resolution itself needs as an input - deliberately
+        /// bypassing <see cref="_actualBorderTopWidth"/>'s cache, which <see cref="SetCollapsedUsedBorderWidths"/>
+        /// overwrites with the box-model *used* half-width for the rest of a collapsed table's layout
+        /// pass. <see cref="CollapsedBorderModel.Resolve"/> itself runs before that override is applied
+        /// (safe to read <see cref="ActualBorderTopWidth"/> directly), but
+        /// <see cref="CollapsedBorderModel.ResolveRepeatedGroupBoundary"/> runs at the very end of the
+        /// pass, once a repeated group's final per-page geometry exists - by then the override is
+        /// already active, and reading the cached property there would resolve against half of an
+        /// earlier, unrelated resolution instead of this cell's real declared border.
+        /// </summary>
+        internal double NaturalBorderTopWidth =>
+            Style.Border.BorderTopStyle.Value == LineStyle.None
+                ? 0d : CssValueParser.GetActualBorderWidth(Style.Border.BorderTopWidth, Owner);
+
+        internal double NaturalBorderRightWidth =>
+            Style.Border.BorderRightStyle.Value == LineStyle.None
+                ? 0d : CssValueParser.GetActualBorderWidth(Style.Border.BorderRightWidth, Owner);
+
+        internal double NaturalBorderBottomWidth =>
+            Style.Border.BorderBottomStyle.Value == LineStyle.None
+                ? 0d : CssValueParser.GetActualBorderWidth(Style.Border.BorderBottomWidth, Owner);
+
+        internal double NaturalBorderLeftWidth =>
+            Style.Border.BorderLeftStyle.Value == LineStyle.None
+                ? 0d : CssValueParser.GetActualBorderWidth(Style.Border.BorderLeftWidth, Owner);
+
+        internal void InvalidateBorderTopWidth() { if (!_hasCollapsedUsedBorderWidths) _actualBorderTopWidth = double.NaN; }
+        internal void InvalidateBorderRightWidth() { if (!_hasCollapsedUsedBorderWidths) _actualBorderRightWidth = double.NaN; }
+        internal void InvalidateBorderBottomWidth() { if (!_hasCollapsedUsedBorderWidths) _actualBorderBottomWidth = double.NaN; }
+        internal void InvalidateBorderLeftWidth() { if (!_hasCollapsedUsedBorderWidths) _actualBorderLeftWidth = double.NaN; }
+
+        private bool _hasCollapsedUsedBorderWidths;
+
+        /// <summary>
+        /// States this box's <i>used</i> border widths under CSS 2.1 §17.6.2's collapsing model - half the
+        /// resolved grid-line width on each edge, rather than the box's own computed <c>border-*-width</c>
+        /// (which <see cref="CollapsedBorderModel"/> still needs to read as a resolver *input*, so this
+        /// overrides the derived <c>Actual*Width</c> family only, never the declared style itself). Every
+        /// existing reader of <c>ActualBorderTopWidth</c>/etc - <c>ClientLeft</c>/<c>ClientTop</c>, content
+        /// insets, <c>GetAvailableCellWidth</c>, <c>GetWidthSum</c> - then sees the used value with no
+        /// call-site change. Set once per table per layout pass by <c>CssLayoutEngineTable</c>, before any
+        /// cell is measured or laid out; <see cref="InvalidateBorderTopWidth"/> and its three siblings
+        /// become no-ops while this is active, so an incidental style re-application mid-pass cannot wipe
+        /// a stated value back to "recompute from the declared border".
+        /// </summary>
+        internal void SetCollapsedUsedBorderWidths(double top, double right, double bottom, double left)
+        {
+            _actualBorderTopWidth = top;
+            _actualBorderRightWidth = right;
+            _actualBorderBottomWidth = bottom;
+            _actualBorderLeftWidth = left;
+            _hasCollapsedUsedBorderWidths = true;
+        }
+
+        /// <summary>Undoes <see cref="SetCollapsedUsedBorderWidths"/> - called on every box that no longer participates in a collapsed table (or never did), so its border widths resolve normally again.</summary>
+        internal void ClearCollapsedUsedBorderWidths()
+        {
+            _hasCollapsedUsedBorderWidths = false;
+            _actualBorderTopWidth = double.NaN;
+            _actualBorderRightWidth = double.NaN;
+            _actualBorderBottomWidth = double.NaN;
+            _actualBorderLeftWidth = double.NaN;
+        }
 
         #endregion
 

--- a/src/PeachPDF/Html/Core/Dom/TableGrid.cs
+++ b/src/PeachPDF/Html/Core/Dom/TableGrid.cs
@@ -1,0 +1,184 @@
+using PeachPDF.CSS;
+using System;
+using System.Collections.Generic;
+
+namespace PeachPDF.Html.Core.Dom
+{
+    /// <summary>Where one cell sits on the grid and how far it reaches.</summary>
+    internal readonly record struct CellSpan(int Row, int Column, int RowSpan, int ColSpan)
+    {
+        internal int LastRow => Row + RowSpan - 1;
+        internal int LastColumn => Column + ColSpan - 1;
+    }
+
+    /// <summary>
+    /// The table's logical row×column grid - which real <see cref="CssBox"/> occupies each cell (honoring
+    /// <c>colspan</c>/<c>rowspan</c>), and which row-group/column/column-group each grid line belongs to.
+    /// Built once per layout pass by <see cref="CssLayoutEngineTable"/> and consumed to register
+    /// CSS 2.1 §17.6.2 border-conflict candidates. Carries no geometry - purely topology, so it can be
+    /// built (and tested) before column widths or row heights exist.
+    /// </summary>
+    internal sealed class TableGrid
+    {
+        private readonly CssBox?[,] _slots;
+        private readonly CssBox[] _rows;
+        private readonly CssBox?[] _rowGroups;
+        private readonly CssBox?[] _columns;
+        private readonly CssBox?[] _columnGroups;
+        private readonly bool[] _columnStartsHere;
+        private readonly bool[] _columnGroupStartsHere;
+        private readonly Dictionary<CssBox, CellSpan> _spans;
+
+        internal int RowCount { get; }
+        internal int ColumnCount { get; }
+
+        private TableGrid(
+            CssBox?[,] slots, CssBox[] rows, CssBox?[] rowGroups,
+            CssBox?[] columns, CssBox?[] columnGroups, bool[] columnStartsHere, bool[] columnGroupStartsHere,
+            Dictionary<CssBox, CellSpan> spans)
+        {
+            _slots = slots;
+            _rows = rows;
+            _rowGroups = rowGroups;
+            _columns = columns;
+            _columnGroups = columnGroups;
+            _columnStartsHere = columnStartsHere;
+            _columnGroupStartsHere = columnGroupStartsHere;
+            _spans = spans;
+
+            RowCount = rows.Length;
+            ColumnCount = columnStartsHere.Length;
+        }
+
+        /// <summary>The real box occupying (row, column) - a cell, or the extended cell of a rowspan/colspan reaching in from elsewhere. Null for an out-of-range or genuinely empty slot.</summary>
+        internal CssBox? CellAt(int row, int column) =>
+            row >= 0 && row < RowCount && column >= 0 && column < ColumnCount ? _slots[row, column] : null;
+
+        internal CssBox RowAt(int row) => _rows[row];
+
+        internal CssBox? RowGroupAt(int row) => row >= 0 && row < RowCount ? _rowGroups[row] : null;
+
+        internal CssBox? ColumnAt(int column) => column >= 0 && column < ColumnCount ? _columns[column] : null;
+
+        internal CssBox? ColumnGroupAt(int column) => column >= 0 && column < ColumnCount ? _columnGroups[column] : null;
+
+        /// <summary>True where the &lt;col&gt;/&lt;colgroup span&gt; covering <paramref name="column"/> begins.</summary>
+        internal bool ColumnBoxStartsAt(int column) => column >= 0 && column < ColumnCount && _columnStartsHere[column];
+
+        internal bool ColumnBoxEndsAt(int column) =>
+            column >= 0 && column < ColumnCount && (column == ColumnCount - 1 || _columnStartsHere[column + 1]);
+
+        internal bool ColumnGroupStartsAt(int column) => column >= 0 && column < ColumnCount && _columnGroupStartsHere[column];
+
+        internal bool ColumnGroupEndsAt(int column) =>
+            column >= 0 && column < ColumnCount && (column == ColumnCount - 1 || _columnGroupStartsHere[column + 1]);
+
+        /// <summary>Where <paramref name="cell"/> begins and how far it reaches, in O(1) from any of its occupied slots.</summary>
+        internal bool TryGetSpan(CssBox cell, out CellSpan span) => _spans.TryGetValue(cell, out span);
+
+        internal bool IsFirstRowOfGroup(int row) =>
+            row == 0 || !ReferenceEquals(_rowGroups[row], _rowGroups[row - 1]);
+
+        internal bool IsLastRowOfGroup(int row) =>
+            row == RowCount - 1 || !ReferenceEquals(_rowGroups[row], _rowGroups[row + 1]);
+
+        /// <summary>
+        /// Builds the grid from <paramref name="rows"/> (already row-group-ordered and
+        /// <c>visibility: collapse</c>-filtered - <c>CssLayoutEngineTable._allRows</c>) and
+        /// <paramref name="columns"/> (one entry per column, repeated across a <c>span</c> - matching
+        /// <c>_columns</c>). Every span primitive is injected rather than reached-into directly, so this
+        /// has no dependency on <see cref="CssLayoutEngineTable"/> and is unit-testable on its own.
+        /// </summary>
+        /// <param name="rows">Row-group-ordered, <c>visibility: collapse</c>-filtered rows (<c>_allRows</c>).</param>
+        /// <param name="columns">One entry per column, repeated across a <c>span</c> (<c>_columns</c>).</param>
+        /// <param name="getRealColumnIndex">A cell's starting column within its own row.</param>
+        /// <param name="getRowSpan">A cell's raw <c>rowspan</c> (already clamped to at least 1).</param>
+        /// <param name="getColSpan">A cell's raw <c>colspan</c> (already clamped to at least 1).</param>
+        /// <param name="getLastRow">
+        /// The last grid row (inclusive, 0-based into <paramref name="rows"/>) a cell starting at grid
+        /// row <c>gridRow</c> with the given <c>rowSpan</c> actually reaches - the caller's own concern,
+        /// since a body row's rowspan counts against <c>CssLayoutEngineTable</c>'s original (pre-filter)
+        /// row indices (issue #665) while a header/footer row's does not.
+        /// </param>
+        internal static TableGrid Build(
+            IReadOnlyList<CssBox> rows,
+            IReadOnlyList<CssBox?> columns,
+            Func<CssBox, CssBox, int> getRealColumnIndex,
+            Func<CssBox, int> getRowSpan,
+            Func<CssBox, int> getColSpan,
+            Func<int, CssBox, int, int> getLastRow)
+        {
+            var rowCount = rows.Count;
+            var columnCount = 0;
+            foreach (var box in columns) columnCount++;
+            // _columns may under-count columns implied by cells beyond the declared <col>s - take the
+            // wider of the two so no cell's own span is ever truncated.
+            for (var r = 0; r < rowCount; r++)
+            {
+                foreach (var cell in rows[r].Boxes)
+                {
+                    if (cell is CssSpacingBox) continue;
+                    columnCount = Math.Max(columnCount, getRealColumnIndex(rows[r], cell) + getColSpan(cell));
+                }
+            }
+
+            var slots = new CssBox?[rowCount, Math.Max(columnCount, 1)];
+            var spans = new Dictionary<CssBox, CellSpan>(ReferenceEqualityComparer.Instance);
+
+            for (var r = 0; r < rowCount; r++)
+            {
+                foreach (var cell in rows[r].Boxes)
+                {
+                    // A rowspan placeholder an earlier row's fill-forward already claimed this slot for -
+                    // nothing new to record, the origin row already computed the full span.
+                    if (cell is CssSpacingBox) continue;
+
+                    var c = getRealColumnIndex(rows[r], cell);
+                    var colSpan = Math.Max(1, getColSpan(cell));
+                    var rowSpan = Math.Max(1, getRowSpan(cell));
+                    var lastRow = Math.Max(r, getLastRow(r, cell, rowSpan));
+
+                    spans[cell] = new CellSpan(r, c, lastRow - r + 1, colSpan);
+
+                    for (var rr = r; rr <= lastRow && rr < rowCount; rr++)
+                    {
+                        for (var cc = c; cc < c + colSpan && cc < columnCount; cc++)
+                        {
+                            // A malformed table can declare overlapping cells; the parser tolerates it,
+                            // so the grid does too - first writer keeps the slot.
+                            slots[rr, cc] ??= cell;
+                        }
+                    }
+                }
+            }
+
+            var rowGroups = new CssBox?[rowCount];
+            for (var r = 0; r < rowCount; r++)
+            {
+                var parent = rows[r].ParentBox;
+                rowGroups[r] = parent?.DerivedStyle.ActualDisplay == Keywords.TableRowGroup ? parent : null;
+            }
+
+            var columnBoxes = new CssBox?[columnCount];
+            var columnGroupBoxes = new CssBox?[columnCount];
+            var columnStartsHere = new bool[columnCount];
+            var columnGroupStartsHere = new bool[columnCount];
+            for (var c = 0; c < columnCount; c++)
+            {
+                var box = c < columns.Count ? columns[c] : null;
+                var isGroup = box is not null && box.DerivedStyle.ActualDisplay == Keywords.TableColumnGroup;
+
+                columnBoxes[c] = isGroup ? null : box;
+                columnGroupBoxes[c] = isGroup
+                    ? box
+                    : box?.ParentBox?.DerivedStyle.ActualDisplay == Keywords.TableColumnGroup ? box!.ParentBox : null;
+
+                columnStartsHere[c] = c == 0 || !ReferenceEquals(columnBoxes[c], columnBoxes[c - 1]);
+                columnGroupStartsHere[c] = c == 0 || !ReferenceEquals(columnGroupBoxes[c], columnGroupBoxes[c - 1]);
+            }
+
+            return new TableGrid(
+                slots, [.. rows], rowGroups, columnBoxes, columnGroupBoxes, columnStartsHere, columnGroupStartsHere, spans);
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Handlers/BordersDrawHandler.cs
+++ b/src/PeachPDF/Html/Core/Handlers/BordersDrawHandler.cs
@@ -59,21 +59,123 @@ namespace PeachPDF.Html.Core.Handlers
         {
             if (rect is not { Width: > 0, Height: > 0 }) return;
 
-            if (hasTopEdge && box.BorderTopStyle.Value is not (LineStyle.None or LineStyle.Hidden) && box.ActualBorderTopWidth > 0)
+            // A collapse participant's own stroke on an edge CollapsedBorderModel resolved is drawn once,
+            // later, from CssBox.CollapsedBorderSegments instead (issue #735) - see BorderEdges' own remarks.
+            var suppressed = box.SuppressedBorderEdges;
+
+            if (hasTopEdge && !suppressed.HasFlag(BorderEdges.Top) && box.BorderTopStyle.Value is not (LineStyle.None or LineStyle.Hidden) && box.ActualBorderTopWidth > 0)
             {
                 DrawBorder(Border.Top, box, g, rect, hasLeftEdge, hasRightEdge, true, hasBottomEdge);
             }
-            if (hasLeftEdge && box.BorderLeftStyle.Value is not (LineStyle.None or LineStyle.Hidden) && box.ActualBorderLeftWidth > 0)
+            if (hasLeftEdge && !suppressed.HasFlag(BorderEdges.Left) && box.BorderLeftStyle.Value is not (LineStyle.None or LineStyle.Hidden) && box.ActualBorderLeftWidth > 0)
             {
                 DrawBorder(Border.Left, box, g, rect, true, hasRightEdge, hasTopEdge, hasBottomEdge);
             }
-            if (hasBottomEdge && box.BorderBottomStyle.Value is not (LineStyle.None or LineStyle.Hidden) && box.ActualBorderBottomWidth > 0)
+            if (hasBottomEdge && !suppressed.HasFlag(BorderEdges.Bottom) && box.BorderBottomStyle.Value is not (LineStyle.None or LineStyle.Hidden) && box.ActualBorderBottomWidth > 0)
             {
                 DrawBorder(Border.Bottom, box, g, rect, hasLeftEdge, hasRightEdge, hasTopEdge, true);
             }
-            if (hasRightEdge && box.BorderRightStyle.Value is not (LineStyle.None or LineStyle.Hidden) && box.ActualBorderRightWidth > 0)
+            if (hasRightEdge && !suppressed.HasFlag(BorderEdges.Right) && box.BorderRightStyle.Value is not (LineStyle.None or LineStyle.Hidden) && box.ActualBorderRightWidth > 0)
             {
                 DrawBorder(Border.Right, box, g, rect, hasLeftEdge, true, hasTopEdge, hasBottomEdge);
+            }
+        }
+
+        /// <summary>
+        /// Draws one CSS 2.1 §17.6.2 collapsed-border segment - a plain axis-aligned stripe with no
+        /// mitre, since a collapsed segment butts against its neighbors at grid intersections rather than
+        /// mitring into them the way one box's own four edges do (<see cref="SetInOutsetRectanglePoints"/>
+        /// is what a real box's corner needs; a segment has no corner of its own to cut).
+        /// </summary>
+        /// <param name="g">the device to draw into</param>
+        /// <param name="isHorizontal">Whether this is a horizontal (row) grid-line segment rather than a vertical (column) one - decides stripe orientation for double/groove/ridge and dash direction.</param>
+        /// <param name="rect">the segment's own bounding rectangle</param>
+        /// <param name="style">the resolved border style</param>
+        /// <param name="color">the resolved border color</param>
+        /// <param name="width">the resolved border width</param>
+        internal static void DrawCollapsedSegment(RGraphics g, bool isHorizontal, RRect rect, LineStyle style, RColor color, double width)
+        {
+            if (rect is not { Width: > 0, Height: > 0 } || width <= 0 || style is LineStyle.None or LineStyle.Hidden) return;
+
+            switch (style)
+            {
+                case LineStyle.Double or LineStyle.Groove or LineStyle.Ridge:
+                    DrawDoubleOrGrooveRidgeSegment(g, isHorizontal, rect, style, color, width);
+                    break;
+
+                case LineStyle.Dotted or LineStyle.Dashed:
+                {
+                    var pen = GetPen(g, style, color, width);
+                    if (isHorizontal)
+                    {
+                        var y = rect.Top + width / 2;
+                        g.DrawLine(pen, rect.Left, y, rect.Right, y);
+                    }
+                    else
+                    {
+                        var x = rect.Left + width / 2;
+                        g.DrawLine(pen, x, rect.Top, x, rect.Bottom);
+                    }
+                    break;
+                }
+
+                default:
+                {
+                    // Solid, Inset, Outset - a collapsed segment has no owning box to shade a bevel
+                    // "into" the way DrawBorder's per-edge convention does, so this approximates with
+                    // the same asymmetry GetColor already uses for a box's own top/left edges (a
+                    // horizontal segment behaves like a top edge, a vertical one like a left edge -
+                    // both darken for Inset, stay normal for Outset).
+                    var resolvedColor = style == LineStyle.Inset ? Darken(color) : color;
+                    g.DrawPolygon(g.GetSolidBrush(resolvedColor),
+                    [
+                        new RPoint(rect.Left, rect.Top),
+                        new RPoint(rect.Right, rect.Top),
+                        new RPoint(rect.Right, rect.Bottom),
+                        new RPoint(rect.Left, rect.Bottom)
+                    ]);
+                    break;
+                }
+            }
+        }
+
+        /// <summary>Value-based twin of <see cref="DrawDoubleOrGrooveRidgeBorder"/> for one collapsed-border segment - see <see cref="DrawCollapsedSegment"/>.</summary>
+        private static void DrawDoubleOrGrooveRidgeSegment(RGraphics g, bool isHorizontal, RRect rect, LineStyle style, RColor color, double width)
+        {
+            double outerWidth;
+            double innerWidth;
+            RColor outerColor;
+            RColor innerColor;
+
+            if (style == LineStyle.Double)
+            {
+                outerWidth = innerWidth = Math.Max(1, Math.Floor(width / 3));
+                outerColor = innerColor = color;
+            }
+            else
+            {
+                outerWidth = innerWidth = width / 2;
+                outerColor = style == LineStyle.Groove ? Darken(color) : color;
+                innerColor = style == LineStyle.Groove ? color : Darken(color);
+            }
+
+            var outerPen = g.GetPen(outerColor);
+            outerPen.Width = outerWidth;
+            outerPen.DashStyle = RDashStyle.Solid;
+
+            var innerPen = g.GetPen(innerColor);
+            innerPen.Width = innerWidth;
+            innerPen.DashStyle = RDashStyle.Solid;
+
+            if (isHorizontal)
+            {
+                g.DrawLine(outerPen, rect.Left, rect.Top + outerWidth / 2, rect.Right, rect.Top + outerWidth / 2);
+                g.DrawLine(innerPen, rect.Left, rect.Top + width - innerWidth / 2, rect.Right, rect.Top + width - innerWidth / 2);
+            }
+            else
+            {
+                g.DrawLine(outerPen, rect.Left + outerWidth / 2, rect.Top, rect.Left + outerWidth / 2, rect.Bottom);
+                g.DrawLine(innerPen, rect.Left + width - innerWidth / 2, rect.Top, rect.Left + width - innerWidth / 2, rect.Bottom);
             }
         }
 

--- a/src/PeachPDF/Html/Core/Paint/FragmentPainter.Decorations.cs
+++ b/src/PeachPDF/Html/Core/Paint/FragmentPainter.Decorations.cs
@@ -590,6 +590,24 @@ namespace PeachPDF.Html.Core.Paint
         }
 
         /// <summary>
+        /// Draws a <c>border-collapse: collapse</c> table's resolved borders - see
+        /// <see cref="CssBox.CollapsedBorderSegments"/> and the call site's own remarks for why this runs
+        /// where it does.
+        /// </summary>
+        private static void PaintCollapsedTableBorders(RGraphics g, CssBox box, double originY, RRect clip)
+        {
+            // Segments are recorded in document space, same as ColumnRuleSegments - see PaintColumnRules.
+            foreach (var segment in box.CollapsedBorderSegments!)
+            {
+                var visualRect = new RRect(segment.Rect.X, segment.Rect.Y - originY, segment.Rect.Width, segment.Rect.Height);
+
+                if (!IsRectVisible(visualRect, clip)) continue;
+
+                BordersDrawHandler.DrawCollapsedSegment(g, segment.IsHorizontal, visualRect, segment.Style, segment.Color, segment.Width);
+            }
+        }
+
+        /// <summary>
         /// Draws a box's resolved <c>content: url(...)</c> image, once per decoration rectangle.
         /// </summary>
         private static void PaintContentImage(RGraphics g, CssBox box, BoxFragment fragment)

--- a/src/PeachPDF/Html/Core/Paint/FragmentPainter.cs
+++ b/src/PeachPDF/Html/Core/Paint/FragmentPainter.cs
@@ -510,6 +510,16 @@ namespace PeachPDF.Html.Core.Paint
                 }
             }
 
+            // CSS 2.1 §17.6.2's resolved borders are drawn once per grid-line run, after every
+            // table-internal background and content has painted - which is the whole fix (issue #735):
+            // boxes paint in tree order, so a later row's opaque cell background would otherwise erase
+            // the border the row above it shares with it. Before the outline pass, because an outline is
+            // always on top (CSS UI 4 §4).
+            if (box.CollapsedBorderSegments is { Count: > 0 })
+            {
+                PaintCollapsedTableBorders(g, box, fragment.OriginY, clip);
+            }
+
             if (outlinePaints is not null)
             {
                 foreach (var (paintRect, geometry) in outlinePaints)


### PR DESCRIPTION
## Summary

- Implements real CSS 2.1 §17.6.2 border-conflict resolution for `border-collapse: collapse` tables, replacing a flat hardcoded 1pt row/column overlap that ignored actual declared border widths.
- Resolved borders now paint once, after every table-internal background, instead of every participant (table/row/cell) painting its own border independently — this is what let a later row's opaque background erase the border it shared with the row above.
- Adds full origin-priority resolution: cell > row > row-group > column > column-group > table, plus width and style-priority tiebreaks, per the spec.
- Brings `<col>`/`<colgroup>` into both border-conflict resolution and background painting (previously entirely unpainted).
- Fixes collapsed borders on a repeated `<thead>`/`<tfoot>` to resolve and paint correctly on every page they repeat on, not just the first — the boundary between a repeated group and the table body is now re-resolved fresh per page against whichever row actually starts/ends that page.

Fixes #735

A follow-on, pre-existing gap surfaced while testing this (a rowspan cell inside a multi-row `<thead>`/`<tfoot>` can be dropped from the border-resolution grid entirely) is tracked separately as #736 and documented as an accepted gap — it's a deeper `TableGrid` construction issue affecting more than just this change, and is scoped out of this PR intentionally.

## Test plan

- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (8825 tests)
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] Diff coverage ≥90% (measured at 92%)
- [x] New TestHarness showcase (`table_collapsed_border_resolution`) demonstrating conflict resolution, `<col>`/`<colgroup>` participation, `border-style: hidden`, and per-page repeated-header boundary correctness
- [x] The GitHub issue's own repro, and a multi-page repeated-header repro, rendered through the CLI and rasterized with both PDFium and MuPDF for visual confirmation