### PR TITLE
Fix stale "no vertical-writing-mode support" doc claim for vi/vb/cqi/cqb

### DIFF
--- a/.claude/accepted-gaps/viewport-and-container-inline-block-units-ignore-writing-mode.md
+++ b/.claude/accepted-gaps/viewport-and-container-inline-block-units-ignore-writing-mode.md
@@ -1,0 +1,31 @@
+# `vi`/`vb` and `cqi`/`cqb` don't follow the root/container's `writing-mode`
+
+Tracking issue: [#795](https://github.com/jhaygood86/PeachPDF/issues/795). Part of the real vertical
+`writing-mode: vertical-rl`/`vertical-lr` layout work tracked in
+[#547](https://github.com/jhaygood86/PeachPDF/issues/547); see
+[.claude/accepted-gaps/no-vertical-writing-mode-layout.md](no-vertical-writing-mode-layout.md) for the
+rest of that project's scope.
+
+[CSS Values and Units 4 §6.2](https://www.w3.org/TR/css-values-4/#viewport-relative-lengths) defines
+`vi`/`vb` as relative to the initial containing block's size in the inline/block axis of the *root
+element's own* writing mode, and [CSS Containment 3 §6.2](https://www.w3.org/TR/css-contain-3/#container-lengths)
+defines `cqi`/`cqb` the same way against a query container's own writing mode. Under
+`vertical-rl`/`vertical-lr`, `vi` should track the physical height axis and `vb` the physical width axis —
+the inline/block axes are rotated 90° from `horizontal-tb`.
+
+`Length.ToPixels` (`src/PeachPDF/CSS/Values/Length.cs`) resolves both pairs as plain physical aliases
+regardless of writing-mode: `Unit.Vi` always shares `Unit.Vw`'s `viewportWidthPt` branch and `Unit.Vb`
+always shares `Unit.Vh`'s `viewportHeightPt` branch; `Unit.Cqi`/`Unit.Cqb` are aliased to
+`containerInlineSizePt`/`containerBlockSizePt` the same way, but those parameters are themselves always
+populated from physical width/height, with no writing-mode-aware inline/block resolution anywhere in the
+call chain.
+
+This is narrower than, and independent of, the rest of the real vertical-writing-mode layout work: box,
+line, flex, and table layout already correctly rotate the inline/block axis via `WritingModeFrame`/
+`LogicalPropertyResolver`, but no viewport- or container-unit resolution path consults either of those.
+Closing this needs `Length.ToPixels`'s `Vi`/`Vb`/`Cqi`/`Cqb` branches (and the container-unit basis
+lookup) to consult the relevant box's resolved `WritingMode` and swap in the block-axis basis when it's
+vertical, mirroring how `LogicalPropertyResolver` already does for margin/padding/inset.
+
+The reader-facing note is in `docs/html-css-support.md`'s CSS Viewport Units and CSS Container Queries
+sections.

--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -1030,9 +1030,12 @@ against is the PDF page box — the same page-box dimensions [CSS Media Queries]
 | `vmin` | 1% of the smaller of the page box's width and height |
 | `vmax` | 1% of the larger of the page box's width and height |
 
-`vi`/`vb` (the logical inline/block axis forms) are treated the same as `vw`/`vh` — PeachPDF has no
-vertical-writing-mode support, so the inline axis is always horizontal and the block axis always
-vertical, the same treatment [`cqi`/`cqb`](#css-container-queries) already get.
+`vi`/`vb` (the logical inline/block axis forms) are treated the same as `vw`/`vh` — they always resolve
+against the page box's physical width/height and do not follow the root element's own `writing-mode`,
+the same treatment [`cqi`/`cqb`](#css-container-queries) give a query container's own `writing-mode`.
+This is narrower than the [real vertical-writing-mode layout](#text-layout) supported elsewhere in the
+engine: a `vertical-rl`/`vertical-lr` root element still gets `vi === vw` and `vb === vh` rather than the
+inline/block axis actually rotating with it.
 
 The small (`sv*`), large (`lv*`), and dynamic (`dv*`) viewport variants (`svw`, `svh`, `svi`, `svb`,
 `svmin`, `svmax`, and the equivalent `lv*`/`dv*` forms) are all fully supported, and all resolve
@@ -1078,8 +1081,8 @@ Supported ([CSS Containment 3](https://developer.mozilla.org/en-US/docs/Web/CSS/
 | `width`/`min-width`/`max-width`/`inline-size` (and the `min-`/`max-`/range-syntax forms) | Evaluated against the container's own resolved inline-axis size |
 | `height`/`min-height`/`max-height`/`block-size`, `aspect-ratio`, `orientation` | Evaluated against the container's own resolved block-axis size — **only meaningful against a `container-type: size` container**; against an `inline-size`-only container these never match (it tracks the inline axis only), regardless of the container's actual height |
 | `style(<property>: <value>)` | Matches when the nearest eligible ancestor query container's own resolved value for `<property>` equals `<value>`. Unlike size queries, **any** query container is eligible regardless of `container-type` — `container-type: normal` (the initial value, so effectively any element) still qualifies, since a style query needs no layout containment. `and`/`or`/`not` combine multiple `style()` feature checks; a combined operand needs its own parenthesized declaration (`style((--a: 1) and (--b: 2))`), matching `@supports`'s own grammar. Comparison is a trimmed, literal-text match against the container's resolved value — reliable for custom properties (values are opaque, author-controlled text) and for a standard property whose authored value already matches PeachPDF's own canonical serialization (e.g. keyword values like `style(display: block)`), but not full computed-value equivalence (`style(color: red)` won't match a container that resolves to `rgb(255, 0, 0)`) |
-| `cqw`, `cqi` | 1% of the nearest ancestor query container's own resolved inline-axis size |
-| `cqh`, `cqb` | 1% of the nearest ancestor query container's own resolved block-axis size (only meaningful against a `size` container — `0` against an `inline-size`-only one, which doesn't track that axis) |
+| `cqw`, `cqi` | 1% of the nearest ancestor query container's own resolved inline-axis size — `cqi` is always treated as `cqw` (physical width), not adjusted for the container's own `writing-mode` (see the equivalent `vi`/`vb` caveat under [CSS Viewport Units](#css-viewport-units)) |
+| `cqh`, `cqb` | 1% of the nearest ancestor query container's own resolved block-axis size (only meaningful against a `size` container — `0` against an `inline-size`-only one, which doesn't track that axis) — `cqb` is always treated as `cqh` (physical height), same caveat as `cqi` above |
 | `cqmin`, `cqmax` | The smaller/larger of `cqi` and `cqb` |
 | Container-relative unit with no eligible ancestor container | Falls back to the corresponding small-viewport unit (`cqw`→`svw`, `cqh`→`svh`, `cqi`→`svi`, `cqb`→`svb`, `cqmin`→`svmin`, `cqmax`→`svmax`) — see [CSS Viewport Units](#css-viewport-units) |
 | Container-relative unit in `font-size` (e.g. `font-size: 10cqw`) | Resolves to `0` for any element with text content — a font-caching order limitation, not the general no-ancestor-container fallback above; a real ancestor container is found, but its size isn't available yet at the point text content first resolves the font. Works only for the uncommon case of an element with no text content of its own |

--- a/src/PeachPDF/CSS/Values/Length.cs
+++ b/src/PeachPDF/CSS/Values/Length.cs
@@ -439,10 +439,11 @@ namespace PeachPDF.CSS
             Cqmin,
             Cqmax,
             // CSS Values and Units 4 §6.2 small/large/dynamic viewport-percentage units. Vi/Vb get the
-            // same horizontal-tb-only treatment Cqi/Cqb already have (Vi === Vw, Vb === Vh) - this engine
-            // has no vertical-writing-mode support. Small/large/dynamic variants all resolve identically
-            // here (see ToPixels) - a PDF page box has no scrollbar or dynamic browser chrome to distinguish
-            // them by.
+            // same horizontal-tb-only treatment Cqi/Cqb already have (Vi === Vw, Vb === Vh) - neither is
+            // adjusted for the root element's/container's own writing-mode, independent of this engine's
+            // real vertical-writing-mode layout support elsewhere (see docs/html-css-support.md's CSS
+            // Viewport Units section). Small/large/dynamic variants all resolve identically here (see
+            // ToPixels) - a PDF page box has no scrollbar or dynamic browser chrome to distinguish them by.
             Vi,
             Vb,
             Svw,


### PR DESCRIPTION
## Summary

`docs/html-css-support.md`'s `vi`/`vb`/`cqi`/`cqb` rows claimed "PeachPDF has no vertical-writing-mode support" as the justification for aliasing these logical units to their physical (`vw`/`vh`/`cqw`/`cqh`) equivalents. That claim predates this project's vertical-writing-mode layout work and is no longer true - real `vertical-rl`/`vertical-lr` layout and painting are supported elsewhere in the engine.

This corrects the doc wording to describe the actual, narrower limitation (these four units specifically don't follow the root/container's own `writing-mode`) and records it as its own accepted gap with a tracking issue, consistent with how every other vertical-writing-mode limitation in this project is documented.

## Test plan

- [x] Documentation-only change plus a new accepted-gap file; no code behavior changed beyond a comment clarification in `Length.cs`
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` - 0 warnings, 0 errors