### PR TITLE
Update PeachImage to 0.4.2 and use its HasAlpha API

### DIFF
--- a/.claude/migration-notes/2026-08-26-hasalpha-reflects-declared-not-scanned-alpha.md
+++ b/.claude/migration-notes/2026-08-26-hasalpha-reflects-declared-not-scanned-alpha.md
@@ -1,0 +1,14 @@
+# Raster embed path now follows the source's declared alpha channel, not a scan of real pixel transparency
+
+Previously: whether a decoded raster image embedded losslessly (preserving alpha, as an uncompressed PDF
+bitmap) or as lossy JPEG was decided by scanning every decoded pixel's alpha byte for real transparency -
+an image with a declared alpha channel but no actually-transparent pixels (e.g. an RGBA-color-type PNG
+where every pixel happens to have alpha=255) took the smaller JPEG path, same as a fully opaque source in
+any other format.
+
+Now: the same decision is made by PeachImage's own `Image.HasAlpha`, which reflects whether the *source
+format itself declares an alpha channel* (PNG color type, WebP alpha flag, GIF transparent-index
+declaration, BMP alpha mask, etc.) rather than whether any pixel is actually translucent. An image whose
+source declares alpha - even if every pixel in it is fully opaque - now takes the lossless embed path
+(larger, uncompressed) instead of JPEG. Images without a declared alpha channel are unaffected and
+continue to JPEG-embed as before.

--- a/src/PeachPDF.Tests/PdfSharpCore/PeachImageSourceTests.cs
+++ b/src/PeachPDF.Tests/PdfSharpCore/PeachImageSourceTests.cs
@@ -2,6 +2,7 @@ using MigraDocCore.DocumentObjectModel.MigraDoc.DocumentObjectModel.Shapes;
 using PeachImage;
 using PeachImage.Formats.Bmp;
 using PeachImage.Formats.Jpeg;
+using PeachImage.Formats.Png;
 using PeachImage.Formats.Webp;
 using PeachPDF.PdfSharpCore.Utils;
 using PeachPDF.Tests.TestSupport;
@@ -66,9 +67,20 @@ namespace PeachPDF.Tests.PdfSharpCoreTests
             return ms.ToArray();
         }
 
-        private static byte[] MakeBmpBytes(int width, int height, byte r, byte g, byte b, byte a = 255)
+        // Rgb24, not the Rgba32 MakeSolidImage below builds - BmpEncoder always writes an explicit
+        // alpha mask for an Rgba32 source (no opaque-content auto-downgrade like PNG's indexed mode
+        // has), so routing through MakeSolidImage would make every "opaque BMP" fixture declare an
+        // alpha channel it doesn't need, which Image.HasAlpha (unlike the old per-pixel scan) now takes
+        // at face value. Every caller here wants a genuinely non-alpha-declaring opaque BMP.
+        private static byte[] MakeBmpBytes(int width, int height, byte r, byte g, byte b)
         {
-            using var image = MakeSolidImage(width, height, r, g, b, a);
+            using var image = Image.Create(width, height, PixelFormat.Rgb24);
+            var pixels = image.GetPixelSpan();
+            for (int i = 0; i < pixels.Length; i += 3)
+            {
+                pixels[i] = r; pixels[i + 1] = g; pixels[i + 2] = b;
+            }
+
             using var ms = new MemoryStream();
             image.Save(ms, "bmp", new BmpEncoderOptions());
             return ms.ToArray();
@@ -112,13 +124,30 @@ namespace PeachPDF.Tests.PdfSharpCoreTests
         [Fact]
         public void FromBinary_OpaquePng_IsNotTransparent()
         {
-            // Transparent reflects real alpha content (a full pixel scan), not source format - an
-            // opaque PNG (a=255 everywhere) takes the lossy JPEG embed path exactly like an opaque
-            // JPEG/BMP/WebP/AVIF source would, since there's no alpha channel to lose.
+            // Transparent reflects Image.HasAlpha - whether the source format declares an alpha
+            // channel, not a per-pixel scan. This fixture is small and uniform-color, so PeachImage's
+            // encoder auto-picks indexed color (no alpha chunk) for it; it takes the lossy JPEG embed
+            // path exactly like an opaque JPEG/BMP/WebP/AVIF source would.
             var bytes = MakePngBytes(4, 4, 255, 0, 0);
             var img = ImageSource.FromBinary("test.png", () => bytes);
 
             Assert.False(img.Transparent);
+        }
+
+        [Fact]
+        public void FromBinary_OpaqueTruecolorPng_IsTransparent()
+        {
+            // Unlike the indexed-color case above: a PNG explicitly encoded with a real alpha channel
+            // (color type 6) reports Transparent = true from Image.HasAlpha even though every pixel is
+            // fully opaque (a=255 everywhere) - HasAlpha reflects the source's declared alpha channel,
+            // not whether any pixel is actually translucent.
+            using var image = MakeSolidImage(4, 4, 255, 0, 0, a: 255);
+            using var ms = new MemoryStream();
+            image.Save(ms, "png", new PngEncoderOptions { ColorMode = PngColorMode.Truecolor });
+
+            var img = ImageSource.FromBinary("test.png", () => ms.ToArray());
+
+            Assert.True(img.Transparent);
         }
 
         [Fact]
@@ -134,8 +163,9 @@ namespace PeachPDF.Tests.PdfSharpCoreTests
         public void FromBinary_GifWithTransparency_IsTransparent()
         {
             // Previously (PNG-magic-byte sniff): this GIF would have been mis-routed to the lossy JPEG
-            // path, silently dropping its transparency, since only a PNG signature counted. A real
-            // pixel-alpha scan catches it regardless of source format.
+            // path, silently dropping its transparency, since only a PNG signature counted.
+            // Image.HasAlpha (source-format-declared alpha, from GIF's own transparent-index
+            // declaration) catches it regardless of source format.
             var gifBytes = Convert.FromBase64String(
                 "R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==");
 

--- a/src/PeachPDF/PdfSharpCore/Utils/PeachImageSource.cs
+++ b/src/PeachPDF/PdfSharpCore/Utils/PeachImageSource.cs
@@ -4,8 +4,6 @@ using PeachImage.Formats.Bmp;
 using PeachImage.Formats.Jpeg;
 using System;
 using System.IO;
-using System.Numerics;
-using System.Runtime.InteropServices;
 
 namespace PeachPDF.PdfSharpCore.Utils
 {
@@ -56,7 +54,7 @@ namespace PeachPDF.PdfSharpCore.Utils
             try
             {
                 var decoded = Image.Load(stream, Rgba32DecoderOptions);
-                return new PeachImageSourceImpl(name, decoded, quality, HasRealAlpha(decoded));
+                return new PeachImageSourceImpl(name, decoded, quality, decoded.HasAlpha);
             }
             catch (ImageFormatException ex)
             {
@@ -71,43 +69,15 @@ namespace PeachPDF.PdfSharpCore.Utils
         }
 
         // Whether to embed losslessly (preserving alpha, via SaveAsPdfBitmap) or as lossy JPEG is
-        // decided by real alpha content, not by source format - a WebP/AVIF/GIF image with genuine
-        // transparency needs the lossless path exactly as much as a PNG does (see
-        // .claude/migration-notes for the behavior change this replaced: a PNG-magic-byte sniff that
-        // silently dropped alpha on any non-PNG-sniffed source). Decoding always produces Rgba32 (see
-        // Rgba32DecoderOptions above), so this scans every pixel's alpha byte once, right after decode.
-        //
-        // Vectorized: GetPixelSpan() is R,G,B,A bytes, tightly packed, so reinterpreting it as a uint
-        // span puts each pixel's alpha byte in the top byte of its uint (little-endian). A batch of
-        // pixels is fully opaque iff every uint, masked to its top byte, still reads 0xFF000000 - so
-        // ANDing a whole Vector<uint> batch against that mask and comparing to the same mask broadcast
-        // finds a non-opaque pixel anywhere in the batch in one comparison, with an early exit the
-        // moment one is found (most images are either fully opaque or have alpha concentrated in one
-        // region, so most calls return well before scanning the whole buffer).
-        private static bool HasRealAlpha(Image decoded)
-        {
-            ReadOnlySpan<uint> pixels = MemoryMarshal.Cast<byte, uint>(decoded.GetPixelSpan());
-            const uint alphaMask = 0xFF000000u;
-            var maskVector = new Vector<uint>(alphaMask);
-
-            int i = 0;
-            int vectorizedLength = pixels.Length - pixels.Length % Vector<uint>.Count;
-            for (; i < vectorizedLength; i += Vector<uint>.Count)
-            {
-                var batch = new Vector<uint>(pixels.Slice(i, Vector<uint>.Count));
-                if (!Vector.EqualsAll(batch & maskVector, maskVector))
-                    return true;
-            }
-
-            for (; i < pixels.Length; i++)
-            {
-                if ((pixels[i] & alphaMask) != alphaMask)
-                    return true;
-            }
-
-            return false;
-        }
-
+        // decided by Image.HasAlpha - PeachImage 0.4.2+'s own record of whether the *source* declares
+        // an alpha channel (PNG color type, WebP alpha flag, GIF transparent-index declaration, BMP
+        // alpha mask, etc.), set by every codec from the source's header/chunk metadata rather than a
+        // per-pixel scan. That means a source that declares alpha but happens to be fully opaque (e.g.
+        // an RGBA-color-type PNG with alpha=255 everywhere) now takes the lossless path even though no
+        // pixel is actually translucent - a deliberate trade of "know it from the format" over "prove it
+        // from the pixels", not an oversight. See .claude/migration-notes for the behavior change this
+        // replaced: a per-pixel Vector<uint> scan of the decoded Rgba32 buffer that decided the embed
+        // path from real transparency rather than declared format capability.
         private sealed class PeachImageSourceImpl : IImageSource
         {
             private readonly Image _rgba;

--- a/src/PeachPDF/PeachPDF.csproj
+++ b/src/PeachPDF/PeachPDF.csproj
@@ -40,7 +40,7 @@
 		net10.0-conditioned - see .claude/recent-fixes/2026-08-15-net10-image-codec-ported-to-peachimage.md).
 	-->
 	<ItemGroup>
-		<PackageReference Include="PeachImage" Version="0.4.1" />
+		<PackageReference Include="PeachImage" Version="0.4.2" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Remove="PdfSharpCore\Resources\Messages.restext" />


### PR DESCRIPTION
## Summary
- Bumps the `PeachImage` package reference to 0.4.2.
- Replaces `PeachImageSource`'s hand-rolled vectorized per-pixel alpha scan with PeachImage 0.4.2's new `Image.HasAlpha`, which reflects whether the source format declares an alpha channel (PNG color type, WebP alpha flag, GIF transparent-index declaration, BMP alpha mask, etc.) rather than scanning decoded pixels for real transparency.
- This is a deliberate behavior change: a source that declares an alpha channel but is fully opaque (e.g. an RGBA-color-type PNG with alpha=255 everywhere) now takes the lossless embed path instead of JPEG. Recorded in a migration note.

## Test plan
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings, 0 errors
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~PeachImageSource"` — 33/33 passed
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite, 9280 passed / 9 skipped (platform-specific) / 0 failed