### PR TITLE
Fix table border/cellpadding attribute cascade to cells

### DIFF
--- a/.claude/recent-fixes/2026-08-17-table-cellpadding-border-cascade-defeated-by-defaulting-loop.md
+++ b/.claude/recent-fixes/2026-08-17-table-cellpadding-border-cascade-defeated-by-defaulting-loop.md
@@ -1,0 +1,58 @@
+# Presentational `border`/`cellpadding` table attributes now actually reach `<td>` cells, closing issue #636
+
+[Issue #636](https://github.com/jhaygood86/PeachPDF/issues/636) reported that the deprecated
+presentational `border` and `cellpadding` HTML attributes on a `<table>` never actually cascaded to
+its `<td>` cells - `DomParser.ApplyTableBorder`/`ApplyTablePadding` (both via the shared
+`SetForAllCells` cell-finding helper) silently did nothing observable, even though `SetForAllCells`
+correctly found and mutated the right `CssBox` objects.
+
+Root cause was not `SetForAllCells`'s traversal (the issue's own suspected cause) - a debug trace
+proved it found and set the right cell's `PaddingLeft` every time. The real cause is cascade timing:
+`TranslateAttributes` (which reads the table's `border`/`cellpadding` attributes and drove these two
+methods) runs mid-cascade, from inside `CascadeApplyStyles` for the **table box itself**, before a
+`<td>` descendant's own `CascadeApplyStyles` call has run (the recursion into `box.Boxes` happens
+*after* `TranslateAttributes` returns for the current box - see the loop at the end of
+`CascadeApplyStyles`). Setting a property on the cell that early makes the cell's `ComputedStyle`
+diverge from the shared `ComputedStyle.Default` singleton. `CascadeApplyStyles`'s own "defaulting"
+step has a documented fast path that skips re-asserting every property's CSS initial value when a
+box's `ComputedStyle` is still that shared `Default` (a guaranteed no-op) - but once diverged, the
+cell's own **still-pending** `CascadeApplyStyles` call takes the *other* branch and re-asserts every
+property's initial value, silently clobbering the border/padding value just written from the table.
+
+Fixed by splitting the per-cell cascade out of `TranslateAttributes` into its own pass,
+`DomParser.ApplyTablePresentationalAttributesToCells`, invoked once right after the top-level
+`CascadeApplyStyles(root)` call returns (i.e. after the *entire* tree's cascade has finished) and
+before `CorrectAnonymousTables` runs - so the tree still has its as-authored shape, which is what
+`SetForAllCells`'s traversal (one level for a bare `<tr>`, two levels through an explicit
+`<thead>`/`<tbody>`) already expects. `TranslateBorder` still sets the table's own border
+unconditionally, same as before; only the cell-cascading half of the work moved.
+
+## Load-bearing lessons
+
+**A traversal bug and a clobbering bug produce the identical symptom** (the target property reads
+back as unset) **and only a debug trace distinguishes them.** The issue's own suspected cause -
+`SetForAllCells` not finding the right boxes - was plausible and specific, but wrong; adding a
+temporary `File.AppendAllText` trace into `SetForAllCells` and the test (`ACTION on l2 hash=...`
+immediately followed by `FOUND cell hash=...` with the *same* hash, but `paddingLeft=0` anyway) proved
+the write happened on the right object and then evaporated - which redirected the investigation to
+*when* the write happened relative to the rest of the cascade, not *where*.
+
+**A "no-op fast path" gated on reference-equality to a shared default is a trap for any code that
+mutates a box before that box's own initialization has run.** `CascadeApplyStyles`'s defaulting-loop
+skip (`if (!ReferenceEquals(box.ComputedStyle, ComputedStyle.Default))`) is correct and cheap for the
+ordinary case (nothing has touched the box yet), but it means *any* out-of-band property write against
+a box that hasn't had its own cascade pass yet will be silently reverted once that pass finally runs -
+not just this table/cellpadding path. Worth checking for the same shape (write-before-own-cascade) if
+a similar "translate this attribute onto some other box" mechanism is added later.
+
+## Evidence
+
+Five tests in `PresentationalAttributeIntegrationTests.cs`
+(`BorderAttribute_OnTable_CascadesASolidBorderToCells`, `BorderAttributeZero_OnTable_DoesNotCascadeABorderToCells`,
+`BorderAttribute_OnATableWithATbody_StillCascadesToCells`, `CellpaddingAttribute_CascadesToTableCells`,
+`CellpaddingAttribute_OnATableWithATbody_StillCascadesToCells`), written test-first and confirmed to
+fail against the pre-fix code with the exact symptom the diagnosis predicted (padding/border reading
+back as the CSS initial value), then confirmed to pass post-fix. Full suite green (8875 tests,
+net8.0), zero warnings on `dotnet build -t:Rebuild`, and manual inspection of the collected Cobertura
+coverage confirms both new branches (border/no-border, cellpadding/no-cellpadding) in the new
+`ApplyTablePresentationalAttributesToCells` pass are exercised in both directions.

--- a/src/PeachPDF.Tests/Integration/BorderStylePaintIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/BorderStylePaintIntegrationTests.cs
@@ -286,12 +286,9 @@ namespace PeachPDF.Tests.Integration
         // ─── deprecated presentational `border` HTML attribute always resolves solid ──
         // DomParser.CascadeApplyStyles' HtmlConstants.Border case: a non-zero `border` attribute forces
         // every side's style to solid (CssProperty<LineStyle>.FromValue(Keywords.Solid, LineStyle.Solid)
-        // / the shared SolidBorderStyle constant). Only the plain-element path is covered here -
-        // ApplyTableBorder's TD-cascading path (SetForAllCells) was found, while writing this test, to
-        // already not actually reach the cells regardless of this PR's changes (the same pre-existing gap
-        // affects cellpadding/ApplyTablePadding, which uses the identical SetForAllCells mechanism) - a
-        // pre-existing issue unrelated to the border-style/LineStyle conversion, out of scope here and
-        // tracked separately (issue #636).
+        // / the shared SolidBorderStyle constant). Only the plain-element path is covered here - the
+        // table-to-cell cascade (ApplyTableBorder/SetForAllCells, issue #636) is covered by
+        // PresentationalAttributeIntegrationTests.BorderAttribute_OnTable_CascadesASolidBorderToCells.
 
         [Fact]
         public async Task PresentationalBorderAttribute_OnAPlainElement_ForcesSolidOnAllSides()

--- a/src/PeachPDF.Tests/Integration/PresentationalAttributeIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/PresentationalAttributeIntegrationTests.cs
@@ -203,16 +203,50 @@ namespace PeachPDF.Tests.Integration
         [Fact]
         public async Task BorderAttribute_OnTable_SetsSolidBorderOnTheTableItself()
         {
-            // Exercises TranslateBorder's tag.Name == "table" branch, which (attempts to) cascade a 1px
-            // solid border onto every cell via ApplyTableBorder/SetForAllCells - which has the same
-            // pre-existing #636 gap as CellpaddingAttribute_DoesNotYetReachTableCells above and
-            // PresentationalBorderAttribute_OnAPlainElement_ForcesSolidOnAllSides's comment in
-            // BorderStylePaintIntegrationTests, so only the table's own border is asserted here.
+            // Exercises TranslateBorder's tag.Name == "table" branch. See BorderAttribute_OnTable_CascadesASolidBorderToCells
+            // below for the per-cell cascade (issue #636).
             var (root, _) = await BuildAndLayout(Wrap("<table id='t' border='1'><tr><td>x</td></tr></table>"));
             var table = FindById(root, "t")!;
 
             Assert.Equal(LineStyle.Solid, table.BorderTopStyle.Value);
             Assert.Equal("1px", table.BorderTopWidth);
+        }
+
+        [Fact]
+        public async Task BorderAttribute_OnTable_CascadesASolidBorderToCells()
+        {
+            // Regression for issue #636: ApplyTableBorder's SetForAllCells call used to run mid-cascade
+            // (from inside the table's own TranslateAttributes), before the cell's own CascadeApplyStyles
+            // pass ran - which then reset the cell's just-set border back to its initial value (see
+            // CascadeApplyStyles's "defaulting" step, which re-runs once a box's ComputedStyle diverges
+            // from the shared Default singleton). The cascade to cells now happens after the whole tree's
+            // cascade has completed, so it survives.
+            var (root, _) = await BuildAndLayout(Wrap("<table border='1'><tr><td id='c'>x</td></tr></table>"));
+            var cell = FindById(root, "c")!;
+
+            Assert.Equal(LineStyle.Solid, cell.BorderTopStyle.Value);
+            Assert.Equal("1px", cell.BorderTopWidth);
+            Assert.Equal("1px", cell.BorderLeftWidth);
+            Assert.Equal("1px", cell.BorderRightWidth);
+            Assert.Equal("1px", cell.BorderBottomWidth);
+        }
+
+        [Fact]
+        public async Task BorderAttributeZero_OnTable_DoesNotCascadeABorderToCells()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<table border='0'><tr><td id='c'>x</td></tr></table>"));
+            var cell = FindById(root, "c")!;
+
+            Assert.Equal(LineStyle.None, cell.BorderTopStyle.Value);
+        }
+
+        [Fact]
+        public async Task BorderAttribute_OnATableWithATbody_StillCascadesToCells()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<table border='1'><tbody><tr><td id='c'>x</td></tr></tbody></table>"));
+            var cell = FindById(root, "c")!;
+
+            Assert.Equal(LineStyle.Solid, cell.BorderTopStyle.Value);
         }
 
         [Fact]
@@ -237,19 +271,28 @@ namespace PeachPDF.Tests.Integration
         }
 
         [Fact]
-        public async Task CellpaddingAttribute_DoesNotYetReachTableCells()
+        public async Task CellpaddingAttribute_CascadesToTableCells()
         {
-            // ApplyTablePadding's TD-cascading path (SetForAllCells) has the same pre-existing gap as
-            // ApplyTableBorder's (see PresentationalBorderAttribute_OnAPlainElement_ForcesSolidOnAllSides's
-            // comment in BorderStylePaintIntegrationTests): it doesn't traverse the anonymous
-            // table-row-group box CSS inserts around a bare <tr>, so cellpadding never actually reaches
-            // the cell today - tracked separately as issue #636, out of scope here. This documents the
-            // current (pre-existing) behavior rather than silently leaving the `cellpadding` switch-case
-            // uncovered.
+            // Regression for issue #636: ApplyTablePadding's SetForAllCells call used to run mid-cascade
+            // (from inside the table's own TranslateAttributes), before the cell's own CascadeApplyStyles
+            // pass ran - which then reset the cell's just-set padding back to its initial value. The
+            // cascade to cells now happens after the whole tree's cascade has completed, so it survives.
             var (root, _) = await BuildAndLayout(Wrap("<table id='t' cellpadding='5'><tr><td id='c'>x</td></tr></table>"));
             var cell = FindById(root, "c")!;
 
-            Assert.Equal("0", cell.PaddingLeft);
+            Assert.Equal("5px", cell.PaddingLeft);
+            Assert.Equal("5px", cell.PaddingTop);
+            Assert.Equal("5px", cell.PaddingRight);
+            Assert.Equal("5px", cell.PaddingBottom);
+        }
+
+        [Fact]
+        public async Task CellpaddingAttribute_OnATableWithATbody_StillCascadesToCells()
+        {
+            var (root, _) = await BuildAndLayout(Wrap("<table cellpadding='5'><tbody><tr><td id='c'>x</td></tr></tbody></table>"));
+            var cell = FindById(root, "c")!;
+
+            Assert.Equal("5px", cell.PaddingLeft);
         }
 
         [Fact]

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -130,6 +130,10 @@ namespace PeachPDF.Html.Core.Parse
             // descending into a CssBoxSvg - see their `if (box is CssBoxSvg) return;` and issue #159.
             CascadeApplyStyles(cssValueParser, root, cssData, media, containerSizes);
 
+            // Must run after the whole tree's cascade above, not from inside it - see
+            // ApplyTablePresentationalAttributesToCells's remarks / issue #636.
+            ApplyTablePresentationalAttributesToCells(root);
+
             EnsureListItemMarkers(cssValueParser, root, cssData, media, containerSizes);
 
             ApplyFirstLetterPseudoElements(cssValueParser, root, cssData, media, containerSizes);
@@ -1550,9 +1554,8 @@ namespace PeachPDF.Html.Core.Parse
                     case HtmlConstants.Cellspacing:
                         box.BorderSpacing = TranslateLength(value);
                         break;
-                    case HtmlConstants.Cellpadding:
-                        ApplyTablePadding(box, value);
-                        break;
+                    // Cellpadding's per-cell cascade (ApplyTablePadding) is applied later, in
+                    // ApplyTablePresentationalAttributesToCells - see its remarks / issue #636.
                     case HtmlConstants.Color:
                         box.Color = value.ToLower();
                         break;
@@ -1659,8 +1662,10 @@ namespace PeachPDF.Html.Core.Parse
 
         /// <summary>
         /// Translates the <c>border</c> attribute: sets the border width (and, unless "0", a solid
-        /// style) on the element itself, additionally cascading a 1px solid border to every cell when
-        /// the element is a <c>table</c>.
+        /// style) on the element itself. For a <c>table</c>, the per-cell 1px solid border cascade
+        /// (<see cref="ApplyTableBorder"/>) is applied later, in <see cref="ApplyTablePresentationalAttributesToCells"/>
+        /// - not here, since it must run after the whole tree's cascade has finished (see that method's
+        /// remarks / issue #636).
         /// </summary>
         private static void TranslateBorder(HtmlTag tag, CssBox box, string value)
         {
@@ -1668,12 +1673,7 @@ namespace PeachPDF.Html.Core.Parse
                 box.BorderLeftStyle = box.BorderTopStyle = box.BorderRightStyle = box.BorderBottomStyle = SolidBorderStyle;
             box.BorderLeftWidth = box.BorderTopWidth = box.BorderRightWidth = box.BorderBottomWidth = TranslateLength(value);
 
-            if (tag.Name.Equals(HtmlConstants.Table, StringComparison.OrdinalIgnoreCase))
-            {
-                if (value != "0")
-                    ApplyTableBorder(box, "1px");
-            }
-            else
+            if (!tag.Name.Equals(HtmlConstants.Table, StringComparison.OrdinalIgnoreCase))
             {
                 box.BorderTopStyle = box.BorderLeftStyle = box.BorderRightStyle = box.BorderBottomStyle = SolidBorderStyle;
             }
@@ -1824,6 +1824,46 @@ namespace PeachPDF.Html.Core.Parse
             var len = new CssLength(htmlLength);
 
             return len.HasError ? string.Format(NumberFormatInfo.InvariantInfo, "{0}px", htmlLength) : htmlLength;
+        }
+
+        /// <summary>
+        /// Applies the deprecated presentational <c>border</c>/<c>cellpadding</c> table attributes' TD
+        /// cascade (<see cref="ApplyTableBorder"/>/<see cref="ApplyTablePadding"/>), for every
+        /// <c>table</c> in the tree, directly from the element's own attributes.
+        /// </summary>
+        /// <remarks>
+        /// This must run as its own pass, after <see cref="CascadeApplyStyles"/> has finished for the
+        /// *entire* tree - not from inside <see cref="TranslateAttributes"/>, which runs mid-cascade for
+        /// the table box itself, before a cell descendant's own <see cref="CascadeApplyStyles"/> call has
+        /// run. Setting a cell's property that early diverges its <c>ComputedStyle</c> away from the
+        /// shared <c>Default</c> singleton, which then makes that cell's own (still-pending)
+        /// <see cref="CascadeApplyStyles"/> call take its defaulting-loop's non-fast-path branch and
+        /// re-assert every property's initial value - silently clobbering the value just cascaded from
+        /// the table. Running this pass only after the whole tree's cascade has completed avoids that
+        /// entirely (issue #636). It runs before <see cref="CorrectAnonymousTables"/> so the tree still
+        /// has its as-authored shape, matching what <see cref="SetForAllCells"/>'s traversal expects.
+        /// </remarks>
+        private static void ApplyTablePresentationalAttributesToCells(CssBox box)
+        {
+            if (box.HtmlTag is { } tag && tag.Name.Equals(HtmlConstants.Table, StringComparison.OrdinalIgnoreCase))
+            {
+                var border = tag.TryGetAttribute(HtmlConstants.Border);
+                if (!string.IsNullOrEmpty(border) && border != "0")
+                {
+                    ApplyTableBorder(box, "1px");
+                }
+
+                var cellpadding = tag.TryGetAttribute(HtmlConstants.Cellpadding);
+                if (!string.IsNullOrEmpty(cellpadding))
+                {
+                    ApplyTablePadding(box, cellpadding);
+                }
+            }
+
+            foreach (var childBox in box.Boxes)
+            {
+                ApplyTablePresentationalAttributesToCells(childBox);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- The deprecated presentational `border`/`cellpadding` HTML attributes on a `<table>` never actually reached `<td>` cells, even though `SetForAllCells` correctly located them - `ApplyTableBorder`/`ApplyTablePadding` ran mid-cascade, from inside the table's own `TranslateAttributes` call, before a cell descendant's own `CascadeApplyStyles` pass had run. Writing to the cell that early diverged its `ComputedStyle` away from the shared `Default` singleton, which made the cell's still-pending cascade take its defaulting loop's non-fast-path branch and silently reset the value right back to its CSS initial value.
- Moved the per-cell cascade into its own pass (`DomParser.ApplyTablePresentationalAttributesToCells`), run once after the whole tree's cascade has finished, so the values survive.

## Test plan
- [x] Added regression tests in `PresentationalAttributeIntegrationTests.cs` covering `border`/`cellpadding` cascading to cells (with/without an explicit `<tbody>`, and `border="0"` not cascading), written test-first and confirmed to fail against the pre-fix code.
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - full suite green (8875 tests).
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` - zero warnings.
- [x] Verified diff coverage on the changed lines via the collected Cobertura report.

Fixes #636