### PR TITLE
Downscale oversized raster images before PDF embedding

### DIFF
--- a/.claude/accepted-gaps/svg-pattern-transform-scale-not-seen-by-raster-image-downscale.md
+++ b/.claude/accepted-gaps/svg-pattern-transform-scale-not-seen-by-raster-image-downscale.md
@@ -1,0 +1,38 @@
+# A raster `<image>` inside an SVG `<pattern>` doesn't account for `patternTransform`'s scale when downscaling
+
+`PdfGenerateConfig.DownscaleImages` resizes an oversized raster image down to its actual on-page display
+size before embedding, computed in `XGraphicsPdfRenderer.Realize` by folding the currently-active CTM's
+scale into the image's own destRect (`PdfSharpCore/Drawing.Pdf/XGraphicsPdfRenderer.cs`). This correctly
+covers an ordinary CSS `transform:` on an `<img>`/background, and an SVG element/group `transform`, since
+both apply through the same page-level CTM the image is ultimately drawn against.
+
+It does not cover a raster `<image>` painted inside an SVG `<pattern>` whose `patternTransform` scales the
+tile up. `SvgRenderer.PaintPatternFill` renders the pattern's content into its own Form XObject via
+`GraphicsAdapter.CreateTile` at the pattern's native `width`/`height`, then places that tile on the page
+wrapped in a separate `patternTransform` scale (`Adapters/GraphicsAdapter.cs`'s `CreateTile` /
+`SvgRenderer.cs`'s `PaintPatternFill`). A `<image>` drawn inside the tile's own content stream computes its
+downscale target from the CTM realized *within that tile* — which has no visibility into the extra scale
+`patternTransform` applies only when the finished tile is placed on the page, in a different content
+stream. The image ends up downscaled to fit the tile's *unscaled* size, then visibly blurry once
+`patternTransform` scales the tile (and its already-shrunk raster content) back up.
+
+Example that triggers it:
+
+```svg
+<pattern width="10" height="10" patternTransform="scale(5)">
+  <image href="photo.jpg" width="10" height="10"/>
+</pattern>
+```
+
+This is a new, narrow gap `DownscaleImages` introduces — before it existed, every image always embedded at
+full resolution, so there was no downscale decision to get wrong here. `DownscaleImages = false` avoids it
+entirely (nothing is ever downscaled). A correct fix needs `CreateTile`'s caller to communicate the tile's
+eventual placement scale down into the tile's own graphics state before any nested raster `<image>` is
+painted into it — a real design task (the tile's *vector* content must not be affected, only a nested
+raster image's resize decision), not a one-line fix, and out of scope for the change that introduced
+`DownscaleImages`. The two other `CreateTile` callers in this codebase (the opacity-group tile and the
+`<mask>` luminosity tile, both in `SvgRenderer.cs`) place their tiles 1:1 with no extra scale, so they are
+unaffected.
+
+Revisit if a real user document hits this (a raster photo used as SVG pattern fill content with a scaling
+`patternTransform` is an uncommon combination).

--- a/.claude/migration-notes/2026-08-23-images-downscale-and-real-alpha-detection.md
+++ b/.claude/migration-notes/2026-08-23-images-downscale-and-real-alpha-detection.md
@@ -1,0 +1,28 @@
+# Raster images now downscale before embedding; alpha detection is now real, not a PNG sniff
+
+**Downscaling.** Previously: every raster image (`<img>`, `background-image`, `<object>`/`<video poster>`,
+list-style-image/marker, `::before`/`::after content: url(...)`, and SVG `<image>`) was embedded in the PDF
+at its full decoded pixel resolution, regardless of how small it was actually displayed - a 6000x4000
+source photo shown at 200x150 CSS px still shipped at full resolution, bloating output file size for no
+visible benefit.
+
+Now: `PdfGenerateConfig.DownscaleImages` (default `true`) resizes an oversized image down to (roughly) its
+actual on-page display size before embedding, using PeachImage's `Image.Resize` (Bicubic filter).
+`PdfGenerateConfig.MaximumDownscaleMultiplier` (default `1.0`) adds headroom above the exact display size
+if set above `1.0`; `PdfGenerateConfig.DownscaleQuality` (default `70`) is the JPEG quality used
+specifically for a resized, non-alpha image's own encode (full-resolution JPEG embeds are unaffected). The
+same source image used at genuinely different display sizes in one document embeds once per distinct size
+rather than once at whichever size was drawn first. Set `DownscaleImages = false` to restore the previous
+always-full-resolution behavior.
+
+**Alpha detection.** Previously: whether an image was embedded losslessly (preserving alpha, as an
+uncompressed PDF bitmap) or as lossy JPEG was decided by sniffing the source file's first 4 bytes for the
+PNG signature - not by checking whether the image actually has any real transparency. A WebP, AVIF, or GIF
+image with genuine alpha was silently routed to the lossy JPEG path and lost its transparency; conversely,
+a fully opaque PNG took the lossless (larger, uncompressed) path it didn't need.
+
+Now: every decoded image is scanned for real alpha content once, regardless of source format, and that
+scan result (not the source format) decides the embed path. WebP/AVIF/GIF images with genuine transparency
+now render correctly; an opaque PNG now JPEG-embeds like any other opaque source, which is also smaller in
+most cases. Images with real alpha are unaffected by `DownscaleImages`'s JPEG-quality behavior above - they
+stay on the lossless embed path regardless of downscaling, just resized.

--- a/src/PeachPDF.Tests/Integration/ImageDownscaleTransformIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/ImageDownscaleTransformIntegrationTests.cs
@@ -1,0 +1,83 @@
+using PeachPDF.PdfSharpCore;
+using PeachPDF.Tests.TestSupport;
+using System;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    // Covers DownscaleImages end-to-end through real HTML/CSS/SVG rendering, specifically the case
+    // XGraphicsPdfRenderer.Realize's CTM fold-in exists for: a raster image painted while a transform
+    // (CSS `transform:` or an SVG element/group transform) is active on the graphics state ends up at
+    // destRect size * transform scale on the actual page, not destRect size alone. See the lower-level,
+    // exact-pixel-math coverage in ImageDrawingTests.DownscaleImages_UnderActiveTransform_AccountsForTransformScale
+    // for the same fix tested directly against XGraphics; this file confirms real layout/paint actually
+    // reaches that code for both the HTML and SVG paths.
+    public class ImageDownscaleTransformIntegrationTests
+    {
+        private static async Task<string> GetPdfText(string html)
+        {
+            var generator = new PdfGenerator();
+            var config = new PdfGenerateConfig { PageSize = PageSize.A4, CompressContentStreams = false };
+            config.SetMargins(0);
+            var doc = await generator.GeneratePdf(html, config);
+            var ms = new MemoryStream();
+            doc.Save(ms);
+            return Encoding.Latin1.GetString(ms.ToArray());
+        }
+
+        private static string LargePngDataUri() =>
+            "data:image/png;base64," + Convert.ToBase64String(RasterPngFixture.MakeSolidRgbaPngBytes(400, 400, 255, 0, 0));
+
+        private static int MaxEmbeddedWidth(string pdfText)
+        {
+            var max = 0;
+            foreach (Match m in Regex.Matches(pdfText, @"/Width (\d+)"))
+            {
+                var w = int.Parse(m.Groups[1].Value);
+                if (w > max) max = w;
+            }
+            return max;
+        }
+
+        [Fact]
+        public async Task DownscaleImages_ImgUnderCssTransformScale_EmbedsAtTransformedSize()
+        {
+            var dataUri = LargePngDataUri();
+            string Html(string transform) =>
+                $"<!DOCTYPE html><html><body style=\"margin:0\">" +
+                $"<img src=\"{dataUri}\" style=\"display:block;width:20px;height:20px;{transform}\"/>" +
+                $"</body></html>";
+
+            var plainWidth = MaxEmbeddedWidth(await GetPdfText(Html("")));
+            var scaledWidth = MaxEmbeddedWidth(await GetPdfText(Html("transform:scale(2);transform-origin:top left;")));
+
+            Assert.True(plainWidth > 0);
+            Assert.True(plainWidth < 400, $"expected downscaling to shrink the 400px source, got {plainWidth}");
+            // Allow rounding slack around the ideal 2x rather than asserting an exact literal - layout
+            // contributes its own rounding on top of the resize target's own ceiling.
+            Assert.InRange(scaledWidth, plainWidth * 2 - 2, plainWidth * 2 + 2);
+        }
+
+        [Fact]
+        public async Task DownscaleImages_SvgImageUnderGroupTransform_EmbedsAtTransformedSize()
+        {
+            var dataUri = LargePngDataUri();
+            string Html(string transform) =>
+                "<!DOCTYPE html><html><body style=\"margin:0\">" +
+                "<svg width=\"200\" height=\"200\" xmlns=\"http://www.w3.org/2000/svg\">" +
+                $"<g transform=\"{transform}\"><image href=\"{dataUri}\" width=\"20\" height=\"20\"/></g>" +
+                "</svg></body></html>";
+
+            var plainWidth = MaxEmbeddedWidth(await GetPdfText(Html("")));
+            var scaledWidth = MaxEmbeddedWidth(await GetPdfText(Html("scale(2)")));
+
+            Assert.True(plainWidth > 0);
+            Assert.True(plainWidth < 400, $"expected downscaling to shrink the 400px source, got {plainWidth}");
+            Assert.InRange(scaledWidth, plainWidth * 2 - 2, plainWidth * 2 + 2);
+        }
+    }
+}

--- a/src/PeachPDF.Tests/PdfSharpCore/Drawing/ImageDrawingTests.cs
+++ b/src/PeachPDF.Tests/PdfSharpCore/Drawing/ImageDrawingTests.cs
@@ -2,6 +2,7 @@ using PeachPDF.PdfSharpCore.Drawing;
 using PeachPDF.PdfSharpCore.Pdf;
 using PeachPDF.PdfSharpCore.Utils;
 using PeachPDF.Tests.TestSupport;
+using System.Text;
 
 using PeachPDF.Fonts;
 
@@ -96,6 +97,158 @@ namespace PeachPDF.Tests.PdfSharpCoreTests.Drawing
             document.Save(stream);
 
             Assert.True(stream.Length > 0);
+        }
+
+        // --- Downscaling: embedded /Width /Height reflects the display size, not the source size ---
+        // (this repo's testing convention: assert real PDF structure, not just "didn't throw" - a
+        // content-stream substring match alone doesn't prove what actually got embedded.)
+
+        private static string SaveAndReadAscii(PdfDocument document)
+        {
+            using var stream = new MemoryStream();
+            document.Save(stream);
+            return Encoding.ASCII.GetString(stream.ToArray());
+        }
+
+        private static int CountOccurrences(string haystack, string needle)
+        {
+            int count = 0, index = 0;
+            while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += needle.Length;
+            }
+            return count;
+        }
+
+        [Fact]
+        public void DownscaleImages_ShrinksEmbeddedResolutionToDisplaySize()
+        {
+            var document = new PdfDocument();
+            var page = document.AddPage();
+            var gfx = XGraphics.FromPdfPage(page);
+
+            var bytes = RasterPngFixture.MakeSolidRgbaPngBytes(200, 200, 255, 0, 0);
+            using var xImage = XImage.FromStream(() => new MemoryStream(bytes));
+
+            // 20pt display size, default MaximumDownscaleMultiplier (1.0): 20 / 0.75 = 26.67px, rounds to 27.
+            gfx.DrawImage(xImage, 0, 0, 20, 20);
+
+            var pdfText = SaveAndReadAscii(document);
+
+            Assert.Contains("/Width 27", pdfText);
+            Assert.Contains("/Height 27", pdfText);
+            Assert.DoesNotContain("/Width 200", pdfText);
+        }
+
+        [Fact]
+        public void DownscaleImagesDisabled_EmbedsAtNaturalResolution()
+        {
+            var document = new PdfDocument();
+            document.Options.DownscaleImages = false;
+            var page = document.AddPage();
+            var gfx = XGraphics.FromPdfPage(page);
+
+            var bytes = RasterPngFixture.MakeSolidRgbaPngBytes(200, 200, 255, 0, 0);
+            using var xImage = XImage.FromStream(() => new MemoryStream(bytes));
+
+            gfx.DrawImage(xImage, 0, 0, 20, 20);
+
+            var pdfText = SaveAndReadAscii(document);
+
+            Assert.Contains("/Width 200", pdfText);
+            Assert.Contains("/Height 200", pdfText);
+        }
+
+        [Fact]
+        public void DownscaleImages_SameSourceAtTwoDisplaySizes_EmbedsTwoDistinctCopies()
+        {
+            var document = new PdfDocument();
+            var page = document.AddPage();
+            var gfx = XGraphics.FromPdfPage(page);
+
+            var bytes = RasterPngFixture.MakeSolidRgbaPngBytes(200, 200, 0, 255, 0);
+            using var xImage = XImage.FromStream(() => new MemoryStream(bytes));
+
+            gfx.DrawImage(xImage, 0, 0, 20, 20);   // 20 / 0.75 = 26.67px, rounds to 27
+            gfx.DrawImage(xImage, 0, 0, 40, 40);   // 40 / 0.75 = 53.33px, rounds to 53
+
+            var pdfText = SaveAndReadAscii(document);
+
+            Assert.Contains("/Width 27", pdfText);
+            Assert.Contains("/Width 53", pdfText);
+        }
+
+        [Fact]
+        public void DownscaleImages_SameSourceAtSameDisplaySizeTwice_EmbedsOnlyOnce()
+        {
+            // Regression guard for the common case (e.g. a logo reused unchanged across a repeating
+            // header/footer): dedup by (path, target size) must still collapse repeat draws at the
+            // identical size to a single embedded copy, exactly as plain path-based dedup already did
+            // before downscaling existed.
+            var document = new PdfDocument();
+            var page = document.AddPage();
+            var gfx = XGraphics.FromPdfPage(page);
+
+            var bytes = RasterPngFixture.MakeSolidRgbaPngBytes(200, 200, 0, 0, 255);
+            using var xImage = XImage.FromStream(() => new MemoryStream(bytes));
+
+            gfx.DrawImage(xImage, 0, 0, 20, 20);
+            gfx.DrawImage(xImage, 50, 50, 20, 20);
+
+            var pdfText = SaveAndReadAscii(document);
+
+            Assert.Equal(1, CountOccurrences(pdfText, "/Width 27"));
+        }
+
+        [Fact]
+        public void DownscaleImages_UnderActiveTransform_AccountsForTransformScale()
+        {
+            // A raster image drawn while a transform (CSS `transform: scale(...)`, or an SVG viewport/
+            // element transform - both apply via the same XGraphics.PushTransform/ScaleTransform
+            // mechanism) is active on the graphics state ends up at destRect size * transform scale on
+            // the actual page, not destRect size alone. Realize() must fold that scale in before
+            // computing a downscale target, or a transformed image gets embedded too small and displays
+            // visibly blurry once the transform blows it back up.
+            var document = new PdfDocument();
+            var page = document.AddPage();
+            var gfx = XGraphics.FromPdfPage(page);
+
+            var bytes = RasterPngFixture.MakeSolidRgbaPngBytes(200, 200, 255, 255, 0);
+            using var xImage = XImage.FromStream(() => new MemoryStream(bytes));
+
+            gfx.ScaleTransform(2.0, 2.0);
+            // 20pt destRect under a 2x active transform -> 40pt true on-page size -> 40 / 0.75 = 53.33px, rounds to 53.
+            gfx.DrawImage(xImage, 0, 0, 20, 20);
+
+            var pdfText = SaveAndReadAscii(document);
+
+            Assert.Contains("/Width 53", pdfText);
+            Assert.DoesNotContain("/Width 27", pdfText);
+        }
+
+        [Fact]
+        public void DownscaleImages_UnderNonUniformTransformScale_AccountsForEachAxisSeparately()
+        {
+            // A single geometric-mean-of-determinant scalar applied to both axes would be wrong here:
+            // scaleX(3) alone has a determinant-derived area scale of sqrt(3) =~ 1.73, which if applied
+            // to both axes would under-size the stretched (x) axis and over-size the untouched (y) axis.
+            // Realize() must extract each axis's own scale from the CTM's basis vectors instead.
+            var document = new PdfDocument();
+            var page = document.AddPage();
+            var gfx = XGraphics.FromPdfPage(page);
+
+            var bytes = RasterPngFixture.MakeSolidRgbaPngBytes(200, 200, 0, 255, 255);
+            using var xImage = XImage.FromStream(() => new MemoryStream(bytes));
+
+            gfx.ScaleTransform(3.0, 1.0);
+            // x: 20pt * 3 = 60pt -> 60 / 0.75 = 80px. y: 20pt * 1 = 20pt -> 20 / 0.75 = 26.67px, rounds to 27.
+            gfx.DrawImage(xImage, 0, 0, 20, 20);
+
+            var pdfText = SaveAndReadAscii(document);
+
+            Assert.Contains("/Width 80", pdfText);
+            Assert.Contains("/Height 27", pdfText);
         }
     }
 }

--- a/src/PeachPDF.Tests/PdfSharpCore/PeachImageSourceTests.cs
+++ b/src/PeachPDF.Tests/PdfSharpCore/PeachImageSourceTests.cs
@@ -2,6 +2,7 @@ using MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes;
 using PeachImage;
 using PeachImage.Formats.Bmp;
 using PeachImage.Formats.Jpeg;
+using PeachImage.Formats.Webp;
 using PeachPDF.PdfSharpCore.Utils;
 using PeachPDF.Tests.TestSupport;
 using System.IO;
@@ -109,10 +110,52 @@ namespace PeachPDF.Tests.PdfSharpCoreTests
         // --- FromBinary: dimensions / Transparent heuristic ---
 
         [Fact]
-        public void FromBinary_Png_IsTransparent()
+        public void FromBinary_OpaquePng_IsNotTransparent()
         {
+            // Transparent reflects real alpha content (a full pixel scan), not source format - an
+            // opaque PNG (a=255 everywhere) takes the lossy JPEG embed path exactly like an opaque
+            // JPEG/BMP/WebP/AVIF source would, since there's no alpha channel to lose.
             var bytes = MakePngBytes(4, 4, 255, 0, 0);
             var img = ImageSource.FromBinary("test.png", () => bytes);
+
+            Assert.False(img.Transparent);
+        }
+
+        [Fact]
+        public void FromBinary_PngWithRealAlpha_IsTransparent()
+        {
+            var bytes = MakePngBytes(4, 4, 255, 0, 0, a: 128);
+            var img = ImageSource.FromBinary("test.png", () => bytes);
+
+            Assert.True(img.Transparent);
+        }
+
+        [Fact]
+        public void FromBinary_GifWithTransparency_IsTransparent()
+        {
+            // Previously (PNG-magic-byte sniff): this GIF would have been mis-routed to the lossy JPEG
+            // path, silently dropping its transparency, since only a PNG signature counted. A real
+            // pixel-alpha scan catches it regardless of source format.
+            var gifBytes = Convert.FromBase64String(
+                "R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==");
+
+            var img = ImageSource.FromBinary("pixel.gif", () => gifBytes);
+
+            Assert.True(img.Transparent);
+        }
+
+        [Fact]
+        public void FromBinary_WebpWithRealAlpha_IsTransparent()
+        {
+            // Same bug as the GIF case above, for WebP: a PNG-magic-byte sniff would never flag this as
+            // transparent no matter how much real alpha it carries. Built with PeachImage's own lossless
+            // (VP8L) encoder, which preserves alpha, rather than a fixture file (unlike the decode-only
+            // WebpTestImageBase64 fixture used elsewhere in this file).
+            using var image = MakeSolidImage(4, 4, 10, 20, 30, a: 128);
+            using var ms = new MemoryStream();
+            image.Save(ms, "webp", new WebpEncoderOptions());
+
+            var img = ImageSource.FromBinary("test.webp", () => ms.ToArray());
 
             Assert.True(img.Transparent);
         }
@@ -286,7 +329,7 @@ namespace PeachPDF.Tests.PdfSharpCoreTests
 
             Assert.Equal(3, img.Width);
             Assert.Equal(5, img.Height);
-            Assert.True(img.Transparent);
+            Assert.False(img.Transparent);
         }
 
         [Fact]
@@ -321,7 +364,7 @@ namespace PeachPDF.Tests.PdfSharpCoreTests
 
             Assert.Equal(2, img.Width);
             Assert.Equal(2, img.Height);
-            Assert.True(img.Transparent);
+            Assert.False(img.Transparent);
         }
 
         [Fact]
@@ -386,6 +429,51 @@ namespace PeachPDF.Tests.PdfSharpCoreTests
 
             Assert.Equal(10, reloaded.Width);
             Assert.Equal(12, reloaded.Height);
+        }
+
+        [Fact]
+        public void SaveAsJpeg_WithTargetSize_ResizesOutput()
+        {
+            var img = ImageSource.FromBinary("src.png", () => MakePngBytes(40, 30, 0, 128, 255));
+            var ms = new MemoryStream();
+            img.SaveAsJpeg(ms, targetWidth: 10, targetHeight: 8);
+
+            ms.Position = 0;
+            var reloaded = ImageSource.FromStream("out.jpg", () => new MemoryStream(ms.ToArray()));
+
+            Assert.Equal(10, reloaded.Width);
+            Assert.Equal(8, reloaded.Height);
+        }
+
+        [Fact]
+        public void SaveAsPdfBitmap_WithTargetSize_ResizesOutput()
+        {
+            var img = ImageSource.FromBinary("src.png", () => MakePngBytes(40, 30, 0, 128, 255, a: 128));
+            var ms = new MemoryStream();
+            img.SaveAsPdfBitmap(ms, targetWidth: 10, targetHeight: 8);
+
+            using var decoded = Image.Load(new MemoryStream(ms.ToArray()));
+
+            Assert.Equal(10, decoded.Width);
+            Assert.Equal(8, decoded.Height);
+        }
+
+        [Fact]
+        public void SaveAsJpeg_WithMatchingTargetSize_DoesNotResize()
+        {
+            // targetWidth/targetHeight equal to the natural size must take the cheap no-resize path -
+            // this is what PdfImageTable relies on to skip PeachImage.Resize entirely when a caller
+            // (e.g. DownscaleImages = false, or a display size that's already smaller than the source)
+            // determined no actual shrink is needed.
+            var img = ImageSource.FromBinary("src.png", () => MakePngBytes(10, 8, 0, 128, 255));
+            var ms = new MemoryStream();
+            img.SaveAsJpeg(ms, targetWidth: 10, targetHeight: 8);
+
+            ms.Position = 0;
+            var reloaded = ImageSource.FromStream("out.jpg", () => new MemoryStream(ms.ToArray()));
+
+            Assert.Equal(10, reloaded.Width);
+            Assert.Equal(8, reloaded.Height);
         }
 
         // --- Output encoding: actual pixel-data correctness, not just header bytes ---

--- a/src/PeachPDF/PdfGenerateConfig.cs
+++ b/src/PeachPDF/PdfGenerateConfig.cs
@@ -236,6 +236,31 @@ namespace PeachPDF
         public bool EnableInteractivePdfForms { get; set; } = false;
 
         /// <summary>
+        /// When set to <c>true</c> (the default), a raster image whose decoded pixel size is larger than
+        /// its on-page display size is resized down before being embedded in the PDF, shrinking output
+        /// file size with no visible quality loss. Set to <c>false</c> to always embed images at their
+        /// full decoded resolution, as PeachPDF did before this option existed.
+        /// </summary>
+        public bool DownscaleImages { get; set; } = true;
+
+        /// <summary>
+        /// The JPEG quality (0-100) used when <see cref="DownscaleImages"/> actually resizes an image
+        /// that has no real alpha channel (and so would be JPEG-encoded anyway). Has no effect on
+        /// full-resolution JPEG embeds, and never applies to images with real transparency - those stay
+        /// on the lossless embed path regardless of downscaling, just resized. Defaults to <c>70</c>.
+        /// </summary>
+        public int DownscaleQuality { get; set; } = 70;
+
+        /// <summary>
+        /// When <see cref="DownscaleImages"/> resizes an image, the resize target is the image's on-page
+        /// display size multiplied by this value, clamped to never exceed the image's natural decoded
+        /// size (downscaling never upscales). For example, an image displayed at 60x40 with a multiplier
+        /// of <c>2.0</c> resizes to 120x80 - useful headroom for zooming or printing. Defaults to
+        /// <c>1.0</c> (resize to exactly the display size).
+        /// </summary>
+        public double MaximumDownscaleMultiplier { get; set; } = 1.0;
+
+        /// <summary>
         /// Set all 4 margins to the given value.
         /// </summary>
         /// <param name="value"></param>

--- a/src/PeachPDF/PdfGenerator.cs
+++ b/src/PeachPDF/PdfGenerator.cs
@@ -201,6 +201,9 @@ namespace PeachPDF
             if (string.IsNullOrEmpty(html) && config.NetworkLoader is null) return;
 
             document.PdfDocument.Options.CompressContentStreams = config.CompressContentStreams;
+            document.PdfDocument.Options.DownscaleImages = config.DownscaleImages;
+            document.PdfDocument.Options.DownscaleQuality = config.DownscaleQuality;
+            document.PdfDocument.Options.MaximumDownscaleMultiplier = config.MaximumDownscaleMultiplier;
 
             _pdfSharpAdapter.NetworkLoader = config.NetworkLoader ?? new DataUriNetworkLoader();
             _pdfSharpAdapter.AllowLocalFileAccess = config.AllowLocalFileAccess;

--- a/src/PeachPDF/PdfSharpCore/Drawing.Pdf/XGraphicsPdfRenderer.cs
+++ b/src/PeachPDF/PdfSharpCore/Drawing.Pdf/XGraphicsPdfRenderer.cs
@@ -638,7 +638,7 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
         {
             const string format = Config.SignificantFigures4;
 
-            string name = Realize(image);
+            string name = Realize(image, width, height);
             if (!(image is XForm))
             {
                 if (_gfx.PageDirection == XPageDirection.Downwards)
@@ -690,7 +690,7 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             double width = destRect.Width;
             double height = destRect.Height;
 
-            string name = Realize(image);
+            string name = Realize(image, width, height);
             if (!(image is XForm))
             {
                 if (_gfx.PageDirection == XPageDirection.Downwards)
@@ -1594,7 +1594,7 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
         /// <summary>
         /// Makes the specified image to the current graphics object.
         /// </summary>
-        string Realize(XImage image)
+        string Realize(XImage image, double width, double height)
         {
             BeginPage();
             BeginGraphicMode();
@@ -1604,7 +1604,26 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             _gfxState.RealizeNonStrokeTransparency(1, _colorMode);
 
             XForm form = image as XForm;
-            return form != null ? GetFormName(form) : GetImageName(image);
+            if (form != null)
+                return GetFormName(form);
+
+            // width/height is the caller's own destRect, before any transform active on the graphics
+            // state (an SVG viewport transform, or a CSS `transform: scale(...)`) is applied - fold in
+            // that transform's own scale so a downscale decision made in GetImageName sees the image's
+            // true final on-page size. Ordinary (untransformed) draws have an identity/translation-only
+            // CTM here, so this is a no-op (both scales == 1) for the common case.
+            //
+            // Per-axis, not a single geometric-mean-of-determinant scalar: the length of the CTM's own
+            // transformed X/Y basis vectors (columns (M11,M12) and (M21,M22)) gives the true horizontal/
+            // vertical scale even when they differ (CSS `scaleX`/`scaleY`, a non-uniform `matrix()`), and
+            // is exact under rotation too, since rotation preserves each basis vector's length. A single
+            // sqrt(|det|) scalar applied to both axes - the area scale factor - would be wrong for any
+            // non-uniform scale (e.g. `scaleX(3)` on a square image would under-size the stretched axis
+            // and over-size the other).
+            var ctm = _gfxState.RealizedCtm;
+            var scaleX = Math.Sqrt(ctm.M11 * ctm.M11 + ctm.M12 * ctm.M12);
+            var scaleY = Math.Sqrt(ctm.M21 * ctm.M21 + ctm.M22 * ctm.M22);
+            return GetImageName(image, width * scaleX, height * scaleY);
         }
 
         /// <summary>
@@ -1732,7 +1751,7 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             double width = destRect.Width;
             double height = destRect.Height;
 
-            string name = Realize(image);
+            string name = Realize(image, width, height);
 
             BeginPage();
             image.Finish();
@@ -1816,7 +1835,7 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             double width = destRect.Width;
             double height = destRect.Height;
 
-            string name = Realize(image);
+            string name = Realize(image, width, height);
 
             BeginPage();
             image.Finish();
@@ -1886,11 +1905,11 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
         /// <summary>
         /// Gets the resource name of the specified image within this page or form.
         /// </summary>
-        internal string GetImageName(XImage image)
+        internal string GetImageName(XImage image, double width, double height)
         {
             if (_page != null)
-                return _page.GetImageName(image);
-            return _form.GetImageName(image);
+                return _page.GetImageName(image, width, height);
+            return _form.GetImageName(image, width, height);
         }
 
         /// <summary>

--- a/src/PeachPDF/PdfSharpCore/Drawing/ImageSource.cs
+++ b/src/PeachPDF/PdfSharpCore/Drawing/ImageSource.cs
@@ -20,9 +20,22 @@ namespace MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes
             int Width { get; }
             int Height { get; }
             string Name { get; }
-            void SaveAsJpeg(MemoryStream ms);
+
+            /// <summary>
+            /// Encodes as JPEG. When <paramref name="targetWidth"/>/<paramref name="targetHeight"/> are
+            /// given and differ from <see cref="Width"/>/<see cref="Height"/>, the image is resized to
+            /// that pixel size first. <paramref name="qualityOverride"/> replaces the instance's own
+            /// default quality when given (used for a downscaled embed's own quality setting).
+            /// </summary>
+            void SaveAsJpeg(MemoryStream ms, int? targetWidth = null, int? targetHeight = null, int? qualityOverride = null);
             bool Transparent { get; }
-            void SaveAsPdfBitmap(MemoryStream ms);
+
+            /// <summary>
+            /// Encodes as an uncompressed PDF-embeddable bitmap. When <paramref name="targetWidth"/>/
+            /// <paramref name="targetHeight"/> are given and differ from <see cref="Width"/>/
+            /// <see cref="Height"/>, the image is resized to that pixel size first.
+            /// </summary>
+            void SaveAsPdfBitmap(MemoryStream ms, int? targetWidth = null, int? targetHeight = null);
         }
 
         /// <remarks>
@@ -37,12 +50,6 @@ namespace MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes
         protected abstract IImageSource FromBinaryImpl(string name, Func<byte[]> imageSource, int? quality = 75);
         /// <inheritdoc cref="FromFileImpl"/>
         protected abstract IImageSource FromStreamImpl(string name, Func<Stream> imageStream, int? quality = 75);
-
-        // PNG magic bytes: 89 50 4E 47. Used by PeachImageSource to compute the PNG-sniff-as-
-        // "Transparent" heuristic.
-        protected static bool IsPng(byte[] bytes) =>
-            bytes.Length >= 4 &&
-            bytes[0] == 0x89 && bytes[1] == 0x50 && bytes[2] == 0x4E && bytes[3] == 0x47;
 
         public static IImageSource FromFile(string path, int? quality = 75)
         {

--- a/src/PeachPDF/PdfSharpCore/Drawing/XForm.cs
+++ b/src/PeachPDF/PdfSharpCore/Drawing/XForm.cs
@@ -390,10 +390,10 @@ namespace PeachPDF.PdfSharpCore.Drawing
         /// <summary>
         /// Gets the resource name of the specified image within this form.
         /// </summary>
-        internal string GetImageName(XImage image)
+        internal string GetImageName(XImage image, double width, double height)
         {
             Debug.Assert(IsTemplate, "This function is for form templates only.");
-            PdfImage pdfImage = _document.ImageTable.GetImage(image);
+            PdfImage pdfImage = _document.ImageTable.GetImage(image, width, height);
             Debug.Assert(pdfImage != null);
             string name = Resources.AddImage(pdfImage);
             return name;
@@ -402,9 +402,9 @@ namespace PeachPDF.PdfSharpCore.Drawing
         /// <summary>
         /// Implements the interface because the primary function is internal.
         /// </summary>
-        string IContentStream.GetImageName(XImage image)
+        string IContentStream.GetImageName(XImage image, double width, double height)
         {
-            return GetImageName(image);
+            return GetImageName(image, width, height);
         }
 
         internal PdfFormXObject PdfForm

--- a/src/PeachPDF/PdfSharpCore/Drawing/XImage.cs
+++ b/src/PeachPDF/PdfSharpCore/Drawing/XImage.cs
@@ -172,18 +172,18 @@ namespace PeachPDF.PdfSharpCore.Drawing
             }
         }
 
-        public MemoryStream AsJpeg()
+        public MemoryStream AsJpeg(int? targetWidth = null, int? targetHeight = null, int? qualityOverride = null)
         {
             var ms = new MemoryStream();
-            _source.SaveAsJpeg(ms);
+            _source.SaveAsJpeg(ms, targetWidth, targetHeight, qualityOverride);
             ms.Position = 0;
             return ms;
         }
 
-        public MemoryStream AsBitmap()
+        public MemoryStream AsBitmap(int? targetWidth = null, int? targetHeight = null)
         {
             var ms = new MemoryStream();
-            _source.SaveAsPdfBitmap(ms);
+            _source.SaveAsPdfBitmap(ms, targetWidth, targetHeight);
             ms.Position = 0;
             return ms;
         }
@@ -337,9 +337,22 @@ namespace PeachPDF.PdfSharpCore.Drawing
 
         /// <summary>
         /// Cache PdfImageTable.ImageSelector to speed up finding the right PdfImage
-        /// if this image is used more than once.
+        /// if this image is used more than once. Valid only when no resize applies (see
+        /// PdfImageTable.GetImage) - a resize target makes the selector depend on display size too, so
+        /// that case is cached separately below.
         /// </summary>
         internal PdfImageTable.ImageSelector _selector = null!;
+
+        /// <summary>
+        /// Caches the selector PdfImageTable.GetImage computed for the immediately preceding call, keyed
+        /// by the display size (in PDF points) it was computed for - e.g. a logo redrawn identically
+        /// across a repeating header/footer - so a resized image reused unchanged doesn't pay a fresh
+        /// ComputeTargetPixelSize call and ImageSelector allocation on every single draw.
+        /// </summary>
+        internal PdfImageTable.ImageSelector _lastSizedSelector = null!;
+        internal double _lastSizedSelectorWidthPt;
+        internal double _lastSizedSelectorHeightPt;
+
         private IImageSource _source = null!;
     }
 }

--- a/src/PeachPDF/PdfSharpCore/Pdf.Advanced/IContentStream.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf.Advanced/IContentStream.cs
@@ -39,7 +39,7 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
 
         string GetFontName(XFont font, out PdfFont pdfFont);
 
-        string GetImageName(XImage image);
+        string GetImageName(XImage image, double width, double height);
 
         string GetFormName(XForm form);
     }

--- a/src/PeachPDF/PdfSharpCore/Pdf.Advanced/PdfDictionaryWithContentStream.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf.Advanced/PdfDictionaryWithContentStream.cs
@@ -99,9 +99,9 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
         /// <summary>
         /// Gets the resource name of the specified image within this dictionary.
         /// </summary>
-        internal string GetImageName(XImage image)
+        internal string GetImageName(XImage image, double width, double height)
         {
-            PdfImage pdfImage = _document.ImageTable.GetImage(image);
+            PdfImage pdfImage = _document.ImageTable.GetImage(image, width, height);
             Debug.Assert(pdfImage != null);
             string name = Resources.AddImage(pdfImage);
             return name;
@@ -110,7 +110,7 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
         /// <summary>
         /// Implements the interface because the primary function is internal.
         /// </summary>
-        string IContentStream.GetImageName(XImage image)
+        string IContentStream.GetImageName(XImage image, double width, double height)
         {
             throw new NotImplementedException();
         }

--- a/src/PeachPDF/PdfSharpCore/Pdf.Advanced/PdfFormXObject.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf.Advanced/PdfFormXObject.cs
@@ -103,7 +103,7 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
         }
 
 
-        string IContentStream.GetImageName(XImage image)
+        string IContentStream.GetImageName(XImage image, double width, double height)
         {
             throw new NotImplementedException();
         }

--- a/src/PeachPDF/PdfSharpCore/Pdf.Advanced/PdfImage.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf.Advanced/PdfImage.cs
@@ -44,15 +44,20 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
     internal sealed partial class PdfImage : PdfXObject
     {
         /// <summary>
-        /// Initializes a new instance of PdfImage from an XImage.
+        /// Initializes a new instance of PdfImage from an XImage. When <paramref name="targetWidth"/>/
+        /// <paramref name="targetHeight"/> are given, the image is resized to that pixel size before
+        /// being embedded (see <see cref="PdfImageTable.GetImage"/>), and every <c>/Width</c>/<c>/Height</c>
+        /// this type writes uses that size rather than the image's own natural decoded size.
         /// </summary>
-        public PdfImage(PdfDocument document, XImage image)
+        public PdfImage(PdfDocument document, XImage image, int? targetWidth = null, int? targetHeight = null)
             : base(document)
         {
             Elements.SetName(Keys.Type, "/XObject");
             Elements.SetName(Keys.Subtype, "/Image");
 
             _image = image;
+            _targetWidth = targetWidth;
+            _targetHeight = targetHeight;
 
             ////// TODO: identify multiple used images. If the image already exists use the same XRef.
             ////_defaultName = PdfImageTable.NextImageName;
@@ -93,6 +98,15 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
         }
 
         readonly XImage _image;
+        readonly int? _targetWidth;
+        readonly int? _targetHeight;
+
+        /// <summary>
+        /// The pixel size this image is actually embedded at - <c>_targetWidth</c>/<c>_targetHeight</c>
+        /// when a resize applies, otherwise the source's own natural decoded size.
+        /// </summary>
+        int EffectiveWidth => _targetWidth ?? _image.PixelWidth;
+        int EffectiveHeight => _targetHeight ?? _image.PixelHeight;
 
         /// <summary>
         /// Returns 'Image'.
@@ -109,7 +123,12 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
         {
             byte[] imageBits = null;
 
-            using (MemoryStream memory = _image.AsJpeg())
+            // A resize only ever reaches here for an image with no real alpha (PdfImageTable only
+            // resizes; whether that resize lands on the Jpeg or NonJpeg path is still decided by
+            // XImage.Initialize's Transparent check) - so DownscaleQuality applies exactly when a resize
+            // is actually happening, and leaves a full-resolution JPEG embed's own quality untouched.
+            int? qualityOverride = _targetWidth.HasValue ? _document.Options.DownscaleQuality : null;
+            using (MemoryStream memory = _image.AsJpeg(_targetWidth, _targetHeight, qualityOverride))
             {
                 imageBits = memory.ToArray();
             }
@@ -136,8 +155,8 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
             }
             if (_image.Interpolate)
                 Elements[Keys.Interpolate] = PdfBoolean.True;
-            Elements[Keys.Width] = new PdfInteger(_image.PixelWidth);
-            Elements[Keys.Height] = new PdfInteger(_image.PixelHeight);
+            Elements[Keys.Width] = new PdfInteger(EffectiveWidth);
+            Elements[Keys.Height] = new PdfInteger(EffectiveHeight);
             Elements[Keys.BitsPerComponent] = new PdfInteger(8);
             Elements[Keys.ColorSpace] = new PdfName("/DeviceRGB");
         }
@@ -170,7 +189,7 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
         {
             int pdfVersion = Owner.Version;
             MemoryStream memory = new MemoryStream();
-            memory = _image.AsBitmap();
+            memory = _image.AsBitmap(_targetWidth, _targetHeight);
             // THHO4THHO Use ImageImporterBMP here to avoid redundant code.
 
             int streamLength = (int)memory.Length;
@@ -182,8 +201,10 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
                 memory.Read(imageBits, 0, streamLength);
                 memory.Dispose();
 
-                int height = _image.PixelHeight;
-                int width = _image.PixelWidth;
+                // Must match whatever pixel size AsBitmap() above actually encoded - the BMP bytes are
+                // self-validated against these below, and they're also what ends up in /Width /Height.
+                int height = EffectiveHeight;
+                int width = EffectiveWidth;
 
                 // TODO: we could define structures for
                 //   BITMAPFILEHEADER

--- a/src/PeachPDF/PdfSharpCore/Pdf.Advanced/PdfImageTable.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf.Advanced/PdfImageTable.cs
@@ -49,19 +49,48 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
         { }
 
         /// <summary>
-        /// Gets a PdfImage from an XImage. If no PdfImage already exists, a new one is created.
+        /// Gets a PdfImage from an XImage, sized/embedded for use at the given on-page display size (PDF
+        /// points). If no matching PdfImage already exists, a new one is created.
         /// </summary>
-        public PdfImage GetImage(XImage image)
+        public PdfImage GetImage(XImage image, double widthPt, double heightPt)
         {
-            ImageSelector selector = image._selector;
-            if (selector == null)
+            ImageSelector selector;
+            int? targetWidth = null;
+            int? targetHeight = null;
+
+            if (!Owner.Options.DownscaleImages)
             {
-                selector = new ImageSelector(image);
-                image._selector = selector;
+                // No resize ever applies while downscaling is off, so the selector never depends on
+                // display size - the original single-selector-per-XImage cache, unconditionally.
+                selector = image._selector ??= new ImageSelector(image);
             }
+            else if (image._lastSizedSelector != null
+                && image._lastSizedSelectorWidthPt == widthPt
+                && image._lastSizedSelectorHeightPt == heightPt)
+            {
+                // Same (image, display size) as the immediately preceding call - e.g. a logo redrawn
+                // identically across a repeating header/footer - reuse the selector without recomputing
+                // ComputeTargetPixelSize or allocating a new ImageSelector. Safe to skip straight to the
+                // dictionary lookup below without targetWidth/targetHeight: this selector, if it needed a
+                // resize, is already a key in _images from whichever call first computed it, so the
+                // TryGetValue below is guaranteed to hit and a fresh PdfImage is never constructed here.
+                selector = image._lastSizedSelector;
+            }
+            else
+            {
+                (targetWidth, targetHeight) = ComputeTargetPixelSize(image, widthPt, heightPt);
+                selector = targetWidth.HasValue
+                    ? new ImageSelector(image, targetWidth, targetHeight)
+                    : (image._selector ??= new ImageSelector(image));
+
+                image._lastSizedSelector = selector;
+                image._lastSizedSelectorWidthPt = widthPt;
+                image._lastSizedSelectorHeightPt = heightPt;
+            }
+
             if (!_images.TryGetValue(selector, out PdfImage pdfImage))
             {
-                pdfImage = new PdfImage(Owner, image);
+                pdfImage = new PdfImage(Owner, image, targetWidth, targetHeight);
                 //pdfImage.Document = _document;
                 Debug.Assert(pdfImage.Owner == Owner);
                 _images[selector] = pdfImage;
@@ -70,17 +99,54 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
         }
 
         /// <summary>
+        /// Computes the pixel size to resize <paramref name="image"/> to before embedding, or
+        /// <c>(null, null)</c> when no resize should happen: downscaling is off
+        /// (<see cref="PdfDocumentOptions.DownscaleImages"/>), the display size isn't known/positive, or
+        /// the image's natural size is already no larger than the (multiplier-adjusted) display size.
+        /// Never upscales - the result is always clamped to the image's own natural pixel dimensions.
+        /// </summary>
+        private (int? width, int? height) ComputeTargetPixelSize(XImage image, double widthPt, double heightPt)
+        {
+            if (!Owner.Options.DownscaleImages) return (null, null);
+            if (!(widthPt > 0) || !(heightPt > 0)) return (null, null);
+
+            var naturalWidth = image.PixelWidth;
+            var naturalHeight = image.PixelHeight;
+            if (naturalWidth <= 0 || naturalHeight <= 0) return (null, null);
+
+            var multiplier = Owner.Options.MaximumDownscaleMultiplier;
+            var widthPx = widthPt / PeachPDF.CSS.Length.PointsPerPx * multiplier;
+            var heightPx = heightPt / PeachPDF.CSS.Length.PointsPerPx * multiplier;
+
+            // Round rather than ceiling: the target size also doubles as the dedup key (see GetImage),
+            // so two boxes a document author considers "the same display size" but that resolve to
+            // e.g. 99.98px and 100.02px through different layout paths (a percentage width vs. a flex
+            // basis, say) round to the same target and so still dedup to one embed, rather than
+            // ceiling-splitting them into 100px/101px and two full copies. The up-to-half-pixel
+            // softness this can add is well within MaximumDownscaleMultiplier's own headroom margin.
+            var targetWidth = Math.Clamp((int)Math.Round(widthPx, MidpointRounding.AwayFromZero), 1, naturalWidth);
+            var targetHeight = Math.Clamp((int)Math.Round(heightPx, MidpointRounding.AwayFromZero), 1, naturalHeight);
+
+            if (targetWidth >= naturalWidth && targetHeight >= naturalHeight) return (null, null);
+
+            return (targetWidth, targetHeight);
+        }
+
+        /// <summary>
         /// Map from ImageSelector to PdfImage.
         /// </summary>
         readonly Dictionary<ImageSelector, PdfImage> _images = new Dictionary<ImageSelector, PdfImage>();
 
         /// <summary>
-        /// A collection of information that uniquely identifies a particular PdfImage.
+        /// A collection of information that uniquely identifies a particular PdfImage. When a resize
+        /// target is in play, the target pixel size is part of the identity - the same source image used
+        /// at two different display sizes embeds as two distinct PdfImages, each correctly sized, rather
+        /// than one embed at whichever size happened to be requested first.
         /// </summary>
         internal class ImageSelector
         {
             /// <summary>
-            /// Initializes a new instance of ImageSelector from an XImage.
+            /// Initializes a new instance of ImageSelector from an XImage, with no resize target.
             /// </summary>
             public ImageSelector(XImage image)
             {
@@ -93,24 +159,38 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
                 _path = image._path.ToLowerInvariant();
             }
 
+            /// <summary>
+            /// Initializes a new instance of ImageSelector from an XImage and the pixel size it will be
+            /// resized to before embedding.
+            /// </summary>
+            public ImageSelector(XImage image, int? targetWidth, int? targetHeight) : this(image)
+            {
+                _targetWidth = targetWidth;
+                _targetHeight = targetHeight;
+            }
+
             public string Path
             {
                 get { return _path; }
                 set { _path = value; }
             }
             string _path;
+            readonly int? _targetWidth;
+            readonly int? _targetHeight;
 
             public override bool Equals(object? obj)
             {
                 ImageSelector selector = obj as ImageSelector;
                 if (selector == null)
                     return false;
-                return _path == selector._path;
+                return _path == selector._path
+                    && _targetWidth == selector._targetWidth
+                    && _targetHeight == selector._targetHeight;
             }
 
             public override int GetHashCode()
             {
-                return _path.GetHashCode();
+                return HashCode.Combine(_path, _targetWidth, _targetHeight);
             }
         }
     }

--- a/src/PeachPDF/PdfSharpCore/Pdf/PdfDocumentOptions.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf/PdfDocumentOptions.cs
@@ -103,5 +103,35 @@ namespace PeachPDF.PdfSharpCore.Pdf
             set { _useFlateDecoderForJpegImages = value; }
         }
         PdfUseFlateDecoderForJpegImages _useFlateDecoderForJpegImages = PdfUseFlateDecoderForJpegImages.Never;
+
+        /// <summary>
+        /// Mirrors <see cref="PeachPDF.PdfGenerateConfig.DownscaleImages"/> - see there for behavior.
+        /// </summary>
+        public bool DownscaleImages
+        {
+            get { return _downscaleImages; }
+            set { _downscaleImages = value; }
+        }
+        bool _downscaleImages = true;
+
+        /// <summary>
+        /// Mirrors <see cref="PeachPDF.PdfGenerateConfig.DownscaleQuality"/> - see there for behavior.
+        /// </summary>
+        public int DownscaleQuality
+        {
+            get { return _downscaleQuality; }
+            set { _downscaleQuality = value; }
+        }
+        int _downscaleQuality = 70;
+
+        /// <summary>
+        /// Mirrors <see cref="PeachPDF.PdfGenerateConfig.MaximumDownscaleMultiplier"/> - see there for behavior.
+        /// </summary>
+        public double MaximumDownscaleMultiplier
+        {
+            get { return _maximumDownscaleMultiplier; }
+            set { _maximumDownscaleMultiplier = value; }
+        }
+        double _maximumDownscaleMultiplier = 1.0;
     }
 }

--- a/src/PeachPDF/PdfSharpCore/Pdf/PdfPage.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf/PdfPage.cs
@@ -534,9 +534,9 @@ namespace PeachPDF.PdfSharpCore.Pdf
         /// <summary>
         /// Gets the resource name of the specified image within this page.
         /// </summary>
-        internal string GetImageName(XImage image)
+        internal string GetImageName(XImage image, double width, double height)
         {
-            PdfImage pdfImage = _document.ImageTable.GetImage(image);
+            PdfImage pdfImage = _document.ImageTable.GetImage(image, width, height);
             Debug.Assert(pdfImage != null);
             string name = Resources.AddImage(pdfImage);
             return name;
@@ -545,9 +545,9 @@ namespace PeachPDF.PdfSharpCore.Pdf
         /// <summary>
         /// Implements the interface because the primary function is internal.
         /// </summary>
-        string IContentStream.GetImageName(XImage image)
+        string IContentStream.GetImageName(XImage image, double width, double height)
         {
-            return GetImageName(image);
+            return GetImageName(image, width, height);
         }
 
         /// <summary>

--- a/src/PeachPDF/PdfSharpCore/Utils/PeachImageSource.cs
+++ b/src/PeachPDF/PdfSharpCore/Utils/PeachImageSource.cs
@@ -4,6 +4,8 @@ using PeachImage.Formats.Bmp;
 using PeachImage.Formats.Jpeg;
 using System;
 using System.IO;
+using System.Numerics;
+using System.Runtime.InteropServices;
 
 namespace PeachPDF.PdfSharpCore.Utils
 {
@@ -16,7 +18,7 @@ namespace PeachPDF.PdfSharpCore.Utils
         {
             var bytes = imageSource.Invoke();
             using var ms = new MemoryStream(bytes, writable: false);
-            return Decode(name, ms, quality ?? 75, IsPng(bytes));
+            return Decode(name, ms, quality ?? 75);
         }
 
         protected override IImageSource FromFileImpl(string path, int? quality = 75) =>
@@ -32,23 +34,13 @@ namespace PeachPDF.PdfSharpCore.Utils
             // read) falls back to the original copy-into-a-fresh-buffer path.
             if (stream is MemoryStream existing && existing.Position == 0)
             {
-                return DecodeFromMemoryStream(name, existing, quality ?? 75);
+                return Decode(name, existing, quality ?? 75);
             }
 
             using var copy = new MemoryStream();
             stream.CopyTo(copy);
             copy.Position = 0;
-            return DecodeFromMemoryStream(name, copy, quality ?? 75);
-        }
-
-        private static IImageSource DecodeFromMemoryStream(string name, MemoryStream ms, int quality)
-        {
-            var header = new byte[4];
-            int read = ms.Read(header, 0, 4);
-            ms.Position = 0;
-            bool isPng = read == 4 && IsPng(header);
-
-            return Decode(name, ms, quality, isPng);
+            return Decode(name, copy, quality ?? 75);
         }
 
         // PeachImage 0.2.1+ guarantees Image.Load(stream, options) converts to TargetPixelFormat in one
@@ -59,12 +51,12 @@ namespace PeachPDF.PdfSharpCore.Utils
         // stream's content, not from anything this class knows up front.
         private static readonly DecoderOptions Rgba32DecoderOptions = new() { TargetPixelFormat = PixelFormat.Rgba32 };
 
-        private static PeachImageSourceImpl Decode(string name, Stream stream, int quality, bool isPng)
+        private static PeachImageSourceImpl Decode(string name, Stream stream, int quality)
         {
             try
             {
                 var decoded = Image.Load(stream, Rgba32DecoderOptions);
-                return new PeachImageSourceImpl(name, decoded, quality, isPng);
+                return new PeachImageSourceImpl(name, decoded, quality, HasRealAlpha(decoded));
             }
             catch (ImageFormatException ex)
             {
@@ -76,6 +68,44 @@ namespace PeachPDF.PdfSharpCore.Utils
                 // bytes) to that contract, rather than letting it crash the whole render.
                 throw new InvalidOperationException(ex.Message, ex);
             }
+        }
+
+        // Whether to embed losslessly (preserving alpha, via SaveAsPdfBitmap) or as lossy JPEG is
+        // decided by real alpha content, not by source format - a WebP/AVIF/GIF image with genuine
+        // transparency needs the lossless path exactly as much as a PNG does (see
+        // .claude/migration-notes for the behavior change this replaced: a PNG-magic-byte sniff that
+        // silently dropped alpha on any non-PNG-sniffed source). Decoding always produces Rgba32 (see
+        // Rgba32DecoderOptions above), so this scans every pixel's alpha byte once, right after decode.
+        //
+        // Vectorized: GetPixelSpan() is R,G,B,A bytes, tightly packed, so reinterpreting it as a uint
+        // span puts each pixel's alpha byte in the top byte of its uint (little-endian). A batch of
+        // pixels is fully opaque iff every uint, masked to its top byte, still reads 0xFF000000 - so
+        // ANDing a whole Vector<uint> batch against that mask and comparing to the same mask broadcast
+        // finds a non-opaque pixel anywhere in the batch in one comparison, with an early exit the
+        // moment one is found (most images are either fully opaque or have alpha concentrated in one
+        // region, so most calls return well before scanning the whole buffer).
+        private static bool HasRealAlpha(Image decoded)
+        {
+            ReadOnlySpan<uint> pixels = MemoryMarshal.Cast<byte, uint>(decoded.GetPixelSpan());
+            const uint alphaMask = 0xFF000000u;
+            var maskVector = new Vector<uint>(alphaMask);
+
+            int i = 0;
+            int vectorizedLength = pixels.Length - pixels.Length % Vector<uint>.Count;
+            for (; i < vectorizedLength; i += Vector<uint>.Count)
+            {
+                var batch = new Vector<uint>(pixels.Slice(i, Vector<uint>.Count));
+                if (!Vector.EqualsAll(batch & maskVector, maskVector))
+                    return true;
+            }
+
+            for (; i < pixels.Length; i++)
+            {
+                if ((pixels[i] & alphaMask) != alphaMask)
+                    return true;
+            }
+
+            return false;
         }
 
         private sealed class PeachImageSourceImpl : IImageSource
@@ -96,15 +126,45 @@ namespace PeachPDF.PdfSharpCore.Utils
                 Transparent = transparent;
             }
 
-            public void SaveAsJpeg(MemoryStream ms)
+            public void SaveAsJpeg(MemoryStream ms, int? targetWidth = null, int? targetHeight = null, int? qualityOverride = null)
             {
                 // JPEG ignores the alpha channel of a Rgba32 source.
-                _rgba.Save(ms, "jpeg", new JpegEncoderOptions { Quality = _quality });
+                using var scope = new ResizeScope(_rgba, targetWidth, targetHeight);
+                scope.Source.Save(ms, "jpeg", new JpegEncoderOptions { Quality = qualityOverride ?? _quality });
             }
 
-            public void SaveAsPdfBitmap(MemoryStream ms)
+            public void SaveAsPdfBitmap(MemoryStream ms, int? targetWidth = null, int? targetHeight = null)
             {
-                _rgba.Save(ms, "bmp", new BmpEncoderOptions());
+                using var scope = new ResizeScope(_rgba, targetWidth, targetHeight);
+                scope.Source.Save(ms, "bmp", new BmpEncoderOptions());
+            }
+
+            // Resolves to either the original decoded image or a resized clone, so SaveAsJpeg/
+            // SaveAsPdfBitmap share one resize decision instead of duplicating it. Disposing a scope
+            // that didn't resize is a no-op - it never owns _rgba.
+            private readonly struct ResizeScope : IDisposable
+            {
+                public readonly Image Source;
+                private readonly bool _owned;
+
+                public ResizeScope(Image rgba, int? targetWidth, int? targetHeight)
+                {
+                    if (targetWidth is int w && targetHeight is int h && (w != rgba.Width || h != rgba.Height))
+                    {
+                        Source = rgba.Resize(w, h, new ResizeOptions { Filter = ResamplingFilter.Bicubic });
+                        _owned = true;
+                    }
+                    else
+                    {
+                        Source = rgba;
+                        _owned = false;
+                    }
+                }
+
+                public void Dispose()
+                {
+                    if (_owned) Source.Dispose();
+                }
             }
 
             // IImageSource doesn't declare IDisposable (XImage never disposes its IImageSource) - the


### PR DESCRIPTION
## Summary
- Adds `PdfGenerateConfig.DownscaleImages` (default `true`), `DownscaleQuality` (default `70`), and `MaximumDownscaleMultiplier` (default `1.0`): an image whose decoded pixel size is larger than its on-page display size is now resized down before being embedded, shrinking output PDF size with no visible quality loss.
- The same source image used at genuinely different display sizes in one document embeds once per distinct size, rather than once at whichever size was drawn first.
- Bundles a related bug fix: whether an image embeds losslessly (preserving alpha) or as lossy JPEG is now decided by a real per-pixel alpha scan (vectorized via `System.Numerics.Vector<uint>`) instead of sniffing for the PNG file signature — the old sniff was silently dropping alpha on WebP/AVIF/GIF sources.
- `XGraphicsPdfRenderer.Realize` now folds the active CTM's per-axis scale into an image's resize target, so a raster image drawn under an active CSS `transform:` or SVG viewport/element transform is sized for its true on-page footprint, not its untransformed `destRect`.
- One narrow gap surfaced by review is documented rather than fixed: a raster `<image>` inside an SVG `<pattern>` with a scaling `patternTransform` doesn't see that scale when downscaling (Form-XObject content-stream isolation) — see `.claude/accepted-gaps/svg-pattern-transform-scale-not-seen-by-raster-image-downscale.md`.

## Test plan
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings, 0 errors
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 9176 passed, 0 failed
- [x] Diff coverage: 97% (3 missing lines are pre-existing, unrelated interface-delegation boilerplate)
- [x] 8-angle parallel code review; fixed a non-uniform-transform-scale bug and a per-draw allocation regression it surfaced before merging