### PR TITLE
Fix CSS Grid item stretch/measurement to honor box-sizing: border-box

### DIFF
--- a/.claude/accepted-gaps/flex-stretch-shrink-to-fit-sizing-ignores-box-sizing-border-box.md
+++ b/.claude/accepted-gaps/flex-stretch-shrink-to-fit-sizing-ignores-box-sizing-border-box.md
@@ -1,0 +1,23 @@
+# Flexbox stretch/shrink-to-fit sizing ignores `box-sizing: border-box`
+
+_Tracked as [#815](https://github.com/jhaygood86/PeachPDF/issues/815). Left out of scope by
+[#811](https://github.com/jhaygood86/PeachPDF/issues/811), which fixed the identical bug for CSS Grid._
+
+`CssLayoutEngineFlex.ResizeItem` (main-axis stretch) and `CssLayoutEngineFlex.ShrinkColumnItemToContentWidth`
+(cross-axis shrink-to-fit under `flex-direction: column`) each compute the value they assign to a flex
+item's `box.Width`/`box.Height` by unconditionally subtracting the item's own padding+border from its
+allotted outer size, then assigning that content-space number directly. That's only correct for
+`box-sizing: content-box` — per this engine's own box-sizing contract
+(`CssBox.ActualBoxSizeIncludedWidth`/`ActualBoxSizeIncludedHeight`, `CssBox.StyleProperties.cs`), a
+`border-box` item's `Width`/`Height` string must hold the full outer size instead. A stretched or
+shrink-to-fit flex item using `box-sizing: border-box` with non-zero padding/border currently renders
+smaller than intended, by exactly that padding+border amount — [CSS Box Sizing Module Level 3
+§2](https://www.w3.org/TR/css-sizing-3/#box-sizing).
+
+#811's fix touched the shared `ItemContentCommit.CommitLayout` (the final, real-page-grid layout pass
+both `CssLayoutEngineGrid` and `CssLayoutEngineFlex` route through), which prevents that shared code
+path from compounding the error on top of what `ResizeItem`/`ShrinkColumnItemToContentWidth` already
+got wrong — but does not fix those two flex-specific call sites themselves. Closing this gap is
+flex-engine work (mirroring the `PlaceItemInCell`/`MeasureItemHeight` fix #811 made to
+`CssLayoutEngineGrid.cs`) distinct from the Grid fix, so it was filed as a follow-up rather than folded
+into that PR.

--- a/.claude/migration-notes/2026-08-24-grid-item-stretch-now-honors-box-sizing-border-box.md
+++ b/.claude/migration-notes/2026-08-24-grid-item-stretch-now-honors-box-sizing-border-box.md
@@ -1,0 +1,26 @@
+# CSS Grid item stretch now honors `box-sizing: border-box`
+
+**Landed:** 2026-08-24 — CSS Grid `gap` renders far wider than the specified value (#811)
+**Doc section:** docs/html-css-support.md § [Grid](../../docs/html-css-support.md#grid)
+
+A stretched grid item (the default `align-items`/`justify-items: stretch`, or an explicit one) with
+`box-sizing: border-box` and non-zero padding/border previously rendered exactly that padding+border
+narrower/shorter than its actual track — `CssLayoutEngineGrid.cs`'s item-placement and auto-row-height
+measurement code, and the shared `ItemContentCommit.CommitLayout` final layout pass it and
+`CssLayoutEngineFlex` both go through, all assigned a *content-space* size to the item's `Width`/`Height`
+regardless of its box-sizing, which this engine's own box-sizing contract only treats as correct for
+`content-box`.
+
+The shrunk item left the grid container's own background visible around it — for a document using the
+`gap` + background-color divider technique with `box-sizing: border-box` (as most authors set globally, via
+`* { box-sizing: border-box }`) and padded cells, this looked exactly like an oversized `gap`, even though
+`gap`'s own value was rendered correctly throughout. A document relying on this combination will now see
+each stretched item fill its track/row exactly (as an unstretched, explicitly-sized border-box item already
+did), so any divider or background peeking through a gap shrinks down to the actual specified `gap` size.
+
+`CssLayoutEngineFlex`'s own placement-phase stretch/shrink-to-fit sizing (`ResizeItem`,
+`ShrinkColumnItemToContentWidth`) has the same content-space-only assumption and is not fixed by this
+change — a `display:flex` container with `box-sizing:border-box` padded items can still size items smaller
+than intended. Tracked separately: see
+[flex-stretch-shrink-to-fit-sizing-ignores-box-sizing-border-box.md](../accepted-gaps/flex-stretch-shrink-to-fit-sizing-ignores-box-sizing-border-box.md)
+and [#815](https://github.com/jhaygood86/PeachPDF/issues/815).

--- a/src/PeachPDF.Tests/Integration/GridLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/GridLayoutIntegrationTests.cs
@@ -1412,6 +1412,116 @@ namespace PeachPDF.Tests.Integration
                 "the wider content's track should have taken the larger share");
         }
 
+        // ─── box-sizing:border-box grid-item stretch (issue #811) ───────────────
+
+        [Fact]
+        public async Task StretchedBorderBoxItem_WithPadding_FillsItsTrack_GapStaysExact()
+        {
+            // The #811 repro shape: 1fr columns, a px-unit `gap` shorthand, border-box items with
+            // real padding. Before the fix, each item rendered padding+border narrower than its track,
+            // exposing container background around it - which read as a far-oversized gap.
+            var html = Wrap(@"
+                <div id='container' style='display:grid; width:300pt; grid-template-columns:repeat(3, 1fr); gap:1px;'>
+                    <div class='item' style='box-sizing:border-box; padding:10pt 14pt;'>A</div>
+                    <div class='item' style='box-sizing:border-box; padding:10pt 14pt;'>B</div>
+                    <div class='item' style='box-sizing:border-box; padding:10pt 14pt;'>C</div>
+                </div>");
+            var (root, _) = await BuildAndLayout(html);
+            var items = FindAllByClass(root, "item");
+            Assert.Equal(3, items.Count);
+
+            const double gapPt = 0.75; // 1px -> pt
+            var expectedTrack = (300.0 - 2 * gapPt) / 3;
+            foreach (var item in items)
+                Assert.Equal(expectedTrack, item.ActualBoxSizingWidth, 1.0);
+            Assert.Equal(gapPt, items[1].Location.X - items[0].ActualRight, 0.5);
+            Assert.Equal(gapPt, items[2].Location.X - items[1].ActualRight, 0.5);
+        }
+
+        [Fact]
+        public async Task GapShorthand_PxUnit_ConvertsToExactPoints()
+        {
+            // No existing test used the `gap` shorthand or a px unit (all used `column-gap:<N>pt`
+            // longhand) - close that coverage gap independent of the box-sizing angle above.
+            var html = Wrap(@"
+                <div id='container' style='display:grid; width:203pt; grid-template-columns:100pt 100pt; gap:4px;'>
+                    <div id='a' style='height:10pt;'></div>
+                    <div id='b' style='height:10pt;'></div>
+                </div>");
+            var (root, _) = await BuildAndLayout(html);
+            var a = FindById(root, "a")!;
+            var b = FindById(root, "b")!;
+            Assert.Equal(3, b.Location.X - a.ActualRight, 0.5); // 4px -> 3pt
+        }
+
+        [Fact]
+        public async Task StretchedBorderBoxItem_AutoWidthContainer_GapStaysExact()
+        {
+            // The exact real-world shape from #811: no explicit container width (fills its containing
+            // block), 1fr columns, border-box padded items.
+            var html = Wrap(@"
+                <div id='container' style='display:grid; grid-template-columns:repeat(3, 1fr); gap:1px;'>
+                    <div class='item' style='box-sizing:border-box; padding:10pt 14pt;'>A</div>
+                    <div class='item' style='box-sizing:border-box; padding:10pt 14pt;'>B</div>
+                    <div class='item' style='box-sizing:border-box; padding:10pt 14pt;'>C</div>
+                </div>");
+            var (root, _) = await BuildAndLayout(html);
+            var container = FindById(root, "container")!;
+            var items = FindAllByClass(root, "item");
+            Assert.Equal(3, items.Count);
+
+            const double gapPt = 0.75; // 1px -> pt
+            var expectedTrack = (container.ActualBoxSizingWidth - 2 * gapPt) / 3;
+            foreach (var item in items)
+                Assert.Equal(expectedTrack, item.ActualBoxSizingWidth, 1.0);
+            Assert.Equal(gapPt, items[1].Location.X - items[0].ActualRight, 0.5);
+            Assert.Equal(gapPt, items[2].Location.X - items[1].ActualRight, 0.5);
+        }
+
+        [Fact]
+        public async Task StretchedBorderBoxItem_WithPadding_FillsRowHeight()
+        {
+            // Row-axis analog: a border-box item with padding, stretched (default align-items) to fill
+            // an auto row whose height is driven by a taller sibling. This is the one new test in this
+            // group that runs against a real page grid (the harness's default), so it also exercises
+            // ItemContentCommit.CommitLayout's own final-pass copy of the box-sizing bug - which
+            // silently re-shrinks a border-box item's height back down after PlaceItemInCell has
+            // already stretched it correctly, on every real (non-measurement) layout pass.
+            var html = Wrap(@"
+                <div id='container' style='display:grid; width:200pt; grid-template-columns:100pt 100pt;'>
+                    <div id='tall' style='height:80pt;'>Tall</div>
+                    <div id='short' style='box-sizing:border-box; padding:10pt;'>Short</div>
+                </div>");
+            var (root, _) = await BuildAndLayout(html);
+            var tall = FindById(root, "tall")!;
+            var shortBox = FindById(root, "short")!;
+            Assert.Equal(tall.ActualBoxSizingHeight, shortBox.ActualBoxSizingHeight, 1.0);
+        }
+
+        [Fact]
+        public async Task JustifySelfStart_BorderBoxItem_SameOuterWidthAsContentBox()
+        {
+            // The fit-content (non-stretch) auto-width branch clamps/measures in a mix of content- and
+            // outer-space (GetFitContentWidth's own result already folds the item's padding/border in);
+            // regardless of that, box-sizing must not change the item's rendered OUTER size here - a
+            // border-box item with the same content/padding/border as a content-box one should shrink to
+            // the exact same footprint (box-sizing only changes what an explicit `width` declaration
+            // means, never how shrink-to-fit sizing renders).
+            var htmlContent = Wrap(@"
+                <div id='container' style='display:grid; width:300pt; grid-template-columns:300pt;'>
+                    <div id='a' style='box-sizing:content-box; justify-self:start; padding:20pt; border:2pt solid black;'>Hi</div>
+                </div>");
+            var htmlBorder = Wrap(@"
+                <div id='container' style='display:grid; width:300pt; grid-template-columns:300pt;'>
+                    <div id='a' style='box-sizing:border-box; justify-self:start; padding:20pt; border:2pt solid black;'>Hi</div>
+                </div>");
+            var (rootContent, _) = await BuildAndLayout(htmlContent);
+            var (rootBorder, _) = await BuildAndLayout(htmlBorder);
+            var aContent = FindById(rootContent, "a")!;
+            var aBorder = FindById(rootBorder, "a")!;
+            Assert.Equal(aContent.ActualBoxSizingWidth, aBorder.ActualBoxSizingWidth, 0.01);
+        }
+
         private static string Wrap(string body) =>
             $"<!DOCTYPE html><html><head></head><body>{body}</body></html>";
 

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineGrid.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineGrid.cs
@@ -1249,7 +1249,11 @@ namespace PeachPDF.Html.Core.Dom
         /// restore" idiom.</summary>
         private async ValueTask<double> MeasureItemHeight(RGraphics g, CssBox box, double columnWidth)
         {
-            var cssWidth = Math.Max(0, columnWidth - HorizontalMarginBorderPadding(box));
+            // box.Width must end up holding whatever CssBox.ActualBoxSizeIncludedWidth's own box-sizing
+            // contract expects it to: content-space for content-box (subtract the item's own padding/
+            // border along with its margin), or its full outer footprint for border-box (subtract only
+            // its margin - ActualBoxSizeIncludedWidth is already 0 there).
+            var cssWidth = Math.Max(0, columnWidth - box.ActualMarginLeft - box.ActualMarginRight - box.ActualBoxSizeIncludedWidth);
             var savedWidth = box.Width;
             box.Width = FormatLayoutUnits(cssWidth);
 
@@ -1282,13 +1286,23 @@ namespace PeachPDF.Html.Core.Dom
             {
                 // An auto-width block would fill its containing block, so a grid item's width must be pinned:
                 // stretch → the cell's content width; otherwise its fit-content size clamped to the cell.
+                // Either way, `used` is in content-space (stretch) or already folds the item's own
+                // padding/border in (GetFitContentWidth) - box.Width must end up holding whatever
+                // ActualBoxSizeIncludedWidth's own box-sizing contract expects (content-space for
+                // content-box, the full outer footprint for border-box), so its own padding/border is
+                // added back for border-box (where ActualBoxSizeIncludedWidth is 0) and left alone for
+                // content-box (where it already equals that padding/border, cancelling to a no-op).
+                var ownPaddingBorder = HorizontalMarginBorderPadding(box) - box.ActualMarginLeft - box.ActualMarginRight;
                 var used = stretchWidth
                     ? cellContentWidth
                     : await CssLayoutEngine.GetFitContentWidth(g, box, cellContentWidth);
-                box.Width = FormatLayoutUnits(used);
+                box.Width = FormatLayoutUnits(Math.Max(0, used + ownPaddingBorder - box.ActualBoxSizeIncludedWidth));
             }
             if (stretchHeight)
-                box.Height = FormatLayoutUnits(Math.Max(0, cellHeight - VerticalMarginBorderPadding(box)));
+            {
+                var usedHeight = Math.Max(0, cellHeight - box.ActualMarginTop - box.ActualMarginBottom - box.ActualBoxSizeIncludedHeight);
+                box.Height = FormatLayoutUnits(usedHeight);
+            }
 
             box.Location = new RPoint(_gridBox.ClientLeft, _gridBox.ClientTop);
             box.ActualBottom = box.Location.Y;
@@ -1422,11 +1436,6 @@ namespace PeachPDF.Html.Core.Dom
             box.ActualMarginLeft + box.ActualMarginRight
             + box.ActualPaddingLeft + box.ActualPaddingRight
             + box.ActualBorderLeftWidth + box.ActualBorderRightWidth;
-
-        private static double VerticalMarginBorderPadding(CssBox box) =>
-            box.ActualMarginTop + box.ActualMarginBottom
-            + box.ActualPaddingTop + box.ActualPaddingBottom
-            + box.ActualBorderTopWidth + box.ActualBorderBottomWidth;
 
         // ─── Subgrid (CSS Grid Level 2 §9) ─────────────────────────────────────────
 

--- a/src/PeachPDF/Html/Core/Fragmentation/ItemContentCommit.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/ItemContentCommit.cs
@@ -37,13 +37,22 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// <remarks>
         /// <para>
         /// A <b>fresh</b> commit (<paramref name="resume"/> null) pins <paramref name="box"/>'s
-        /// content-box <c>Width</c>/<c>Height</c> to its already-resolved outer size
+        /// <c>Width</c>/<c>Height</c> to its already-resolved outer size
         /// (<see cref="CssBox.ActualBoxSizingWidth"/>/<see cref="CssBox.ActualBoxSizingHeight"/>)
         /// before laying out — every earlier phase already decided this item's size, and
         /// re-deriving it from an "auto" property here (the value every earlier phase temporarily
         /// sets and then reverts, since none of them are the item's <i>final</i> layout) would let
         /// this, genuinely final, layout disagree with the size the rest of the engine's algorithm
-        /// already committed to. Unlike those earlier phases, this pin is <b>not</b> reverted
+        /// already committed to. The value pinned is content-space for <c>content-box</c> (the
+        /// outer size minus this box's own padding/border) but the outer size itself for
+        /// <c>border-box</c> — <see cref="CssBox.ActualBoxSizeIncludedWidth"/>/<c>Height</c>'s own
+        /// box-sizing contract, which a border-box item's <c>Width</c>/<c>Height</c> string must
+        /// keep honoring here: unlike <c>Width</c> (only consumed by this box's own content layout,
+        /// which needs a content-space wrap bound either way), <c>Height</c> is re-read by every
+        /// pass's own epilogue (<see cref="CssLayoutEngine.ApplyHeight"/>), which assigns it straight
+        /// to the used outer height — pinning a border-box item's content height there would shrink
+        /// it back down by its own padding+border on this, the pass whose result actually ships
+        /// (issue #811). Unlike those earlier phases, this pin is <b>not</b> reverted
         /// afterward: a later fragmentainer pass resuming this same item (<paramref name="resume"/>
         /// non-null) must see the same <c>Width</c>/<c>Height</c> the first pass used, or a nested
         /// engine that re-derives its own content box from them
@@ -63,13 +72,12 @@ namespace PeachPDF.Html.Core.Fragmentation
         {
             if (resume is null)
             {
-                var horizontalPB = box.ActualPaddingLeft + box.ActualPaddingRight
-                    + box.ActualBorderLeftWidth + box.ActualBorderRightWidth;
-                var verticalPB = box.ActualPaddingTop + box.ActualPaddingBottom
-                    + box.ActualBorderTopWidth + box.ActualBorderBottomWidth;
-
-                box.Width = FormatLayoutUnits(Math.Max(0, box.ActualBoxSizingWidth - horizontalPB));
-                box.Height = FormatLayoutUnits(Math.Max(0, box.ActualBoxSizingHeight - verticalPB));
+                // box.Width/Height must hold whatever CssBox.ActualBoxSizeIncludedWidth/Height's own
+                // box-sizing contract expects: content-space for content-box (subtract its own
+                // padding/border back out of the outer size), or the outer size directly for
+                // border-box (ActualBoxSizeIncludedWidth/Height is already 0 there, so this is a no-op).
+                box.Width = FormatLayoutUnits(Math.Max(0, box.ActualBoxSizingWidth - box.ActualBoxSizeIncludedWidth));
+                box.Height = FormatLayoutUnits(Math.Max(0, box.ActualBoxSizingHeight - box.ActualBoxSizeIncludedHeight));
 
                 box.RectanglesReset();
             }


### PR DESCRIPTION
## Summary

- A stretched or auto-row-measured CSS Grid item with `box-sizing: border-box` and non-zero padding/border rendered exactly that padding+border narrower/shorter than its actual track. The shrunk item exposed the grid container's own background around it — for a document using the `gap` + background-color divider technique (as in the reported repro), this looked like an oversized `gap`, even though `gap`'s own value was rendered correctly the whole time.
- Root cause spans two places: `CssLayoutEngineGrid.cs`'s `PlaceItemInCell`/`MeasureItemHeight`, and the shared `ItemContentCommit.CommitLayout` final layout pass (used by both Grid and Flex, and the one that actually runs on every real page-grid render) — both assigned a content-space size to the item's `Width`/`Height` unconditionally, which this engine's own box-sizing contract (`CssBox.ActualBoxSizeIncludedWidth`/`Height`) only makes correct for `content-box`.
- Verified end-to-end against the exact reported repro, rasterized with both PDFium and MuPDF — the divider lines now render as exact 1px hairlines instead of ~30-40px blocks.
- Flexbox has the identical bug pattern in `CssLayoutEngineFlex.ResizeItem`/`ShrinkColumnItemToContentWidth`; tracked separately as #815 (not fixed here, since it's flex-engine-specific work distinct from this Grid fix, though the shared `ItemContentCommit.CommitLayout` fix here does prevent it from being made worse by that shared path).

## Test plan

- [x] Added regression tests in `GridLayoutIntegrationTests.cs`: `gap` shorthand in px units with border-box padded items (both a fixed-width and an auto-width container), a row-axis (auto row height) analog, a px-unit `gap` coverage test (previously untested — only `column-gap:<N>pt` longhand existed), and a border-box-vs-content-box consistency check for the non-stretch (`justify-self`) fit-content path.
- [x] Full `PeachPDF.Tests` suite (net8.0): 9181 passed, 0 failed.
- [x] 100% diff coverage on changed lines.
- [x] `dotnet build -t:Rebuild`: 0 warnings.
- [x] Rendered the exact issue repro through the CLI and rasterized with both PDFium and MuPDF — both agree, hairlines render correctly.
- [x] 5-angle post-change review pass; addressed a real simplification finding (removed duplicate box-sizing-adjustment helpers in favor of the existing `CssBox.ActualBoxSizeIncludedWidth`/`Height`) and filed/tracked the flex analog as a proper accepted-gap + issue rather than leaving it as prose.

Fixes #811