### PR TITLE
Fix crash generating PDFs for documents with an empty-fragment anchor link

### DIFF
--- a/.claude/recent-fixes/2026-08-22-empty-fragment-anchor-link-crash.md
+++ b/.claude/recent-fixes/2026-08-22-empty-fragment-anchor-link-crash.md
@@ -1,0 +1,34 @@
+# Empty-fragment anchor link (`<a href="#">`) crashed PDF generation
+
+`PdfGenerator.HandleLinks`'s local `ResolveAnchorTarget(anchorId)` helper called
+`HtmlContainer.GetElementRectangle(anchorId)` unconditionally for every link where
+`LinkElementData.IsAnchor` is true (`Href[0] == '#'`). `LinkElementData.AnchorId` returns
+`string.Empty` when `Href` is exactly `"#"` (length 1) rather than `"#some-id"` - a very common
+real-world pattern for a JS-driven no-op link (`<a href="#">click me</a>`, popular in copy-pasted
+"kitchen sink" HTML samples - this is exactly how issue #801 was found). `GetElementRectangle`
+asserts its `elementId` argument is non-null/non-empty via `ArgChecker.AssertArgNotNullOrEmpty` and
+throws `ArgumentNullException("elementId")`, which surfaced to the user as a generation-halting crash
+for any document containing such a link - no way to opt out or work around it short of stripping the
+link from the HTML first.
+
+**Fix:** `ResolveAnchorTarget` now returns `null` immediately when `anchorId.Length == 0`, before
+calling `GetElementRectangle`. Both call sites that reach it already treat a `null` result as "no
+target, don't create an annotation" (`if (target is not { } t) continue;` in both the main
+`HandleLinks` loop and `HandleRunningElementLinks`), so a single guard in the shared helper fixes both
+paths - the running-element path (`PdfGenerator.cs`'s `HandleRunningElementLinks`, which independently
+derives `anchorId = href[1..]` from the running-element box's own `href` attribute) had the exact same
+bug via its own code path into the same helper.
+
+**Not done:** `BookmarkOutlineBuilder.ApplyDestination` was already correct - it guards with
+`target.Length > 1 && target[0] == '#'` before slicing, so `target[1..]` is never empty there. That
+existing pattern is what confirmed the fix here should live in the shared resolver rather than only
+guarding the AnchorId-producing side.
+
+**Evidence:** reproduced the crash with the exact HTML from issue #801 (a large HTML5-kitchen-sink
+sample containing `<a href="#">Home</a>` inside a `<menuitem>`) via the CLI - confirmed the pre-fix
+build throws `System.ArgumentNullException: Value cannot be null. (Parameter 'elementId')` mid-paint,
+and the post-fix build generates the PDF successfully. Added
+`AnchorLink_EmptyFragment_DoesNotThrowAndAddsNoAnnotation` to
+`PeachPDF.Tests/Integration/AnchorLinkDestinationTests.cs` asserting generation doesn't throw and adds
+no annotation for `<a href="#">`. Full `dotnet test --framework net8.0` suite (9107 passed, 9 skipped,
+0 failed) and `dotnet build PeachPDF.slnx -t:Rebuild` (0 warnings) both clean.

--- a/src/PeachPDF.Tests/Integration/AnchorLinkDestinationTests.cs
+++ b/src/PeachPDF.Tests/Integration/AnchorLinkDestinationTests.cs
@@ -59,6 +59,21 @@ namespace PeachPDF.Tests.Integration
                 $"Target starts its own fresh page (break-before:page), so its bottom-up Top ({top}) should be near the full page height ({pageHeight}), not near 0.");
         }
 
+        // Regression test for issue #801: an `<a href="#">` (an empty fragment, a common JS-driven
+        // no-op link pattern in real-world HTML) has Href.Length == 1, so LinkElementData.AnchorId
+        // evaluates to string.Empty rather than a real id. HandleLinks's ResolveAnchorTarget local
+        // passed that empty string straight to HtmlContainer.GetElementRectangle, which asserts its
+        // elementId argument is non-null/non-empty and threw ArgumentNullException("elementId"),
+        // crashing PDF generation for any document containing such a link.
+        [Fact]
+        public async Task AnchorLink_EmptyFragment_DoesNotThrowAndAddsNoAnnotation()
+        {
+            var html = "<html><body><a href='#'>no-op</a></body></html>";
+            var result = await new PdfGenerator().GeneratePdf(html, PageSize.A4);
+
+            Assert.Equal(0, result.PdfDocument.Pages[0].Annotations.Count);
+        }
+
         // PdfGenerator.HandleLinks always calls the internal HtmlContainer.GetLinks(bookmarkBoxes)
         // overload now (so bookmark collection rides along on the same walk, see
         // DomUtils.GetAllLinkAndBookmarkBoxes), leaving the public no-arg GetLinks() only reachable by

--- a/src/PeachPDF/PdfGenerator.cs
+++ b/src/PeachPDF/PdfGenerator.cs
@@ -626,6 +626,12 @@ namespace PeachPDF
             // never disagree about which page an anchor lands on.
             (int PageIndex, double TopPt)? ResolveAnchorTarget(string anchorId)
             {
+                // href="#" (an empty fragment, commonly used as a JS-driven no-op link) reaches here
+                // as an empty anchorId - there is no element to target, so treat it the same as an
+                // anchor whose target simply wasn't found rather than let the elementId-not-null-or-empty
+                // guard inside GetElementRectangle throw.
+                if (anchorId.Length == 0) return null;
+
                 var anchorRect = container.GetElementRectangle(anchorId);
                 return anchorRect.HasValue
                     ? PageAnchorResolver.ResolveRectToPage(inner, ppp, slotToPage, maxMappedSlot, fragmentainers.Count, anchorRect.Value)


### PR DESCRIPTION
## Summary
- `<a href="#">` — a common JS-driven no-op link pattern — has an empty `AnchorId`. `PdfGenerator.HandleLinks`'s `ResolveAnchorTarget` helper passed that empty id straight into `HtmlContainer.GetElementRectangle`, which throws `ArgumentNullException("elementId")` on a null/empty id, crashing PDF generation for any document containing such a link.
- Guard `ResolveAnchorTarget` to return `null` for an empty anchor id before calling `GetElementRectangle`. Both call sites already treat a `null` result as "no target, skip the annotation" (`HandleLinks`'s main loop and `HandleRunningElementLinks`), so this single guard fixes both paths.
- Reproduced with the exact "kitchen sink" HTML sample from the issue (contains `<a href="#">Home</a>`) via the CLI; confirmed the crash before the fix and clean PDF generation after.

## Test plan
- [x] Added `AnchorLink_EmptyFragment_DoesNotThrowAndAddsNoAnnotation` to `PeachPDF.Tests/Integration/AnchorLinkDestinationTests.cs`
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 9107 passed, 9 skipped, 0 failed
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings, 0 errors
- [x] Manually reproduced the original crash with the issue's sample HTML via the CLI and confirmed the fix resolves it

Fixes #801