### PR TITLE
Fix collapsed table border segments bleeding past interior grid lines

### DIFF
--- a/.claude/migration-notes/2026-08-14-collapsed-table-border-no-longer-bleeds-past-interior-lines.md
+++ b/.claude/migration-notes/2026-08-14-collapsed-table-border-no-longer-bleeds-past-interior-lines.md
@@ -1,0 +1,17 @@
+# A `border-collapse: collapse` table's cell background no longer bleeds past an interior border
+
+Before this fix, an interior horizontal or vertical grid line in a `border-collapse: collapse`
+table painted its resolved border centered on the *edge* of the row/column overlap band rather
+than the band's true center. In practice this meant the border segment only covered roughly the
+half of the overlap nearer one side, leaving the other half showing through as a thin sliver of
+the neighboring cell's background color past the border line - most visibly a `background-color`
+appearing to bleed about half a border-width above/below (or left/right of) a `border-bottom`/
+`border-right`/etc. line shared between two collapsed cells.
+
+Document authors relying on a collapsed table's border visually meeting an adjacent cell's
+background with no gap or overlap (a common pattern for colored status/alert rows) will now see
+the border fully cover the shared line, with no bleed. This also applies to a repeating
+`<thead>`/`<tfoot>`'s own boundary line to the table body, and to a vertical column divider that
+spans a repeating header/footer's full row range.
+
+No markup or CSS change is needed - this is a rendering correctness fix with no new API surface.

--- a/.claude/recent-fixes/2026-08-14-collapsed-border-segment-centered-on-wrong-point.md
+++ b/.claude/recent-fixes/2026-08-14-collapsed-border-segment-centered-on-wrong-point.md
@@ -1,0 +1,76 @@
+# Collapsed table borders now center on the true grid-line, closing issue #744
+
+[Issue #744](https://github.com/jhaygood86/PeachPDF/issues/744) reported a `border-collapse: collapse`
+table's `<td>` background bleeding about 1px past a shared `border-bottom` into the row above.
+Root cause: `GetGridLineY`/`GetGridLineX` in `CssLayoutEngineTable.cs` returned one *edge* of an
+interior grid line's row/column overlap band (`row.ActualBottom`, a cell's `Location.X`/`ActualRight`),
+not the band's center - but `EmitCollapsedBorderSegments`/`EmitHeaderFooterBorderSegments` always
+built each border segment's rect *centered* on that returned value. For an outer table edge this is
+correct (the row's own half-reservation and the table's own separately-applied half sit on
+non-overlapping sides of that point), but for an interior line the two neighboring rows/cells
+deliberately overlap by the *whole* resolved border width (the #735 fix's own design - see
+`2026-08-13-collapsed-table-borders-css-2-1-17-6-2.md`), so centering on one edge only covered half
+that overlap, leaving the other half open for the later-painted neighbor's background to show
+through. Fixed by making both methods (plus `SnapshotLineY`, a local function duplicating the same
+logic against `BoxGeometrySnapshot` for repeated `<thead>`/`<tfoot>` proxies) return/compute the true
+center, subtracting or adding half the resolved line width depending on which edge the raw value
+named.
+
+## Load-bearing lessons
+
+**A doc comment can be stale evidence of the bug it's describing.** `GetGridLineY`'s old comment
+claimed "a boundary's two neighboring rows already agree on it exactly" - flatly contradicted by
+`VerticalSpacingAt`/`HorizontalSpacingAt`'s own documented `-width` (not `-width/2`) interior-line
+overlap, which the fix's own new doc comment cites. The mismatch between what a comment claims and
+what the code next to it actually does was itself the signal that this "row above's `ActualBottom`
+stands for the shared line" claim was never true post-#735, not a coincidental phrasing choice.
+
+**Fixing the same defect in one of several structurally-parallel call sites and missing another is
+easy, and this diff did exactly that once.** A post-change review agent (cross-file-tracer angle)
+found that the header/footer's own internal vertical-divider segments still read
+`SnapshotLineY(boundaryLine)` *uncorrected* even after the horizontal boundary segment's own
+`boundaryY`/`correctedY` got the fix - both read the same conceptual grid line, but only one path
+carried the correction, so a vertical divider spanning a repeated group's full row range would
+visibly fail to meet the corrected horizontal boundary at the corner. Fixed by making
+`SnapshotLineY` itself apply the correction whenever `line == boundaryLine`, computed once
+(`boundaryHalfWidth`) and shared by every consumer - the vertical-divider loop, the per-page
+`ResolveRepeatedGroupBoundary` branch, and the no-adjacent-row fallback branch - rather than each
+computing (and needing to remember to compute) its own copy.
+
+**A review finding that "looks like" a bug can still be refuted by tracing the actual layout code,
+not just the border-segment-emission code.** A second review angle (altitude) flagged that the
+per-page `boundaryY` correction reads `model.HorizontalLineWidth[boundaryLine]` (the static,
+DOM-order-resolved model) rather than the fresh per-page border width `ResolveRepeatedGroupBoundary`
+resolves against the real visually-adjacent row, and argued this could drift on a table with
+heterogeneous row border widths across pages. Refuted by reading where a repeated header/footer's
+physical page-break position actually comes from: `cursor.CurrentY += headerRoom` where
+`headerRoom = _headerHeight + VerticalSpacingAt(HeaderRowCountInGrid)` (and the mirrored footer
+case), both keyed off the *static* model uniformly on every page, regardless of which row a
+repeated header ends up above. The physical space reserved for the boundary line is fixed once by
+the static model; only the *painted* border's style/color/width legitimately varies per page. Using
+the static model's width for the position correction is therefore self-consistent with how layout
+actually reserved the space - using the fresh per-page width instead would have been the bug.
+
+**Independent-of-the-computation-under-test ground truth is what actually catches a regression.**
+A first attempt at a regression test for the vertical-divider consistency bug compared the vertical
+segment's endpoint to the horizontal boundary segment's own derived center
+(`boundary.Rect.Y + boundary.Rect.Height / 2`) - this passed even with the fix's correction zeroed
+out, because both values are built from the *same* shared `boundaryHalfWidth`, so they drift
+together and never disagree with each other regardless of whether that shared value is right. The
+test that actually failed pre-fix and passed post-fix compares against the midpoint of two values
+computed by an entirely separate code path (`headerProxy.ActualBottom` and the first body row's own
+`Location.Y`, set by the ordinary row cursor in `LayoutBodyRows`) - genuinely independent of
+`EmitHeaderFooterBorderSegments` entirely.
+
+## Evidence
+
+Four new tests in `CollapsedBorderGeometryTests.cs` assert exact `CollapsedBorderSegment.Rect`
+geometry (not paint order, which `CollapsedBorderPaintTests.cs` already covered and would not have
+caught this class of bug) for: an interior horizontal line, an interior vertical line, a repeated
+`<thead>`'s boundary-to-body line, a `<thead>`-immediately-meets-`<tfoot>`-with-no-body-rows corner
+case, and the vertical-divider-meets-boundary consistency case - each written test-first, confirmed
+to fail against the pre-fix code with the exact half-border-width discrepancy the diagnosis
+predicted, then confirmed to pass post-fix. Full suite green (8838 tests, net8.0), 100% diff
+coverage, zero warnings on `dotnet build -t:Rebuild`. The reporter's own repro HTML was rendered
+through the CLI and rasterized with both PDFium and MuPDF, before and after the fix - both
+renderers agree the background bleed is gone.

--- a/src/PeachPDF.Tests/Html/Core/Paint/CollapsedBorderGeometryTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Paint/CollapsedBorderGeometryTests.cs
@@ -1,0 +1,223 @@
+using PeachPDF.CSS;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Tests.TestSupport;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Html.Core.Paint
+{
+    /// <summary>
+    /// <see cref="CssBox.CollapsedBorderSegments"/>' exact geometry at an interior grid line - distinct
+    /// from <see cref="CollapsedBorderPaintTests"/>, which only checks paint <i>order</i>. An interior
+    /// line's two neighbors deliberately overlap by the whole resolved border width (not just meet at a
+    /// point - see <see href="https://github.com/jhaygood86/PeachPDF/issues/735">issue #735</see>'s own
+    /// notes), so the border segment painted over that overlap must cover the <i>whole</i> band, not just
+    /// the half nearer one side - a segment centered on the wrong point still "draws a border" and still
+    /// passes a paint-order check, but leaves a sliver of the overlap uncovered where the later-painted
+    /// neighbor's background shows through past the border line
+    /// (<see href="https://github.com/jhaygood86/PeachPDF/issues/744">issue #744</see>).
+    /// </summary>
+    public class CollapsedBorderGeometryTests
+    {
+        private static CssBox FindTable(CssBox root) =>
+            LayoutHarness.Descendants(root).First(b => b.DerivedStyle.ActualDisplay is Keywords.Table or Keywords.InlineTable);
+
+        [Fact]
+        public async Task Issue744Repro_InteriorHorizontalBorderCoversFullOverlapBand()
+        {
+            var html = LayoutHarness.Wrap(@"
+                <table style='border-collapse:collapse;width:100%'>
+                    <tr style='border-bottom:solid #000 1pt'><td style='border-bottom:solid #000 1pt;background-color:red'>!</td><td style='border-bottom:solid #000 1pt'>Missing Emergency Contact</td></tr>
+                    <tr style='border-bottom:solid #000 1pt'><td style='border-bottom:solid #000 1pt;background-color:#ffff00'>!</td><td style='border-bottom:solid #000 1pt'>Missing Emergency Contact</td></tr>
+                </table>");
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var table = FindTable(root);
+
+            var rows = table.Boxes.Where(b => b.DerivedStyle.ActualDisplay == Keywords.TableRow).ToList();
+            Assert.Equal(2, rows.Count);
+            var rowAbove = rows[0];
+            var rowBelow = rows[1];
+
+            Assert.NotNull(table.CollapsedBorderSegments);
+
+            // The interior line sits between the two rows' own edges - find it by proximity to their
+            // midpoint rather than assuming index order, since the table's own outer top/bottom edges
+            // also emit horizontal segments.
+            var midpoint = (rowAbove.ActualBottom + rowBelow.Location.Y) / 2;
+            var interior = table.CollapsedBorderSegments!
+                .Where(s => s.IsHorizontal)
+                .OrderBy(s => Math.Abs(s.Rect.Y + s.Rect.Height / 2 - midpoint))
+                .First();
+
+            // Ground truth, independent of the segment itself: the overlap band is exactly
+            // [rowBelow.Location.Y, rowAbove.ActualBottom] (row-below's top to row-above's bottom) - the
+            // segment must cover that whole band, not just the half nearer one row.
+            Assert.Equal(rowBelow.Location.Y, interior.Rect.Y, 3);
+            Assert.Equal(rowAbove.ActualBottom, interior.Rect.Y + interior.Rect.Height, 3);
+        }
+
+        [Fact]
+        public async Task Issue744Repro_InteriorVerticalBorderCoversFullOverlapBand()
+        {
+            var html = LayoutHarness.Wrap(@"
+                <table style='border-collapse:collapse;width:100%'>
+                    <tr><td style='border-right:solid #000 1pt;background-color:red'>A</td><td style='border-left:solid #000 1pt;background-color:#ffff00'>B</td></tr>
+                    <tr><td style='border-right:solid #000 1pt'>C</td><td style='border-left:solid #000 1pt'>D</td></tr>
+                </table>");
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var table = FindTable(root);
+
+            var firstRowCells = table.Boxes
+                .First(b => b.DerivedStyle.ActualDisplay == Keywords.TableRow).Boxes
+                .Where(b => b.DerivedStyle.ActualDisplay == Keywords.TableCell)
+                .ToList();
+            Assert.Equal(2, firstRowCells.Count);
+            var leftCell = firstRowCells[0];
+            var rightCell = firstRowCells[1];
+
+            Assert.NotNull(table.CollapsedBorderSegments);
+
+            var midpoint = (leftCell.ActualRight + rightCell.Location.X) / 2;
+            var interior = table.CollapsedBorderSegments!
+                .Where(s => !s.IsHorizontal)
+                .OrderBy(s => Math.Abs(s.Rect.X + s.Rect.Width / 2 - midpoint))
+                .First();
+
+            // Ground truth: the overlap band is exactly [rightCell.Location.X, leftCell.ActualRight].
+            Assert.Equal(rightCell.Location.X, interior.Rect.X, 3);
+            Assert.Equal(leftCell.ActualRight, interior.Rect.X + interior.Rect.Width, 3);
+        }
+
+        [Fact]
+        public async Task Issue744Repro_RepeatedTheadBoundaryCoversFullOverlapBand()
+        {
+            // A <thead> always goes through a CssProxyBox, even when it appears (and repeats) exactly
+            // once - deliberately kept to a single page here (a handful of rows, default page size) so
+            // there is exactly one proxy and one boundary segment, with no cross-page ambiguity about
+            // which of the source box's accumulated CollapsedBorderSegments belongs to which page.
+            var html = LayoutHarness.Wrap(@"
+                <table style='border-collapse:collapse;width:100%'>
+                    <thead><tr><th style='border-bottom:solid #000 1pt'>Header</th></tr></thead>
+                    <tbody>
+                        <tr><td style='border-bottom:solid #000 1pt;background-color:#ffff00'>Row 1</td></tr>
+                        <tr><td style='border-bottom:solid #000 1pt'>Row 2</td></tr>
+                    </tbody>
+                </table>");
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var table = FindTable(root);
+
+            var headerProxy = table.Boxes.OfType<CssProxyBox>()
+                .First(p => p.Display.Value == DisplayMode.TableHeaderGroup);
+            var segments = headerProxy.SourceBox.CollapsedBorderSegments;
+            Assert.NotNull(segments);
+
+            // The header's own boundary-to-body line is its own last (largest-Y) horizontal segment - its
+            // only other horizontal segment is its own outer top edge, which has a smaller Y.
+            var boundary = segments!.Where(s => s.IsHorizontal).OrderByDescending(s => s.Rect.Y).First();
+            var proxyBottom = headerProxy.ActualBottom;
+
+            Assert.Equal(proxyBottom - boundary.Width, boundary.Rect.Y, 3);
+            Assert.Equal(proxyBottom, boundary.Rect.Y + boundary.Rect.Height, 3);
+        }
+
+        [Fact]
+        public async Task Issue744Repro_TheadImmediatelyMeetsTfootWithNoBodyRows_BoundaryCoversFullOverlapBand()
+        {
+            // No <tbody> row exists on either side of the thead/tfoot seam, so EmitHeaderFooterBorderSegments
+            // falls back to SnapshotLineY(boundaryLine) instead of ResolveRepeatedGroupBoundary - a distinct
+            // code path from the other two geometry tests above, which both go through an adjacent body row.
+            // The seam is still genuinely interior to the whole table (a real row - the footer's - sits on
+            // its other side), so it still needs the overlap-band-to-center correction.
+            var html = LayoutHarness.Wrap(@"
+                <table style='border-collapse:collapse;width:100%'>
+                    <thead><tr><th style='border-bottom:solid #000 1pt'>Header</th></tr></thead>
+                    <tfoot><tr><td style='border-top:solid #000 1pt'>Footer</td></tr></tfoot>
+                </table>");
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var table = FindTable(root);
+
+            var headerProxy = table.Boxes.OfType<CssProxyBox>()
+                .First(p => p.Display.Value == DisplayMode.TableHeaderGroup);
+            var footerProxy = table.Boxes.OfType<CssProxyBox>()
+                .First(p => p.Display.Value == DisplayMode.TableFooterGroup);
+
+            var segments = headerProxy.SourceBox.CollapsedBorderSegments;
+            Assert.NotNull(segments);
+
+            var boundary = segments!.Where(s => s.IsHorizontal).OrderByDescending(s => s.Rect.Y).First();
+            var proxyBottom = headerProxy.ActualBottom;
+
+            // Ground truth, independent of the segment itself: header and footer overlap by the full
+            // resolved border width here too (the same border-collapse convention as two adjacent body
+            // rows - see GetGridLineY's remarks), so the footer's own top names the overlap band's other
+            // edge, not a point coincident with the header's own bottom.
+            Assert.Equal(footerProxy.Location.Y, boundary.Rect.Y, 3);
+            Assert.Equal(proxyBottom, boundary.Rect.Y + boundary.Rect.Height, 3);
+        }
+
+        [Fact]
+        public async Task Issue744Repro_RepeatedTheadVerticalDividerMeetsBoundaryAtSameLine()
+        {
+            // A column divider spanning the header's full row range ends at the same grid line the
+            // horizontal boundary-to-body segment sits on - both must agree on that line's exact
+            // center, or the divider visibly overshoots/undershoots the horizontal border by half its
+            // width at the corner. Both read the boundary line through SnapshotLineY, which has to
+            // apply its correction consistently regardless of which loop calls it.
+            var html = LayoutHarness.Wrap(@"
+                <table style='border-collapse:collapse;width:100%'>
+                    <thead><tr>
+                        <th style='border-bottom:solid #000 1pt;border-right:solid #000 1pt'>A</th>
+                        <th style='border-bottom:solid #000 1pt;border-left:solid #000 1pt'>B</th>
+                    </tr></thead>
+                    <tbody>
+                        <tr>
+                            <td style='border-bottom:solid #000 1pt;border-right:solid #000 1pt'>1</td>
+                            <td style='border-bottom:solid #000 1pt;border-left:solid #000 1pt'>2</td>
+                        </tr>
+                        <tr>
+                            <td style='border-right:solid #000 1pt'>3</td>
+                            <td style='border-left:solid #000 1pt'>4</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var table = FindTable(root);
+
+            var headerProxy = table.Boxes.OfType<CssProxyBox>()
+                .First(p => p.Display.Value == DisplayMode.TableHeaderGroup);
+            var segments = headerProxy.SourceBox.CollapsedBorderSegments;
+            Assert.NotNull(segments);
+
+            var proxyBottom = headerProxy.ActualBottom;
+
+            // Ground truth, fully independent of any border-segment computation: the overlap band's
+            // bottom is the header proxy's own ActualBottom, and its top is the first body row's own
+            // Location.Y (set by the ordinary row cursor in LayoutBodyRows, which reaches this row via
+            // "cursor.CurrentY += headerRoom" - an entirely separate code path from
+            // EmitHeaderFooterBorderSegments). The true center is the midpoint of those two real,
+            // independently-computed layout values - comparing the vertical segment's endpoint to the
+            // horizontal boundary segment's own (Rect.Y + Rect.Height/2) instead would be circular, since
+            // both are built from the same correction and would still agree even if that correction were
+            // wrong.
+            var firstBodyRow = LayoutHarness.Descendants(root)
+                .First(b => b.DerivedStyle.ActualDisplay == Keywords.TableRow);
+            var trueBoundaryCenterY = (proxyBottom + firstBodyRow.Location.Y) / 2;
+
+            // Every vertical segment in the header spans the same single row, so each one's bottom
+            // reaches the boundary line - all of them must land exactly there.
+            var verticalSegments = segments!.Where(s => !s.IsHorizontal).ToList();
+            Assert.NotEmpty(verticalSegments);
+            foreach (var vertical in verticalSegments)
+            {
+                Assert.Equal(trueBoundaryCenterY, vertical.Rect.Y + vertical.Rect.Height, 3);
+            }
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
@@ -646,12 +646,12 @@ namespace PeachPDF.Html.Core.Dom
             for (var line = lineStart; line <= lineEnd; line++)
             {
                 if (model.HorizontalLineWidth[line] <= 0) continue;
-                var y = GetGridLineY(grid, line);
+                var y = GetGridLineY(grid, line, model);
 
                 EmitRuns(grid.ColumnCount, col => model.Horizontal(line, col), (start, end, border) =>
                 {
-                    var x0 = GetGridLineX(grid, start);
-                    var x1 = GetGridLineX(grid, end);
+                    var x0 = GetGridLineX(grid, start, model);
+                    var x1 = GetGridLineX(grid, end, model);
                     if (x0 is null || x1 is null) return;
 
                     segments.Add(new CollapsedBorderSegment(true,
@@ -666,13 +666,13 @@ namespace PeachPDF.Html.Core.Dom
             for (var line = 0; line <= grid.ColumnCount; line++)
             {
                 if (model.VerticalLineWidth[line] <= 0) continue;
-                var x = GetGridLineX(grid, line);
+                var x = GetGridLineX(grid, line, model);
                 if (x is null) continue;
 
                 EmitRuns(rowEnd - rowStart, i => model.Vertical(rowStart + i, line), (start, end, border) =>
                 {
-                    var y0 = GetGridLineY(grid, rowStart + start);
-                    var y1 = GetGridLineY(grid, rowStart + end);
+                    var y0 = GetGridLineY(grid, rowStart + start, model);
+                    var y1 = GetGridLineY(grid, rowStart + end, model);
 
                     segments.Add(new CollapsedBorderSegment(false,
                         new RRect(x.Value - border.Width / 2, y0, border.Width, y1 - y0),
@@ -742,14 +742,40 @@ namespace PeachPDF.Html.Core.Dom
 
                 var segments = isHeader ? headerSegments! : footerSegments!;
 
+                // boundaryLine/boundaryIsInterior need to be known before SnapshotLineY is defined, since
+                // SnapshotLineY's own two "outer" branches also cover the group's boundary-to-body line
+                // (whichever of them is reached when line == boundaryLine) - see the remarks below.
+                var boundaryLine = isHeader ? sourceStart + sourceCount : sourceStart;
+
+                // Whether the boundary line is genuinely interior to the whole table (a real opposing row
+                // exists on the other side somewhere) - as opposed to the table's own true outer edge. Only
+                // an interior line's reported position needs the overlap-band-to-center correction; see
+                // GetGridLineY's remarks.
+                var boundaryIsInterior = boundaryLine > 0 && boundaryLine < grid.RowCount;
+                var boundaryHalfWidth = boundaryIsInterior ? model.HorizontalLineWidth[boundaryLine] / 2.0 : 0.0;
+
                 double? SnapshotLineY(int line)
                 {
                     if (line <= sourceStart)
-                        return snapshot.TryGetGeometry(grid.RowAt(sourceStart), out var top) ? top.Location.Y : null;
+                    {
+                        if (!snapshot.TryGetGeometry(grid.RowAt(sourceStart), out var top)) return null;
+                        // The group's own top is the table's true outer edge (header) or the boundary to
+                        // the body (footer) - only the latter needs the correction, and only when line is
+                        // actually that boundary (line == boundaryLine can only hold for a footer here,
+                        // since a header's boundary sits at its own *bottom*, the other branch below).
+                        return line == boundaryLine ? top.Location.Y + boundaryHalfWidth : top.Location.Y;
+                    }
                     if (line >= sourceStart + sourceCount)
-                        return snapshot.TryGetGeometry(grid.RowAt(sourceStart + sourceCount - 1), out var bottom)
-                            ? bottom.ActualBottom : null;
-                    return snapshot.TryGetGeometry(grid.RowAt(line - 1), out var above) ? above.ActualBottom : null;
+                    {
+                        if (!snapshot.TryGetGeometry(grid.RowAt(sourceStart + sourceCount - 1), out var bottom)) return null;
+                        return line == boundaryLine ? bottom.ActualBottom - boundaryHalfWidth : bottom.ActualBottom;
+                    }
+                    // Interior to the group's own row range - see GetGridLineY's remarks: the row above's
+                    // ActualBottom names the overlap band's bottom edge, not its center, so half the
+                    // resolved line width has to come back off it.
+                    return snapshot.TryGetGeometry(grid.RowAt(line - 1), out var above)
+                        ? above.ActualBottom - model.HorizontalLineWidth[line] / 2.0
+                        : null;
                 }
 
                 // The group's own internal lines and whichever of its two outer edges is not the
@@ -765,8 +791,8 @@ namespace PeachPDF.Html.Core.Dom
 
                     EmitRuns(grid.ColumnCount, col => model.Horizontal(line, col), (start, end, border) =>
                     {
-                        var x0 = GetGridLineX(grid, start);
-                        var x1 = GetGridLineX(grid, end);
+                        var x0 = GetGridLineX(grid, start, model);
+                        var x1 = GetGridLineX(grid, end, model);
                         if (x0 is null || x1 is null) return;
 
                         segments.Add(new CollapsedBorderSegment(true,
@@ -778,7 +804,7 @@ namespace PeachPDF.Html.Core.Dom
                 for (var line = 0; line <= grid.ColumnCount; line++)
                 {
                     if (model.VerticalLineWidth[line] <= 0) continue;
-                    var x = GetGridLineX(grid, line);
+                    var x = GetGridLineX(grid, line, model);
                     if (x is null) continue;
 
                     EmitRuns(sourceCount, i => model.Vertical(sourceStart + i, line), (start, end, border) =>
@@ -796,7 +822,6 @@ namespace PeachPDF.Html.Core.Dom
                 var proxyTop = proxy.Location.Y;
                 var proxyBottom = proxy.ActualBottom;
                 var groupRow = isHeader ? sourceStart + sourceCount - 1 : sourceStart;
-                var boundaryLine = isHeader ? sourceStart + sourceCount : sourceStart;
 
                 // The row whose *span* reaches this boundary, not the first one whose own Location.Y is
                 // past it: border-collapse overlaps adjacent boxes by (up to) the resolved line width, so
@@ -815,12 +840,21 @@ namespace PeachPDF.Html.Core.Dom
                         grid, groupRow, groupRowGroup, HeaderRowCountInGrid + adjacentRowIndex,
                         groupIsAbove: isHeader, IsLeftToRight());
 
-                    var boundaryY = isHeader ? proxyBottom : proxyTop;
+                    // proxyBottom/proxyTop each name one edge of the overlap band, exactly like
+                    // GetGridLineY's raw row.ActualBottom (header, band's bottom edge) and GetGridLineX's
+                    // primary-branch cell.Location.X (footer, band's top edge, same "the row after this
+                    // line" convention) - so the same half-width correction applies here. This has to
+                    // agree exactly with SnapshotLineY(boundaryLine)'s own now-corrected value (used by the
+                    // vertical-divider loop above for any run spanning the group's full row range) - both
+                    // read from the same proxyBottom/bottom.ActualBottom (equivalently proxyTop/top.Location.Y)
+                    // and the same model.HorizontalLineWidth[boundaryLine], so a divider that reaches this
+                    // line still meets the boundary segment exactly, not offset by half its width.
+                    var boundaryY = isHeader ? proxyBottom - boundaryHalfWidth : proxyTop + boundaryHalfWidth;
 
                     EmitRuns(grid.ColumnCount, col => resolved[col], (start, end, border) =>
                     {
-                        var x0 = GetGridLineX(grid, start);
-                        var x1 = GetGridLineX(grid, end);
+                        var x0 = GetGridLineX(grid, start, model);
+                        var x1 = GetGridLineX(grid, end, model);
                         if (x0 is null || x1 is null) return;
 
                         segments.Add(new CollapsedBorderSegment(true,
@@ -837,14 +871,16 @@ namespace PeachPDF.Html.Core.Dom
                     // resolution already models correctly (Column/ColumnGroup/Table origins apply exactly
                     // at line 0/RowCount - see CollectHorizontal), unlike the fresh per-page resolution
                     // above, which deliberately excludes those origins because they don't apply to a
-                    // genuinely interior line.
+                    // genuinely interior line. SnapshotLineY(boundaryLine) already carries the correction
+                    // (see its own definition above), so its value is used directly with no further
+                    // adjustment here.
                     var y = SnapshotLineY(boundaryLine);
                     if (y is not null)
                     {
                         EmitRuns(grid.ColumnCount, col => model.Horizontal(boundaryLine, col), (start, end, border) =>
                         {
-                            var x0 = GetGridLineX(grid, start);
-                            var x1 = GetGridLineX(grid, end);
+                            var x0 = GetGridLineX(grid, start, model);
+                            var x1 = GetGridLineX(grid, end, model);
                             if (x0 is null || x1 is null) return;
 
                             segments.Add(new CollapsedBorderSegment(true,
@@ -894,30 +930,48 @@ namespace PeachPDF.Html.Core.Dom
         }
 
         /// <summary>
-        /// The document-space Y of horizontal grid line <paramref name="line"/> (0..RowCount), read from
-        /// this pass's real, laid-out row geometry rather than derived arithmetically - a boundary's two
-        /// neighboring rows already agree on it exactly (that agreement is the whole point of the
-        /// border-collapse overlap), so the row above's own <c>ActualBottom</c> stands for the shared line.
+        /// The document-space Y of horizontal grid line <paramref name="line"/>'s <i>center</i>
+        /// (0..RowCount), read from this pass's real, laid-out row geometry rather than derived
+        /// arithmetically. At an outer edge (<c>line &lt;= 0</c> or <c>line &gt;= RowCount</c>) a row's own
+        /// half-border reservation and the table's own separately-applied half sit on non-overlapping
+        /// sides of one point, so that row's own <c>Location.Y</c>/<c>ActualBottom</c> already <i>is</i>
+        /// the center. At an <b>interior</b> line the two neighboring rows instead overlap by the <i>whole</i>
+        /// resolved line width (border-collapse's overlap-then-paint-border-last model - see
+        /// <see cref="VerticalSpacingAt"/>), so the row above's own <c>ActualBottom</c> names only the
+        /// overlap band's bottom edge, not its center - halving <paramref name="model"/>'s resolved width
+        /// back off it is what recovers the true center a segment must be built around.
         /// </summary>
-        private static double GetGridLineY(TableGrid grid, int line)
+        private static double GetGridLineY(TableGrid grid, int line, CollapsedBorderModel model)
         {
             if (line <= 0) return grid.RowAt(0).Location.Y;
             if (line >= grid.RowCount) return grid.RowAt(grid.RowCount - 1).ActualBottom;
-            return grid.RowAt(line - 1).ActualBottom;
+            return grid.RowAt(line - 1).ActualBottom - model.HorizontalLineWidth[line] / 2.0;
         }
 
         /// <summary>
-        /// The document-space X of vertical grid line <paramref name="line"/> (0..ColumnCount) - read off
-        /// the first real cell anywhere in the grid whose own edge is that line, since a ragged row can
-        /// leave some rows with no cell there at all. Null only for a column with no real cell in any row
-        /// on either side of it (a fully empty column), which has no geometry to draw a segment at.
+        /// The document-space X of vertical grid line <paramref name="line"/>'s <i>center</i>
+        /// (0..ColumnCount) - read off the first real cell anywhere in the grid whose own edge is that
+        /// line, since a ragged row can leave some rows with no cell there at all. Null only for a column
+        /// with no real cell in any row on either side of it (a fully empty column), which has no geometry
+        /// to draw a segment at.
         /// </summary>
-        private static double? GetGridLineX(TableGrid grid, int line)
+        /// <remarks>
+        /// See <see cref="GetGridLineY"/>'s own remarks for why an outer edge needs no adjustment while an
+        /// interior one does. Unlike the row axis, an interior line's two branches here return <i>opposite</i>
+        /// edges of the overlap band - the first branch (a real cell starting at this column) names the
+        /// band's left/min-X edge, so recovering the center means <i>adding</i> half the resolved width;
+        /// the fallback (a cell ending at this column, found only when no row starts one here - e.g. a
+        /// colspan crossing the line from the left) names the band's right/max-X edge, so recovering the
+        /// center means <i>subtracting</i> it instead.
+        /// </remarks>
+        private static double? GetGridLineX(TableGrid grid, int line, CollapsedBorderModel model)
         {
+            var halfWidth = line > 0 && line < grid.ColumnCount ? model.VerticalLineWidth[line] / 2.0 : 0.0;
+
             for (var r = 0; r < grid.RowCount; r++)
             {
-                if (line < grid.ColumnCount && grid.CellAt(r, line) is { } right) return right.Location.X;
-                if (line > 0 && grid.CellAt(r, line - 1) is { } left) return left.ActualRight;
+                if (line < grid.ColumnCount && grid.CellAt(r, line) is { } right) return right.Location.X + halfWidth;
+                if (line > 0 && grid.CellAt(r, line - 1) is { } left) return left.ActualRight - halfWidth;
             }
 
             return null;

--- a/src/PeachPDF/PeachPDF.csproj
+++ b/src/PeachPDF/PeachPDF.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<AssemblyName>PeachPDF</AssemblyName>
 		<PackageId>PeachPDF</PackageId>
-		<PackageVersion>0.9.11</PackageVersion>
+		<PackageVersion>0.9.12</PackageVersion>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageIcon>peach.png</PackageIcon>
 		<IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
## Summary
- `GetGridLineY`/`GetGridLineX` centered each collapsed-border segment on one edge of an interior grid line's row/column overlap band instead of the band's true center, leaving half the band uncovered so a later-painted neighbor's background bled past the border line.
- Fixed both methods, plus the parallel `SnapshotLineY` path used for repeating `<thead>`/`<tfoot>` groups (including the vertical-divider endpoints at a group's boundary-to-body line, which needed the identical correction to stay consistent with the horizontal boundary segment).

Fixes #744

## Test plan
- [x] Added `CollapsedBorderGeometryTests.cs` — 5 tests asserting exact `CollapsedBorderSegment.Rect` geometry (interior horizontal line, interior vertical line, repeated `<thead>` boundary, thead-immediately-meets-tfoot-with-no-body-rows corner case, vertical-divider/boundary corner consistency), each written test-first and confirmed to fail against the pre-fix code.
- [x] Full suite: 8838 passed, 0 failed (`dotnet test --framework net8.0`)
- [x] 100% diff coverage
- [x] `dotnet build -t:Rebuild`: 0 warnings
- [x] Reporter's repro HTML rendered via CLI and rasterized with both PDFium and MuPDF — bleed confirmed present before, gone after, in both renderers