### PR TITLE
Fix vertical RTL inline content anchoring to its final bottom edge

### DIFF
--- a/.claude/accepted-gaps/no-vertical-writing-mode-layout.md
+++ b/.claude/accepted-gaps/no-vertical-writing-mode-layout.md
@@ -522,12 +522,12 @@ Three narrower, pre-existing bugs were found (not introduced) while building and
 independent of its own five features — each had its own tracking issue since each needed its own focused
 fix: a float's own starting position inside a vertical box's block content is physically meaningless, and
 `clear` on an ordinary block child is unimplemented ([#796](https://github.com/jhaygood86/PeachPDF/issues/796));
-an RTL auto-height inline-only vertical box positions its words against the placement-time provisional
-(page-height) bottom edge rather than the box's own final settled one
-([#797](https://github.com/jhaygood86/PeachPDF/issues/797), from #761/#778-era code); and
-`CreateVerticalLineBoxes`'s own auto-width shrink (#761) corrupted `Location.X` for an absolutely/fixed-
-positioned descendant with an auto width, since it assumed `Location.X` was always a block-start edge free
-to move, which is false once a CSS `left` offset already gave it real meaning.
+a direction:rtl vertical box positioned its own inline content's words against the placement-time
+provisional bottom edge rather than the box's own final settled one (#797, from #761/#778-era code, since
+fixed — see `.claude/recent-fixes/`); and `CreateVerticalLineBoxes`'s own auto-width shrink (#761) corrupted
+`Location.X` for an absolutely/fixed-positioned descendant with an auto width, since it assumed `Location.X`
+was always a block-start edge free to move, which is false once a CSS `left` offset already gave it real
+meaning.
 [#798](https://github.com/jhaygood86/PeachPDF/issues/798) fixes this properly rather than just gating it
 off: for `vertical-rl` specifically, `Location.X` now stays pinned to the CSS `left` offset while the
 box's already-laid-out content (words and descendants, placed against a pre-shrink placeholder anchor
@@ -553,10 +553,6 @@ would double-apply the same shift.
   non-floated block child is unimplemented** ([#796](https://github.com/jhaygood86/PeachPDF/issues/796)).
   Column wrap-around avoidance for text flowing around a float ([#768](https://github.com/jhaygood86/PeachPDF/issues/768),
   closed) is unaffected by this — it queries wherever the float actually ends up, not where it "should".
-- **An RTL, auto-height, inline-only vertical box positions its words against the placement-time
-  provisional bottom edge instead of its own final settled one**, landing them outside the box entirely
-  ([#797](https://github.com/jhaygood86/PeachPDF/issues/797)) — reproduces with plain text, independent of
-  `text-align`/bidi/hyphenation/floats/positioning.
 - **A nested inline element's own border/padding/margin does not reserve inline-axis (physical left/right,
   for `vertical-rl`/`vertical-lr`) space** ([#769](https://github.com/jhaygood86/PeachPDF/issues/769)), and
   its block-axis (physical top/bottom) padding/border is applied once per column it spans rather than once

--- a/.claude/recent-fixes/2026-08-23-vertical-rtl-inline-content-anchors-to-final-bottom-edge.md
+++ b/.claude/recent-fixes/2026-08-23-vertical-rtl-inline-content-anchors-to-final-bottom-edge.md
@@ -1,0 +1,61 @@
+# Vertical rtl inline content anchors to final bottom edge
+
+_Landed 2026-08-23._
+
+[Issue #797](https://github.com/jhaygood86/PeachPDF/issues/797): a `direction: rtl` vertical box
+(`vertical-rl`/`vertical-lr`) with inline-only content positioned every word far outside its own real
+bottom edge. Reproduced with plain, unstyled text — no `text-align`, bidi, hyphenation, floats, or
+positioning involved. Pre-existing, from the earlier #761/#778-era `CreateVerticalLineBoxes` work;
+surfaced while building and testing #768.
+
+**Root cause was a guard bug, not a missing feature.** `CreateVerticalLineBoxes` places words using a
+`WritingModeFrame` built against a provisional bottom edge (an auto-height box's own documented
+page-height wrap-limit fallback, or a definite height's `DefiniteContentHeight`). Under
+`direction: rtl`, `WritingModeFrame.InlineStartIsBottom` is true, so every word's physical `Top` is
+anchored against whatever `clientBottom` the frame was built with. The method's own finalize pass
+(`ApplyVerticalTextAlignment` → `ApplyVerticalFlushAlignment`, added by #768) is supposed to re-anchor
+words to the box's real final edge — but `ApplyVerticalFlushAlignment`'s guard
+(`if (toBottom ? !(diff > 0) : !(diff < 0)) return;`) silently discarded the correction whenever
+`diff` (the shift needed to flush the column) came out negative for the `toBottom: true` branch. That
+branch is exactly what CSS-initial `text-align: start` resolves to under vertical+RTL, which is why
+plain, unstyled text reproduced the bug 100% of the time — `text-align: left`/`end`'s `toBottom: false`
+branch happened to apply the same-sign correction by coincidence of guard direction, masking the defect
+for that half of the alignment matrix. Fixed by replacing the directional guard with an unconditional
+near-zero-only skip (`if (!(Math.Abs(diff) > 0)) return;`), matching the sibling
+`ApplyVerticalCenterAlignment`'s own (already-correct) guard shape — `diff` is, by construction, exactly
+the needed shift; there's no direction in which a nonzero value should be discarded.
+
+**A second, latent gap needed the #778 precedent to close properly.** Even with the guard fixed, the
+locally-computed "final" bottom edge `CreateVerticalLineBoxes` uses for its finalize pass is not
+actually final: `min-height`/`max-height` clamping (`CssLayoutEngine.ApplyHeight`/`GetBoxHeight`) only
+runs later, in `CssBox.PerformLayoutEpilogue`, and — unlike this method's own local height math —
+applies regardless of whether the box's own `height` is auto or an explicit length. A post-change review
+agent proved this live (a `height: 50pt; min-height: 400pt` RTL vertical box with plain text still
+landed words flush around 70pt instead of the real ~420pt bottom) after the guard fix alone had already
+passed the literal issue repro. This is the same class of bug #778 hit for this box's own block-level
+children, whose fix (`CssBox._pendingCrossAxisRtlReflection`, consumed from `PerformLayoutEpilogue`
+right after `ApplyHeight`) is the direct precedent reused here: the finalize loop
+(`ApplyVerticalTextAlignment`/`ApplyVerticalBidiReordering`/`BubbleRectangles`/`AssignRectanglesToBoxes`)
+was extracted into a new `internal static CssLayoutEngine.FinalizeVerticalLineBoxes`, and for every
+`direction: rtl` vertical box (not just auto-height ones — deferring is a no-op whenever not strictly
+needed, so there's no reason to gate it more narrowly), `CreateVerticalLineBoxes` now sets a new
+`CssBox._pendingVerticalInlineFinalize` flag instead of finalizing immediately.
+`PerformLayoutEpilogue` consumes it right after `CssLayoutEngine.ApplyHeight`, calling
+`FinalizeVerticalLineBoxes` with `WritingModeFrame.For(this)` and this box's own now-live
+`ClientTop`/`ClientBottom`. Unlike the block-children case, a plain `bool` flag is enough — the epilogue
+runs on the very box whose `LineBoxes`/`Client*`/`WritingMode`/`Direction` are already live instance
+state, so nothing needs to be captured ahead of time. No new `OffsetContentTop`-style geometry-shifting
+primitive was needed either: the finalize pass already recomputes word positions from scratch
+(`GetColumnContentExtent` re-scans current words, computes a fresh `diff`, writes `word.Top`) rather
+than shifting by a delta, so `blockBox.Location` is guaranteed untouched by construction — deferring
+just means calling that same recomputation later, with the true edges.
+
+LTR vertical is unaffected either way (its natural placement never depends on `clientBottom`), and
+`LayoutOutOfFlowDescendants` stays unconditional and unmoved relative to the branch, since it resolves
+only against `ClientLeft`/`ClientTop`/`ClientRight` (already final) and never reads line-box/word
+alignment results. New tests in `VerticalTextAlignIntegrationTests.cs` (the literal repro, a
+`vertical-lr` variant, explicit `text-align: right`, and a `text-align: left` regression guard) and
+`VerticalWritingModeLayoutIntegrationTests.cs` (`min-height` growing an auto-height box, and `min-height`
+overriding a smaller explicit `height` — the case the review agent's live repro caught) pin both fixes.
+Full net8.0 suite (9118 passing, zero regressions), 100% diff coverage on the changed lines, and a
+zero-warning `dotnet build -t:Rebuild` all pass.

--- a/src/PeachPDF.Tests/Integration/VerticalTextAlignIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/VerticalTextAlignIntegrationTests.cs
@@ -199,5 +199,95 @@ namespace PeachPDF.Tests.Integration
                 Assert.Equal(el.ClientBottom, firstColumn[^1].Bottom, 1);
             }
         }
+
+        [Fact]
+        public async Task VerticalRl_Rtl_AutoHeight_PlainText_WordsStayWithinTheBoxsOwnFinalBottomEdge()
+        {
+            // Issue #797: an auto-height RTL vertical box's own natural word placement is anchored during
+            // layout against a large placeholder bottom edge (CreateVerticalLineBoxes's own heightIsAuto
+            // wrap-limit fallback). text-align's default "start" resolves to physical-right (flush-bottom)
+            // under vertical+rtl (ApplyVerticalTextAlignment), which must re-anchor every word to the box's
+            // own real, much closer final ClientBottom once it settles - a guard bug in
+            // ApplyVerticalFlushAlignment instead silently skipped that correction, landing every word far
+            // outside the box's own bottom edge.
+            var html = LayoutHarness.Wrap("""
+                <div id="el" style="writing-mode: vertical-rl; direction: rtl; width: 200pt">Some plain text with no other styling.</div>
+                """);
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var el = LayoutHarness.FindById(root, "el")!;
+            var words = Words(el);
+            Assert.NotEmpty(words);
+
+            foreach (var word in words)
+            {
+                Assert.True(word.Top >= el.ClientTop - 1,
+                    $"word '{word.Text}' Top {word.Top} is above ClientTop {el.ClientTop}");
+                Assert.True(word.Bottom <= el.ClientBottom + 1,
+                    $"word '{word.Text}' Bottom {word.Bottom} is below ClientBottom {el.ClientBottom}");
+            }
+
+            // Default text-align:start resolves to physical-right (flush-bottom) under vertical+rtl.
+            Assert.Equal(el.ClientBottom, words.Max(w => w.Bottom), 1);
+        }
+
+        [Fact]
+        public async Task VerticalLr_Rtl_AutoHeight_PlainText_WordsStayWithinTheBoxsOwnFinalBottomEdge()
+        {
+            // vertical-lr's InlineStartIsBottom asymmetry matches vertical-rl's own (same Y-axis logic;
+            // only the block/X-axis anchor differs between the two writing modes).
+            var html = LayoutHarness.Wrap("""
+                <div id="el" style="writing-mode: vertical-lr; direction: rtl; width: 200pt">Some plain text with no other styling.</div>
+                """);
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var el = LayoutHarness.FindById(root, "el")!;
+            var words = Words(el);
+            Assert.NotEmpty(words);
+
+            foreach (var word in words)
+            {
+                Assert.True(word.Top >= el.ClientTop - 1);
+                Assert.True(word.Bottom <= el.ClientBottom + 1);
+            }
+
+            Assert.Equal(el.ClientBottom, words.Max(w => w.Bottom), 1);
+        }
+
+        [Fact]
+        public async Task VerticalRl_Rtl_AutoHeight_TextAlignRight_WordsFlushToTheBoxsRealBottomEdge()
+        {
+            // Confirms the fix isn't accidentally keyed off the start-vs-right resolution rather than the
+            // underlying ApplyVerticalFlushAlignment guard itself - explicit "right" resolves to the exact
+            // same toBottom:true branch as the default "start" does under direction:rtl.
+            var html = LayoutHarness.Wrap("""
+                <div id="el" style="writing-mode: vertical-rl; direction: rtl; width: 200pt; text-align: right">Some plain text with no other styling.</div>
+                """);
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var el = LayoutHarness.FindById(root, "el")!;
+            var words = Words(el);
+            Assert.NotEmpty(words);
+            Assert.Equal(el.ClientBottom, words.Max(w => w.Bottom), 1);
+            Assert.True(words.Min(w => w.Top) >= el.ClientTop - 1);
+        }
+
+        [Fact]
+        public async Task VerticalRl_Rtl_AutoHeight_TextAlignLeft_WordsFlushToTheBoxsRealTopEdge()
+        {
+            // A regression guard for the toBottom:false branch, which happened to apply its correction
+            // even before this fix (its guard's sign coincidentally matched what an auto-height RTL box
+            // needs) - no existing test combined this with auto height, only definite height.
+            var html = LayoutHarness.Wrap("""
+                <div id="el" style="writing-mode: vertical-rl; direction: rtl; width: 200pt; text-align: left">Some plain text with no other styling.</div>
+                """);
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var el = LayoutHarness.FindById(root, "el")!;
+            var words = Words(el);
+            Assert.NotEmpty(words);
+            Assert.Equal(el.ClientTop, words.Min(w => w.Top), 1);
+            Assert.True(words.Max(w => w.Bottom) <= el.ClientBottom + 1);
+        }
     }
 }

--- a/src/PeachPDF.Tests/Integration/VerticalWritingModeLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/VerticalWritingModeLayoutIntegrationTests.cs
@@ -601,6 +601,71 @@ namespace PeachPDF.Tests.Integration
         }
 
         [Fact]
+        public async Task VerticalRl_Rtl_AutoHeight_MinHeightGrowsTheBox_PlainTextStillAnchorsToTheRealFinalBottom()
+        {
+            // The inline-content analog of VerticalRl_Rtl_MinHeightGrowsTheBoxAfterContent_...: the
+            // finalize pass (text-align/bidi) that anchors this box's own words to its bottom edge must run
+            // against the box's real, min-height-clamped ClientBottom (settled by CssLayoutEngine.ApplyHeight
+            // in the layout epilogue), not the smaller, content-only edge CreateVerticalLineBoxes computes
+            // locally before ApplyHeight has run - deferring to CssBox.PerformLayoutEpilogue (issue #797) is
+            // what makes this possible.
+            var html = LayoutHarness.Wrap("""
+                <div id="el" style="writing-mode: vertical-rl; direction: rtl; width: 200pt; min-height: 400pt">Some plain text with no other styling.</div>
+                """);
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var el = LayoutHarness.FindById(root, "el")!;
+
+            // min-height won: the box's own real height is 400pt, taller than its content alone would
+            // drive it.
+            Assert.Equal(400, el.ActualBottom - el.Location.Y, 1);
+
+            var words = el.LineBoxes.SelectMany(l => l.Words).Where(w => !w.IsLineBreak && !w.IsSpaces).ToList();
+            Assert.NotEmpty(words);
+
+            foreach (var word in words)
+            {
+                Assert.True(word.Top >= el.ClientTop - 1);
+                Assert.True(word.Bottom <= el.ClientBottom + 1);
+            }
+
+            // Default text-align:start resolves to physical-right under vertical+rtl - words flush to the
+            // box's real (min-height-driven) bottom, not the smaller content-only extent.
+            Assert.Equal(el.ClientBottom, words.Max(w => w.Bottom), 1);
+        }
+
+        [Fact]
+        public async Task VerticalRl_Rtl_ExplicitHeight_MinHeightOverridesIt_PlainTextStillAnchorsToTheRealFinalBottom()
+        {
+            // min-height/max-height clamping (CssLayoutEngine.ApplyHeight/GetBoxHeight) applies regardless
+            // of whether this box's own height is auto or an explicit length - so an *explicit* height
+            // overridden by a larger min-height reproduces the same #797 symptom the auto-height case does:
+            // CreateVerticalLineBoxes's own local finalClientBottom (DefiniteContentHeight-driven, i.e. the
+            // explicit height alone) never accounts for min-height winning in the layout epilogue. Deferring
+            // finalize for every direction:rtl vertical box (not just auto-height ones) is what closes this.
+            var html = LayoutHarness.Wrap("""
+                <div id="el" style="writing-mode: vertical-rl; direction: rtl; width: 200pt; height: 50pt; min-height: 400pt">Some plain text with no other styling.</div>
+                """);
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var el = LayoutHarness.FindById(root, "el")!;
+
+            // min-height won over the explicit (smaller) height: the box's own real height is 400pt.
+            Assert.Equal(400, el.ActualBottom - el.Location.Y, 1);
+
+            var words = el.LineBoxes.SelectMany(l => l.Words).Where(w => !w.IsLineBreak && !w.IsSpaces).ToList();
+            Assert.NotEmpty(words);
+
+            foreach (var word in words)
+            {
+                Assert.True(word.Top >= el.ClientTop - 1);
+                Assert.True(word.Bottom <= el.ClientBottom + 1);
+            }
+
+            Assert.Equal(el.ClientBottom, words.Max(w => w.Bottom), 1);
+        }
+
+        [Fact]
         public async Task VerticalRl_OrthogonalHorizontalChild_LaysOutOwnContentHorizontally_WhilePlacedAsOneAtomicBlock()
         {
             // A writing-mode: horizontal-tb block child nested inside a vertical-rl parent is an

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -2023,6 +2023,22 @@ namespace PeachPDF.Html.Core.Dom
         private List<CssBox>? _pendingCrossAxisRtlReflection;
 
         /// <summary>
+        /// Set by <see cref="CssLayoutEngine.CreateVerticalLineBoxes"/> when this box is a <c>direction: rtl</c>
+        /// vertical-writing-mode box with inline-only content, whose own text-align/bidi finalize pass had to
+        /// be deferred to <see cref="PerformLayoutEpilogue"/> rather than run immediately - see that method's
+        /// own remarks for why. Set regardless of whether this box's own <c>height</c> is auto or an explicit
+        /// length: <c>min-height</c>/<c>max-height</c> clamping applies to both.
+        /// </summary>
+        /// <remarks>
+        /// Unlike <see cref="_pendingCrossAxisRtlReflection"/> (issue #778's own precedent for this box's
+        /// block-level children), a plain flag is enough here: <see cref="PerformLayoutEpilogue"/> runs on
+        /// this very box, so its own now-final Client edges/LineBoxes/WritingMode/Direction are all already
+        /// live instance state at consumption time - nothing needs to be captured ahead of time the way
+        /// "which children to reflect" does for the block-children case.
+        /// </remarks>
+        internal bool _pendingVerticalInlineFinalize;
+
+        /// <summary>
         /// Whether this box has already taken an <see cref="EarlyBreak"/> on this fragmentainer pass.
         /// </summary>
         /// <remarks>
@@ -5215,6 +5231,19 @@ namespace PeachPDF.Html.Core.Dom
             }
 
             _pendingCrossAxisRtlReflection = null;
+
+            if (_pendingVerticalInlineFinalize)
+            {
+                // Only now - after ApplyHeight has settled min-height/max-height clamping - are ClientTop/
+                // ClientBottom this box's own true final inline-axis edges. WritingModeFrame.For(this) reads
+                // them (plus ClientLeft/ClientRight/WritingMode/Direction) directly off this box. This only
+                // ever re-positions this box's own Words (ApplyVerticalTextAlignment/ApplyVerticalBidiReordering
+                // write word.Top directly) - it must NOT move this box's own Location, unlike the
+                // block-children reflection above, since this box's own position was assigned by its parent
+                // and stays fixed.
+                CssLayoutEngine.FinalizeVerticalLineBoxes(this, WritingModeFrame.For(this), ClientTop, ClientBottom);
+                _pendingVerticalInlineFinalize = false;
+            }
 
             CssLayoutEngine.ApplyParentHeight(this);
 

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -653,6 +653,44 @@ namespace PeachPDF.Html.Core.Dom
             var finalFrame = WritingModeFrame.ForContentBox(blockBox.ClientLeft, clientTop,
                 blockBox.ClientRight, finalClientBottom, blockBox.WritingMode.Value, blockBox.Direction.Value);
 
+            // A direction:rtl vertical box's own natural word placement (the loop above) is anchored against
+            // clientTop + wrapLimit - for an auto-height box that is only a provisional placeholder edge, not
+            // this box's real final bottom. Worse, finalClientBottom (computed locally just above) is itself
+            // not fully final for ANY height (auto or definite): min-height/max-height clamping
+            // (CssLayoutEngine.ApplyHeight/GetBoxHeight) only runs later, in the layout epilogue, and applies
+            // regardless of whether this box's own `height` is auto or an explicit length - reusing this
+            // method's own local edge here would reintroduce a version of issue #778's own symptom for text
+            // whenever min-height/max-height moves the box's real bottom away from that local value. So for
+            // every direction:rtl vertical box, finalize is deferred to CssBox.PerformLayoutEpilogue instead
+            // of running immediately - see CssBox._pendingVerticalInlineFinalize's own remarks. LTR vertical
+            // is unaffected either way, since its natural placement never depends on clientBottom at all, so
+            // deferring would have nothing to gain there.
+            if (frame.InlineStartIsBottom)
+            {
+                blockBox._pendingVerticalInlineFinalize = true;
+            }
+            else
+            {
+                FinalizeVerticalLineBoxes(blockBox, finalFrame, clientTop, finalClientBottom);
+            }
+
+            await LayoutOutOfFlowDescendants(g, blockBox, outOfFlowDescendants);
+        }
+
+        /// <summary>
+        /// The per-column text-align/bidi finalize pass for <see cref="CreateVerticalLineBoxes"/>'s own line
+        /// boxes, against the box's real final inline-axis edges. Takes <paramref name="finalFrame"/>/
+        /// <paramref name="clientTop"/>/<paramref name="clientBottom"/> as parameters rather than reading them
+        /// live off <paramref name="blockBox"/> - the immediate call site (a definite-height box, or an
+        /// auto-height LTR vertical one) still needs its own locally-computed edges, since
+        /// <paramref name="blockBox"/>'s own <c>ClientBottom</c> is not genuinely final until
+        /// <c>ApplyHeight</c> runs in the layout epilogue; only the deferred call site
+        /// (<see cref="CssBox.PerformLayoutEpilogue"/>, after <c>ApplyHeight</c> has run) can safely pass the
+        /// box's own live Client edges.
+        /// </summary>
+        internal static void FinalizeVerticalLineBoxes(CssBox blockBox, WritingModeFrame finalFrame,
+            double clientTop, double clientBottom)
+        {
             for (var i = 0; i < blockBox.LineBoxes.Count; i++)
             {
                 var lineBox = blockBox.LineBoxes[i];
@@ -661,14 +699,12 @@ namespace PeachPDF.Html.Core.Dom
                 // text-align before bidi, for the same reason FinalizeLineBoxes orders them this way for
                 // horizontal flow: alignment establishes the column's own outer span, and bidi only ever
                 // reflects positions within that span - it never moves the span's own edges.
-                ApplyVerticalTextAlignment(lineBox, finalFrame, isLastColumn, clientTop, finalClientBottom);
-                ApplyVerticalBidiReordering(lineBox, finalFrame, clientTop, finalClientBottom);
+                ApplyVerticalTextAlignment(lineBox, finalFrame, isLastColumn, clientTop, clientBottom);
+                ApplyVerticalBidiReordering(lineBox, finalFrame, clientTop, clientBottom);
 
                 BubbleRectangles(blockBox, lineBox);
                 lineBox.AssignRectanglesToBoxes();
             }
-
-            await LayoutOutOfFlowDescendants(g, blockBox, outOfFlowDescendants);
         }
 
         /// <summary>
@@ -3177,10 +3213,20 @@ namespace PeachPDF.Html.Core.Dom
             var targetTop = toBottom ? clientBottom - (contentBottom - contentTop) : clientTop;
             var diff = targetTop - contentTop;
 
-            // Natural placement can already sit flush at either edge depending on direction (unlike
-            // horizontal, where it is always flush-left) - a one-directional diff > 0 guard would silently
-            // skip the case where natural placement needs to move toward physical-top instead.
-            if (toBottom ? !(diff > 0) : !(diff < 0)) return;
+            // targetTop - contentTop is, by construction, exactly the shift needed to flush the column's
+            // content to the requested edge - there is no direction in which a nonzero diff should be
+            // discarded. The previous one-directional guard (diff > 0 for toBottom, diff < 0 otherwise)
+            // assumed natural (pre-alignment) placement is never further from the target edge than "the
+            // wrong way", which holds for a definite-height box or LTR vertical content (whose natural
+            // placement never depends on clientBottom), but not for an auto-height RTL vertical box: its
+            // natural placement is anchored during word layout against a placeholder bottom edge far below
+            // the real one (see CreateVerticalLineBoxes's own heightIsAuto wrapLimit fallback), so both
+            // toBottom:true and toBottom:false need a same-direction (very negative) correction once the
+            // real, much closer final bottom is known - toBottom:false's guard happened to allow this by
+            // coincidence of sign; toBottom:true's did not, leaving every word positioned far outside the
+            // box's own real bottom edge (issue #797). Only a genuinely near-zero diff (content already
+            // flush) is worth skipping, matching ApplyVerticalCenterAlignment's own guard shape.
+            if (!(Math.Abs(diff) > 0)) return;
 
             foreach (var word in lineBox.Words)
             {


### PR DESCRIPTION
## Summary
- A `direction: rtl` vertical box (`vertical-rl`/`vertical-lr`) with inline-only content positioned every word far outside its own real bottom edge, reproducing with plain unstyled text.
- `ApplyVerticalFlushAlignment`'s directional guard silently discarded the re-anchoring correction whenever it was needed most - exactly the default `text-align: start` case under RTL.
- Fixing the guard alone left a latent gap for `min-height`/`max-height`: the finalize pass now defers to `PerformLayoutEpilogue` (after `ApplyHeight` resolves the box's true final edges) for every `direction: rtl` vertical box, mirroring the precedent already used for this box's own block-level children.

Fixes #797

## Test plan
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~VerticalTextAlign|FullyQualifiedName~VerticalWritingMode"` - 88 passed
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - 9118 passed, 0 failed
- [x] Diff coverage on changed lines: 100%
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` - 0 warnings, 0 errors