### PR TITLE
Fix vertical-rl auto-width shrink corrupting absolute/fixed positioned boxes

### DIFF
--- a/.claude/accepted-gaps/no-vertical-writing-mode-layout.md
+++ b/.claude/accepted-gaps/no-vertical-writing-mode-layout.md
@@ -201,7 +201,9 @@ atomic replaced element (`<img>`) already is. (Its own *outer width*, when auto,
 — see [#777](https://github.com/jhaygood86/PeachPDF/issues/777), closed, below.) Auto width/height on the
 vertical box itself shrink to the accumulated block-axis/
 cross-axis extent of its children, reusing `CssLayoutEngine.ShrinkAutoWidthTo` (widened to `internal`) —
-the same block-start-stays-fixed mechanism the inline-only case already established.
+the same block-start-stays-fixed mechanism the inline-only case already established. (A same-writing-mode
+child's own contribution to that accumulation was, until [#798](https://github.com/jhaygood86/PeachPDF/issues/798),
+measured before that child's own auto-width shrink had run — see #798's own entry below.)
 
 Such a box is treated as monolithic with respect to its parent's own page fragmentation, the same
 `MonolithicContent.IsUnresumableOrthogonalFlow` treatment the inline-only case and a vertical table already
@@ -517,16 +519,32 @@ an active shift toward the bottom edge. Verified with new integration test files
 tests, zero regressions).
 
 Three narrower, pre-existing bugs were found (not introduced) while building and testing #768, confirmed
-independent of its own five features, and deliberately left unfixed — each has its own tracking issue since
-each needs its own focused fix: a float's own starting position inside a vertical box's block content is
-physically meaningless, and `clear` on an ordinary block child is unimplemented
-([#796](https://github.com/jhaygood86/PeachPDF/issues/796)); an RTL auto-height inline-only vertical box
-positions its words against the placement-time provisional (page-height) bottom edge rather than the box's
-own final settled one ([#797](https://github.com/jhaygood86/PeachPDF/issues/797), from #761/#778-era code);
-and `CreateVerticalLineBoxes`'s own auto-width shrink (#761) corrupts `Location.X` for an
-absolutely/fixed-positioned descendant with an auto width, since it assumes `Location.X` is always a
-block-start edge free to move, which is false once a CSS `left` offset already gave it real meaning
-([#798](https://github.com/jhaygood86/PeachPDF/issues/798)).
+independent of its own five features — each had its own tracking issue since each needed its own focused
+fix: a float's own starting position inside a vertical box's block content is physically meaningless, and
+`clear` on an ordinary block child is unimplemented ([#796](https://github.com/jhaygood86/PeachPDF/issues/796));
+an RTL auto-height inline-only vertical box positions its words against the placement-time provisional
+(page-height) bottom edge rather than the box's own final settled one
+([#797](https://github.com/jhaygood86/PeachPDF/issues/797), from #761/#778-era code); and
+`CreateVerticalLineBoxes`'s own auto-width shrink (#761) corrupted `Location.X` for an absolutely/fixed-
+positioned descendant with an auto width, since it assumed `Location.X` was always a block-start edge free
+to move, which is false once a CSS `left` offset already gave it real meaning.
+[#798](https://github.com/jhaygood86/PeachPDF/issues/798) fixes this properly rather than just gating it
+off: for `vertical-rl` specifically, `Location.X` now stays pinned to the CSS `left` offset while the
+box's already-laid-out content (words and descendants, placed against a pre-shrink placeholder anchor
+before the true content extent was known) is reconciled against it with a new `CssBox.OffsetContentLeft`
+primitive — a variant of the existing `OffsetLeft` subtree translator that moves everything *except* the
+box's own `Location` — so the box's auto width still genuinely shrinks to content instead of only its
+position being correct (`vertical-lr` was never affected: its anchor, `ClientLeft`, was always already
+tied to `Location.X`). Fixing this surfaced a second, distinct pre-existing bug in the same area, also
+fixed by #798: `CssBox.LayoutVerticalBlockChildren` measured a same-writing-mode block-level child's width
+from `ResolveOwnInlineSize`'s pre-content-layout (stretch-to-available) estimate, before that child's own
+auto-width shrink — which only runs later, inside its own content layout — had actually narrowed it, so an
+auto-width vertical-rl box with block-level (not just inline) children never shrunk to fit regardless of
+positioning scheme. Now re-measured after the child's own content layout runs — no further `Location.X`
+correction needed even for `vertical-rl`: a child with its own recursive `ShrinkAutoWidthTo` (inline
+content, or a nested block-children pass) already re-anchored its own `Location.X` against its own
+pre-shrink `ActualRight` during that call, so re-deriving it again from the stale placeholder width here
+would double-apply the same shift.
 
 ## What's still out of scope
 
@@ -539,9 +557,6 @@ block-start edge free to move, which is false once a CSS `left` offset already g
   provisional bottom edge instead of its own final settled one**, landing them outside the box entirely
   ([#797](https://github.com/jhaygood86/PeachPDF/issues/797)) — reproduces with plain text, independent of
   `text-align`/bidi/hyphenation/floats/positioning.
-- **`CreateVerticalLineBoxes`'s own auto-width shrink corrupts `Location.X` for an absolutely/fixed-positioned
-  descendant whose own width is auto** ([#798](https://github.com/jhaygood86/PeachPDF/issues/798)) — an
-  explicit `width` avoids the bug.
 - **A nested inline element's own border/padding/margin does not reserve inline-axis (physical left/right,
   for `vertical-rl`/`vertical-lr`) space** ([#769](https://github.com/jhaygood86/PeachPDF/issues/769)), and
   its block-axis (physical top/bottom) padding/border is applied once per column it spans rather than once

--- a/.claude/recent-fixes/2026-08-23-vertical-rl-out-of-flow-shrink-preserves-location.md
+++ b/.claude/recent-fixes/2026-08-23-vertical-rl-out-of-flow-shrink-preserves-location.md
@@ -1,0 +1,82 @@
+# Vertical-rl out-of-flow shrink preserves Location.X
+
+_Landed 2026-08-23._
+
+[Issue #798](https://github.com/jhaygood86/PeachPDF/issues/798): `CssLayoutEngine.ShrinkAutoWidthTo`
+(added for #761) shrinks a vertical box's auto width to its content's own block-axis extent. For
+`vertical-rl` (`WritingModeFrame.BlockStartIsRight`), it did this by capturing the pre-shrink
+`ActualRight`, overwriting `Location.X` with a content-derived value, then re-applying the captured
+`ActualRight` — correct for an ordinary in-flow box, where `Location.X` is just wherever the parent's
+block-axis cursor put it, genuinely free to move. For an absolutely/fixed-positioned box, `Location.X`
+was already set by `CssBox.CommitBlockChildOffset` from the box's own CSS `left` offset *before* this
+box's own content layout ran — a real, CSS-meaningful value, not a placeholder — so overwriting it
+silently discarded the offset.
+
+**First cut (gate on `!IsOutOfFlow`) was too broad.** The obvious minimal fix — skip the shrink entirely
+whenever the box is out-of-flow — used `CssBox.IsOutOfFlow` (`IsFloated || Position is Absolute or
+Fixed`), which also matches floats. A float's `Location.X` comes from `CommitBlockChildOffset`'s
+*flow-stacking* branch (`CssLayoutEngine.FloatBox` avoidance), not a CSS offset — exactly as free to
+move as an ordinary in-flow box's, and was never buggy. Gating on `IsOutOfFlow` would have silently
+stopped floats from shrinking to content too. A code-review pass (two independent finder agents, one via
+`code-review`, one custom) caught this from first principles by reading `CommitBlockChildOffset` itself
+rather than trusting the `IsOutOfFlow` name. Narrowed to `Position.Value is PositionMode.Absolute or
+PositionMode.Fixed`; a new test (`VerticalRl_FloatWithAutoWidth_StillShrinksToContent`) pins that floats
+keep shrinking.
+
+**Skipping the shrink entirely (rather than reconciling it) was itself checked and rejected.** A
+diagnostic run showed `Position.Fixed` with a single-glyph auto-width span landing at **150pt** wide
+(not content-sized at all — `CssLayoutEngine.GetBoxWidth`'s shrink-to-fit branch is gated on
+`Position.Absolute` only, excluding `Fixed`), and `Position.Absolute` with a block-level child at
+**~206pt** (the container's full available width). Position was correct; width silently stopped
+shrinking to fit in exactly the cases PeachPDF's general (non-vertical-aware) width resolution doesn't
+already produce a tight value. Real fix: `Location.X` stays pinned, and the box's already-laid-out
+content — words and descendants, placed by `CreateVerticalLineBoxes`/`LayoutVerticalBlockChildren`
+against a pre-shrink placeholder anchor (`ClientRight` at frame-construction time, unrelated to the true
+`left` offset) before the true content extent was known — is reconciled against the pinned edge with a
+uniform physical-X shift (`WritingModeFrame.ToPhysical` is a pure translation for a fixed frame, so the
+gap between the two anchors is provably a constant delta, not a reordering).
+
+**The shift primitive already existed, just coupled to moving `Location` too.** `CssBox.OffsetLeft`
+already deep-translates a box's own `Rectangles`/`Words` and recurses into `Boxes` (skipping a descendant
+whose containing block lies outside the translation root via `EscapesTranslationOf`), then moves the
+box's own `Location.X` and fires `OnTranslated`/fragment-tree invalidation. Factored the
+`Rectangles`/`Words` part out into `ShiftOwnLineGeometryLeft`, shared by the existing `OffsetLeft` and a
+new `CssBox.OffsetContentLeft` that does everything `OffsetLeft` does *except* move `this.Location` —
+exactly what's needed when the box's own position is pinned but its content isn't. `Word.Left`/`Top` are
+absolute physical coordinates (not box-relative), confirmed by tracing `CssRect`'s backing field, so this
+shift is load-bearing, not optional — without it the content stays painted at the old placeholder
+position while the box's own reported bounds shrink around a different one.
+
+**A third, unrelated bug surfaced while verifying the width fix, and got fixed in the same change** (the
+same block-content diagnostic that exposed the `Position.Fixed`/`Position.Absolute` gaps above also hit
+it): `CssBox.LayoutVerticalBlockChildren` measures a same-writing-mode block-level child's `childWidth`
+from `ResolveOwnInlineSize`'s pre-content-layout (stretch-to-available) estimate — *before* that child's
+own auto-width shrink, which only runs later inside `LayoutContentAtItsAssignedPosition`, has actually
+narrowed it. Reproduced with a plain **in-flow** `vertical-rl` box (no positioning involved at all):
+width stayed at ~555pt (full available width) regardless of #798. Fixed by re-reading the child's true
+width (`childBox.ActualRight - childBox.Location.X`) immediately after its own content layout runs, so
+the `logicalBlockOffset` accumulator reflects what the child actually occupies.
+
+**A first cut of that fix also re-derived the child's `Location.X`, which double-shifted it.** The
+reasoning seemed sound — mirror `ShrinkAutoWidthTo`'s own in-flow branch and move `Location.X` against
+the corrected width for `vertical-rl` — but missed that the child, if it has its own recursive
+`ShrinkAutoWidthTo` call (inline-only content dispatching to `CreateVerticalLineBoxes`, or block content
+to a nested `LayoutVerticalBlockChildren`), has *already* done exactly that: it captured its own
+pre-shrink `ActualRight` (the fixed block-start anchor this outer loop placed it against) before its own
+content layout touched anything, and moved its own `Location.X` against that same anchor. Re-deriving
+`Location.X` again here from the stale placeholder `childWidth` applied that shift a second time on top
+of an already-correct position. A second review pass caught it by actually running the code: the new
+test below only asserted width, which stayed correct throughout (translating a box moves `Location.X`
+and `ActualRight` together, leaving `Size.Width` — and so the assertion — unchanged), while `Location.X`
+silently landed the child's block-start edge **540pt past its own parent's content-box edge**. Fixed by
+deleting the `OffsetLeft` call outright — the child needs no position correction from its parent at all,
+`vertical-lr` or `vertical-rl` alike, only the accumulator does — and the test now also pins
+`box.ActualRight` against `wrapper.ClientRight` so a reintroduced double-shift fails loudly.
+
+Verified: rasterized the issue's own repro (both PDFium and MuPDF agree — the box sits tightly at (5pt,
+5pt) from its container, sized to the glyph, not stretched or misplaced); full net8.0 suite (9112
+passing, zero regressions); zero-warning `dotnet build -t:Rebuild`; every new/changed line covered
+(checked directly against the coverage XML, not assumed). Six new tests in
+`VerticalWritingModeLayoutIntegrationTests.cs` cover: absolute/fixed with auto-width inline content
+(position *and* width), floats (unaffected), and both absolute and plain in-flow boxes with auto-width
+block-level children (position *and* width, after the double-shift fix above).

--- a/src/PeachPDF.Tests/Integration/VerticalWritingModeLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/VerticalWritingModeLayoutIntegrationTests.cs
@@ -1397,9 +1397,8 @@ namespace PeachPDF.Tests.Integration
             // anonymous-block correction splits it out of "Before"/"After" the same way it splits out a
             // float; el itself ends up block-children-dispatched (LineBoxes.Count == 0), not inline-only,
             // so words are gathered from every descendant rather than from el's own LineBoxes. An explicit
-            // width sidesteps a separate, pre-existing bug (CreateVerticalLineBoxes's own auto-width-shrink
-            // logic, from #761, corrupts an absolutely-positioned descendant's own Location.X when its
-            // width is auto - unrelated to #768, not fixed here).
+            // width keeps this test focused on #768's own scope; the auto-width case (once a separate bug,
+            // #798) has its own test below.
             var html = LayoutHarness.Wrap("""
                 <div id="el" style="writing-mode: vertical-rl; position: relative; width: 200px; height: 200px">
                 Before <span id="abs" style="position: absolute; left: 5pt; top: 5pt; width: 20pt">X</span> After
@@ -1427,6 +1426,38 @@ namespace PeachPDF.Tests.Integration
             Assert.Equal(el.ClientTop + 5, abs.Location.Y, 1);
         }
 
+        // ── Issue #798: auto-width out-of-flow descendant no longer has its Location.X corrupted ──
+
+        [Fact]
+        public async Task VerticalRl_InlineNestedAbsolutePositionedSpanWithAutoWidth_PositionsAgainstAncestor()
+        {
+            // Same shape as VerticalRl_InlineNestedAbsolutePositionedSpan_..., minus the explicit width
+            // that test uses to dodge #798 - CreateVerticalLineBoxes's own auto-width shrink used to
+            // overwrite abs's Location.X (already correctly set from `left: 5pt` by CommitBlockChildOffset)
+            // with a content-derived value, since it assumed Location.X was always a free-to-move
+            // block-start edge. It isn't, for an out-of-flow box.
+            var html = LayoutHarness.Wrap("""
+                <div id="el" style="writing-mode: vertical-rl; position: relative; width: 200px; height: 200px">
+                Before <span id="abs" style="position: absolute; left: 5pt; top: 5pt">X</span> After
+                </div>
+                """);
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var el = LayoutHarness.FindById(root, "el");
+            var abs = LayoutHarness.FindById(root, "abs");
+            Assert.NotNull(el);
+            Assert.NotNull(abs);
+
+            Assert.Equal(el!.ClientLeft + 5, abs!.Location.X, 1);
+            Assert.Equal(el.ClientTop + 5, abs.Location.Y, 1);
+
+            // Width still shrinks to content too, not just position: the placeholder-anchored content is
+            // reconciled with the pinned Location.X via CssBox.OffsetContentLeft, not left at whatever
+            // unconstrained width the box had before its own content layout ran.
+            var width = abs.ActualRight - abs.Location.X;
+            Assert.True(width > 0 && width < 50, $"auto width should shrink to its short content, got {width}");
+        }
+
         [Fact]
         public async Task VerticalRl_InlineNestedFixedPositionedSpan_PositionsAgainstThePage()
         {
@@ -1442,6 +1473,107 @@ namespace PeachPDF.Tests.Integration
 
             Assert.Equal(10, fixedBox!.Location.X, 1);
             Assert.Equal(10, fixedBox.Location.Y, 1);
+        }
+
+        [Fact]
+        public async Task VerticalRl_InlineNestedFixedPositionedSpanWithAutoWidth_PositionsAgainstThePage()
+        {
+            // Auto-width counterpart of VerticalRl_InlineNestedFixedPositionedSpan_PositionsAgainstThePage,
+            // covering the Position.Fixed branch of the same #798 fix.
+            var html = LayoutHarness.Wrap("""
+                <div id="el" style="writing-mode: vertical-rl; width: 200px; height: 200px">
+                Before <span id="fixed" style="position: fixed; left: 10pt; top: 10pt">X</span> After
+                </div>
+                """);
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var fixedBox = LayoutHarness.FindById(root, "fixed");
+            Assert.NotNull(fixedBox);
+
+            Assert.Equal(10, fixedBox!.Location.X, 1);
+            Assert.Equal(10, fixedBox.Location.Y, 1);
+
+            var width = fixedBox.ActualRight - fixedBox.Location.X;
+            Assert.True(width > 0 && width < 50, $"auto width should shrink to its short content, got {width}");
+        }
+
+        [Fact]
+        public async Task VerticalRl_AbsolutePositionedBoxWithBlockContent_WidthShrinksToContentToo()
+        {
+            // A block-level (not inline-only) child dispatches through LayoutVerticalBlockChildren rather
+            // than CreateVerticalLineBoxes - absBox's own width:auto shrink happens there instead, via the
+            // same ShrinkAutoWidthTo call, so it needs the identical Location.X-preserving treatment.
+            var html = LayoutHarness.Wrap("""
+                <div id="wrapper" style="width: 600pt; writing-mode: vertical-rl; position: relative">
+                <div id="absBox" style="position: absolute; left: 10pt; top: 10pt">
+                <p>A block child not this box's own direct text</p>
+                </div>
+                </div>
+                """);
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var wrapper = LayoutHarness.FindById(root, "wrapper");
+            var absBox = LayoutHarness.FindById(root, "absBox");
+            Assert.NotNull(wrapper);
+            Assert.NotNull(absBox);
+
+            Assert.Equal(wrapper!.ClientLeft + 10, absBox!.Location.X, 1);
+            Assert.Equal(wrapper.ClientTop + 10, absBox.Location.Y, 1);
+
+            var width = absBox.ActualRight - absBox.Location.X;
+            Assert.True(width > 0 && width < 50, $"auto width should shrink to its short content, got {width}");
+        }
+
+        [Fact]
+        public async Task VerticalRl_InFlowBoxWithAutoWidthBlockChild_WidthShrinksToContent()
+        {
+            // Not an out-of-flow scenario at all: LayoutVerticalBlockChildren measured a same-writing-mode
+            // block child's width from ResolveOwnInlineSize's pre-content-layout (stretch) estimate, before
+            // that child's own auto-width shrink (inside its own content layout) had actually narrowed it -
+            // so the parent's own shrink-to-fit accumulated the wrong, unshrunk child width regardless of
+            // positioning scheme. Independent of #798, found while verifying its fix.
+            var html = LayoutHarness.Wrap("""
+                <div id="wrapper" style="writing-mode: vertical-rl">
+                <div id="box">
+                <p>A block child not this box's own direct text</p>
+                </div>
+                </div>
+                """);
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var wrapper = LayoutHarness.FindById(root, "wrapper");
+            var box = LayoutHarness.FindById(root, "box");
+            Assert.NotNull(wrapper);
+            Assert.NotNull(box);
+
+            // Position, not just width: box's block-start edge (its own ActualRight, since vertical-rl)
+            // must stay flush with wrapper's own content-box right edge - the anchor LayoutVerticalBlockChildren
+            // placed it against - not drift from a redundant second position correction.
+            Assert.Equal(wrapper!.ClientRight, box!.ActualRight, 1);
+
+            var width = box.ActualRight - box.Location.X;
+            Assert.True(width > 0 && width < 50, $"auto width should shrink to its short content, got {width}");
+        }
+
+        [Fact]
+        public async Task VerticalRl_FloatWithAutoWidth_StillShrinksToContent()
+        {
+            // The #798 guard only fires for Position.Absolute/Fixed, not the broader IsOutOfFlow (which
+            // also covers floats) - a float's own Location.X comes from CommitBlockChildOffset's
+            // flow-stacking branch (CssLayoutEngine.FloatBox avoidance), not a CSS `left` offset, so it's
+            // exactly as free to move as an ordinary in-flow box's and must keep shrinking to content.
+            var html = LayoutHarness.Wrap("""
+                <div id="wrapper" style="writing-mode: vertical-rl; width: 300px; height: 300px">
+                <div id="floatBox" style="float: right">Hi</div>
+                </div>
+                """);
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var floatBox = LayoutHarness.FindById(root, "floatBox");
+            Assert.NotNull(floatBox);
+
+            var width = floatBox!.ActualRight - floatBox.Location.X;
+            Assert.True(width > 0 && width < 50, $"float's auto width should shrink to its short content, got {width}");
         }
 
         [Fact]

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -3802,6 +3802,19 @@ namespace PeachPDF.Html.Core.Dom
 
                 await childBox.LayoutContentAtItsAssignedPosition(g);
 
+                // A same-writing-mode, non-orthogonal child (excluded from the fit-content branch above)
+                // reaches its own auto-width shrink - if it has one - only now, inside its own content
+                // layout: e.g. an inline-only child dispatches to CreateVerticalLineBoxes, which calls
+                // ShrinkAutoWidthTo on itself. `childWidth` above was captured from ResolveOwnInlineSize's
+                // pre-content-layout (stretch-to-available) estimate, so it's stale once that shrink has
+                // run - re-read the child's now-true width so the accumulator below reflects what the
+                // child actually occupies. No Location.X correction is needed here even for vertical-rl:
+                // the child's own recursive ShrinkAutoWidthTo already captured ITS OWN pre-shrink
+                // ActualRight (this child's block-start edge, placed above) as ITS anchor and moved its
+                // own Location.X against it - re-deriving Location.X again here from the placeholder
+                // childWidth would double-apply that same shift on top of an already-correct position.
+                childWidth = childBox.ActualRight - childBox.Location.X;
+
                 // IsBlockAxisMarginCollapseThrough mirrors IsMarginCollapseThrough's own recursive
                 // "self-collapsing empty box" definition, gated on this child's already-resolved
                 // block-axis extent rather than a Width style token (see that method's own remarks for
@@ -6918,6 +6931,51 @@ namespace PeachPDF.Html.Core.Dom
         /// </remarks>
         private void OffsetLeft(double amount, CssBox translationRoot)
         {
+            ShiftOwnLineGeometryLeft(amount);
+
+            foreach (var b in Boxes)
+            {
+                if (b.EscapesTranslationOf(translationRoot)) continue;
+
+                b.OffsetLeft(amount, translationRoot);
+            }
+
+            Location = Location with { X = Location.X + amount };
+            OnTranslated(amount, 0);
+        }
+
+        /// <summary>
+        /// Like <see cref="OffsetLeft(double)"/>, but leaves this box's own <see cref="Location"/> in
+        /// place - only its content (line rectangles, words, and descendants) shifts.
+        /// </summary>
+        /// <remarks>
+        /// For an out-of-flow box under <c>vertical-rl</c>, <see cref="CssLayoutEngine.ShrinkAutoWidthTo"/>
+        /// (issue #798) needs this: such a box's content is laid out against a placeholder block-start
+        /// anchor before its true content extent is known, but its <c>Location.X</c> is separately pinned
+        /// to a CSS <c>left</c> offset that must never move. Once the real content extent settles, the
+        /// content - not <c>Location</c> - is what has to move to reconcile the two.
+        /// </remarks>
+        internal void OffsetContentLeft(double amount)
+        {
+            ShiftOwnLineGeometryLeft(amount);
+
+            foreach (var b in Boxes)
+            {
+                if (b.EscapesTranslationOf(this)) continue;
+
+                b.OffsetLeft(amount, this);
+            }
+
+            OnTranslated(amount, 0);
+        }
+
+        /// <summary>
+        /// The <see cref="Rectangles"/>/<see cref="Words"/> half of <see cref="OffsetLeft(double)"/> and
+        /// <see cref="OffsetContentLeft"/> - the part both share, since they differ only in whether
+        /// <see cref="Location"/> itself moves.
+        /// </summary>
+        private void ShiftOwnLineGeometryLeft(double amount)
+        {
             List<CssLineBox> lines = [];
             foreach (var line in Rectangles.Keys)
                 lines.Add(line);
@@ -6932,16 +6990,6 @@ namespace PeachPDF.Html.Core.Dom
             {
                 word.Left += amount;
             }
-
-            foreach (var b in Boxes)
-            {
-                if (b.EscapesTranslationOf(translationRoot)) continue;
-
-                b.OffsetLeft(amount, translationRoot);
-            }
-
-            Location = Location with { X = Location.X + amount };
-            OnTranslated(amount, 0);
         }
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -710,12 +710,41 @@ namespace PeachPDF.Html.Core.Dom
         /// Internal rather than private: <see cref="CssBox.LayoutVerticalBlockChildren"/> reuses this
         /// directly for its own auto-width shrink (issue #760) rather than duplicating the
         /// <see cref="WritingModeFrame.BlockStartIsRight"/>-vs-<c>Location.X</c> subtlety above.
+        /// <para>
+        /// For an absolutely/fixed-positioned box under <c>vertical-rl</c>, <c>Location.X</c> is not a
+        /// block-start edge free to move - it was already set by <see cref="CssBox.CommitBlockChildOffset"/>
+        /// from the box's own CSS <c>left</c> offset before this box's own content layout ran, so the
+        /// vertical-rl branch below pins <c>Location.X</c> and shifts the already-laid-out content instead
+        /// (issue #798), via <see cref="CssBox.OffsetContentLeft"/>. This deliberately checks
+        /// <c>Position.Value</c> rather than the broader <see cref="CssBox.IsOutOfFlow"/> (which also
+        /// covers floats): a float reaches <see cref="CssBox.CommitBlockChildOffset"/>'s flow-stacking
+        /// branch instead, so its <c>Location.X</c> is a computed avoidance position, not a CSS offset -
+        /// exactly as free to move as an ordinary in-flow box's, and correctly takes the ordinary branch
+        /// below.
+        /// </para>
         /// </remarks>
         internal static void ShrinkAutoWidthTo(CssBox blockBox, WritingModeFrame frame, double contentBlockExtent)
         {
             // The content-box edge the block axis has reached, in the same physical coordinate
             // ToPhysical already anchors every word to - independent of which side is block-start.
             var contentFarEdgeX = frame.ToPhysical(0, contentBlockExtent).X;
+
+            if (frame.BlockStartIsRight && blockBox.Position.Value is PositionMode.Absolute or PositionMode.Fixed)
+            {
+                // Content was laid out against a placeholder block-start anchor (this box's pre-shrink
+                // ActualRight) before its true extent was known, but Location.X is pinned to a CSS `left`
+                // offset that must not move. ToPhysical is a pure translation for a fixed frame, so the
+                // gap between where the content's block-end edge landed and where Location.X actually is
+                // is a uniform shift - move the content to close it, not Location.
+                var trueRight = blockBox.ActualRight;
+                var contentLeftEdge = contentFarEdgeX - blockBox.ActualPaddingLeft - blockBox.ActualBorderLeftWidth;
+                var delta = blockBox.Location.X - contentLeftEdge;
+
+                if (delta != 0) blockBox.OffsetContentLeft(delta);
+
+                blockBox.ActualRight = blockBox.Location.X + (trueRight - contentLeftEdge);
+                return;
+            }
 
             if (frame.BlockStartIsRight)
             {


### PR DESCRIPTION
## Summary
- `CreateVerticalLineBoxes`'s auto-width shrink assumed a box's `Location.X` was always a free-to-move block-start edge under `vertical-rl`. For an absolutely/fixed-positioned box, `Location.X` is instead already pinned to a CSS `left` offset set before content layout ran, so the shrink silently corrupted it.
- Now keeps `Location.X` pinned and reconciles the box's already-laid-out content against it via a new `CssBox.OffsetContentLeft` primitive, so auto width still shrinks to fit content rather than only the position being fixed.
- Also fixes a related bug found while verifying this: `LayoutVerticalBlockChildren` measured a same-writing-mode block-level child's width before that child's own auto-width shrink had run, so a `vertical-rl` box with block-level (not just inline) children never shrunk to fit, in-flow or out-of-flow alike.

Fixes #798

## Test plan
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 9112 passing, 0 failures, 0 regressions
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings
- [x] New/changed lines confirmed covered directly against the coverage XML
- [x] Rasterized the issue's own repro with both PDFium and MuPDF — box sits tightly at the correct position, matching the reported CSS
- [x] 6 new regression tests in `VerticalWritingModeLayoutIntegrationTests.cs` covering absolute/fixed positioning with auto-width inline content, floats (confirmed unaffected), and block-level children (in-flow and out-of-flow)