### PR TITLE
Bump package version from 0.9.10 to 0.9.11

### DIFF
--- a/src/PeachPDF/PeachPDF.csproj
+++ b/src/PeachPDF/PeachPDF.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<AssemblyName>PeachPDF</AssemblyName>
 		<PackageId>PeachPDF</PackageId>
-		<PackageVersion>0.9.10</PackageVersion>
+		<PackageVersion>0.9.11</PackageVersion>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageIcon>peach.png</PackageIcon>
 		<IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
## Summary
- Bump `PackageVersion` in `src/PeachPDF/PeachPDF.csproj` from 0.9.10 to 0.9.11 to prepare for the next NuGet release.

## Test plan
- No functional changes; version bump only.