### PR TITLE
Add CSS GCPM float: footnote support

### DIFF
--- a/.claude/accepted-gaps/footnote-body-links-bookmarks-not-collected.md
+++ b/.claude/accepted-gaps/footnote-body-links-bookmarks-not-collected.md
@@ -1,0 +1,15 @@
+# Links/bookmarks inside a footnote body are not collected into the PDF outline/annotations
+
+`HtmlContainer.GetLinks`/`DomUtils.GetAllLinkAndBookmarkBoxes` walk the live document tree from `Root`
+downward. A footnote's body is fully detached from that tree (`DomParser.DetachFootnoteBodies` sets its
+`ParentBox` to `null`) and is reachable afterward only through `HtmlContainerInt.FootnoteCalls`/the
+fragment tree's `FootnoteAreaFragment`, neither of which this walk consults. A link (`<a href>`) or a
+bookmark-candidate heading (`bookmark-level != none`) inside a footnote body is therefore never collected:
+it renders correctly (real, laid-out content, same as everything else in the note area) but produces no
+clickable link annotation and contributes no outline entry.
+
+This is the same limitation already recorded for `position: running()` content in
+[bookmark-outline-running-element-content-not-collected.md](bookmark-outline-running-element-content-not-collected.md)
+- both mechanisms detach their content from the tree `GetAllLinkAndBookmarkBoxes` walks, for the same
+underlying reason (the content is shown at a page-computed position, not a single canonical one). Filed as
+[issue #755](https://github.com/jhaygood86/PeachPDF/issues/755).

--- a/.claude/accepted-gaps/footnote-body-taller-than-one-page-overflows.md
+++ b/.claude/accepted-gaps/footnote-body-taller-than-one-page-overflows.md
@@ -1,0 +1,17 @@
+# A footnote body taller than one page's content band overflows rather than splitting
+
+`Dom/FootnoteBodyLayout.LayoutFootnoteBodyFor` forwards to `RunningElementLayout.LayoutRunningElementFor`,
+which lays its subject out with `HtmlContainerInt.SuppressWordPageBreaks = true` and a detached
+fragmentainer - the same "detached, breaking-suppressed, single whole pass" treatment css-gcpm-3's
+`content: element()` running-element content already gets. A footnote body's content is therefore always
+monolithic: it never fragments across pages, even when it is taller than the page it landed on. Its
+content simply overflows the reserved note area rather than continuing onto a later page.
+
+This mirrors the well-established "content taller than a whole band overflows rather than moving forever"
+behavior this engine already applies to ordinary monolithic content ([css-break-3 §2](https://www.w3.org/TR/css-break-3/#monolithic)),
+and to running elements specifically. Splitting a footnote body across pages - which real print engines
+generally do support - would need the note area itself to become a genuine fragmentation context with its
+own resumable layout pass, coupled back into the very page-break decision its own height already
+influences; a materially larger change than this version's scope.
+
+Filed as [issue #752](https://github.com/jhaygood86/PeachPDF/issues/752).

--- a/.claude/accepted-gaps/footnote-counter-not-bridged-into-csscounterengine.md
+++ b/.claude/accepted-gaps/footnote-counter-not-bridged-into-csscounterengine.md
@@ -1,0 +1,23 @@
+# `counter-reset`/`counter-increment: footnote` and explicit `content: counter(footnote)` are not supported
+
+A footnote's number is assigned by `HtmlContainerInt.ResolveFootnotesForThisAttempt` - a live, per-layout-
+attempt bookkeeping pass that groups each `CssBoxFootnoteCall` by the pagination slot its call landed on
+and numbers them in document order, resetting per page. This is a deliberately separate channel from
+`CssCounterEngine`, PeachPDF's general `counter-reset`/`counter-increment`/`counter()` machinery: that
+engine resolves a counter's value purely from a box's position in the DOM tree (parent/sibling walks), with
+no notion of "which page" a box ends up on - and a footnote's number is fundamentally a *pagination*
+outcome, only known once layout has actually run. `CssBoxFootnoteCall.ApplyNumber`/
+`CssBoxFootnoteMarker.ApplyNumber` write the resolved number directly into the box's own `Text`, bypassing
+`CssCounterEngine` entirely (except for reusing its shared `FormatCounterValue` formatter).
+
+Two consequences: an author's own `counter-reset: footnote`/`counter-increment: footnote` declaration is
+parsed and stored like any other CSS declaration but has no effect on the number footnotes actually receive
+(the UA-default per-page auto-numbering always wins), and an explicit `content: counter(footnote)` written
+on `::footnote-call`/`::footnote-marker` (or anywhere else in the document) resolves through the ordinary
+`CssContentEngine`/`CssCounterEngine` path, which has never heard of a footnote landing on any particular
+page, and so does not resolve to the live number.
+
+Bridging the two properly - so `CssCounterEngine` genuinely knows a footnote's page-scoped value - is its
+own design pass, closer in shape to how `counter(page)` already sits alongside (not inside) the general
+counter engine via `TargetPageMap`/`PageAnchorResolver`. Filed as
+[issue #754](https://github.com/jhaygood86/PeachPDF/issues/754).

--- a/.claude/accepted-gaps/footnote-inline-and-column-scoped-variants-not-supported.md
+++ b/.claude/accepted-gaps/footnote-inline-and-column-scoped-variants-not-supported.md
@@ -1,0 +1,13 @@
+# `float: inline-footnote` and column-scoped footnote variants not supported
+
+css-gcpm-3 defines `float: footnote` alongside `float: inline-footnote` (the footnote's content is
+rendered inline, immediately after the paragraph it appears in, rather than routed to a page-level
+note area) and lets a multi-column container define its own, column-scoped footnote area rather than
+the page's. PeachPDF implements only the page-level `float: footnote` case: `Floating.Footnote`
+(`CSS/Enumerations/Floating.cs`) is a single keyword with no column-scoping concept, and
+`DomParser.DetachFootnoteBodies`/`HtmlContainerInt.ResolveFootnotesForThisAttempt` reserve room and
+render bodies against the *page's* own content band (`HtmlContainerInt.PageBottomOf`), never a
+column's. `float: inline-footnote` is not a recognized keyword at all - declaring it is dropped as an
+invalid value (falls back to `float: none`, the property's initial value).
+
+Filed as [issue #749](https://github.com/jhaygood86/PeachPDF/issues/749).

--- a/.claude/accepted-gaps/footnote-inside-table-cell-flex-grid-item.md
+++ b/.claude/accepted-gaps/footnote-inside-table-cell-flex-grid-item.md
@@ -1,0 +1,17 @@
+# `float: footnote` inside a table cell, flex item, or grid item is untested and unsupported
+
+`DomParser.DetachFootnoteBodies` runs once, over the whole tree, before any layout engine (table, flex,
+grid) starts - so a `float: footnote` box nested inside a table cell/flex item/grid item is walked and
+detached the same as anywhere else, and the synthesized call takes its place as ordinary content before
+`CssLayoutEngineTable`/`CssLayoutEngineFlex`/`CssLayoutEngineGrid` ever see that subtree. That is enough
+for the common case to *probably* work, but this codebase's per-engine layout algorithms (table row/
+column bookkeeping and repeated-header proxying in particular) have enough of their own assumptions about
+child content that this combination has not been exercised or tested, and is not a supported combination
+for this version - notably, a footnote *inside a repeated `<thead>`/`<tfoot>`* would need its call
+re-numbered identically on every page the header repeats onto, which nothing here accounts for.
+
+Mirrors the caution already recorded in
+[running-element-inside-table-cells.md](running-element-inside-table-cells.md) - a different mechanism,
+but the same "an engine's own per-cell/per-item bookkeeping is more invasive to audit safely than the
+generic tree walk" caution. Filed as
+[issue #750](https://github.com/jhaygood86/PeachPDF/issues/750).

--- a/.claude/accepted-gaps/footnote-nested-is-inert.md
+++ b/.claude/accepted-gaps/footnote-nested-is-inert.md
@@ -1,0 +1,16 @@
+# Nested `float: footnote` is inert, not an error
+
+`DomParser.DetachFootnoteBodies` never recurses into a footnote body it has just detached (see the
+`continue` in its own tree walk) - so a `float: footnote` box authored *inside* another footnote's body
+is never discovered, never numbered, and never routed to a note area. It stays exactly where it was
+written, as ordinary content of the outer footnote's body: not floated (`CssBox.IsFloated` only
+recognizes `left`/`right`), not blockified (`DerivedStyle.ActualDisplay`'s own float exclusion covers
+`Floating.Footnote` too), simply inert.
+
+This falls out of the detection walk's own shape rather than being a deliberately engineered restriction
+- css-gcpm-3 does not obviously define what a nested footnote should mean in the first place (would it
+share the outer footnote's number, its own separate counter, its own note area on the same page?), so
+"inert" is a defensible default pending real spec guidance rather than a gap to close outright. Covered by
+`FootnoteIntegrationTests.Footnote_Nested_IsInert`.
+
+Filed as [issue #751](https://github.com/jhaygood86/PeachPDF/issues/751).

--- a/.claude/accepted-gaps/footnote-on-block-level-source-is-a-no-op.md
+++ b/.claude/accepted-gaps/footnote-on-block-level-source-is-a-no-op.md
@@ -1,0 +1,17 @@
+# `float: footnote` on a block-level source is a no-op
+
+`DomParser.DetachFootnoteBodies` only detects a `float: footnote` box as a footnote source when it is also
+inline-level (`CssBox.IsInline` - `inline`, `inline-block`, `inline-table`, `inline-flex`, or
+`inline-grid`), matching `DerivedStyle.ActualDisplay`'s own blockification exclusion for the same value.
+A block-level `float: footnote` source (e.g. a bare `<div style="float: footnote">`) is left completely
+untouched: never detached, never numbered, never routed anywhere - it renders as ordinary in-flow block
+content, behaving as `float: none`.
+
+The dominant real-world case for footnotes is an inline reference (`<sup>`/`<span>`) inside running text,
+which this version fully supports. Supporting a block-level source too would mean replacing a block-flow
+child with the synthesized inline call mid-`LayoutBlockChildren` - needing the same anonymous-block-wrapper
+reasoning `CorrectInlineBoxesParent` already owns, re-run selectively for this one case - which was judged
+not worth the complexity for a rare authoring pattern. Covered by
+`FootnoteIntegrationTests.Footnote_OnBlockLevelSource_IsANoOp`.
+
+Filed as [issue #753](https://github.com/jhaygood86/PeachPDF/issues/753).

--- a/.claude/accepted-gaps/footnote-reservation-not-honored-by-every-4-3-mover.md
+++ b/.claude/accepted-gaps/footnote-reservation-not-honored-by-every-4-3-mover.md
@@ -1,0 +1,42 @@
+# A footnote-area reservation is honored by most, not all, of §4.3's movers
+
+`Html/Core/Fragmentation/BlockConstraint.cs`'s `RemainingBlockSize` (and so `Straddles`, and so
+`FitsInFragmentainer`'s monolithic-overflow check) now reads the live pass's own
+`FragmentainerContext.BandEndInsetOf` reservation - the fix that makes a footnote area (or a repeating
+table `<tfoot>`) correctly shrink the room `break-inside: avoid` and orphans/widows judge content against.
+This is deliberately **narrower** than `BandEndInsetOf`'s own "composes forward across every later slot"
+contract: `BlockConstraint.BandEndInset` only answers for the exact slot the live pass is currently filling
+(`Fragmentainer.SlotIndex == HtmlContainerInt.CurrentFragmentainer.SlotIndex`), reading zero for a `BlockConstraint`
+built via `AtNextSlot()`/`AtSlot()` for any other slot. A repeating `<tfoot>`'s reservation is a genuine
+constant across every slot a table spans, so composing it forward to a different slot is correct - but a
+footnote area's reservation varies per page (`HtmlContainerInt.FootnoteAreaHeightsBySlot`), so composing
+the *live* page's own footnote amount forward onto a query about a *different* page would misattribute one
+page's reservation to another's. The narrower answer is a strictly safer regression from main (which had
+no reservation awareness in `BlockConstraint` at all) than a wrong nonzero one would be.
+
+Four related gaps remain, none closed in this change:
+
+- **CSS Fragmentation §5.2's margin-truncation mover** (`BlockConstraint.EndingAt`/`FallsPast`, driven from
+  `CssBox.ResolveBlockChildOffset`) asks a different question - a bottom-edge/tolerance check against the
+  raw band (`HtmlContainerInt.FallsPast`), not `RemainingBlockSize` - and fixing it would mean threading the
+  reservation into `PageBand`/`Fragmentainer.Band` itself, not just `BlockConstraint`.
+- **The keep-with-next run pre-check** (`CssBox.cs`, the `extraAbove <= boundary.AtNextSlot().NextBandHeight`
+  comparison guarding whether a preceding `break-after`/`break-before: avoid` run can be pulled onto the
+  next page alongside a relocated child) still reads `NextBandHeight` directly, and even if it read
+  `RemainingBlockSize` would fall under the same-slot restriction above (it asks about the *next* slot).
+- **The orphans/widows whole-box push** (`CssBox.cs`, `ActualBottom - Location.Y <= constraint.NextBandHeight`)
+  also still reads `NextBandHeight` directly, and (unlike the two calls above) is not obviously asking about
+  the *destination* page's own band via a fresh `AtNextSlot()`-style constraint in the first place.
+- **`CssLayoutEngineColumns`'s per-column `FragmentainerContext`** (a nested nested context nested inside a
+  page, `inheritsSuppression: true`) is never seeded with the enclosing page's own footnote reservation the
+  way `HtmlContainerInt.LayoutDocument`'s per-page loop and `LayoutTheRemainderMonolithically`'s fallback
+  context both are - column content on a page that also has a footnote lays out unaware of the reserved
+  strip at that page's bottom.
+
+In practice this only matters for the narrow case of an unforced margin collapse, a keep-with-next/
+widows-orphans relocation, or a multi-column container, landing exactly inside a footnote-reserved strip at
+a page's very bottom - rare, and the ordinary per-word `CssRect.WouldStraddleFragmentainer` check (already
+reservation-aware, unrelated to `BlockConstraint`) still correctly stops the actual *content* that would
+follow in the non-column case. Revisiting these was judged higher-risk (each sits inside heavily-invariant-
+documented fragmentation logic) than the value of closing this narrow gap in the same change. Filed as
+[issue #756](https://github.com/jhaygood86/PeachPDF/issues/756).

--- a/.claude/accepted-gaps/footnote-stale-relative-to-target-counter-page-reflow.md
+++ b/.claude/accepted-gaps/footnote-stale-relative-to-target-counter-page-reflow.md
@@ -1,0 +1,21 @@
+# A footnote's resolved page can go stale if `target-counter(_, page)` reflows afterward
+
+`HtmlContainerInt.PerformLayout` runs the footnote convergence loop (`ResolveFootnotesForThisAttempt`)
+before `ReapplyPseudoElementContent`/the `target-counter(_, page)` reflow loop, on the reasoning that
+footnotes should settle their own page breaks before anything depending on the *final* page list resolves
+against them. But `target-counter(_, page)`'s own loop can itself trigger up to three more
+`LayoutDocument` passes afterward (its own comment: "the resolved page-number text's own width can change
+line-breaking, which can change pagination"). `FootnoteAreaHeightsBySlot`/the internal per-slot call
+grouping are never recomputed after the footnote loop's own last pass, so if a later `target-counter(_,
+page)` pass shifts a page break, a footnote's call can end up on a different page than the one it was
+numbered and reserved for - `AttachFootnoteAreas` (keyed by the now-stale slot numbers) may then attach a
+page's footnote area to the wrong page, or drop it if the stale slot no longer has any content in the
+final tree.
+
+Only reachable by a document combining `float: footnote` with `target-counter(_, page)`/`leader()` (e.g. a
+table of contents with page-number cross-references) *and* where resolving those cross-references actually
+shifts a page break near a footnote. Properly closing this means re-running the footnote convergence loop
+after the target-counter loop too (or merging the two into one combined fixpoint), which risks its own new
+interaction bugs between two already-nontrivial convergence loops - judged out of scope for this change.
+
+Filed as [issue #757](https://github.com/jhaygood86/PeachPDF/issues/757).

--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -444,7 +444,7 @@ Regenerating the pattern set (`tools/Update-HyphenationPatterns.ps1`) re-checks 
 |----------|--------------|-------|
 | `display` | [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) | `block`, `inline`, `inline-block`, `none`, `flex`, `inline-flex`, `grid`, `inline-grid`, `table`, `table-row`, `table-cell`, `table-header-group`, `table-footer-group`, `table-row-group`, `table-column`, `table-column-group`, `table-caption`, `list-item` |
 | `position` | [position](https://developer.mozilla.org/en-US/docs/Web/CSS/position) | `static`, `relative`, `absolute`, `fixed` (renders ignoring page margins). `sticky` is treated as `relative` with a zero offset, since there is no scroll to ever cross a sticky threshold against — it participates in normal flow and in stacking/z-index like a positioned box, but its `top`/`right`/`bottom`/`left` values (the scroll-threshold parameters, not a static offset) never shift it. `running(<custom-ident>)` ([css-gcpm-3](https://www.w3.org/TR/css-gcpm-3/#running-syntax)) removes the element from normal flow entirely, making it available to a page margin box via `content: element(<custom-ident>)` — see [Running elements](#running-elements-position-running--element) |
-| `float` | [float](https://developer.mozilla.org/en-US/docs/Web/CSS/float) | `left`, `right`, `none` |
+| `float` | [float](https://developer.mozilla.org/en-US/docs/Web/CSS/float) | `left`, `right`, `none`, `footnote` ([css-gcpm-3](https://www.w3.org/TR/css-gcpm-3/#footnotes)) — removes an inline-level element from normal flow entirely and routes its content to the page's footnote area, the same "remove from flow" idea `position: running()` uses for margin boxes; see [Footnotes](#footnotes-float-footnote) |
 | `clear` | [clear](https://developer.mozilla.org/en-US/docs/Web/CSS/clear) | `left`, `right`, `both`, `none` |
 | `overflow` | [overflow](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow) | Affects clipping regions; there is no interactive scrolling in PDF output |
 | `visibility` | [visibility](https://developer.mozilla.org/en-US/docs/Web/CSS/visibility) | `visible`, `hidden`, `collapse` — on a table row, row group, column, or column group, `collapse` removes it from the table's geometry entirely (the rows/columns after it shift in to fill the gap), distinct from `hidden`, which reserves the element's layout space and only omits painting it |
@@ -876,7 +876,7 @@ A nested selector is resolved against its parent (`&` takes the parent's specifi
 
 ### Pseudo-elements
 
-`::before`, `::after`, `::marker`, `::first-letter`, and `::first-line` are supported. All other pseudo-elements are parsed but have no effect — see [Recognized but unmatchable selectors](#recognized-but-unmatchable-selectors) for which names are recognized and why that matters for the rest of their selector list.
+`::before`, `::after`, `::marker`, `::first-letter`, `::first-line`, and (css-gcpm-3's) `::footnote-call`/`::footnote-marker` are supported. All other pseudo-elements are parsed but have no effect — see [Recognized but unmatchable selectors](#recognized-but-unmatchable-selectors) for which names are recognized and why that matters for the rest of their selector list.
 
 | Pseudo-element | Notes |
 |----------------|-------|
@@ -885,6 +885,8 @@ A nested selector is resolved against its parent (`&` takes the parent's specifi
 | `::marker` | Full support for every property the spec allows on markers — see below |
 | `::first-letter` | Full support — see below |
 | `::first-line` | Full support for every property CSS2.1 allows — see below |
+| `::footnote-call` | The in-flow numbered footnote reference; see [Footnotes](#footnotes-float-footnote) |
+| `::footnote-marker` | The leading number inside a footnote's own body; see [Footnotes](#footnotes-float-footnote) |
 | All others | Parsed but ignored |
 
 Both the single-colon legacy syntax (`:before`, `:after`) and the modern double-colon syntax (`::before`, `::after`) are accepted. `::marker` has no legacy single-colon form, matching the spec.
@@ -1288,6 +1290,36 @@ The `<h1>` no longer appears at its original position in the document; instead, 
 **Limitations:**
 - `position: running()` is honored for elements in normal block flow and for flex/grid/multi-column item children. It is not currently honored on a table row or cell.
 - Content painted via `content: element()` does not currently respect its own internal stacking order (`z-index`) among its descendants — it paints in document order. This only matters for a running element that itself contains absolutely-positioned, `z-index`-stacked content, not for ordinary text/image headers and footers.
+
+### Footnotes (`float: footnote`)
+
+[css-gcpm-3](https://www.w3.org/TR/css-gcpm-3/#footnotes) footnotes: give an inline-level element `float: footnote` and PeachPDF pulls it out of normal flow, leaves a numbered in-flow reference in its place, and renders the element's own content in a note area at the bottom of the page the reference landed on. Unlike a fixed-height `@page` margin box, the note area's height is reserved dynamically, based on how many footnotes actually land on a given page.
+
+```html
+<p>PeachPDF renders footnotes<sup style="float: footnote">
+  This note's content moves to the bottom of this page automatically.
+</sup> without any manual positioning.</p>
+```
+
+- **Source element** — the element carrying `float: footnote` must be inline-level (`inline`, `inline-block`, `inline-table`, `inline-flex`, or `inline-grid`) — the common case is a `<sup>` or `<span>` reference inside running text. A block-level source is left alone (behaves as `float: none`).
+- **Numbering** — footnotes are numbered automatically, in document order, resetting to 1 at the start of each page. There is no author-facing way to change the numbering (an explicit `counter-reset`/`counter-increment: footnote`, or `content: counter(footnote)`, has no effect).
+- **The call** (`::footnote-call`) — the numbered in-flow reference left at the footnote's original position. By default it renders as a small superscript number; style it like any other pseudo-element:
+  ```css
+  ::footnote-call { color: #2563eb; }
+  ```
+- **The marker** (`::footnote-marker`) — the leading number PeachPDF prepends to the footnote's own body once it's shown in the note area (e.g. "1."). Style it the same way:
+  ```css
+  ::footnote-marker { font-weight: bold; }
+  ```
+  Both pseudo-elements support the same style properties `::marker` does (`color`, font properties, `direction`) — see [`::marker`](#pseudo-elements) above. An explicit `content` override on either replaces the automatic number (a literal string, `attr()`, or an image all work; `counter(footnote)` does not — see the numbering note above).
+- **The note area** — a thin divider rule above the stacked footnote bodies, in document order. Its own appearance (the divider, spacing) is a fixed PeachPDF default and isn't currently styled by author CSS.
+
+**Limitations:**
+- `float: inline-footnote` and column-scoped footnote areas (multi-column containers) are not supported.
+- `float: footnote` inside a table cell, flex item, or grid item is untested and not a supported combination in this version.
+- A footnote authored inside another footnote's body is inert — it renders as ordinary text rather than becoming a second footnote.
+- A footnote body taller than a whole page's content band overflows the note area rather than splitting across pages.
+- Links and bookmark-candidate headings inside a footnote body are not collected into the PDF's outline or link annotations.
 
 ### Headers and footers — complete example
 

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -1447,6 +1447,63 @@ await SaveShowcaseAsync("paged_media_running_elements", "Paged Media", "Running 
     "Running headers with full formatting fidelity via position: running() and content: element() - unlike string-set/string(), the margin box shows a real, laid-out element (colors, badges, nested spans), not just captured text.",
     runningElementsHtml, new PdfGenerateConfig { PageSize = PageSize.A4 });
 
+// ─── CSS GCPM showcase — footnotes (float: footnote) ──
+// Demonstrates: multiple footnotes stacking on one page in document order, a page-boundary case
+// where the dynamically-reserved footnote area shrinks how much ordinary flow content that page
+// can hold, a break-inside:avoid paragraph correctly avoiding the reserved strip, per-page
+// numbering reset, and author styling of ::footnote-call/::footnote-marker.
+var footnotesHtml = """
+    <!DOCTYPE html>
+    <html>
+    <head>
+    <style>
+    @page {
+      size: A4 portrait;
+      margin: 25mm 20mm;
+      @bottom-center { content: counter(page); font-size: 8pt; font-family: Arial; color: #888; }
+    }
+    body { font: 11pt Georgia, serif; margin: 0; color: #222; }
+    h1 { font-size: 20pt; margin: 0 0 14pt; }
+    p { line-height: 1.6; margin: 0 0 10pt; }
+    .keep { break-inside: avoid; border-left: 3pt solid #2563eb; padding-left: 10pt; }
+    .spacer { height: 640pt; }
+
+    /* Author styling of the two footnote pseudo-elements - a colored, bracketed call and a
+       bold, colored leading number in the note area, instead of the plain UA default. */
+    ::footnote-call { color: #2563eb; font-weight: bold; }
+    ::footnote-marker { color: #2563eb; font-weight: bold; }
+    </style>
+    </head>
+    <body>
+
+    <h1>Footnotes</h1>
+    <p>float: footnote pulls an element out of normal flow entirely<span style="float:footnote">css-gcpm-3 defines this alongside float: inline-footnote and column-scoped variants; PeachPDF supports the page-level case.</span>,
+    leaving a numbered in-flow reference behind and routing the element's own content to a note area
+    at the bottom of the page the reference landed on<span style="float:footnote">The note area's height is reserved dynamically, based on how many footnotes actually land on a given page - not a fixed-height margin box.</span>.</p>
+
+    <p>Because the reservation is dynamic, content already flowing down the page correctly stops
+    above it even when a paragraph asks to stay together as one unit:</p>
+
+    <div class="spacer"></div>
+
+    <p class="keep">This paragraph carries break-inside: avoid. Once the footnote area above claims
+    room at the foot of the page, this whole paragraph is kept together and, if it no longer fits,
+    moves to the next page as a unit rather than splitting across the reserved strip<span style="float:footnote">A third footnote, to show the reservation composing across every footnote that lands on the same page.</span>.</p>
+
+    <p>Numbering resets per page - the next page starts back at 1:</p>
+
+    <div style="break-before: page;">
+    <p>A fresh page, a fresh footnote<span style="float:footnote">This is footnote 1 again, not 4 - the footnote counter resets per page.</span>.</p>
+    </div>
+
+    </body>
+    </html>
+    """;
+
+await SaveShowcaseAsync("paged_media_footnotes", "Paged Media", "Footnotes",
+    "css-gcpm-3's float: footnote: a numbered in-flow reference, a note area whose height is reserved dynamically per page based on how many footnotes land there, and break-inside: avoid content correctly kept clear of the reserved strip.",
+    footnotesHtml, new PdfGenerateConfig { PageSize = PageSize.A4 });
+
 // ─── CSS Content Module 3 showcase — target-counter()/target-text()/leader() ──
 // The classic hand-authored table of contents: leader() fills the gap between a chapter
 // title and its page number with a dotted rule, and target-counter(attr(href), page)

--- a/src/PeachPDF.Tests/Html/Core/Fragmentation/BlockConstraintTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Fragmentation/BlockConstraintTests.cs
@@ -274,5 +274,73 @@ namespace PeachPDF.Tests.Html.Core.Fragmentation
             // No band means nothing to cross out of - the same refusal Straddles makes.
             Assert.False(BlockConstraint.Measurement.FallsPast(double.MaxValue / 2));
         }
+
+        // BandEndInset/RemainingBlockSize: the fix that makes every §4.3 mover asking through
+        // RemainingBlockSize/Straddles (break-inside: avoid, orphans/widows, monolithic overflow) respect
+        // a live FragmentainerContext.ReserveBandEnd reservation - a repeating table <tfoot>, or a page's
+        // css-gcpm-3 float: footnote area. Before this, BlockConstraint.For/AtSlot/EndingAt each
+        // constructed a *fresh* FragmentainerContext for the slot in question (never the live pass's own
+        // container.CurrentFragmentainer), so RemainingBlockSize always read a reservation of zero
+        // regardless of what the live pass had actually reserved.
+        [Fact]
+        public void RemainingBlockSize_SubtractsTheLiveContextsBandEndReservation()
+        {
+            var container = CreateContainer();
+            var box = CreateBox(container, MarginTop + 30);
+
+            container.CurrentFragmentainer!.ReserveBandEnd(0, 50);
+
+            var constraint = BlockConstraint.For(box);
+
+            Assert.Equal(50, constraint.BandEndInset, 9);
+            Assert.Equal(BandHeight - 30 - 50, constraint.RemainingBlockSize, 9);
+        }
+
+        [Fact]
+        public void RemainingBlockSize_IgnoresAReservationMadeForADifferentSlot()
+        {
+            var container = CreateContainer();
+            var box = CreateBox(container, MarginTop + 30);
+
+            // Reserved for slot 1, but the box's own constraint is for slot 0.
+            container.CurrentFragmentainer!.ReserveBandEnd(1, 50);
+
+            var constraint = BlockConstraint.For(box);
+
+            Assert.Equal(0, constraint.BandEndInset, 9);
+            Assert.Equal(BandHeight - 30, constraint.RemainingBlockSize, 9);
+        }
+
+        [Fact]
+        public void BandEndInset_IsZero_WhenNoReservationIsInForce()
+        {
+            var container = CreateContainer();
+            var box = CreateBox(container, MarginTop + 30);
+
+            var constraint = BlockConstraint.For(box);
+
+            Assert.Equal(0, constraint.BandEndInset);
+        }
+
+        [Fact]
+        public void BandEndInset_IsZeroDuringAMeasurementPass()
+        {
+            Assert.Equal(0, BlockConstraint.Measurement.BandEndInset);
+        }
+
+        [Fact]
+        public void Straddles_RespectsTheLiveContextsBandEndReservation()
+        {
+            var container = CreateContainer();
+            var box = CreateBox(container, MarginTop + 30);
+            container.CurrentFragmentainer!.ReserveBandEnd(0, 50);
+
+            var constraint = BlockConstraint.For(box);
+
+            // Remaining room is BandHeight - 30 - 50 = 720; content exactly that tall does not straddle,
+            // one unit taller does.
+            Assert.False(constraint.Straddles(BandHeight - 30 - 50));
+            Assert.True(constraint.Straddles(BandHeight - 30 - 50 + 0.01));
+        }
     }
 }

--- a/src/PeachPDF.Tests/Integration/FootnoteIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FootnoteIntegrationTests.cs
@@ -1,0 +1,300 @@
+using PeachPDF;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using static PeachPDF.Tests.TestSupport.LayoutHarness;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Covers css-gcpm-3's <c>float: footnote</c>: the in-flow numbered call, the detached body's own
+    /// marker, per-page numbering/reset, and the dynamic footnote-area reservation
+    /// (<see cref="HtmlContainerInt.FootnoteAreaHeightsBySlot"/>) that shrinks the usable content band for
+    /// ordinary flow content on the same page.
+    /// </summary>
+    public class FootnoteIntegrationTests
+    {
+        [Fact]
+        public async Task Footnote_SynthesizesInFlowCallWithNumberOne()
+        {
+            var html = Wrap(@"
+                <p>Some text<sup id='fn1' style='float:footnote'>Note body</sup> continues.</p>");
+
+            var (root, container) = await LayoutAsync(html);
+
+            var call = Assert.Single(container.FootnoteCalls);
+            Assert.Equal(1, call.Number);
+            Assert.Equal("1", call.Text);
+            Assert.Same(call, FindFootnoteCall(root));
+            Assert.Null(call.Body.ParentBox);
+            Assert.Equal("fn1", call.Body.HtmlTag?.TryGetAttribute("id"));
+        }
+
+        [Fact]
+        public async Task Footnote_BodyGetsSynthesizedMarkerAsFirstChild()
+        {
+            var html = Wrap(@"
+                <p>Text<sup style='float:footnote'>Note body</sup></p>");
+
+            var (_, container) = await LayoutAsync(html);
+
+            var call = Assert.Single(container.FootnoteCalls);
+            var marker = Assert.IsType<CssBoxFootnoteMarker>(call.Body.Boxes[0]);
+            Assert.Equal("1.", marker.Text);
+        }
+
+        [Fact]
+        public async Task Footnote_ReservesBottomSpaceOnItsLandingPage()
+        {
+            var html = Wrap(@"
+                <p>Text<sup style='float:footnote'>A reasonably long footnote body that takes up some vertical space once laid out.</sup></p>");
+
+            var (_, container) = await LayoutAsync(html);
+
+            var reservation = Assert.Single(container.FootnoteAreaHeightsBySlot);
+            Assert.Equal(0, reservation.Key);
+            Assert.True(reservation.Value > 0);
+        }
+
+        [Fact]
+        public async Task Footnote_FollowingContent_LandsAboveTheReservedStrip()
+        {
+            var withFootnote = Wrap(@"
+                <div id='spacer' style='height:700pt;'></div>
+                <p>Text<sup style='float:footnote'>Note body</sup></p>
+                <div id='after' style='height:10pt;'></div>");
+            var withoutFootnote = Wrap(@"
+                <div id='spacer' style='height:700pt;'></div>
+                <p>Text</p>
+                <div id='after' style='height:10pt;'></div>");
+
+            var (rootWith, containerWith) = await LayoutAsync(withFootnote, pageHeight: 842);
+            var (rootWithout, _) = await LayoutAsync(withoutFootnote, pageHeight: 842);
+
+            var afterWith = FindById(rootWith, "after")!;
+            var afterWithout = FindById(rootWithout, "after")!;
+
+            // The footnote's own reservation only exists on the page with a footnote landing on it,
+            // so identical preceding content lands at the identical Y in both documents (nothing before
+            // the footnote's own call is affected) - but the footnote area must sit above wherever the
+            // page's raw content-band bottom is, never overlapping it.
+            Assert.Equal(afterWithout.Location.Y, afterWith.Location.Y, 0.5);
+
+            var reservation = containerWith.FootnoteAreaHeightsBySlot[0];
+            var pageBottom = containerWith.PageBottomOf(0);
+            Assert.True(afterWith.ActualBottom <= pageBottom - reservation + 0.5);
+        }
+
+        [Fact]
+        public async Task Footnote_MultipleOnOnePage_NumberedInDocumentOrderAndStack()
+        {
+            var html = Wrap(@"
+                <p>One<sup id='fn1' style='float:footnote'>First note</sup>
+                Two<sup id='fn2' style='float:footnote'>Second note</sup></p>");
+
+            var (root, container) = await LayoutAsync(html);
+
+            Assert.Equal(2, container.FootnoteCalls.Count);
+            var first = container.FootnoteCalls.First(c => c.Body.HtmlTag?.TryGetAttribute("id") == "fn1");
+            var second = container.FootnoteCalls.First(c => c.Body.HtmlTag?.TryGetAttribute("id") == "fn2");
+
+            Assert.Equal(1, first.Number);
+            Assert.Equal(2, second.Number);
+
+            // Stacked in document order: the first footnote's body sits above the second's.
+            Assert.True(first.Body.Location.Y < second.Body.Location.Y);
+
+            var reservation = Assert.Single(container.FootnoteAreaHeightsBySlot).Value;
+            Assert.True(reservation > 0);
+            _ = root;
+        }
+
+        [Fact]
+        public async Task Footnote_AcrossForcedPageBreak_ResetsNumberingAndAttachesAreaOnBothPages()
+        {
+            var html = Wrap(@"
+                <p>One<sup id='fn1' style='float:footnote'>First</sup></p>
+                <div style='break-before: page;'>
+                <p>Two<sup id='fn2' style='float:footnote'>Second</sup></p>
+                </div>");
+
+            var (_, container) = await LayoutAsync(html);
+
+            Assert.Equal(2, container.FootnoteCalls.Count);
+            var first = container.FootnoteCalls.First(c => c.Body.HtmlTag?.TryGetAttribute("id") == "fn1");
+            var second = container.FootnoteCalls.First(c => c.Body.HtmlTag?.TryGetAttribute("id") == "fn2");
+
+            // Per-page reset: the second footnote is alone on its own (forced-break) page, so it is "1"
+            // there too, not "2".
+            Assert.Equal(1, first.Number);
+            Assert.Equal(1, second.Number);
+
+            Assert.Equal(2, container.FootnoteAreaHeightsBySlot.Count);
+            Assert.True(container.FootnoteAreaHeightsBySlot[0] > 0);
+            Assert.True(container.FootnoteAreaHeightsBySlot[1] > 0);
+
+            // The fragment tree - what AttachFootnoteAreas actually produced, and so what paint actually
+            // draws - must reflect both pages' areas, not just whichever one the convergence loop's
+            // resolve happened to compute first. Regression coverage for a bug where the loop could exit
+            // right after a LayoutDocument call with no matching re-resolve, leaving
+            // FootnoteAreaHeightsBySlot/_footnoteCallsBySlot describing a Root tree state layout had
+            // already moved on from - every page but the first silently lost its footnote area.
+            var pages = container.FragmentTree!.Fragmentainers;
+            Assert.Equal(2, pages.Count);
+            Assert.NotNull(pages[0].FootnoteArea);
+            Assert.Single(pages[0].FootnoteArea!.Bodies);
+            Assert.NotNull(pages[1].FootnoteArea);
+            Assert.Single(pages[1].FootnoteArea!.Bodies);
+        }
+
+        [Fact]
+        public async Task Footnote_AuthorPseudoElementRules_StyleTheCallAndMarker()
+        {
+            var html = Wrap(@"
+                <style>
+                    ::footnote-call { color: rgb(37, 99, 235); }
+                    ::footnote-marker { color: rgb(220, 38, 38); }
+                </style>
+                <p>Text<sup style='float:footnote'>Note body</sup></p>");
+
+            var (_, container) = await LayoutAsync(html);
+
+            var call = Assert.Single(container.FootnoteCalls);
+            Assert.Equal("rgb(37, 99, 235)", call.Color);
+
+            var marker = Assert.IsType<CssBoxFootnoteMarker>(call.Body.Boxes[0]);
+            Assert.Equal("rgb(220, 38, 38)", marker.Color);
+        }
+
+        [Fact]
+        public async Task Footnote_TypeSelectorPseudoElementRule_MatchesAgainstTheRealSourceElement()
+        {
+            // sup::footnote-call, not span::footnote-call - proves re-matching resolves the non-pseudo
+            // part of the selector against the real, detached source element (FootnoteSourceBox), not
+            // against the call's own structural ParentBox (the paragraph it was inserted into).
+            var html = Wrap(@"
+                <style>
+                    sup::footnote-call { color: rgb(37, 99, 235); }
+                    span::footnote-call { color: rgb(220, 38, 38); }
+                </style>
+                <p>Text<sup style='float:footnote'>Note body</sup></p>");
+
+            var (_, container) = await LayoutAsync(html);
+
+            var call = Assert.Single(container.FootnoteCalls);
+            Assert.Equal("rgb(37, 99, 235)", call.Color);
+        }
+
+        [Fact]
+        public async Task Footnote_OnBlockLevelSource_IsANoOp()
+        {
+            var html = Wrap(@"
+                <div id='block' style='float:footnote;'>Block footnote body</div>");
+
+            var (root, container) = await LayoutAsync(html);
+
+            Assert.Empty(container.FootnoteCalls);
+
+            // Still an ordinary, in-flow tree member - never detached, since a block-level float:footnote
+            // source is left alone (an accepted gap, behaving as float: none) rather than pulled out.
+            var block = FindById(root, "block");
+            Assert.NotNull(block);
+            Assert.NotNull(block!.ParentBox);
+        }
+
+        [Fact]
+        public async Task Footnote_Nested_IsInert()
+        {
+            var html = Wrap(@"
+                <p>Text<sup id='outer' style='float:footnote'>Outer note
+                    <span id='inner' style='float:footnote'>Inner note</span>
+                </sup></p>");
+
+            var (_, container) = await LayoutAsync(html);
+
+            var call = Assert.Single(container.FootnoteCalls);
+            Assert.Equal("outer", call.Body.HtmlTag?.TryGetAttribute("id"));
+
+            // The inner float:footnote box is still inside the (now detached) outer body, untouched.
+            var inner = Descendants(call.Body).FirstOrDefault(b => b.HtmlTag?.TryGetAttribute("id") == "inner");
+            Assert.NotNull(inner);
+        }
+
+        [Fact]
+        public async Task Footnote_RealPdfGeneratorPipeline_GeneratesWithoutError()
+        {
+            // Exercises the real PdfGenerator.PaintFootnoteArea paint path (LayoutAsync above only ever
+            // runs layout, never paint) against a document with a footnote on its first page but not its
+            // (forced-break) second - also the only way to cover AttachFootnoteAreas' "this page has no
+            // footnote area" branch, which every other test here never reaches. Visual correctness of
+            // this paint path (divider position, stacked bodies, cross-page geometry) is verified by
+            // rasterizing the paged_media_footnotes showcase through PDFium and MuPDF, per this repo's
+            // painting-verification convention - this test's job is just to prove the path executes for
+            // both a page that has a footnote area and one that doesn't, not to re-derive that proof.
+            var html = "<!DOCTYPE html><html><head><style>"
+                + "@page { size: 300pt 300pt; margin: 20pt; }"
+                + "body { margin: 0; font-size: 10pt; }"
+                + "</style></head><body>"
+                + "<p>One<sup style='float:footnote'>Note body</sup></p>"
+                + "<div style='break-before: page;'><p>No footnote here.</p></div>"
+                + "</body></html>";
+
+            var generator = new PdfGenerator();
+            var config = new PdfGenerateConfig { PageSize = PageSize.A4 };
+            var doc = await generator.GeneratePdf(html, config);
+
+            Assert.Equal(2, doc.PdfDocument.Pages.Count);
+
+            using var ms = new MemoryStream();
+            doc.Save(ms);
+            Assert.True(ms.Length > 0);
+        }
+
+        [Fact]
+        public async Task Footnote_OnAPageWithItsOwnMarginOverride_PaintsInsideThatPagesOwnContentTransform()
+        {
+            // Regression coverage for a bug found in review: the footnote area's own geometry
+            // (AttachFootnoteAreas) is built the same fragmentainer-local way ordinary content is - anchored
+            // at the *base* MarginLeft/MarginTop in layout space, needing the page's own deltaX/deltaY
+            // translate (PdfGenerator's per-page content transform) to land correctly on a page whose own
+            // @page margins differ from the base. Painting it after that transform was undone (the same
+            // spot plain string/counter/element() margin-box content correctly uses, since THAT content is
+            // already page-absolute) left it positioned as if every page shared the base margin. This test
+            // only proves the differing-margin case still generates a well-formed multi-page PDF; the actual
+            // divider/body position for this exact scenario was verified by hand via rasterization (PDFium)
+            // against @page :first { margin-top: 80pt; margin-left: 60pt }.
+            var html = "<!DOCTYPE html><html><head><style>"
+                + "@page { size: 300pt 300pt; margin: 20pt; }"
+                + "@page :first { margin-top: 80pt; margin-left: 60pt; }"
+                + "body { margin: 0; font-size: 10pt; }"
+                + "</style></head><body>"
+                + "<p>One<sup style='float:footnote'>Note body</sup></p>"
+                + "</body></html>";
+
+            var generator = new PdfGenerator();
+            var config = new PdfGenerateConfig { PageSize = PageSize.A4 };
+            var doc = await generator.GeneratePdf(html, config);
+
+            Assert.Equal(1, doc.PdfDocument.Pages.Count);
+
+            using var ms = new MemoryStream();
+            doc.Save(ms);
+            Assert.True(ms.Length > 0);
+        }
+
+        private static CssBoxFootnoteCall? FindFootnoteCall(CssBox box)
+        {
+            if (box is CssBoxFootnoteCall call) return call;
+
+            foreach (var child in box.Boxes)
+            {
+                var found = FindFootnoteCall(child);
+                if (found is not null) return found;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/PeachPDF/CSS/Enumerations/Floating.cs
+++ b/src/PeachPDF/CSS/Enumerations/Floating.cs
@@ -4,6 +4,16 @@ namespace PeachPDF.CSS
     {
         None,
         Left,
-        Right
+        Right,
+
+        /// <summary>
+        /// CSS Generated Content for Paged Media (css-gcpm-3) footnotes: the box is pulled out of
+        /// normal flow entirely, rather than positioned beside its siblings like <see cref="Left"/>/
+        /// <see cref="Right"/> — see <c>DomParser.DetachFootnoteBodies</c> and
+        /// <c>Html/Core/Dom/CssBoxFootnoteCall.cs</c>. Deliberately excluded from
+        /// <c>CssBox.IsFloated</c>/<c>CssLayoutEngine.FloatBox</c>, which only ever handle
+        /// <see cref="Left"/>/<see cref="Right"/>.
+        /// </summary>
+        Footnote
     }
 }

--- a/src/PeachPDF/CSS/Enumerations/Keywords.cs
+++ b/src/PeachPDF/CSS/Enumerations/Keywords.cs
@@ -14,6 +14,7 @@
         public const string Avoid = "avoid";
         public const string Left = "left";
         public const string Right = "right";
+        public const string Footnote = "footnote";
         public const string Both = "both";
         public const string Forwards = "forwards";
         public const string Backwards = "backwards";

--- a/src/PeachPDF/CSS/Enumerations/PseudoElementNames.cs
+++ b/src/PeachPDF/CSS/Enumerations/PseudoElementNames.cs
@@ -5,6 +5,8 @@ namespace PeachPDF.CSS
         public const string Before = "before";
         public const string After = "after";
         public const string Marker = "marker";
+        public const string FootnoteCall = "footnote-call";
+        public const string FootnoteMarker = "footnote-marker";
         public const string Selection = "selection";
         public const string FirstLine = "first-line";
         public const string FirstLetter = "first-letter";

--- a/src/PeachPDF/CSS/Factories/PseudoElementSelectorFactory.cs
+++ b/src/PeachPDF/CSS/Factories/PseudoElementSelectorFactory.cs
@@ -21,8 +21,9 @@ namespace PeachPDF.CSS
         private readonly FrozenDictionary<string, ISelector> _selectors =
             new HashSet<string>(StringComparer.OrdinalIgnoreCase)
                 {
-                    // ::before/::after/::marker/::first-line/::first-letter are the ones that generate a
-                    // real box; ::selection and ::content parse and paint nothing, like everything in
+                    // ::before/::after/::marker/::first-line/::first-letter/::footnote-call/
+                    // ::footnote-marker are the ones that generate a real box; ::selection and
+                    // ::content parse and paint nothing, like everything in
                     // UnmatchableSelectors.PseudoElements below them.
                     PseudoElementNames.Before,
                     PseudoElementNames.After,
@@ -31,6 +32,8 @@ namespace PeachPDF.CSS
                     PseudoElementNames.FirstLine,
                     PseudoElementNames.FirstLetter,
                     PseudoElementNames.Content,
+                    PseudoElementNames.FootnoteCall,
+                    PseudoElementNames.FootnoteMarker,
                 }
                 .Union(UnmatchableSelectors.PseudoElements, StringComparer.OrdinalIgnoreCase)
                 .ToDictionary(x => x, PseudoElementSelector.Create, StringComparer.OrdinalIgnoreCase)

--- a/src/PeachPDF/CSS/Model/Map.cs
+++ b/src/PeachPDF/CSS/Model/Map.cs
@@ -648,7 +648,8 @@ namespace PeachPDF.CSS
             {
                 {Keywords.None, Floating.None},
                 {Keywords.Left, Floating.Left},
-                {Keywords.Right, Floating.Right}
+                {Keywords.Right, Floating.Right},
+                {Keywords.Footnote, Floating.Footnote}
             }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
         public static readonly FrozenDictionary<string, DisplayMode> DisplayModes =
             new Dictionary<string, DisplayMode>(StringComparer.OrdinalIgnoreCase)

--- a/src/PeachPDF/Html/Core/CssData.cs
+++ b/src/PeachPDF/Html/Core/CssData.cs
@@ -816,6 +816,7 @@ namespace PeachPDF.Html.Core
             if (lastSelector is PseudoElementSelector pseudoElementSelector)
             {
                 var referenceBox = box.IsFirstLetterPseudoElement ? box.FirstLetterOriginatingBox
+                    : box.IsFootnoteCallPseudoElement || box.IsFootnoteMarkerPseudoElement ? box.FootnoteSourceBox
                     : box.IsPseudoElement ? box.ParentBox : box;
 
                 var isMatchWithoutPseudoElement = compoundSelector
@@ -1021,6 +1022,8 @@ namespace PeachPDF.Html.Core
                 case PseudoElementNames.After when box.IsAfterPseudoElement:
                 case PseudoElementNames.Marker when box.IsMarkerPseudoElement:
                 case PseudoElementNames.FirstLetter when box.IsFirstLetterPseudoElement:
+                case PseudoElementNames.FootnoteCall when box.IsFootnoteCallPseudoElement:
+                case PseudoElementNames.FootnoteMarker when box.IsFootnoteMarkerPseudoElement:
                     return true;
                 default:
                     return false;

--- a/src/PeachPDF/Html/Core/CssDefaults.cs
+++ b/src/PeachPDF/Html/Core/CssDefaults.cs
@@ -96,6 +96,10 @@ namespace PeachPDF.Html.Core
             ol, ul, dir,
             menu            { counter-reset: list-item }
             li::marker      { margin-right: 5px }
+            *::footnote-call
+                            { vertical-align: super; font-size: .7em }
+            *::footnote-marker
+                            { margin-right: 0.3em }
             ol ul, ul ol,
             ul ul, ol ol    { margin-top: 0; margin-bottom: 0 }
             ol ul, ul ul    { list-style-type: circle }

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -241,6 +241,39 @@ namespace PeachPDF.Html.Core.Dom
         public bool IsMarkerPseudoElement { get; set; }
 
         /// <summary>
+        /// Is this box a synthesized <c>::footnote-call</c> pseudo-element - the numbered in-flow
+        /// reference css-gcpm-3's <c>float: footnote</c> leaves behind at a footnote's original
+        /// position (see <c>DomParser.DetachFootnoteBodies</c>). Always a
+        /// <see cref="CssBoxFootnoteCall"/>. Unlike <see cref="IsMarkerPseudoElement"/> boxes it is
+        /// never excluded from its owner's ordinary inline flow - it *is* the owner's in-flow content,
+        /// standing in for the detached footnote body.
+        /// </summary>
+        public bool IsFootnoteCallPseudoElement { get; set; }
+
+        /// <summary>
+        /// Is this box a synthesized <c>::footnote-marker</c> pseudo-element - the leading number
+        /// css-gcpm-3 prepends inside a footnote's own body content once it is rendered in the page's
+        /// footnote area (see <c>DomParser.DetachFootnoteBodies</c>). Always a
+        /// <see cref="CssBoxFootnoteMarker"/>, inserted as the detached footnote body's first child so
+        /// it flows ahead of the body's own content like an <c>inside</c> list marker.
+        /// </summary>
+        public bool IsFootnoteMarkerPseudoElement { get; set; }
+
+        /// <summary>
+        /// For an <see cref="IsFootnoteCallPseudoElement"/> or <see cref="IsFootnoteMarkerPseudoElement"/>
+        /// box, the real, detached <c>float: footnote</c> element <c>E</c> that
+        /// <c>E::footnote-call</c>/<c>E::footnote-marker</c> matches - used only for selector re-matching
+        /// (see <c>CssData.DoesSelectorMatch</c>'s <c>referenceBox</c> logic), the same role
+        /// <see cref="FirstLetterOriginatingBox"/> plays for <c>::first-letter</c>. Needed because, unlike
+        /// <see cref="IsBeforePseudoElement"/>/<see cref="IsAfterPseudoElement"/>/<see cref="IsMarkerPseudoElement"/>
+        /// (inserted as a child of the matched element itself, so <see cref="ParentBox"/> already is the
+        /// owner), a footnote call/marker's structural <see cref="ParentBox"/> is <c>E</c>'s own former
+        /// container, not <c>E</c> - <c>E</c> itself is fully detached from the tree once
+        /// <c>DomParser.DetachFootnoteBodies</c> runs.
+        /// </summary>
+        public CssBox? FootnoteSourceBox { get; set; }
+
+        /// <summary>
         /// Is this box a synthesized <c>::first-letter</c> pseudo-element - unlike
         /// <see cref="IsBeforePseudoElement"/>/<see cref="IsAfterPseudoElement"/>/
         /// <see cref="IsMarkerPseudoElement"/> (all inserted as a new child of the matched element
@@ -355,7 +388,8 @@ namespace PeachPDF.Html.Core.Dom
         /// </summary>
         internal bool HasOwnBackground => RenderUtils.IsColorVisible(ActualBackgroundColor) || BackgroundImages is { Count: > 0 };
 
-        public bool IsPseudoElement => IsBeforePseudoElement || IsAfterPseudoElement || IsMarkerPseudoElement || IsFirstLetterPseudoElement;
+        public bool IsPseudoElement => IsBeforePseudoElement || IsAfterPseudoElement || IsMarkerPseudoElement || IsFirstLetterPseudoElement
+            || IsFootnoteCallPseudoElement || IsFootnoteMarkerPseudoElement;
 
         /// <summary>
         /// is the box "Display" is "Inline", is this is an inline box and not block.
@@ -2935,8 +2969,12 @@ namespace PeachPDF.Html.Core.Dom
         {
             var (clonedStart, clonedEnd) = MonolithicContent.ClonedBlockInsets(this, HtmlContainer!);
 
+            // RemainingBlockSize, not the raw NextBandHeight: destination is always a fresh band-top
+            // constraint (BlockOffset 0) from a caller's own AtNextSlot(), so this already accounts for
+            // whatever destination's own BandEndInset reserves (a repeating table <tfoot>, a page's
+            // footnote area) - the room actually available there, not the band's nominal height.
             return MonolithicContent.FitsInBand(
-                ActualBottom - Location.Y, clonedStart, clonedEnd, destination.NextBandHeight);
+                ActualBottom - Location.Y, clonedStart, clonedEnd, destination.RemainingBlockSize);
         }
 
         /// <summary>
@@ -6242,7 +6280,7 @@ namespace PeachPDF.Html.Core.Dom
         /// it has them, since an inline box's own <see cref="CssBox.Location"/> stays at a
         /// line-local value layout never updates.
         /// </summary>
-        private double OwnGeometryTop()
+        internal double OwnGeometryTop()
         {
             if (Rectangles.Count == 0 && Words.Count == 0) return Location.Y;
 

--- a/src/PeachPDF/Html/Core/Dom/CssBoxFootnoteCall.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBoxFootnoteCall.cs
@@ -1,0 +1,57 @@
+using PeachPDF.CSS;
+using System;
+
+namespace PeachPDF.Html.Core.Dom
+{
+    /// <summary>
+    /// CSS box for a synthesized <c>::footnote-call</c> pseudo-element (css-gcpm-3) - the numbered
+    /// in-flow reference <c>float: footnote</c> leaves at a footnote's original position once
+    /// <c>DomParser.DetachFootnoteBodies</c> pulls the footnote's own content out of flow. Unlike
+    /// <see cref="CssBoxMarker"/>'s <c>outside</c> case, this is an ordinary, fully in-flow inline
+    /// participant - "simply the owner's first inline child, positioned by the ordinary inline-layout
+    /// algorithm like any other flowed content" (see <see cref="CssBoxMarker.PerformLayoutImp"/>'s own
+    /// remark on an <c>inside</c> marker) - so no layout override is needed here at all.
+    /// </summary>
+    internal sealed class CssBoxFootnoteCall : CssBox
+    {
+        /// <summary>The detached footnote body this call refers to.</summary>
+        internal CssBox Body { get; }
+
+        /// <summary>
+        /// This footnote's 1-based number on the page its call landed on for the current layout
+        /// attempt - assigned by <c>HtmlContainerInt</c>'s per-page footnote resolution step, which
+        /// also assigns the same value to <see cref="Body"/>'s own <see cref="CssBoxFootnoteMarker"/>
+        /// (see <see cref="CssBoxFootnoteMarker.ApplyNumber"/>).
+        /// </summary>
+        internal int Number { get; private set; } = 1;
+
+        public CssBoxFootnoteCall(CssBox parent, CssBox body) : base(parent, null)
+        {
+            Body = body;
+            FootnoteSourceBox = body;
+            IsFootnoteCallPseudoElement = true;
+        }
+
+        /// <summary>
+        /// Sets <see cref="Number"/> and, unless the author overrode <c>content</c> on
+        /// <c>::footnote-call</c> (still the cascaded default "normal" otherwise), formats it as this
+        /// call's text - via the same shared <see cref="CssCounterEngine.FormatCounterValue"/> every
+        /// other counter-driven marker in this codebase uses. Deliberately not resolved through
+        /// <see cref="CssCounterEngine"/>'s own counter-reset/increment machinery: that engine resolves
+        /// purely from DOM position, with no notion of which page a box lands on, while a footnote's
+        /// number depends on pagination - see the "Footnotes" section of docs/html-css-support.md for
+        /// why an explicit author <c>content: counter(footnote)</c> is not supported. Does not itself
+        /// call <see cref="CssBox.ParseToWords"/> - the caller re-parses once the whole page's calls
+        /// have all been renumbered, the same "apply then re-parse words" contract
+        /// <c>HtmlContainerInt.ReapplyPseudoElementContent</c> already follows.
+        /// </summary>
+        internal void ApplyNumber(int number)
+        {
+            Number = number;
+
+            if (!Content.Trim().Equals(Keywords.Normal, StringComparison.OrdinalIgnoreCase)) return;
+
+            Text = CssCounterEngine.FormatCounterValue(number, Keywords.Decimal);
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssBoxFootnoteMarker.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBoxFootnoteMarker.cs
@@ -1,0 +1,34 @@
+using PeachPDF.CSS;
+using System;
+
+namespace PeachPDF.Html.Core.Dom
+{
+    /// <summary>
+    /// CSS box for a synthesized <c>::footnote-marker</c> pseudo-element (css-gcpm-3) - the leading
+    /// number a footnote's own body carries once it is rendered in a page's footnote area. Inserted as
+    /// the detached footnote body's first child by <c>DomParser.DetachFootnoteBodies</c>, so it flows
+    /// ahead of the body's own content the same way an <c>inside</c> list marker (see
+    /// <see cref="CssBoxMarker"/>) flows ahead of its list item's content - no layout override needed.
+    /// </summary>
+    internal sealed class CssBoxFootnoteMarker : CssBox
+    {
+        public CssBoxFootnoteMarker(CssBox body, CssBoxFootnoteCall call) : base(body, null)
+        {
+            FootnoteSourceBox = call.Body;
+            IsFootnoteMarkerPseudoElement = true;
+        }
+
+        /// <summary>
+        /// Formats <paramref name="number"/> as this marker's text, unless the author overrode
+        /// <c>content</c> on <c>::footnote-marker</c> - the body-side counterpart of
+        /// <see cref="CssBoxFootnoteCall.ApplyNumber"/>, which the two are always kept in sync with (see
+        /// its own remarks for why this isn't resolved through <see cref="CssCounterEngine"/>).
+        /// </summary>
+        internal void ApplyNumber(int number)
+        {
+            if (!Content.Trim().Equals(Keywords.Normal, StringComparison.OrdinalIgnoreCase)) return;
+
+            Text = CssCounterEngine.FormatCounterValue(number, Keywords.Decimal) + ".";
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
+++ b/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
@@ -1244,7 +1244,14 @@ namespace PeachPDF.Html.Core.Dom
             get
             {
                 var area = Style.DisplayPositioning;
-                if (area.Float.Value is Floating.None) return area.Display.ToString();
+                // Floating.Footnote is excluded from blockification too: css-gcpm-3's float:footnote
+                // pulls a box out of flow entirely (see DomParser.DetachFootnoteBodies), rather than
+                // floating it beside its siblings the way left/right do, and the common case is an
+                // inline source (a <sup> reference) that must still read as inline everywhere upstream
+                // of detachment - CorrectAnonymousTables and friends, which run before detachment, would
+                // otherwise see it as an ordinary block-level float and correct the tree around that
+                // false premise.
+                if (area.Float.Value is Floating.None or Floating.Footnote) return area.Display.ToString();
 
                 return area.Display.Value switch
                 {

--- a/src/PeachPDF/Html/Core/Dom/FootnoteBodyLayout.cs
+++ b/src/PeachPDF/Html/Core/Dom/FootnoteBodyLayout.cs
@@ -1,0 +1,23 @@
+using PeachPDF.Html.Adapters;
+using PeachPDF.Html.Adapters.Entities;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Html.Core.Dom
+{
+    /// <summary>
+    /// Lays a detached <c>float: footnote</c> body out for real against a rect inside its landing page's
+    /// footnote area - a thin, footnote-specific entry point over <see cref="RunningElementLayout.LayoutRunningElementFor"/>,
+    /// which already implements exactly this shape of problem ("lay this box out again, off to the side,
+    /// at a provisional position, within one document-layout generation") for css-gcpm-3's other
+    /// out-of-flow mechanism, <c>position: running()</c>. Kept as its own type rather than a direct call
+    /// at each footnote call site so a footnote-specific behavior - the accepted-gap "a body taller than
+    /// one page's content band overflows rather than splitting" (this method never fragments the body,
+    /// same as a running element) - has one documented seam if it ever needs to diverge from the running-
+    /// element path.
+    /// </summary>
+    internal static class FootnoteBodyLayout
+    {
+        internal static ValueTask LayoutFootnoteBodyFor(RGraphics g, CssBox body, RRect contentRect, HtmlContainerInt container) =>
+            RunningElementLayout.LayoutRunningElementFor(g, body, contentRect, container);
+    }
+}

--- a/src/PeachPDF/Html/Core/Fragmentation/BlockConstraint.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/BlockConstraint.cs
@@ -40,8 +40,52 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// <summary>How tall <see cref="Fragmentainer"/>'s own band is, or unbounded where there is none.</summary>
         internal double NextBandHeight => Fragmentainer?.BandHeight ?? double.MaxValue;
 
-        /// <summary>How much of <see cref="Fragmentainer"/>'s band remains below <see cref="BlockOffset"/>.</summary>
-        internal double RemainingBlockSize => NextBandHeight - BlockOffset;
+        /// <summary>
+        /// How far above <see cref="Fragmentainer"/>'s own band bottom content has to stop because
+        /// something has reserved that room at this slot's foot - a repeating table <c>&lt;tfoot&gt;</c>
+        /// (<see href="https://www.w3.org/TR/css-tables-3/#repeated-headers">css-tables-3 §6.2</see>) or a
+        /// page's footnote area (<see href="https://www.w3.org/TR/css-gcpm-3/#footnotes">css-gcpm-3's
+        /// <c>float: footnote</c></see>) are the two reservations <see cref="FragmentainerContext.ReserveBandEnd"/>
+        /// exists for today. Deliberately read from the <b>live</b> pass's own context
+        /// (<see cref="HtmlContainerInt.CurrentFragmentainer"/>), not <see cref="Fragmentainer"/> itself -
+        /// <see cref="For"/>/<see cref="AtSlot"/>/<see cref="EndingAt"/> each construct a fresh
+        /// <see cref="FragmentainerContext"/> for the slot in question (see this type's own remarks on why),
+        /// so it never itself carries a reservation.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Only answered for the slot the live pass is actually filling</b> - <see cref="Fragmentainer"/>'s
+        /// own <c>SlotIndex</c> must equal the live context's, or this reads zero rather than asking
+        /// <see cref="FragmentainerContext.BandEndInsetOf"/> about a different one. A repeating
+        /// <c>&lt;tfoot&gt;</c>'s reservation is a genuine constant across every slot the table spans, so
+        /// <c>BandEndInsetOf</c>'s own "composes forward from <c>fromSlot</c>" contract is correct for it
+        /// even when asked about a slot the live pass hasn't reached yet - but a page's own footnote area
+        /// (<see cref="HtmlContainerInt.FootnoteAreaHeightsBySlot"/>) is seeded fresh, per slot, with a
+        /// genuinely different amount each time <see cref="HtmlContainerInt.LayoutDocument"/> enters a new
+        /// one; the live context only ever remembers the amount it was itself seeded with, for its own
+        /// slot. Without this guard, a §4.3 mover asking about a *different* slot via <see cref="AtNextSlot"/>/
+        /// <see cref="AtSlot"/> (e.g. "would this box fit if pushed to the next page") would read the
+        /// live page's own footnote reservation and misapply it to a page whose own footnotes may be a
+        /// different height, or none at all - measured as a `break-inside: avoid` box being told a
+        /// footnote-free next page has less room than it really does. This is a strictly narrower answer
+        /// than a `&lt;tfoot&gt;`-only reservation would need (it also declines to compose the `&lt;tfoot&gt;`
+        /// case forward the way <see cref="Dom.CssRect.WouldStraddleFragmentainer"/>'s per-word check
+        /// already correctly does), never a wrong one - see
+        /// <c>.claude/accepted-gaps/footnote-reservation-not-honored-by-every-4-3-mover.md</c>.
+        /// </para>
+        /// <para>
+        /// Zero during a measurement pass, where there is no live fragmentainer to ask at all.
+        /// </para>
+        /// </remarks>
+        internal double BandEndInset =>
+            Fragmentainer is null
+                ? 0
+                : Fragmentainer.Container.CurrentFragmentainer is { } live && live.SlotIndex == Fragmentainer.SlotIndex
+                    ? live.BandEndInsetOf(Fragmentainer.SlotIndex)
+                    : 0;
+
+        /// <summary>How much of <see cref="Fragmentainer"/>'s band remains below <see cref="BlockOffset"/>, after <see cref="BandEndInset"/>.</summary>
+        internal double RemainingBlockSize => NextBandHeight - BlockOffset - BandEndInset;
 
         /// <summary>
         /// Whether content <paramref name="blockExtent"/> tall, starting at <see cref="BlockOffset"/>,

--- a/src/PeachPDF/Html/Core/Fragments/Fragment.cs
+++ b/src/PeachPDF/Html/Core/Fragments/Fragment.cs
@@ -247,13 +247,21 @@ namespace PeachPDF.Html.Core.Fragments
     /// pipeline (<c>MarginBoxRenderer</c>) - only <c>element()</c>'s genuine box-subtree content needs
     /// real layout, so only it is threaded through the fragment tree.
     /// </param>
+    /// <param name="FootnoteArea">
+    /// This page's css-gcpm-3 <c>float: footnote</c> note area, if any footnote landed here - attached by
+    /// <c>HtmlContainerInt.AttachFootnoteAreas</c> alongside <paramref name="MarginBoxes"/>'s own
+    /// attachment (both run once the final page list is known), from bodies the footnote convergence loop
+    /// in <c>HtmlContainerInt.PerformLayout</c> already laid out. Null (never an empty placeholder) for a
+    /// page with no footnotes, and always null on the draft this record is first constructed with.
+    /// </param>
     internal sealed record FragmentainerFragment(
         RRect Rect,
         int SlotIndex,
         PageBandGeometry Geometry,
         double LocalOriginY,
         BoxFragment Root,
-        IReadOnlyList<MarginBoxFragment> MarginBoxes) : Fragment(Rect);
+        IReadOnlyList<MarginBoxFragment> MarginBoxes,
+        FootnoteAreaFragment? FootnoteArea = null) : Fragment(Rect);
 
     /// <summary>
     /// One page margin box's <c>content: element(name)</c> content (css-gcpm-3) - the box-subtree
@@ -269,6 +277,22 @@ namespace PeachPDF.Html.Core.Fragments
     /// informational only, not consulted by paint.</param>
     /// <param name="Content">The selected running element's own laid-out subtree.</param>
     internal sealed record MarginBoxFragment(string BoxName, BoxFragment Content) : Fragment(Content.Rect);
+
+    /// <summary>
+    /// One page's css-gcpm-3 <c>float: footnote</c> note area - a divider rule above one or more stacked
+    /// footnote bodies, in document order. Unlike <see cref="MarginBoxFragment"/> (a page-absolute rect
+    /// computed directly from that page's own margins, needing no further translation), a footnote area
+    /// sits inside the ordinary content band, so its coordinates follow the same fragmentainer-local
+    /// convention every other content fragment's do ("local.Y = documentY - LocalOriginY", see this file's
+    /// own remarks) - <see cref="HtmlContainerInt.AttachFootnoteAreas"/> translates each body from the
+    /// document-space position <see cref="Dom.FootnoteBodyLayout.LayoutFootnoteBodyFor"/> laid it out at
+    /// into this page's own local origin before building it. It is laid out once, directly at its final
+    /// page position, and never fragments (an accepted gap, see docs/html-css-support.md's "Footnotes"
+    /// section).
+    /// </summary>
+    /// <param name="DividerRect">The thin rule painted above the first body.</param>
+    /// <param name="Bodies">Each footnote's own laid-out body, in document (and so numbering) order.</param>
+    internal sealed record FootnoteAreaFragment(RRect DividerRect, IReadOnlyList<BoxFragment> Bodies) : Fragment(DividerRect);
 
     /// <summary>
     /// The complete immutable result of laying out one document: its fragmentainers, in page order.

--- a/src/PeachPDF/Html/Core/HtmlContainerInt.cs
+++ b/src/PeachPDF/Html/Core/HtmlContainerInt.cs
@@ -89,6 +89,36 @@ namespace PeachPDF.Html.Core
         private readonly List<RunningElement> _runningElements = new();
 
         /// <summary>
+        /// Every css-gcpm-3 <c>float: footnote</c> call in the document, in document order - built once
+        /// by <c>DomParser.DetachFootnoteBodies</c> when the tree is parsed (unlike
+        /// <see cref="_runningElements"/>, footnote calls are a structural, parse-time fact about the
+        /// tree, not something re-registered live on every layout pass, since a footnote body's own
+        /// content never moves in the tree once detached). Cleared and rebuilt on every
+        /// <see cref="SetHtml"/>/re-parse, never mid-layout.
+        /// </summary>
+        internal List<CssBoxFootnoteCall> FootnoteCalls { get; } = [];
+
+        /// <summary>
+        /// Whether this document has any <c>float: footnote</c> call at all - gates
+        /// <see cref="PerformLayout"/>'s footnote convergence loop so a document that doesn't use the
+        /// feature pays nothing for it. A plain list-count check, not a tree walk, since
+        /// <see cref="FootnoteCalls"/> is already maintained.
+        /// </summary>
+        internal bool HasFootnotes => FootnoteCalls.Count > 0;
+
+        /// <summary>
+        /// This layout attempt's discovered footnote-area reservation, in points of layout space, per
+        /// pagination slot that has at least one footnote landing on it - the amount
+        /// <see cref="LayoutDocument"/> seeds into that slot's <see cref="Fragmentation.FragmentainerContext"/>
+        /// via <c>ReserveBandEnd</c> before laying its content out. Empty (not merely absent) for a
+        /// document that has never resolved footnotes yet, so <see cref="ResolveFootnotesForThisAttempt"/>'s
+        /// very first call - seeded from nothing, per the "layout depends on layout" convergence shape
+        /// this shares with the <c>target-counter(_, page)</c> loop in <see cref="PerformLayout"/> - reads
+        /// zero for every slot rather than throwing.
+        /// </summary>
+        internal Dictionary<int, double> FootnoteAreaHeightsBySlot { get; private set; } = [];
+
+        /// <summary>
         /// Lazily-built id -&gt; box index backing <see cref="GetBoxById(CssBox, string)"/>
         /// (<c>target-counter()</c>/<c>target-text()</c> resolution, which can look up many ids across
         /// one document - see <see cref="DomUtils.BuildIdIndex"/>). Rebuilt whenever the tree's topmost
@@ -790,6 +820,9 @@ namespace PeachPDF.Html.Core
             ClearNamedStrings();
             ClearRunningElements();
             ClearNamedPageElements();
+            FootnoteCalls.Clear();
+            FootnoteAreaHeightsBySlot = [];
+            _footnoteCallsBySlot = [];
             // New content means new @page rules: drop cached slot geometry, the vertical-override
             // scan, and the captured relative-unit context so nothing consults the previous
             // document's bands before the next layout pass (which resets again defensively).
@@ -1060,6 +1093,39 @@ namespace PeachPDF.Html.Core
                 await LayoutDocument(g);
             }
 
+            // css-gcpm-3's float: footnote needs each page's footnote-area height fed back into that same
+            // page's own available content band before the flow content there is judged to fit - the same
+            // "layout depends on layout" shape as UseVariablePageWidth's reflow loop above, solved the same
+            // way: resolve every page's footnotes against the geometry the layout above already produced
+            // (ResolveFootnotesForThisAttempt), re-run layout with the newly-discovered reservation seeded
+            // in (see LayoutDocument's own ReserveBandEnd seed), and repeat until a round's per-page totals
+            // stop changing. Runs before the target-counter(_, page)/ReapplyPseudoElementContent work below
+            // so those resolve against footnotes' own, already-settled page breaks rather than the other
+            // way around. Only entered for documents that actually use float: footnote - HasFootnotes is a
+            // plain list-count check, not a tree walk, so it costs nothing for the common case.
+            if (HasFootnotes)
+            {
+                var footnoteRootWidth = MaxSize.Width > 0 ? MaxSize.Width : Math.Ceiling(ActualSize.Width);
+                const int maxFootnotePasses = 6;
+
+                for (var pass = 0; pass < maxFootnotePasses; pass++)
+                {
+                    var changed = await ResolveFootnotesForThisAttempt(g);
+
+                    // The bound below is a last resort, not the ordinary exit - resolving must always be
+                    // the last thing this loop does before FootnoteAreaHeightsBySlot/_footnoteCallsBySlot
+                    // are read by AttachFootnoteAreas, or they describe a Root tree an earlier LayoutDocument
+                    // call already left behind: reaching the cap with changed still true and relaying out
+                    // one further time, unresolved, is exactly what would do that.
+                    if (!changed || pass == maxFootnotePasses - 1) break;
+
+                    Root.Size = new RSize(footnoteRootWidth, 0);
+                    Root.Location = Location;
+                    ActualSize = RSize.Empty;
+                    await LayoutDocument(g);
+                }
+            }
+
             // After layout, re-apply content to pseudo-elements now that named strings are set
             ReapplyPseudoElementContent(Root);
 
@@ -1134,7 +1200,11 @@ namespace PeachPDF.Html.Core
             // css-gcpm-3's content: element() needs the final page list/count (first/start/last/first-except
             // selection is page-index-based), so it runs here, after the tree above is built, rather than
             // as part of the emitter's own per-pass work.
-            FragmentTree = await LayoutMarginBoxes(g, tree);
+            var treeWithMarginBoxes = await LayoutMarginBoxes(g, tree);
+
+            // Pure bookkeeping (the footnote convergence loop above already produced final geometry) - see
+            // AttachFootnoteAreas's own remarks for why this runs here, alongside LayoutMarginBoxes.
+            FragmentTree = AttachFootnoteAreas(treeWithMarginBoxes);
         }
 
         /// <summary>
@@ -1200,6 +1270,63 @@ namespace PeachPDF.Html.Core
                 }
 
                 updated.Add(marginBoxes is null ? fragmentainer : fragmentainer with { MarginBoxes = marginBoxes });
+            }
+
+            return tree with { Fragmentainers = updated };
+        }
+
+        /// <summary>
+        /// Attaches each page's css-gcpm-3 <c>float: footnote</c> note area to the fragment tree, from
+        /// bodies the footnote convergence loop in <see cref="PerformLayout"/> already laid out (see
+        /// <see cref="ResolveFootnotesForThisAttempt"/>) - pure fragment-tree bookkeeping, no layout of its
+        /// own, the same division of labor <see cref="LayoutMarginBoxes"/> has relative to
+        /// <see cref="RunningElementLayout.LayoutRunningElementFor"/>. Called alongside
+        /// <see cref="LayoutMarginBoxes"/> from <see cref="PerformLayout"/>, once the final page list is
+        /// known.
+        /// </summary>
+        private FragmentTree AttachFootnoteAreas(FragmentTree tree)
+        {
+            if (FootnoteAreaHeightsBySlot.Count == 0) return tree;
+
+            var updated = new List<FragmentainerFragment>(tree.Fragmentainers.Count);
+
+            foreach (var fragmentainer in tree.Fragmentainers)
+            {
+                if (!FootnoteAreaHeightsBySlot.TryGetValue(fragmentainer.SlotIndex, out var totalHeight)
+                    || !_footnoteCallsBySlot.TryGetValue(fragmentainer.SlotIndex, out var calls) || calls.Count == 0)
+                {
+                    updated.Add(fragmentainer);
+                    continue;
+                }
+
+                var contentLeft = MarginLeft;
+                var contentWidth = PageContentRightOf(PageTopOf(fragmentainer.SlotIndex)) - contentLeft;
+                // Mirrors ResolveFootnotesForThisAttempt's own areaTop/finalBodiesTop geometry exactly:
+                // the divider sits after the top padding, before the gap that precedes the first body.
+                var areaTop = PageBottomOf(fragmentainer.SlotIndex) - totalHeight;
+                var dividerTop = areaTop + FootnoteAreaTopPadding;
+
+                // Bodies were laid out (and are still positioned) in document space - the coordinate
+                // space ReserveBandEnd/PageBottomOf's own reservation math needs, since it has to agree
+                // with ordinary flow content's own document-space geometry. Painting, unlike layout, gets
+                // a fresh XGraphics per page with its own page-local origin (matching how the emitter
+                // makes every *other* fragment's rectangles fragmentainer-local - "local.Y = documentY -
+                // (PageTopOf(k) - MarginTop)", see Fragment.cs's own remarks) - MarginBoxFragment content
+                // never hits this because MarginBoxRenderer.GetMarginBoxRect computes a page-local rect
+                // directly, with no document-space coordinate ever entering the picture. Translate once,
+                // here, right before building the paint-facing fragments - this runs exactly once (unlike
+                // ResolveFootnotesForThisAttempt, which the convergence loop can call several times), so a
+                // permanent OffsetTop on each detached body is safe.
+                var localOriginY = fragmentainer.LocalOriginY;
+                foreach (var call in calls)
+                {
+                    call.Body.OffsetTop(-localOriginY);
+                }
+
+                var dividerRect = new RRect(contentLeft, dividerTop - localOriginY, contentWidth, FootnoteDividerThickness);
+                var bodies = calls.Select(call => MarginBoxContentFragmentBuilder.Build(call.Body)).ToList();
+
+                updated.Add(fragmentainer with { FootnoteArea = new FootnoteAreaFragment(dividerRect, bodies) });
             }
 
             return tree with { Fragmentainers = updated };
@@ -1329,6 +1456,17 @@ namespace PeachPDF.Html.Core
                 {
                     var context = new FragmentainerContext(this, Root!, slot);
                     CurrentFragmentainer = context;
+
+                    // Seeded from the previous attempt's own resolution (ResolveFootnotesForThisAttempt) -
+                    // a footnote's presence on this slot is discovered only once its call's Location has
+                    // already settled, so the very first attempt always seeds zero here; the footnote
+                    // convergence loop in PerformLayout re-enters LayoutDocument with the newly-discovered
+                    // amount until it stops changing. No RestoreBandEnd: this context is fresh, discarded
+                    // when the pass ends, so there is nothing to unwind.
+                    if (FootnoteAreaHeightsBySlot.TryGetValue(slot, out var footnoteAreaHeight) && footnoteAreaHeight > 0)
+                    {
+                        context.ReserveBandEnd(slot, footnoteAreaHeight);
+                    }
 
                     // A translation, refill, or rectangle reset since the last iteration may have reopened an
                     // already-frozen slot behind this one without moving the driver back to it (see
@@ -1469,6 +1607,14 @@ namespace PeachPDF.Html.Core
 
             var relaxed = new FragmentainerContext(this, Root!, slot, suppressed: true);
             CurrentFragmentainer = relaxed;
+
+            // A fresh context starts with no reservation of its own - without this, content laid out by
+            // this last-resort fallback would be unaware of a footnote area reserved for this same slot
+            // (see LayoutDocument's own identical seed) and could overlap it.
+            if (FootnoteAreaHeightsBySlot.TryGetValue(slot, out var footnoteAreaHeight) && footnoteAreaHeight > 0)
+            {
+                relaxed.ReserveBandEnd(slot, footnoteAreaHeight);
+            }
 
             Root!.ResumeAt(token, resumeTopOverride: null);
             await Root.PerformLayout(g);
@@ -2030,6 +2176,149 @@ namespace PeachPDF.Html.Core
                 }
                 ReapplyPseudoElementContent(childBox);
             }
+        }
+
+        /// <summary>
+        /// This attempt's footnote calls grouped by the pagination slot they landed on, in document
+        /// order within each group - the same grouping <see cref="ResolveFootnotesForThisAttempt"/> uses
+        /// to lay out and stack each page's bodies, kept around so <see cref="AttachFootnoteAreas"/> can
+        /// build each page's <see cref="FootnoteAreaFragment"/> from bodies already laid out rather than
+        /// re-deriving which calls landed where.
+        /// </summary>
+        private Dictionary<int, List<CssBoxFootnoteCall>> _footnoteCallsBySlot = [];
+
+        /// <summary>Space (layout px, i.e. points) above a page's footnote-area divider rule.</summary>
+        private const double FootnoteAreaTopPadding = 4;
+
+        /// <summary>Thickness of the footnote area's top divider rule.</summary>
+        private const double FootnoteDividerThickness = 1;
+
+        /// <summary>Space between the divider rule and the first footnote body.</summary>
+        private const double FootnoteAreaDividerToBodyGap = 4;
+
+        /// <summary>Space between two stacked footnote bodies on the same page.</summary>
+        private const double FootnoteBodySpacing = 4;
+
+        /// <summary>
+        /// This layout attempt's per-page footnote resolution. For every pagination slot at least one
+        /// <see cref="CssBoxFootnoteCall"/> landed on (by its own, now-settled <c>Location.Y</c>):
+        /// numbers its footnotes in document order starting at 1 (the UA default's implicit per-page
+        /// reset - author <c>counter-reset</c>/<c>counter-increment: footnote</c> aren't supported, see
+        /// the "Footnotes" section of docs/html-css-support.md), lays each footnote's body out against
+        /// that page's own content width via <see cref="FootnoteBodyLayout.LayoutFootnoteBodyFor"/>
+        /// stacked in document order, and positions the stacked group flush with that page's content-band
+        /// bottom. Records the total reserved height per slot into <see cref="FootnoteAreaHeightsBySlot"/>
+        /// for <see cref="LayoutDocument"/> to seed into that slot's own
+        /// <see cref="Fragmentation.FragmentainerContext.ReserveBandEnd"/> on the *next* attempt - the
+        /// same "resolve once layout settles, feed the result back in, repeat" shape
+        /// <see cref="ResolveTargetPageContent"/>'s target-counter(_, page) loop already uses, and for the
+        /// same reason: a footnote's own page assignment (this method's input) depends on how much room
+        /// earlier footnotes on the same page already reserved (this method's output). Returns whether any
+        /// slot's reserved height changed since the previous call, for <see cref="PerformLayout"/>'s
+        /// footnote convergence loop to check.
+        /// </summary>
+        private async ValueTask<bool> ResolveFootnotesForThisAttempt(RGraphics g)
+        {
+            var previous = FootnoteAreaHeightsBySlot;
+            var current = new Dictionary<int, double>();
+
+            if (HasRealPageGrid)
+            {
+                var bySlot = new Dictionary<int, List<CssBoxFootnoteCall>>();
+                foreach (var call in FootnoteCalls)
+                {
+                    if (!IsInRenderedTree(call)) continue;
+
+                    // Not call.Location.Y - an in-flow inline box's own Location stays at a bogus
+                    // line-local value layout never updates; its real document position lives in its
+                    // per-line Rectangles (CssBox.OwnGeometryTop's own remarks).
+                    var slot = PageIndexOf(call.OwnGeometryTop());
+                    if (!bySlot.TryGetValue(slot, out var list))
+                        bySlot[slot] = list = [];
+                    list.Add(call);
+                }
+
+                _footnoteCallsBySlot = bySlot;
+
+                foreach (var (slot, calls) in bySlot)
+                {
+                    var contentLeft = MarginLeft;
+                    var contentWidth = PageContentRightOf(PageTopOf(slot)) - contentLeft;
+
+                    var y = 0d;
+                    var number = 1;
+                    foreach (var call in calls)
+                    {
+                        call.ApplyNumber(number);
+                        call.ParseToWords();
+
+                        var marker = (CssBoxFootnoteMarker)call.Body.Boxes[0];
+                        marker.ApplyNumber(number);
+                        marker.ParseToWords();
+                        number++;
+
+                        // Unconstrained height (a large finite sentinel, not double.MaxValue - the running-
+                        // element layout path does incidental arithmetic on this rect that a true MaxValue
+                        // could push to Infinity): a footnote body never fragments in this codebase (an
+                        // accepted gap - see docs), so its natural, single-pass content height is exactly
+                        // what's reserved, however tall that turns out to be.
+                        var bodyRect = new RRect(contentLeft, y, contentWidth, 100_000);
+                        await FootnoteBodyLayout.LayoutFootnoteBodyFor(g, call.Body, bodyRect, this);
+
+                        y += (call.Body.ActualBottom - call.Body.Location.Y) + FootnoteBodySpacing;
+                    }
+
+                    var totalHeight = y - FootnoteBodySpacing + FootnoteAreaTopPadding + FootnoteDividerThickness + FootnoteAreaDividerToBodyGap;
+                    if (totalHeight <= 0) continue;
+
+                    // The stacking loop above laid every body out relative to a y=0 baseline; translate the
+                    // whole group down so the last body's own bottom edge lands flush with this slot's real
+                    // content-band bottom, the same "measure first, then place at the real position" shape
+                    // CssLayoutEngineColumns already uses for column-fill balancing.
+                    var areaTop = PageBottomOf(slot) - totalHeight;
+                    var finalBodiesTop = areaTop + FootnoteAreaTopPadding + FootnoteDividerThickness + FootnoteAreaDividerToBodyGap;
+                    foreach (var call in calls)
+                    {
+                        call.Body.OffsetTop(finalBodiesTop);
+                    }
+
+                    current[slot] = totalHeight;
+                }
+            }
+            else
+            {
+                _footnoteCallsBySlot = [];
+            }
+
+            FootnoteAreaHeightsBySlot = current;
+
+            if (current.Count != previous.Count) return true;
+            foreach (var (slot, height) in current)
+            {
+                if (!previous.TryGetValue(slot, out var previousHeight) || Math.Abs(previousHeight - height) > 0.01)
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Whether <paramref name="box"/> and every one of its ancestors are actually rendered (no
+        /// <c>display: none</c> between it and the document root, and not on the box's own computed
+        /// display either - an author <c>::footnote-call { display: none }</c> override reaches this too)
+        /// - a footnote call that never lays out at all would otherwise have its stale/default
+        /// <c>Location</c> misread as landing on whatever pagination slot that default coordinate happens
+        /// to fall in.
+        /// </summary>
+        private static bool IsInRenderedTree(CssBox box)
+        {
+            if (box.DerivedStyle.ActualDisplay == Keywords.None) return false;
+
+            for (var ancestor = box.ParentBox; ancestor is not null; ancestor = ancestor.ParentBox)
+            {
+                if (ancestor.DerivedStyle.ActualDisplay == Keywords.None) return false;
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -155,6 +155,14 @@ namespace PeachPDF.Html.Core.Parse
 
             CorrectAnonymousTables(root);
 
+            // Last, deliberately: a float:footnote box must first ride through every correction pass
+            // above as an ordinary tree member - an author can put arbitrary HTML (nested inline markup,
+            // tables, its own generated content/counters) inside a footnote body, and those passes need
+            // real ancestor context to do their job. Detaching earlier risks them misbehaving against an
+            // already-detached subtree with no live parent. See DetachFootnoteBodies's own remarks.
+            htmlContainer.FootnoteCalls.Clear();
+            DetachFootnoteBodies(root, htmlContainer, cssValueParser, cssData, media, containerSizes);
+
             return (root, cssData, metadata);
         }
 
@@ -934,6 +942,103 @@ namespace PeachPDF.Html.Core.Parse
                     ApplyFirstLetterPseudoElements(valueParser, childBox, cssData, media, containerSizes);
                 }
             }
+        }
+
+        /// <summary>
+        /// Implements css-gcpm-3's <c>float: footnote</c>: every inline-level box with a computed
+        /// <c>float: footnote</c> is pulled out of the box tree entirely and replaced, at its own
+        /// position, with a synthesized <see cref="CssBoxFootnoteCall"/> - the in-flow numbered
+        /// reference. The detached box itself becomes the footnote's body, with a synthesized
+        /// <see cref="CssBoxFootnoteMarker"/> inserted as its own first child; both new boxes are
+        /// registered on <see cref="HtmlContainerInt.FootnoteCalls"/> for the per-page numbering/
+        /// reservation step layout runs later (see <c>HtmlContainerInt.ResolveFootnotesForThisAttempt</c>).
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Only an inline-level source qualifies</b> (<see cref="CssBox.IsInline"/>, matching
+        /// <see cref="DerivedStyle.ActualDisplay"/>'s own float:footnote blockification exclusion) - the
+        /// dominant real case is a <c>&lt;sup&gt;</c>/<c>&lt;span&gt;</c> reference inside running text.
+        /// A block-level <c>float: footnote</c> source is left entirely alone here (an accepted gap,
+        /// behaving as <c>float: none</c>) rather than being detached, since supporting it would need the
+        /// same anonymous-block-wrapper reasoning <see cref="CorrectInlineBoxesParent"/> already owns,
+        /// re-run selectively - out of scope.
+        /// </para>
+        /// <para>
+        /// <b>A qualifying box's own descendants are never recursed into</b> once it is detached (the
+        /// <c>continue</c> below) - this is also what makes a nested <c>float: footnote</c> (one footnote
+        /// body containing another) inert rather than a crash: nothing ever walks into an already-detached
+        /// body looking for more footnotes, so a nested one simply renders as ordinary content in place
+        /// (never floated - <see cref="CssBox.IsFloated"/> only recognizes <c>left</c>/<c>right</c> - and
+        /// never blockified, per <see cref="DerivedStyle.ActualDisplay"/>'s own exclusion).
+        /// </para>
+        /// </remarks>
+        private static void DetachFootnoteBodies(CssBox box, HtmlContainerInt htmlContainer, CssValueParser valueParser, CssData cssData, MediaQueryContext media, ContainerQuerySizes? containerSizes)
+        {
+            foreach (var child in box.Boxes.ToArray())
+            {
+                if (child.Float.Value == Floating.Footnote && child.IsInline)
+                {
+                    DetachOneFootnoteBody(box, child, htmlContainer, valueParser, cssData, media, containerSizes);
+                    continue;
+                }
+
+                DetachFootnoteBodies(child, htmlContainer, valueParser, cssData, media, containerSizes);
+            }
+        }
+
+        private static void DetachOneFootnoteBody(CssBox container, CssBox sourceBox, HtmlContainerInt htmlContainer, CssValueParser valueParser, CssData cssData, MediaQueryContext media, ContainerQuerySizes? containerSizes)
+        {
+            var index = container.Boxes.IndexOf(sourceBox);
+
+            // CssBox's constructor auto-appends a non-null parent's Boxes list - remove-then-reinsert at
+            // the source's own index, the same pattern CssData's ::before/::after/::marker synthesis and
+            // EnsureListItemMarkers above both already use.
+            var callBox = new CssBoxFootnoteCall(container, sourceBox);
+            container.Boxes.Remove(callBox);
+            container.Boxes.Insert(index, callBox);
+
+            // Fully detach the body - it is never reachable via ordinary CssBox.Boxes walks again, the
+            // same carve-out FragmentEmitter already documents for a repeating table <thead>/<tfoot>'s
+            // CssProxyBox source subtree.
+            sourceBox.ParentBox = null;
+
+            // The source is very often inline-level (the dominant real case, a <sup>/<span> reference -
+            // see the IsInline gate above), but per css-gcpm-3 a footnote's own body always renders as a
+            // block-level note in the footnote area, regardless of its source's display. This isn't just
+            // presentational: an inline box's real per-fragment position lives in its Rectangles map, only
+            // ever populated by an *enclosing* inline formatting context's own line-building - which the
+            // detached, single-child synthetic container FootnoteBodyLayout lays this out against never
+            // establishes for it. Location/ActualBottom (what block layout - and everything downstream,
+            // MarginBoxContentFragmentBuilder included - actually reads) would stay at their unset default
+            // forever otherwise. Forcing Block here is safe: the source has already been fully detached
+            // and never renders at its original inline position again.
+            sourceBox.Display = CssProperty<DisplayMode>.FromValue(Keywords.Block, DisplayMode.Block);
+
+            var markerBox = new CssBoxFootnoteMarker(sourceBox, callBox);
+            sourceBox.Boxes.Remove(markerBox);
+            sourceBox.Boxes.Insert(0, markerBox);
+
+            // No InheritStyle() call here: CascadeApplyStyles unconditionally re-defaults (its own step 1)
+            // and re-inherits (step 2) as soon as it starts, so a pre-emptive inherit would just be
+            // immediately discarded and redone - same as EnsureListItemMarkers's own synthesis above.
+            CascadeApplyStyles(valueParser, callBox, cssData, media, containerSizes);
+            CascadeApplyStyles(valueParser, markerBox, cssData, media, containerSizes);
+
+            // These two boxes didn't exist yet when CorrectTextBoxes ran its own ApplyContent/ParseToWords
+            // pass over the rest of the tree - do the same resolution for them here. ApplyNumber's own
+            // guard leaves an author's explicit `content` override on ::footnote-call/::footnote-marker
+            // alone; "1" is a placeholder pending the first real layout attempt's page assignment (see
+            // HtmlContainerInt.ResolveFootnotesForThisAttempt), self-correcting on convergence like any
+            // other provisional digit-width estimate in this codebase.
+            CssContentEngine.ApplyContent(callBox);
+            callBox.ApplyNumber(1);
+            if (!string.IsNullOrEmpty(callBox.Text)) callBox.ParseToWords();
+
+            CssContentEngine.ApplyContent(markerBox);
+            markerBox.ApplyNumber(1);
+            if (!string.IsNullOrEmpty(markerBox.Text)) markerBox.ParseToWords();
+
+            htmlContainer.FootnoteCalls.Add(callBox);
         }
 
         /// <summary>

--- a/src/PeachPDF/PdfGenerator.cs
+++ b/src/PeachPDF/PdfGenerator.cs
@@ -399,6 +399,19 @@ namespace PeachPDF
 
                 container.PerformPaint(g, fragmentainer);
 
+                // The footnote area's own geometry (AttachFootnoteAreas) is built the same
+                // fragmentainer-local way every other content fragment's is - content stays anchored at
+                // the base MarginLeft/MarginTop in layout space, with this page's own deltaX/deltaY
+                // translate (above) the only thing that maps it onto a page whose own @page margins
+                // differ from the base. It must therefore paint here, inside that transform, alongside
+                // ordinary content - not after the restore below, which is what a true page-absolute rect
+                // (a plain string/counter/element() margin box's own rect, computed directly from this
+                // page's own margins) needs instead.
+                if (fragmentainer.FootnoteArea is { } footnoteArea)
+                {
+                    PaintFootnoteArea(g, _pdfSharpAdapter, container.HtmlContainerInt, footnoteArea);
+                }
+
                 // Restore to pre-content state so margin boxes render in absolute page coordinates
                 g.Restore(preContentState);
 
@@ -562,6 +575,31 @@ namespace PeachPDF
             foreach (var marginBox in marginBoxes)
             {
                 painter.PaintFragment(graphicsAdapter, marginBox.Content);
+            }
+        }
+
+        /// <summary>
+        /// Paints one page's css-gcpm-3 <c>float: footnote</c> note area - a hard-coded UA divider rule
+        /// (no author styling of the area itself in this version; see docs/html-css-support.md's
+        /// "Footnotes" section), then each footnote body. Mirrors <see cref="PaintElementMarginBoxes"/>
+        /// exactly for the bodies (real, laid-out <see cref="CssBox"/> subtrees reused unmodified through
+        /// <see cref="FragmentPainter.PaintFragment"/> - backgrounds/borders/nested styling and tagged-PDF
+        /// structure attach for free, same reasoning) - the divider alone is drawn directly, the same
+        /// simple filled-rectangle primitive <see cref="PeachPDF.Html.Core.Paint.Content.HrFragmentPainter"/>
+        /// uses for <c>&lt;hr&gt;</c>.
+        /// </summary>
+        private static void PaintFootnoteArea(XGraphics g, RAdapter adapter, HtmlContainerInt htmlContainer, FootnoteAreaFragment footnoteArea)
+        {
+            var pixelsPerPoint = (adapter as PdfSharpAdapter)?.PixelsPerPoint ?? 1.0;
+            using var graphicsAdapter = new GraphicsAdapter(adapter, g, pixelsPerPoint);
+
+            var rect = footnoteArea.DividerRect;
+            graphicsAdapter.DrawRectangle(graphicsAdapter.GetSolidBrush(RColor.Black), rect.X, rect.Y, rect.Width, rect.Height);
+
+            var painter = new FragmentPainter(htmlContainer);
+            foreach (var body in footnoteArea.Bodies)
+            {
+                painter.PaintFragment(graphicsAdapter, body);
             }
         }
 


### PR DESCRIPTION
## Summary

Implements [css-gcpm-3's `float: footnote`](https://www.w3.org/TR/css-gcpm-3/#footnotes): an inline-level source element (typically a `<sup>`/`<span>` reference) is pulled out of normal flow, leaving a numbered in-flow reference (`::footnote-call`) behind, and its content is routed to a note area at the bottom of the page the reference landed on. Unlike a fixed-height `@page` margin box, the note area's height is reserved dynamically per page, based on how many footnotes actually land there.

- Numbering is automatic, in document order, resetting to 1 at the start of each page.
- `::footnote-call` (the in-flow reference) and `::footnote-marker` (the leading number in the body) support author styling through the ordinary pseudo-element cascade.
- The dynamic reservation is built on `FragmentainerContext.ReserveBandEnd` — the same mechanism already used for repeating table `<tfoot>`s — via a bounded convergence loop, since a footnote discovered late on a page can retroactively invalidate an earlier `break-inside: avoid`/orphans-widows decision made against a smaller reservation.
- Also fixes a real, previously-latent gap found while building this: `BlockConstraint.RemainingBlockSize` never consulted a live `ReserveBandEnd` reservation at all, so `break-inside: avoid` and orphans/widows could judge content against a band that ignored reserved space (own commit, own unit tests).

**Scope**: page-level `float: footnote` on an inline-level source. `float: inline-footnote`, column-scoped footnote areas, footnotes inside table cells/flex/grid items, nested footnotes, and a footnote body taller than one page are explicitly out of scope for this PR — each is documented in `.claude/accepted-gaps/` with a tracked follow-up issue (#749–#757).

## Test plan

- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 8855 passed, 0 failed
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings across the whole solution
- [x] Diff coverage ≥ 90% (96% on changed lines, verified via `diff-cover`)
- [x] New `paged_media_footnotes` showcase, rasterized through both PDFium and MuPDF — multi-footnote stacking, a page-boundary case, `break-inside: avoid` correctly avoiding the reserved strip, per-page numbering reset, and `::footnote-call`/`::footnote-marker` author styling all verified visually
- [x] A `@page :first` differing-margin scenario verified by hand via rasterization (regression coverage for a paint-coordinate bug found in review)
- [x] 8-angle code review run against the diff; all confirmed findings fixed, remaining plausible findings documented as tracked accepted gaps