### PR TITLE
Record two gaps found while reviewing #784 as accepted gaps

### DIFF
--- a/.claude/accepted-gaps/absolute-fixed-content-inside-a-thead-tfoot-resolves-against-the-wrong-containing-block.md
+++ b/.claude/accepted-gaps/absolute-fixed-content-inside-a-thead-tfoot-resolves-against-the-wrong-containing-block.md
@@ -1,0 +1,31 @@
+# `position: absolute`/`fixed` content with no positioned ancestor, inside a `<thead>`/`<tfoot>` cell, resolves against the wrong containing block
+
+Tracking issue: [#787](https://github.com/jhaygood86/PeachPDF/issues/787).
+
+`DomUtils.GetNearestPositionedAncestor` walks a box's `ParentBox` chain and falls back to "the root"
+when it finds no positioned ancestor - correct for the true document root, but
+`CssLayoutEngineTable.RemoveHeaderFooterFromTree` sets `_headerBox`/`_footerBox`'s own `ParentBox` to
+`null` to detach a `<thead>`/`<tfoot>` from the live tree *before* `DetachAndMeasureRepeatedRowGroups`
+lays its rows out. For any absolutely/fixed-positioned descendant inside a header/footer cell with no
+positioned ancestor of its own, the walk hits `_headerBox`/`_footerBox` itself and stops there, treating
+a detached, not-yet-positioned mid-tree box as the initial containing block - and since that box's own
+`Location` isn't set until after its row content has already laid out, `left`/`top` resolve against
+roughly `(0, 0)` instead of the real page origin. Confirmed empirically: identical
+`position: absolute; top: 5px; left: 5px` content lands at the correct page-relative position outside
+any table, but inside a `<thead>` cell it lands with its X coordinate alone showing a `(0, 0)` base
+instead of the page's own content-area origin.
+
+This is independent of `writing-mode`, of whether the header/footer actually repeats across pages, and
+of issue #784 (found while reviewing that fix, but pre-existing and unrelated to it) - it affects any
+table with a `<thead>`/`<tfoot>` containing absolutely/fixed-positioned content that has no positioned
+ancestor of its own, which is a common real-world pattern (a small badge/icon overlay in a header cell).
+A related, secondary gap: `BoxGeometrySnapshot.Translate`/`ReflectSubtree` (the mechanism that keeps a
+repeating header/footer's painted snapshot in sync with a live-tree translation) don't have an
+equivalent to `CssBox.OffsetLeft`/`OffsetTop`'s own `EscapesTranslationOf` guard, so once the primary
+containing-block bug above is fixed, an out-of-flow descendant that should stay put during a group-wide
+shift would still move with it in the painted snapshot - worth fixing in the same pass, since testing it
+meaningfully depends on the primary fix landing first.
+
+Not fixed here: this needs `GetNearestPositionedAncestor` (or its caller) to recognize a detached
+subtree's own root and fall back to the true document root/initial containing block instead, which is a
+real, separate investigation and fix - not a narrow adjustment to the #784 work that surfaced it.

--- a/.claude/accepted-gaps/rowspan-crossing-a-thead-tfoot-tbody-boundary-produces-unspecified-geometry.md
+++ b/.claude/accepted-gaps/rowspan-crossing-a-thead-tfoot-tbody-boundary-produces-unspecified-geometry.md
@@ -1,0 +1,31 @@
+# A rowspan cell spanning from `<thead>`/`<tfoot>` into `<tbody>` produces unspecified geometry
+
+Tracking issue: [#788](https://github.com/jhaygood86/PeachPDF/issues/788).
+
+Found during a post-change review pass of issue #784. `TableGrid`/column-placement (`AssignBoxKinds`'s
+combined `_allRows`, `GetLastRowInGrid`'s unclamped header-row arithmetic) genuinely treat a
+`<thead>`/`<tfoot>`-opened rowspan as reaching into `<tbody>`, reserving that column there and shifting
+the tbody row's own cell sideways to make room. But `DetachAndMeasureRepeatedRowGroups`'s own
+rowspan-closing bookkeeping (`headerSpanningCellsEndingOnRow`/`footerSpanningCellsEndingOnRow`,
+`GetEffectiveEndRowIndex` capped at the group's own row count) is entirely disjoint from the body's own
+(`cursor.RowSpannedBoxes`), so such a cell is silently coerced to close at the group's own last row -
+never reaching the body row the grid layer already reserved a column for. The result is a phantom,
+unfilled gap in the tbody row: no cell paints there and no `CssSpacingBox` placeholder stands in for it
+either, since `InsertEmptyBoxes` only ever iterates `_bodyRows`.
+
+This doesn't crash (an existing fix already clamps `TableGrid.Build`'s own row-count arithmetic against
+the whole table rather than one group), but produces geometry the suite's own
+`TableLayout_RowspanExceedingTheadsOwnRowCount_DoesNotThrow` test already documents as unspecified in
+its own doc comment ("the exact geometry a malformed rowspan this large produces isn't otherwise
+specified").
+
+Not attempted as part of #784's own narrower fix (a rowspan cell *entirely contained within* a multi-row
+header/footer group, which only needed one existing scan widened). A real fix for the cross-boundary
+case would need the group-local closing bookkeeping to stop clamping at the group's own last row and
+defer actually closing such a cell until the real body row it ends on has laid out - on an entirely
+separate pass and cursor, potentially on a different page - plus a way for `InsertEmptyBoxes` to place a
+continuation placeholder in `_bodyRows` for a cell that isn't itself part of it, plus reconciling this
+with header/footer repetition at all (what does "the header's rowspan continues into the body" mean on
+a later page, where a fresh header proxy repeats?). Real browsers' own behavior spanning a `rowspan`
+across this boundary is itself inconsistent/questionable, which may make this worth keeping as a
+documented, permanent gap rather than implementing.


### PR DESCRIPTION
## Summary
- Documents two pre-existing gaps surfaced (not introduced) while doing a post-change review pass of #784, each in its own `.claude/accepted-gaps/` file per this repo's own convention.
- Tracks #787 (absolutely/fixed-positioned content with no positioned ancestor inside a `<thead>`/`<tfoot>` cell resolves against the wrong containing block) and #788 (a rowspan cell spanning from `<thead>`/`<tfoot>` into `<tbody>` produces unspecified geometry).
- Both issues remain open — this PR only records them as tracked, accepted gaps; it does not fix either.

## Test plan
- Docs-only change, no code touched.