### PR TITLE
Fix rounded-path rendering under non-default PixelsPerInch

### DIFF
--- a/.claude/accepted-gaps/box-shadow-blur-steps-pixelsperpoint.md
+++ b/.claude/accepted-gaps/box-shadow-blur-steps-pixelsperpoint.md
@@ -1,0 +1,26 @@
+# `box-shadow` blur approximation band count ignores non-default `PixelsPerInch`
+
+`FragmentPainter.Decorations.BlurSteps(double blur)` decides how many concentric ring/rect fills
+approximate a blurred `box-shadow`'s falloff: `Math.Clamp((int)Math.Round(blur * 2), 6, 40)`. The `blur`
+value it reads is already `PixelsPerInch`-inflated layout-space (per issue #814's absolute-length scaling
+contract, applied before `BlurSteps` is called), and `BlurSteps` has no `PixelsPerPoint` awareness of its
+own - so the number of blur layers scales with `PixelsPerInch`, even though each individual ring's
+position/size is correct (fixed for [#812](https://github.com/jhaygood86/PeachPDF/issues/812)'s
+`BuildRingPath`/`BuildLayerRoundRect`).
+
+Confirmed: a `box-shadow: inset 0 0 10pt black` renders with 20 concentric rings at the default
+`PixelsPerInch = 72`, and 40 at `PixelsPerInch = 144` - double the layers, for the identical declared blur
+radius.
+
+Not a "wrong position" bug - purely a rendering-*quality* difference (a smoother or coarser blur
+approximation depending on `PixelsPerInch`, clamped to a 6-40 band range so it's never dramatically
+coarse). Distinct from, and lower-severity than, the position/leak bugs #812 fixed; deliberately not
+bundled into that fix to keep it scoped to what was actually reported.
+
+Discovered while adding #812's own regression test coverage for `BuildRingPath`
+(`BoxShadowPaintIntegrationTests.BlurredInsetShadow_RingBounds_StayWithinPaddingBoxUnderNonDefaultPixelsPerInch`)
+- an earlier draft of that test compared ring counts across two `PixelsPerInch` values and spuriously
+failed on this unrelated difference before being redesigned to assert bounds directly instead.
+
+Tracked as [issue #852](https://github.com/jhaygood86/PeachPDF/issues/852); fix sketch there is dividing
+`blur` by the ambient `PixelsPerPoint` before calling `BlurSteps` (or passing it in and dividing there).

--- a/.claude/accepted-gaps/rounded-border-stroke-width-pixelsperpoint.md
+++ b/.claude/accepted-gaps/rounded-border-stroke-width-pixelsperpoint.md
@@ -1,0 +1,22 @@
+# Border stroke width ignores non-default `PixelsPerInch`
+
+`BordersDrawHandler.GetWidth(Border, CssBox)` returns `box.ActualBorderTopWidth`/`ActualBorderLeftWidth`/
+etc. directly - an internal, `PixelsPerInch`-inflated layout-space value, the same space `CssBox` geometry
+lives in throughout layout. `GetPen(RGraphics g, LineStyle, RColor, double width)` assigns that raw value
+straight to `RPen.Width` with no division by `g.PixelsPerPoint`, unlike every draw *coordinate* in this
+file and in `GraphicsAdapter.cs`, which are all correctly divided before reaching the backend.
+
+At the library's default `PixelsPerInch = 72` (`PixelsPerPoint = 1.0`) this is invisible - dividing by 1.0
+is a no-op. At any other value, every border - straight or rounded - renders visibly thicker than its
+declared width, proportionally to `PixelsPerInch / 72`, while its *position* stays correct (that part was
+fixed for [#812](https://github.com/jhaygood86/PeachPDF/issues/812)'s rounded-path clip/border/background
+position-and-radius scaling; the pen's own stroke *width* is a separate, independent value this fix
+deliberately left alone to keep that PR's scope to what #812 actually reported).
+
+Confirmed visually in the `border_radius_96dpi` TestHarness showcase (added alongside the #812 fix): every
+swatch's `border: 2px solid` renders noticeably bolder at `PixelsPerInch = 96` than at the default 72,
+while every rounded curve's position/size and every overflow-clip boundary render identically at both.
+
+Tracked as [issue #851](https://github.com/jhaygood86/PeachPDF/issues/851); fix sketch there is a one-line
+`width / g.PixelsPerPoint` division in `GetPen` (or at `GetWidth`'s call sites), mirroring the correction
+already applied to border/background/overflow-clip path coordinates.

--- a/.claude/migration-notes/2026-08-28-rounded-border-background-overflow-clip-under-non-default-pixelsperinch.md
+++ b/.claude/migration-notes/2026-08-28-rounded-border-background-overflow-clip-under-non-default-pixelsperinch.md
@@ -1,0 +1,28 @@
+# Rounded borders, backgrounds, `overflow: hidden`, `clip-path`, and box-shadow rings under a non-default `PixelsPerInch`
+
+Previously, under a non-default `PdfGenerateConfig.PixelsPerInch` (anything other than the default 72),
+several kinds of curved/clipped geometry rendered too large and mis-positioned relative to the rest of the
+page, proportionally to `PixelsPerInch / 72`:
+
+- A rounded border's own **stroke** could visibly overshoot past the box's actual content, into whatever
+  rendered below or beside it.
+- A rounded `background-color`/`background-image` fill, or a `background-clip: padding-box`/`content-box`
+  curve, could render offset from the border/content it was meant to fill.
+- An `overflow: hidden` box's rounded descendant clip curve could fail to overlap its own (correctly
+  positioned) content at all - clipping a clipped child's fill, or occasionally its text, away entirely.
+- A `clip-path: polygon()/inset()/circle()/ellipse()` shape could render badly mis-scaled and mis-positioned
+  - e.g. a `circle(50%)` clip rendering as a mangled quarter-shape instead of a full circle.
+- A blurred `box-shadow: inset ...`'s concentric ring fills (its falloff approximation) could render
+  detached from the box they were meant to shade, rather than framing it symmetrically.
+
+All of the above are now correct: rendering at any `PixelsPerInch` produces the same position and size as
+at the (unaffected) default `PixelsPerInch` of 72. Documents that only ever used the default `PixelsPerInch`
+saw no change.
+
+Two related things are **not** part of this fix and still scale incorrectly under a non-default
+`PixelsPerInch`:
+
+- A rounded border's stroke **width** (its thickness, as opposed to its position) - tracked as
+  [issue #851](https://github.com/jhaygood86/PeachPDF/issues/851).
+- A blurred `box-shadow`'s number of concentric approximation layers (a rendering-smoothness difference,
+  not a wrong position) - tracked as [issue #852](https://github.com/jhaygood86/PeachPDF/issues/852).

--- a/.claude/recent-fixes/2026-08-28-rounded-path-pixelsperpoint-scaling.md
+++ b/.claude/recent-fixes/2026-08-28-rounded-path-pixelsperpoint-scaling.md
@@ -1,0 +1,161 @@
+# Box-geometry paths (rounded corners, clip-path, box-shadow rings) ignore non-default PixelsPerInch (issue #812, reopened)
+
+## What was reported
+
+The original [#812 fix](2026-08-24-rounded-overflow-clip-and-joint-radius-reduction.md) (`b41a6671`,
+`425247bd`) addressed two symptoms - a rounded progress-bar's clipped child rendering solid with a
+duplicated "ghost" shape, and a rounded card's own border "leaking" past its box - and was verified
+extensively (unit tests, integration tests, both PDFium and MuPDF rasterization) at the library's default
+`PdfGenerateConfig.PixelsPerInch` of 72. The reporter re-tested the released fix using their production
+config, `PixelsPerInch = 96`, and both symptoms were back, plus a new one: text inside a box with both
+`border-radius` and `overflow: hidden` could vanish entirely.
+
+## What was actually wrong
+
+`PdfSharpAdapter.PixelsPerPoint = PixelsPerInch / 72` inflates the entire internal CSS layout coordinate
+space relative to true PDF points, and every `GraphicsAdapter` draw primitive (`DrawLine`, `DrawRectangle`,
+`PushClip(RRect)`) is individually responsible for dividing its own raw coordinates back down before
+calling into the PdfSharpCore/XGraphics backend. At `PixelsPerInch = 72` (`PixelsPerPoint = 1.0`) a missed
+division is invisible - exactly why the original fix's own thorough (both renderers, both repro shapes)
+verification never caught this, since it predates the very commit that made absolute lengths (like
+`border-radius: 999px`) correctly `PixelsPerPoint`-scaled in the first place
+([2026-08-24-pixelsperinch-absolute-length-scaling.md](2026-08-24-pixelsperinch-absolute-length-scaling.md),
+landed later the same day).
+
+**Four independent code paths** build `RGraphicsPath` box geometry directly from raw, un-divided
+layout-space coordinates, and neither the path-building code nor its consumers
+(`GraphicsAdapter.PushClip(RGraphicsPath)`/`DrawPath`) ever divided by `PixelsPerPoint`:
+
+1. `RenderUtils.GetRoundRect` - shared by the `overflow: hidden` descendant clip curve, rounded
+   background-color/image fills (including `background-clip: padding-box`/`content-box` curves and
+   box-shadow's rounded layer/clip helper), and rounded form-field/list-marker chrome.
+2. `BordersDrawHandler.GetRoundedBorderPath` - a **separate, independent** per-side path builder for the
+   rounded border **stroke** itself, sharing no code with `GetRoundRect`. This is what let symptom B (the
+   border overshoot) reproduce from `border-radius` alone, with no `overflow: hidden` at all - a
+   minimal repro built from the reporter's own follow-up comments (a rounded card containing a header and
+   a 3-column CSS Grid) confirmed this: removing just `overflow: hidden` and keeping `border-radius` still
+   showed the border overshooting past the card's actual content, into unrelated text below.
+3. `CssClipPathResolver.TryBuildClipPath` (and its `BuildPolygon`/`BuildInset`/`BuildCircle`/`BuildEllipse`
+   helpers) - resolves `clip-path: polygon()/inset()/circle()/ellipse()` against the element's border-box,
+   pushed via the same un-dividing `PushClip(RGraphicsPath)`. Found during this fix's own post-change
+   review (three independent review passes converged on it), not in the original report; confirmed with a
+   `clip-path: circle(50%)` repro that rendered as a mangled quarter-shape at `PixelsPerInch = 96` instead
+   of a full circle.
+4. `FragmentPainter.Decorations.BuildRingPath` - the concentric even-odd ring fills that approximate a
+   *blurred inset* `box-shadow`'s falloff (drawn via `DrawPath`, not clipped). Also found during post-change
+   review; confirmed with an `inset 0 0 20px` shadow repro whose ring geometry visibly detached from the
+   box at `PixelsPerInch = 96` instead of framing it symmetrically. Note `BuildLayerRoundRect` - the
+   *outset*-shadow and inset-shadow-*clip* path builder a few lines away in the same file - was already
+   correct, since it's a thin wrapper around the now-fixed `RenderUtils.GetRoundRect` (item 1); only the
+   ring-fill geometry was its own, separately un-divided code.
+
+`RGraphicsPath` has a second, legitimate un-divided-by-design consumer - SVG shape rendering and
+glyph/COLR outline painting - which always paints under an active `g.PushTransform(...)` whose own linear
+part performs the layout→point conversion (the same pattern the absolute-length fix established for SVG's
+viewport transform). Dividing inside the shared `GraphicsPathAdapter`/`PushClip`/`DrawPath` would have
+double-scaled every SVG shape and glyph outline while fixing the four box-geometry consumers above; fixing
+at each path-*building* call site was the correct, fully-scoped fix. A full sweep of every
+`GetGraphicsPath()` call site in the codebase (`grep -rn "\.GetGraphicsPath()"`) after the fact confirmed
+no fifth consumer was missed.
+
+## What was actually done
+
+All four builders above now read `g.PixelsPerPoint` once and divide their rect/radii/length/border-width
+inputs by it before building the path - mirroring exactly how every other `GraphicsAdapter` draw primitive
+divides its own raw coordinates at its own call boundary:
+
+- `RenderUtils.GetRoundRect` and `BordersDrawHandler.GetRoundedBorderPath`: divide the rect, radii, and
+  (for the latter) border widths directly. `GetRoundedBorderPath`'s fix is a mechanical rename-and-divide
+  of the existing per-side arc/line arithmetic; the corner-subset/mitre logic itself (the
+  `noTop`/`noBottom` bevel-avoidance branches) is unchanged.
+- `CssClipPathResolver`: divides only the *final*, fully-resolved coordinate at each `path.Start`/`LineTo`/
+  `AddMove`/`AppendEllipse` call, leaving every upstream `CssValueParser.ParseLength` call (and the
+  `referenceBox` it resolves percentages against) completely untouched. This is deliberate, not just
+  simpler: `ParseLength`'s absolute-length branch already applies its own `PixelsPerPoint` catch-up
+  multiply (per issue #814) independent of the percentage basis passed in, so pre-dividing
+  `referenceBox.Width`/`.Height` before resolution would correctly scale a *percentage* clip-path point but
+  leave an *absolute-length* one (`polygon(10px 10px, ...)`) still un-divided - verified by hand-deriving
+  both cases algebraically before choosing this approach.
+- `FragmentPainter.Decorations.BuildRingPath`: divides `outer`/`hole`'s four edges directly.
+
+## What was deliberately not done
+
+- **Border stroke *width* (not position)** - `BordersDrawHandler.GetWidth`/`GetPen` sets a pen's `Width`
+  from an equally un-divided value, a real, pre-existing, separate bug (wrong stroke *thickness*, not
+  position/shape, and not specific to rounded corners - confirmed visually in the `border_radius_96dpi`
+  TestHarness showcase this fix adds, where every swatch's border renders visibly bolder at
+  `PixelsPerInch = 96` even though every curve's position/size is now correct). Tracked as
+  [issue #851](https://github.com/jhaygood86/PeachPDF/issues/851); see
+  [.claude/accepted-gaps/rounded-border-stroke-width-pixelsperpoint.md](../accepted-gaps/rounded-border-stroke-width-pixelsperpoint.md).
+- **Box-shadow blur approximation band *count*** - `FragmentPainter.Decorations.BlurSteps` reads the
+  still-layout-space `blur` value directly, so the number of concentric ring/rect fills approximating a
+  blur's falloff scales with `PixelsPerInch` (20 rings at 72, 40 at 144, for the same declared blur radius)
+  even though - after this fix - each ring's own position/size is correct. A rendering-*quality* difference,
+  not a wrong-position one; found while writing this fix's own `BuildRingPath` regression test (an earlier
+  draft compared ring counts across two `PixelsPerInch` values and spuriously failed on this unrelated
+  difference before being redesigned to assert bounds directly). Tracked as
+  [issue #852](https://github.com/jhaygood86/PeachPDF/issues/852); see
+  [.claude/accepted-gaps/box-shadow-blur-steps-pixelsperpoint.md](../accepted-gaps/box-shadow-blur-steps-pixelsperpoint.md).
+- **A pre-existing, independent typo** in `GetRoundedBorderPath`'s `Border.Right` case: its top-right arc
+  endpoint offsets by `ActualBorderLeftWidth` where the surrounding, symmetric code all uses the edge's own
+  width (`ActualBorderRightWidth`) - would misplace the top-right corner whenever left and right border
+  widths differ. Unrelated to `PixelsPerPoint`, kept exactly as-is (just correctly scaled) rather than
+  fixed alongside, to keep this change to one concern. Tracked as
+  [issue #853](https://github.com/jhaygood86/PeachPDF/issues/853).
+- The reporter's third, no-minimal-repro-found symptom ("`<dt>` labels in the first metrics row disappear")
+  was not independently reproduced. Plausible under this same root cause (a sufficiently mis-scaled clip
+  path can fail to overlap real content at all, matching the vanished-text symptom that *was* reproduced),
+  but not chased as a separate fix.
+
+## Evidence
+
+- Full suite: `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - 9286 passed, 0
+  failed, 9 skipped (pre-existing platform-gated skips).
+- New tests verified to fail against the pre-fix source (stashed each fix's files individually, reran,
+  every discriminating fixture failed with values matching exactly the predicted un-divided-by-`ppp`
+  magnitude, then restored): `RenderUtilsTests.GetRoundRect_DividesRectAndRadiiByPixelsPerPoint`/
+  `_IsInvariantUnderPixelsPerPoint`, `RoundedBorderStrokePixelsPerPointIntegrationTests`'s two facts,
+  `PaddingContentEdgeRadiusPaintIntegrationTests`'s three new facts (background-clip curve invariance,
+  overflow-clip curve invariance, and the issue's own pill-shape repro staying within bounds),
+  `ClipPathResolverIntegrationTests`'s three new facts (polygon/inset/circle), and
+  `BoxShadowPaintIntegrationTests.BlurredInsetShadow_RingBounds_StayWithinPaddingBoxUnderNonDefaultPixelsPerInch`.
+- A full `grep -rn "\.GetGraphicsPath()"` sweep across `src/PeachPDF` after all four fixes confirmed every
+  box-geometry consumer is now covered and every SVG/glyph-outline consumer is correctly left untouched.
+- Diff coverage vs. `main`: 100% on changed source lines.
+- `dotnet build PeachPDF.slnx -t:Rebuild` - 0 warnings.
+- The issue's own two repros, a grid-card variant built from the reporter's follow-up comments, a
+  `clip-path: circle(50%)` repro, and an `inset 0 0 20px` box-shadow repro, all re-rendered via a direct
+  `PdfGenerator.GeneratePdf` call (not the CLI, which never sets `PixelsPerInch` and defaults to 72 - part
+  of why the original fix's own CLI-based verification never caught this) at `PixelsPerInch = 96`, then
+  rasterized with both PDFium and MuPDF and pixel-diffed against the `PixelsPerInch = 72` render of the
+  same HTML: all five showed real, visible differences before their respective fix (vanished fill, border
+  overshoot into unrelated content, a mangled clip shape, a detached shadow ring) and were pixel-identical
+  (modulo sub-pixel anti-aliasing noise) after.
+- New `border_radius_96dpi` TestHarness showcase, rendered and rasterized with both PDFium and MuPDF:
+  every rounded curve's position/size and every overflow-clip boundary match the default-72 showcase
+  exactly; only the (separately tracked, #851) border stroke thickness differs.
+
+## Traps for a future change
+
+- **This bug class needed re-finding twice within one fix.** The first pass (items 1-2 above) fixed the
+  two builders the original report actually exercised; a post-change review pass (three independent review
+  agents, each searching the codebase from a different angle) found two more sibling instances (items 3-4)
+  that the same root-cause description already implied but the fix hadn't reached. Before declaring a
+  future `PixelsPerPoint`-scaling fix complete, grep every `GetGraphicsPath()` call site in the codebase
+  (not just the ones a specific bug report's repro happens to exercise) and verify each one either divides
+  by `PixelsPerPoint` itself or paints under an ambient `PushTransform` that already does.
+- `RenderUtils.GetRoundRect`, `BordersDrawHandler.GetRoundedBorderPath`, `CssClipPathResolver`, and
+  `FragmentPainter.Decorations.BuildRingPath` are four independent path builders that happen to solve
+  variations of the same problem - a future change to one's `PixelsPerPoint` handling (or any other
+  coordinate-space concern) does **not** automatically apply to the others.
+- `RGraphicsPath`/`GraphicsPathAdapter` deliberately performs no `PixelsPerPoint` scaling anywhere - it's a
+  dumb coordinate carrier, and the *caller* is always responsible for pre-dividing before building a path,
+  exactly like every other `RGraphics` draw primitive divides at its own call boundary. A future new
+  consumer of `GetGraphicsPath()` needs to make its own call on which space its coordinates start in (SVG
+  and glyph-outline paths are pre-divided a different way, via an ambient `PushTransform`) and divide
+  accordingly - there is no single correct default to fall back on.
+- `CssClipPathResolver`'s approach (divide only the final resolved coordinate, never the inputs to
+  `CssValueParser.ParseLength`) is the correct pattern for any similarly-structured future fix: `ParseLength`
+  already applies its own `PixelsPerPoint` catch-up for absolute lengths regardless of what percentage
+  basis it's given, so pre-dividing a shared "reference" value used for *both* percentage resolution and
+  absolute-length composition silently miscales the absolute-length case. Divide once, at the very end.

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -334,6 +334,26 @@ await SaveShowcaseAsync("border_radius", "Backgrounds & Borders", "Border Radius
     "border-radius from simple uniform rounding to per-corner and elliptical radii, on filled and bordered boxes, plus overflow:hidden clipping descendant content to the curve and background-clip's inset curves reduced by border width.",
     radiusHtml, pdfConfig);
 
+// Renders the exact same document as the border_radius showcase above, but at a non-default
+// PixelsPerInch (issue #812, reopened) - every rounded border stroke, background fill, and
+// overflow-clip curve above is built from a PdfSharpAdapter.PixelsPerPoint-inflated layout-space
+// rect/radii; RenderUtils.GetRoundRect and BordersDrawHandler.GetRoundedBorderPath must divide by
+// PixelsPerPoint before building their paths, or the rounded geometry above renders too large and
+// mis-positioned relative to everything else on the page. ShrinkToFit is deliberately left off here
+// (unlike pdfConfig above) since it recomputes its own effective PixelsPerPoint from content
+// measurement and would make the two renders an apples-to-oranges comparison rather than isolating
+// the PixelsPerInch=96-vs-72 difference this showcase exists to demonstrate.
+PdfGenerateConfig pdfConfig96 = new()
+{
+    PageSize = PageSize.A4,
+    PageOrientation = PageOrientation.Portrait,
+    PixelsPerInch = 96
+};
+
+await SaveShowcaseAsync("border_radius_96dpi", "Backgrounds & Borders", "Border Radius (96 DPI)",
+    "The same border-radius coverage as the Border Radius showcase, rendered at PixelsPerInch=96 instead of the library's default 72 — confirms rounded borders, backgrounds, and overflow-clip curves render identically regardless of PixelsPerInch.",
+    radiusHtml, pdfConfig96);
+
 // --- Box-shadow showcase ---
 
 const string ShadowCss = """

--- a/src/PeachPDF.Tests/Html/Core/Utils/RenderUtilsTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Utils/RenderUtilsTests.cs
@@ -17,5 +17,58 @@ namespace PeachPDF.Tests.Html.Core.Utils
 
             Assert.True(path.Closed);
         }
+
+        /// <summary>
+        /// Issue #812 (reopened): <c>GetRoundRect</c> is fed raw layout-space (<c>PixelsPerInch</c>-inflated)
+        /// coordinates - the same space <c>CssBox</c> geometry lives in - but neither
+        /// <c>RGraphics.PushClip(RGraphicsPath)</c> nor <c>DrawPath</c> ever divides a path's coordinates
+        /// by <c>PixelsPerPoint</c> before handing them to the backend, unlike every other draw primitive.
+        /// At a non-default <c>PixelsPerInch</c> (<c>PixelsPerPoint != 1.0</c>), a rounded-rect path built
+        /// from un-divided coordinates renders too large and mis-positioned relative to everything else on
+        /// the page. <c>GetRoundRect</c> must divide by <c>g.PixelsPerPoint</c> itself.
+        /// </summary>
+        [Fact]
+        public void GetRoundRect_DividesRectAndRadiiByPixelsPerPoint()
+        {
+            var g = new RecordingGraphics(new PdfSharpAdapter()) { PixelsPerPointOverride = 2.0 };
+
+            using var path = (RecordingGraphicsPath)RenderUtils.GetRoundRect(g, new RRect(0, 0, 200, 80),
+                20, 20, 20, 20, 20, 20, 20, 20);
+
+            Assert.All(path.Arcs, arc =>
+            {
+                Assert.Equal(10.0, arc.RadiusX);
+                Assert.Equal(10.0, arc.RadiusY);
+            });
+            // Rect (0,0,200,80) / 2.0 = (0,0,100,40) - every point should land within that halved rect.
+            Assert.All(path.Points, p =>
+            {
+                Assert.InRange(p.X, 0, 100);
+                Assert.InRange(p.Y, 0, 40);
+            });
+            Assert.Contains((100.0, 10.0), path.Points); // top-right corner's arc endpoint
+        }
+
+        /// <summary>
+        /// A rounded-rect path built at a non-default <c>PixelsPerInch</c> must come out identical (in
+        /// true point-space terms) to the same shape built at the library's default 72 - <c>PixelsPerInch</c>
+        /// is a pure internal layout-coordinate-scale knob with zero intended visual effect.
+        /// </summary>
+        [Fact]
+        public void GetRoundRect_IsInvariantUnderPixelsPerPoint()
+        {
+            var gDefault = new RecordingGraphics(new PdfSharpAdapter()) { PixelsPerPointOverride = 1.0 };
+            using var pathDefault = (RecordingGraphicsPath)RenderUtils.GetRoundRect(gDefault,
+                new RRect(10, 20, 100, 40), 10, 10, 10, 10, 10, 10, 10, 10);
+
+            // Simulates the real internal-space inflation a box would have at PixelsPerInch=144
+            // (PixelsPerPoint=2.0): every coordinate pre-multiplied by 2 before reaching GetRoundRect.
+            var gScaled = new RecordingGraphics(new PdfSharpAdapter()) { PixelsPerPointOverride = 2.0 };
+            using var pathScaled = (RecordingGraphicsPath)RenderUtils.GetRoundRect(gScaled,
+                new RRect(20, 40, 200, 80), 20, 20, 20, 20, 20, 20, 20, 20);
+
+            Assert.Equal(pathDefault.Arcs, pathScaled.Arcs);
+            Assert.Equal(pathDefault.Points, pathScaled.Points);
+        }
     }
 }

--- a/src/PeachPDF.Tests/Integration/BoxShadowPaintIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/BoxShadowPaintIntegrationTests.cs
@@ -213,6 +213,50 @@ namespace PeachPDF.Tests.Integration
             Assert.DoesNotContain(g.Log, c => c is TestRecordingGraphics.DrawPathCall);
         }
 
+        /// <summary>
+        /// Issue #812 (reopened): the concentric ring fills a blurred inset shadow paints
+        /// (<c>FragmentPainter.Decorations.BuildRingPath</c>) are built from raw layout-space coordinates
+        /// and drawn via <c>RGraphics.DrawPath</c>, which never divides by <c>PixelsPerPoint</c> - so
+        /// <c>BuildRingPath</c> itself must divide. Verified end-to-end (real layout at a non-default
+        /// <c>PixelsPerPoint</c>, not just the isolated path builder) since the bug's actual trigger is the
+        /// box's own layout-space geometry, not a hand-constructed rect.
+        /// </summary>
+        /// <remarks>
+        /// Asserts bounds directly rather than comparing ring-for-ring against a default-PixelsPerInch
+        /// run: <c>FragmentPainter.Decorations.BlurSteps</c> (the blur approximation's band count) is a
+        /// separate, pre-existing PixelsPerPoint-sensitivity - it reads the still-layout-space (un-divided)
+        /// <c>blur</c> value directly, so the number of concentric rings itself varies with
+        /// <c>PixelsPerInch</c> (a rendering-quality knob, not a wrong position/size - out of scope here,
+        /// same category as the pen-width gap tracked in
+        /// .claude/accepted-gaps/rounded-border-stroke-width-pixelsperpoint.md). A ring-count-dependent
+        /// comparison would spuriously fail on that unrelated difference.
+        /// </remarks>
+        [Fact]
+        public async Task BlurredInsetShadow_RingBounds_StayWithinPaddingBoxUnderNonDefaultPixelsPerInch()
+        {
+            const string html = "<div id='el' style='box-shadow: inset 0 0 10pt black; background: white; width: 40pt; height: 30pt'>x</div>";
+
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(html), pixelsPerPoint: 2.0);
+            var el = LayoutHarness.FindById(root, "el")!;
+            var g = new TestRecordingGraphics { PixelsPerPointOverride = 2.0 };
+            FragmentPaintHarness.PaintBox(container, el, g);
+
+            var rings = g.Log.OfType<TestRecordingGraphics.DrawPathCall>()
+                .Where(p => p.Color is { R: 0, G: 0, B: 0, A: > 0 }).ToList();
+            Assert.NotEmpty(rings);
+
+            // The box (with its default 20pt margin) is only 40x30pt - a generous bound around it. Before
+            // the fix, BuildRingPath's un-divided (2x too large) coordinates put every ring's bounds well
+            // outside this range.
+            Assert.All(rings, r =>
+            {
+                Assert.InRange(r.Bounds.Left, -20, 120);
+                Assert.InRange(r.Bounds.Right, -20, 120);
+                Assert.InRange(r.Bounds.Top, -20, 120);
+                Assert.InRange(r.Bounds.Bottom, -20, 120);
+            });
+        }
+
         // ── Helpers ───────────────────────────────────────────────────────────────
 
         private static string Wrap(string body) =>

--- a/src/PeachPDF.Tests/Integration/ClipPathResolverIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/ClipPathResolverIntegrationTests.cs
@@ -162,5 +162,81 @@ namespace PeachPDF.Tests.Integration
             Assert.Null(path);
             Assert.False(useEvenOdd);
         }
+
+        /// <summary>
+        /// Issue #812 (reopened): like <c>RenderUtils.GetRoundRect</c>/<c>BordersDrawHandler.GetRoundedBorderPath</c>,
+        /// <c>TryBuildClipPath</c> is fed raw layout-space coordinates and pushes its path via
+        /// <c>RGraphics.PushClip(RGraphicsPath)</c>, which never divides by <c>PixelsPerPoint</c> - so the
+        /// resolver itself must divide every final coordinate before it reaches the path. Verified directly
+        /// against the resolver (not full layout), so <see cref="TestRecordingGraphics.PixelsPerPointOverride"/>
+        /// alone drives the division; the values below are exactly this class's own
+        /// <see cref="Polygon_ResolvesPercentAndLengthPointsAgainstReferenceBox"/> case, halved.
+        /// </summary>
+        [Fact]
+        public async Task Polygon_NonDefaultPixelsPerPoint_DividesFinalCoordinates()
+        {
+            var box = await BuildBoxAsync();
+            var g = new TestRecordingGraphics { PixelsPerPointOverride = 2.0 };
+            var reference = new RRect(100, 200, 300, 400);
+
+            var built = CssClipPathResolver.TryBuildClipPath(
+                g, "polygon(0% 0%, 100% 0%, 50% 100%)", reference, box, out var path, out _);
+
+            Assert.True(built);
+            var points = ((TestGraphicsPath)path!).Points;
+
+            Assert.Equal(3, points.Count);
+            Assert.Equal(50, points[0].X, 3);
+            Assert.Equal(100, points[0].Y, 3);
+            Assert.Equal(200, points[1].X, 3);
+            Assert.Equal(100, points[1].Y, 3);
+            Assert.Equal(125, points[2].X, 3);
+            Assert.Equal(300, points[2].Y, 3);
+        }
+
+        [Fact]
+        public async Task Inset_NonDefaultPixelsPerPoint_DividesFinalCoordinates()
+        {
+            var box = await BuildBoxAsync();
+            var g = new TestRecordingGraphics { PixelsPerPointOverride = 2.0 };
+            var reference = new RRect(0, 0, 200, 100);
+
+            var built = CssClipPathResolver.TryBuildClipPath(
+                g, "inset(10pt 20pt 30pt 40pt)", reference, box, out var path, out _);
+
+            Assert.True(built);
+            var points = ((TestGraphicsPath)path!).Points;
+
+            // Halved rect LTRB = (20,5)..(90,35), per Inset_ResolvesRectangleEdges's (40,10)..(180,70).
+            Assert.Equal(4, points.Count);
+            Assert.Equal(20, points[0].X, 3);
+            Assert.Equal(5, points[0].Y, 3);
+            Assert.Equal(90, points[1].X, 3);
+            Assert.Equal(5, points[1].Y, 3);
+            Assert.Equal(90, points[2].X, 3);
+            Assert.Equal(35, points[2].Y, 3);
+            Assert.Equal(20, points[3].X, 3);
+            Assert.Equal(35, points[3].Y, 3);
+        }
+
+        [Fact]
+        public async Task Circle_NonDefaultPixelsPerPoint_DividesFinalCoordinates()
+        {
+            var box = await BuildBoxAsync();
+            var g = new TestRecordingGraphics { PixelsPerPointOverride = 2.0 };
+            var reference = new RRect(0, 0, 200, 100);
+
+            var built = CssClipPathResolver.TryBuildClipPath(
+                g, "circle()", reference, box, out var path, out _);
+
+            Assert.True(built);
+            var points = ((TestGraphicsPath)path!).Points;
+
+            // Halved bounds of Circle_ClosestSide_UsesMinCenterToEdgeDistance's (50,0)..(150,100).
+            Assert.Equal(25, points.Min(p => p.X), 3);
+            Assert.Equal(75, points.Max(p => p.X), 3);
+            Assert.Equal(0, points.Min(p => p.Y), 3);
+            Assert.Equal(50, points.Max(p => p.Y), 3);
+        }
     }
 }

--- a/src/PeachPDF.Tests/Integration/PaddingContentEdgeRadiusPaintIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/PaddingContentEdgeRadiusPaintIntegrationTests.cs
@@ -140,5 +140,78 @@ namespace PeachPDF.Tests.Integration
                 Assert.Equal(8.0, arc.RadiusY, 2);
             });
         }
+
+        /// <summary>
+        /// Issue #812 (reopened): the same <c>overflow: hidden</c> clip curve above, and a
+        /// <c>background-clip: padding-box</c> curve, must come out identical (in true point-space terms)
+        /// regardless of <c>PixelsPerInch</c> - it's a pure internal layout-coordinate-scale knob with zero
+        /// intended visual effect. <c>RenderUtils.GetRoundRect</c> is fed raw layout-space coordinates but
+        /// neither it nor its two consumers (<c>PushClip(RGraphicsPath)</c>/<c>DrawPath</c>) used to divide
+        /// by <c>PixelsPerPoint</c> before building/pushing the path, unlike every other draw primitive.
+        /// </summary>
+        [Fact]
+        public async Task OverflowHiddenClipCurve_ArcRadiiAndPosition_AreInvariantUnderNonDefaultPixelsPerInch()
+        {
+            const string html = "<div id='clipper' style='overflow:hidden;border:6pt solid black;border-radius:14pt;" +
+                                 "width:100pt;height:100pt;'>" +
+                                 "<div id='fill' style='width:100%;height:100%;'></div></div>";
+
+            var (rootDefault, containerDefault) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(html));
+            var fillDefault = LayoutHarness.FindById(rootDefault, "fill");
+            Assert.NotNull(fillDefault);
+            var recordingDefault = new RecordingGraphics(new PdfSharpAdapter()) { PixelsPerPointOverride = 1.0 };
+            FragmentPaintHarness.PaintBox(containerDefault, fillDefault!, recordingDefault);
+
+            var (rootScaled, containerScaled) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(html), pixelsPerPoint: 2.0);
+            var fillScaled = LayoutHarness.FindById(rootScaled, "fill");
+            Assert.NotNull(fillScaled);
+            var recordingScaled = new RecordingGraphics(new PdfSharpAdapter()) { PixelsPerPointOverride = 2.0 };
+            FragmentPaintHarness.PaintBox(containerScaled, fillScaled!, recordingScaled);
+
+            Assert.Single(recordingDefault.PushedClipPaths);
+            Assert.Single(recordingScaled.PushedClipPaths);
+            var defaultArcs = recordingDefault.PushedClipPaths[0].Arcs;
+            var scaledArcs = recordingScaled.PushedClipPaths[0].Arcs;
+            Assert.Equal(defaultArcs.Count, scaledArcs.Count);
+            for (var a = 0; a < defaultArcs.Count; a++)
+            {
+                Assert.Equal(defaultArcs[a].RadiusX, scaledArcs[a].RadiusX, 3);
+                Assert.Equal(defaultArcs[a].RadiusY, scaledArcs[a].RadiusY, 3);
+            }
+            Assert.Equal(recordingDefault.PushedClipPaths[0].Points, recordingScaled.PushedClipPaths[0].Points);
+        }
+
+        /// <summary>
+        /// The issue's own symptom-A shape: a pill-shaped (<c>border-radius: 999px</c>) progress-bar track
+        /// clipping its <c>.fill</c> child. Direct regression guard for the reopened report - before the
+        /// fix, the pushed clip curve's un-divided coordinates landed far enough from the fill's own
+        /// (correctly-scaled) position that the clip excluded it entirely, rendering the fill invisible.
+        /// </summary>
+        [Fact]
+        public async Task OverflowHiddenClipCurve_PillShape_NonDefaultPixelsPerInch_StaysWithinTrackBounds()
+        {
+            const string html = "<div id='track' style='flex:1;height:6pt;border-radius:999pt;" +
+                                 "overflow:hidden;width:90pt;'>" +
+                                 "<div id='fill' style='height:100%;width:65%;'></div></div>";
+
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(html), pixelsPerPoint: 2.0);
+            var fill = LayoutHarness.FindById(root, "fill");
+            Assert.NotNull(fill);
+
+            var recording = new RecordingGraphics(new PdfSharpAdapter()) { PixelsPerPointOverride = 2.0 };
+            FragmentPaintHarness.PaintBox(container, fill!, recording);
+
+            Assert.Single(recording.PushedClipPaths);
+            var points = recording.PushedClipPaths[0].Points;
+            Assert.NotEmpty(points);
+
+            // The track (with its default 20pt margin) is only 90x6pt - a generous bound around it.
+            // Before the fix, an un-divided (2x too large) clip path landed points well outside this.
+            Assert.All(points, p =>
+            {
+                Assert.InRange(p.X, 0, 150);
+                Assert.InRange(p.Y, 0, 60);
+            });
+        }
     }
 }

--- a/src/PeachPDF.Tests/Integration/RoundedBorderStrokePixelsPerPointIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/RoundedBorderStrokePixelsPerPointIntegrationTests.cs
@@ -1,0 +1,144 @@
+using PeachPDF.Adapters;
+using PeachPDF.Tests.TestSupport;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Issue #812 (reopened): a rounded border stroke is built by
+    /// <c>BordersDrawHandler.GetRoundedBorderPath</c> - a path builder entirely independent of
+    /// <c>RenderUtils.GetRoundRect</c>, sharing no code with it - from raw, un-divided layout-space
+    /// coordinates. At the library's default <c>PixelsPerInch = 72</c> (<c>PixelsPerPoint = 1.0</c>) a
+    /// missing division is invisible; at any other value the rounded border stroke renders too large and
+    /// mis-positioned relative to the rest of the page (the reported "border leaking past its own box").
+    /// Asserted on the actual per-corner radii/positions a painted stroke path was built with (see
+    /// <see cref="RecordingGraphicsPath.Arcs"/>/<see cref="RecordingGraphicsPath.Points"/>), not just that
+    /// a rounded stroke happened, per this repo's own painting-test convention.
+    /// </summary>
+    public class RoundedBorderStrokePixelsPerPointIntegrationTests
+    {
+        [Fact]
+        public async Task RoundedBorderStroke_ArcRadiiAndPosition_AreInvariantUnderNonDefaultPixelsPerInch()
+        {
+            const string html = "<div id='box' style='width:100pt;height:100pt;" +
+                                 "border:6pt solid black;border-radius:14pt;'></div>";
+
+            var (defaultPaths, scaledPaths) = await LayoutAndPaintAtDefaultAndScaled(html);
+
+            Assert.NotEmpty(defaultPaths);
+            AssertPathsMatch(defaultPaths, scaledPaths);
+        }
+
+        [Fact]
+        public async Task RoundedBorderStroke_NonDefaultPixelsPerInch_StaysWithinBoxBounds()
+        {
+            // Direct regression guard for the reported symptom: before the fix, an un-divided path put
+            // the stroke's corners well outside the box's own (correctly-scaled) bounds at a non-default
+            // PixelsPerInch - here, everything must land inside a small margin of the 100x100pt box.
+            const string html = "<div id='box' style='width:100pt;height:100pt;" +
+                                 "border:6pt solid black;border-radius:14pt;'></div>";
+
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(html), pixelsPerPoint: 2.0);
+            var box = LayoutHarness.FindById(root, "box");
+            Assert.NotNull(box);
+
+            var recording = new RecordingGraphics(new PdfSharpAdapter()) { PixelsPerPointOverride = 2.0 };
+            FragmentPaintHarness.PaintBox(container, box!, recording);
+
+            Assert.NotEmpty(recording.StrokedPaths);
+            var allPoints = recording.StrokedPaths.SelectMany(p => p.Points).ToList();
+            Assert.NotEmpty(allPoints);
+
+            // The box (with its default 20pt margin) sits well within a generous bound - before the fix,
+            // an un-divided (2x too large) path put points ~100pt+ outside this range.
+            Assert.All(allPoints, p =>
+            {
+                Assert.InRange(p.X, 0, 200);
+                Assert.InRange(p.Y, 0, 200);
+            });
+        }
+
+        /// <summary>
+        /// <c>Border.Left</c>/<c>Border.Right</c>'s <c>noTop</c>/<c>noBottom</c> mitre-avoidance branches
+        /// (when the adjacent top/bottom edge is <c>none</c>/<c>hidden</c>, that side's own left/right
+        /// stroke takes the corner arc a mitred edge would otherwise cut) only run when an adjacent edge
+        /// is actually suppressed - exercised here by disabling the top and bottom borders, hitting all
+        /// four corner-arc branches (<c>Border.Right</c>'s top/bottom arcs, <c>Border.Left</c>'s
+        /// bottom/top arcs) the other two facts in this file never reach.
+        /// </summary>
+        [Fact]
+        public async Task RoundedBorderStroke_MitreAvoidanceBranches_AreInvariantUnderNonDefaultPixelsPerInch()
+        {
+            const string html = "<div id='box' style='width:100pt;height:100pt;border:6pt solid black;" +
+                                 "border-top-style:none;border-bottom-style:none;border-radius:14pt;'></div>";
+
+            var (defaultPaths, scaledPaths) = await LayoutAndPaintAtDefaultAndScaled(html);
+
+            // Only the left/right strokes are drawn (top/bottom are `none`).
+            Assert.Equal(2, defaultPaths.Count);
+            AssertPathsMatch(defaultPaths, scaledPaths);
+        }
+
+        // ── Helpers ───────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Lays <paramref name="html"/> out and paints its <c>#box</c> element once at the default
+        /// <c>PixelsPerPoint</c> (1.0) and once at a doubled value (2.0, simulating
+        /// <c>PixelsPerInch = 144</c>) - every internal layout coordinate in the second pass is inflated
+        /// by that factor relative to the first. Returns each pass's recorded stroked paths for the
+        /// caller to compare.
+        /// </summary>
+        private static async Task<(IReadOnlyList<RecordingGraphicsPath> Default, IReadOnlyList<RecordingGraphicsPath> Scaled)>
+            LayoutAndPaintAtDefaultAndScaled(string html)
+        {
+            var (rootDefault, containerDefault) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(html));
+            var boxDefault = LayoutHarness.FindById(rootDefault, "box");
+            Assert.NotNull(boxDefault);
+            var recordingDefault = new RecordingGraphics(new PdfSharpAdapter()) { PixelsPerPointOverride = 1.0 };
+            FragmentPaintHarness.PaintBox(containerDefault, boxDefault!, recordingDefault);
+
+            var (rootScaled, containerScaled) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(html), pixelsPerPoint: 2.0);
+            var boxScaled = LayoutHarness.FindById(rootScaled, "box");
+            Assert.NotNull(boxScaled);
+            var recordingScaled = new RecordingGraphics(new PdfSharpAdapter()) { PixelsPerPointOverride = 2.0 };
+            FragmentPaintHarness.PaintBox(containerScaled, boxScaled!, recordingScaled);
+
+            return (recordingDefault.StrokedPaths, recordingScaled.StrokedPaths);
+        }
+
+        /// <summary>
+        /// Asserts <paramref name="expected"/> and <paramref name="actual"/> hold the same number of
+        /// paths, and each corresponding pair has identical arc radii and point coordinates (3 decimal
+        /// places) - the PixelsPerPoint-invariance this repo's #812 fix guarantees.
+        /// </summary>
+        private static void AssertPathsMatch(IReadOnlyList<RecordingGraphicsPath> expected, IReadOnlyList<RecordingGraphicsPath> actual)
+        {
+            Assert.Equal(expected.Count, actual.Count);
+
+            for (var i = 0; i < expected.Count; i++)
+            {
+                AssertSequenceEqual(expected[i].Arcs, actual[i].Arcs, (e, a) =>
+                {
+                    Assert.Equal(e.RadiusX, a.RadiusX, 3);
+                    Assert.Equal(e.RadiusY, a.RadiusY, 3);
+                });
+
+                AssertSequenceEqual(expected[i].Points, actual[i].Points, (e, a) =>
+                {
+                    Assert.Equal(e.X, a.X, 3);
+                    Assert.Equal(e.Y, a.Y, 3);
+                });
+            }
+        }
+
+        private static void AssertSequenceEqual<T>(IReadOnlyList<T> expected, IReadOnlyList<T> actual, System.Action<T, T> assertItem)
+        {
+            Assert.Equal(expected.Count, actual.Count);
+            for (var i = 0; i < expected.Count; i++)
+                assertItem(expected[i], actual[i]);
+        }
+    }
+}

--- a/src/PeachPDF.Tests/TestSupport/LayoutHarness.cs
+++ b/src/PeachPDF.Tests/TestSupport/LayoutHarness.cs
@@ -20,8 +20,10 @@ namespace PeachPDF.Tests.TestSupport
     {
         /// <summary>
         /// Lays <paramref name="html"/> out on a page of <paramref name="pageWidth"/> ×
-        /// <paramref name="pageHeight"/> points. <c>PixelsPerPoint</c> is pinned to 1.0 to match
-        /// production's default <c>PixelsPerInch = 72</c>, so asserted coordinates read as points.
+        /// <paramref name="pageHeight"/> points. <paramref name="pixelsPerPoint"/> defaults to 1.0 to
+        /// match production's default <c>PixelsPerInch = 72</c>, so asserted coordinates read as points;
+        /// pass a non-default value (e.g. 2.0, simulating <c>PixelsPerInch = 144</c>) for a test whose
+        /// subject is <c>PixelsPerPoint</c>-scaling behavior itself (issue #812 and its siblings).
         /// </summary>
         /// <param name="prepare">
         /// Optional: run against the parsed box tree's root after <c>SetHtml</c> and before layout, for a
@@ -40,9 +42,10 @@ namespace PeachPDF.Tests.TestSupport
             double pageHeight = 842,
             double margin = 20,
             Action<CssBox>? prepare = null,
-            Func<CssBox, HtmlContainerInt, RGraphics, Task>? after = null)
+            Func<CssBox, HtmlContainerInt, RGraphics, Task>? after = null,
+            double pixelsPerPoint = 1.0)
         {
-            var adapter = new PdfSharpAdapter { PixelsPerPoint = 1.0 };
+            var adapter = new PdfSharpAdapter { PixelsPerPoint = pixelsPerPoint };
             var container = new HtmlContainerInt(adapter)
             {
                 MarginTop = margin,
@@ -52,7 +55,7 @@ namespace PeachPDF.Tests.TestSupport
             };
 
             var sheet = new XSize(pageWidth, pageHeight);
-            container.PageSize = Utilities.Utils.Convert(sheet, 1.0);
+            container.PageSize = Utilities.Utils.Convert(sheet, pixelsPerPoint);
 
             await container.SetHtml(html, null);
 
@@ -67,12 +70,12 @@ namespace PeachPDF.Tests.TestSupport
             // puts the root box above the first page's band and makes pagination nonsense.
             var band = new XSize(pageWidth - container.MarginLeft - container.MarginRight,
                                  pageHeight - container.MarginTop - container.MarginBottom);
-            container.PageSize = Utilities.Utils.Convert(band, 1.0);
-            container.MaxSize = Utilities.Utils.Convert(band, 1.0);
-            container.Location = Utilities.Utils.Convert(new XPoint(container.MarginLeft, container.MarginTop), 1.0);
+            container.PageSize = Utilities.Utils.Convert(band, pixelsPerPoint);
+            container.MaxSize = Utilities.Utils.Convert(band, pixelsPerPoint);
+            container.Location = Utilities.Utils.Convert(new XPoint(container.MarginLeft, container.MarginTop), pixelsPerPoint);
 
             var measure = XGraphics.CreateMeasureContext(sheet, XGraphicsUnit.Point, XPageDirection.Downwards);
-            using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            using var graphics = new GraphicsAdapter(adapter, measure, pixelsPerPoint);
             await container.PerformLayout(graphics);
 
             Assert.NotNull(container.Root);

--- a/src/PeachPDF.Tests/TestSupport/RecordingGraphics.cs
+++ b/src/PeachPDF.Tests/TestSupport/RecordingGraphics.cs
@@ -50,6 +50,14 @@ namespace PeachPDF.Tests.TestSupport
         /// </summary>
         public List<RecordingGraphicsPath> DrawnPaths { get; } = [];
 
+        /// <summary>
+        /// Every path stroked via <see cref="DrawPath(RPen, RGraphicsPath)"/>, in order - the rounded
+        /// border-stroke curve <c>BordersDrawHandler.GetRoundedBorderPath</c> builds (issue #812's
+        /// second, independent rounded-path builder; a rounded border always strokes via the <c>RPen</c>
+        /// overload, never the <c>RBrush</c> one <see cref="DrawnPaths"/> tracks).
+        /// </summary>
+        public List<RecordingGraphicsPath> StrokedPaths { get; } = [];
+
         /// <summary>Total PushClip invocations.</summary>
         public int PushCount { get; private set; }
 
@@ -177,7 +185,10 @@ namespace PeachPDF.Tests.TestSupport
 
         public override void DrawImage(RImage image, RRect destRect, RRect srcRect) { }
         public override void DrawImage(RImage image, RRect destRect) { }
-        public override void DrawPath(RPen pen, RGraphicsPath path) { }
+        public override void DrawPath(RPen pen, RGraphicsPath path)
+        {
+            if (path is RecordingGraphicsPath recordingPath) StrokedPaths.Add(recordingPath);
+        }
 
         public override void DrawPath(RBrush brush, RGraphicsPath path)
         {
@@ -208,10 +219,19 @@ namespace PeachPDF.Tests.TestSupport
         /// Borders Level 3 §5.5 rather than using the box's raw declared radius.</summary>
         public List<(Corner Corner, double RadiusX, double RadiusY)> Arcs { get; } = [];
 
-        public override void Start(double x, double y) { }
-        public override void LineTo(double x, double y) { }
-        public override void ArcTo(double x, double y, double radiusX, double radiusY, Corner corner) =>
+        /// <summary>Every <see cref="Start"/>/<see cref="LineTo"/>/<see cref="ArcTo"/> endpoint, in order -
+        /// lets a test read back the path's actual position/size (not just its corner radii), e.g. to
+        /// confirm a rounded-rect path's coordinates came out divided by <c>PixelsPerPoint</c> (issue
+        /// #812), not just its radii.</summary>
+        public List<(double X, double Y)> Points { get; } = [];
+
+        public override void Start(double x, double y) => Points.Add((x, y));
+        public override void LineTo(double x, double y) => Points.Add((x, y));
+        public override void ArcTo(double x, double y, double radiusX, double radiusY, Corner corner)
+        {
+            Points.Add((x, y));
             Arcs.Add((corner, radiusX, radiusY));
+        }
         public override void AddMove(double x, double y) { }
         public override void AddBezierTo(double x1, double y1, double x2, double y2, double x3, double y3) { }
         public override void AddArc(double x, double y, double radiusX, double radiusY, double rotationAngle, bool isLargeArc, bool sweepClockwise) { }

--- a/src/PeachPDF.Tests/TestSupport/TestGraphicsAdapter.cs
+++ b/src/PeachPDF.Tests/TestSupport/TestGraphicsAdapter.cs
@@ -210,6 +210,16 @@ namespace PeachPDF.Tests.TestSupport
         /// tests can inspect the resulting clip geometry (e.g. a transformed clip region).</summary>
         public List<TestGraphicsPath> ClipPaths { get; } = [];
 
+        /// <summary>
+        /// Settable so a test can exercise a non-default <c>PixelsPerPoint</c> (issue #812/#814) without a
+        /// full <c>GraphicsAdapter</c>/PDF stack - defaults to the base <see cref="RGraphics.PixelsPerPoint"/>
+        /// no-op of <c>1.0</c>. A field-backed override (rather than an auto-property) since the base
+        /// virtual member is get-only. Mirrors <c>RecordingGraphics.PixelsPerPointOverride</c>.
+        /// </summary>
+        public double PixelsPerPointOverride { get; set; } = 1.0;
+
+        public override double PixelsPerPoint => PixelsPerPointOverride;
+
         public TestRecordingGraphics() : base(new TestGraphicsAdapter(), new RRect(0, 0, double.MaxValue, double.MaxValue)) { }
 
         public override void DrawString(string str, RFont font, RColor color, RPoint point, RSize size, double letterSpacing = 0, RFontPalette? fontPalette = null, TextShapingFeatures? features = null)

--- a/src/PeachPDF/Html/Core/Handlers/BordersDrawHandler.cs
+++ b/src/PeachPDF/Html/Core/Handlers/BordersDrawHandler.cs
@@ -416,59 +416,81 @@ namespace PeachPDF.Html.Core.Handlers
             var rad = b.ComputeRadii(r);
             if (!rad.IsRounded) return null;
 
+            // r, b's ActualBorder*Width fields, and rad's eight components are all in the caller's
+            // layout-space units (the same PixelsPerInch-inflated space as CssBox geometry). This path
+            // builder is independent of RenderUtils.GetRoundRect (no shared code) and needs the identical
+            // divide-by-PixelsPerPoint correction for the same reason - see that method's remarks (#812).
+            var ppp = g.PixelsPerPoint;
+            var left = r.Left / ppp;
+            var top = r.Top / ppp;
+            var right = r.Right / ppp;
+            var bottom = r.Bottom / ppp;
+            var blw = b.ActualBorderLeftWidth / ppp;
+            var btw = b.ActualBorderTopWidth / ppp;
+            var brw = b.ActualBorderRightWidth / ppp;
+            var bbw = b.ActualBorderBottomWidth / ppp;
+            var radTLX = rad.TLX / ppp;
+            var radTLY = rad.TLY / ppp;
+            var radTRX = rad.TRX / ppp;
+            var radTRY = rad.TRY / ppp;
+            var radBRX = rad.BRX / ppp;
+            var radBRY = rad.BRY / ppp;
+            var radBLX = rad.BLX / ppp;
+            var radBLY = rad.BLY / ppp;
+
             RGraphicsPath? path = null;
             switch (border)
             {
                 case Border.Top:
-                    if (rad.TLX > 0 || rad.TLY > 0 || rad.TRX > 0 || rad.TRY > 0)
+                    if (radTLX > 0 || radTLY > 0 || radTRX > 0 || radTRY > 0)
                     {
                         path = g.GetGraphicsPath();
-                        path.Start(r.Left + b.ActualBorderLeftWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + rad.TLY);
-                        if (rad.TLX > 0 || rad.TLY > 0)
-                            path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2 + rad.TLX, r.Top + b.ActualBorderTopWidth / 2, rad.TLX, rad.TLY, RGraphicsPath.Corner.TopLeft);
-                        path.LineTo(r.Right - b.ActualBorderRightWidth / 2 - rad.TRX, r.Top + b.ActualBorderTopWidth / 2);
-                        if (rad.TRX > 0 || rad.TRY > 0)
-                            path.ArcTo(r.Right - b.ActualBorderRightWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + rad.TRY, rad.TRX, rad.TRY, RGraphicsPath.Corner.TopRight);
+                        path.Start(left + blw / 2, top + btw / 2 + radTLY);
+                        if (radTLX > 0 || radTLY > 0)
+                            path.ArcTo(left + blw / 2 + radTLX, top + btw / 2, radTLX, radTLY, RGraphicsPath.Corner.TopLeft);
+                        path.LineTo(right - brw / 2 - radTRX, top + btw / 2);
+                        if (radTRX > 0 || radTRY > 0)
+                            path.ArcTo(right - brw / 2, top + btw / 2 + radTRY, radTRX, radTRY, RGraphicsPath.Corner.TopRight);
                     }
                     break;
                 case Border.Bottom:
-                    if (rad.BLX > 0 || rad.BLY > 0 || rad.BRX > 0 || rad.BRY > 0)
+                    if (radBLX > 0 || radBLY > 0 || radBRX > 0 || radBRY > 0)
                     {
                         path = g.GetGraphicsPath();
-                        path.Start(r.Right - b.ActualBorderRightWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - rad.BRY);
-                        if (rad.BRX > 0 || rad.BRY > 0)
-                            path.ArcTo(r.Right - b.ActualBorderRightWidth / 2 - rad.BRX, r.Bottom - b.ActualBorderBottomWidth / 2, rad.BRX, rad.BRY, RGraphicsPath.Corner.BottomRight);
-                        path.LineTo(r.Left + b.ActualBorderLeftWidth / 2 + rad.BLX, r.Bottom - b.ActualBorderBottomWidth / 2);
-                        if (rad.BLX > 0 || rad.BLY > 0)
-                            path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - rad.BLY, rad.BLX, rad.BLY, RGraphicsPath.Corner.BottomLeft);
+                        path.Start(right - brw / 2, bottom - bbw / 2 - radBRY);
+                        if (radBRX > 0 || radBRY > 0)
+                            path.ArcTo(right - brw / 2 - radBRX, bottom - bbw / 2, radBRX, radBRY, RGraphicsPath.Corner.BottomRight);
+                        path.LineTo(left + blw / 2 + radBLX, bottom - bbw / 2);
+                        if (radBLX > 0 || radBLY > 0)
+                            path.ArcTo(left + blw / 2, bottom - bbw / 2 - radBLY, radBLX, radBLY, RGraphicsPath.Corner.BottomLeft);
                     }
                     break;
                 case Border.Right:
-                    if (rad.TRX > 0 || rad.TRY > 0 || rad.BRX > 0 || rad.BRY > 0)
+                    if (radTRX > 0 || radTRY > 0 || radBRX > 0 || radBRY > 0)
                     {
                         path = g.GetGraphicsPath();
                         bool noTop = b.BorderTopStyle.Value is LineStyle.None or LineStyle.Hidden;
                         bool noBottom = b.BorderBottomStyle.Value is LineStyle.None or LineStyle.Hidden;
-                        path.Start(r.Right - b.ActualBorderRightWidth / 2 - (noTop ? rad.TRX : 0), r.Top + b.ActualBorderTopWidth / 2 + (noTop ? 0 : rad.TRY));
-                        if ((rad.TRX > 0 || rad.TRY > 0) && noTop)
-                            path.ArcTo(r.Right - b.ActualBorderLeftWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + rad.TRY, rad.TRX, rad.TRY, RGraphicsPath.Corner.TopRight);
-                        path.LineTo(r.Right - b.ActualBorderRightWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - rad.BRY);
-                        if ((rad.BRX > 0 || rad.BRY > 0) && noBottom)
-                            path.ArcTo(r.Right - b.ActualBorderRightWidth / 2 - rad.BRX, r.Bottom - b.ActualBorderBottomWidth / 2, rad.BRX, rad.BRY, RGraphicsPath.Corner.BottomRight);
+                        path.Start(right - brw / 2 - (noTop ? radTRX : 0), top + btw / 2 + (noTop ? 0 : radTRY));
+                        if ((radTRX > 0 || radTRY > 0) && noTop)
+                            path.ArcTo(right - blw / 2, top + btw / 2 + radTRY, radTRX, radTRY, RGraphicsPath.Corner.TopRight);
+                        path.LineTo(right - brw / 2, bottom - bbw / 2 - radBRY);
+                        if ((radBRX > 0 || radBRY > 0) && noBottom)
+                            path.ArcTo(right - brw / 2 - radBRX, bottom - bbw / 2, radBRX, radBRY, RGraphicsPath.Corner.BottomRight);
                     }
                     break;
                 case Border.Left:
-                    if (rad.TLX > 0 || rad.TLY > 0 || rad.BLX > 0 || rad.BLY > 0)
+                    if (radTLX > 0 || radTLY > 0 || radBLX > 0 || radBLY > 0)
                     {
                         path = g.GetGraphicsPath();
                         bool noTop = b.BorderTopStyle.Value is LineStyle.None or LineStyle.Hidden;
                         bool noBottom = b.BorderBottomStyle.Value is LineStyle.None or LineStyle.Hidden;
-                        path.Start(r.Left + b.ActualBorderLeftWidth / 2 + (noBottom ? rad.BLX : 0), r.Bottom - b.ActualBorderBottomWidth / 2 - (noBottom ? 0 : rad.BLY));
-                        if ((rad.BLX > 0 || rad.BLY > 0) && noBottom)
-                            path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2, r.Bottom - b.ActualBorderBottomWidth / 2 - rad.BLY, rad.BLX, rad.BLY, RGraphicsPath.Corner.BottomLeft);
-                        path.LineTo(r.Left + b.ActualBorderLeftWidth / 2, r.Top + b.ActualBorderTopWidth / 2 + rad.TLY);
-                        if ((rad.TLX > 0 || rad.TLY > 0) && noTop)
-                            path.ArcTo(r.Left + b.ActualBorderLeftWidth / 2 + rad.TLX, r.Top + b.ActualBorderTopWidth / 2, rad.TLX, rad.TLY, RGraphicsPath.Corner.TopLeft);
+                        path.Start(left + blw / 2 + (noBottom ? radBLX : 0), bottom - bbw / 2 - (noBottom ? 0 : radBLY));
+                        if ((radBLX > 0 || radBLY > 0) && noBottom)
+                            path.ArcTo(left + blw / 2, bottom - bbw / 2 - radBLY, radBLX, radBLY, RGraphicsPath.Corner.BottomLeft);
+                        path.LineTo(left + blw / 2, top + btw / 2 + radTLY);
+                        if ((radTLX > 0 || radTLY > 0) && noTop)
+                            path.ArcTo(left + blw / 2 + radTLX, top + btw / 2, radTLX, radTLY, RGraphicsPath.Corner.TopLeft);
                     }
                     break;
             }

--- a/src/PeachPDF/Html/Core/Paint/FragmentPainter.Decorations.cs
+++ b/src/PeachPDF/Html/Core/Paint/FragmentPainter.Decorations.cs
@@ -474,21 +474,25 @@ namespace PeachPDF.Html.Core.Paint
 
         /// <summary>Builds an even-odd fill path of <paramref name="outer"/> with a rectangular
         /// <paramref name="hole"/> punched out - a filled ring. Used for inset-shadow falloff layers, since the
-        /// PDF backend has no clip-subtract primitive.</summary>
+        /// PDF backend has no clip-subtract primitive. <paramref name="outer"/>/<paramref name="hole"/> are in
+        /// raw layout-space coordinates, like every other box-geometry <see cref="RGraphicsPath"/> builder -
+        /// divided by <see cref="RGraphics.PixelsPerPoint"/> here since the path itself has no ambient
+        /// transform to divide it back down (issue #812; see <c>RenderUtils.GetRoundRect</c>'s remarks).</summary>
         private static RGraphicsPath BuildRingPath(RGraphics g, RRect outer, RRect hole)
         {
+            var ppp = g.PixelsPerPoint;
             var path = g.GetGraphicsPath();
 
-            path.Start(outer.Left, outer.Top);
-            path.LineTo(outer.Right, outer.Top);
-            path.LineTo(outer.Right, outer.Bottom);
-            path.LineTo(outer.Left, outer.Bottom);
+            path.Start(outer.Left / ppp, outer.Top / ppp);
+            path.LineTo(outer.Right / ppp, outer.Top / ppp);
+            path.LineTo(outer.Right / ppp, outer.Bottom / ppp);
+            path.LineTo(outer.Left / ppp, outer.Bottom / ppp);
             path.CloseFigure();
 
-            path.AddMove(hole.Left, hole.Top);
-            path.LineTo(hole.Right, hole.Top);
-            path.LineTo(hole.Right, hole.Bottom);
-            path.LineTo(hole.Left, hole.Bottom);
+            path.AddMove(hole.Left / ppp, hole.Top / ppp);
+            path.LineTo(hole.Right / ppp, hole.Top / ppp);
+            path.LineTo(hole.Right / ppp, hole.Bottom / ppp);
+            path.LineTo(hole.Left / ppp, hole.Bottom / ppp);
             path.CloseFigure();
 
             path.FillMode = RFillMode.EvenOdd;

--- a/src/PeachPDF/Html/Core/Utils/CssClipPathResolver.cs
+++ b/src/PeachPDF/Html/Core/Utils/CssClipPathResolver.cs
@@ -38,21 +38,28 @@ namespace PeachPDF.Html.Core.Utils
             if (shape is null) return false;
 
             path = g.GetGraphicsPath();
+            // Every coordinate below is resolved against referenceBox/box in raw layout-space (the same
+            // PixelsPerInch-inflated space CssBox geometry lives in, needed so CssValueParser.ParseLength's
+            // own absolute-length PixelsPerPoint catch-up multiply - issue #814 - and the percentage basis
+            // stay consistent with each other). Like RenderUtils.GetRoundRect/BordersDrawHandler.GetRoundedBorderPath
+            // (issue #812), the path itself has no ambient transform to divide it back down, so every final
+            // coordinate is divided by g.PixelsPerPoint right before reaching the path.
+            var ppp = g.PixelsPerPoint;
 
             switch (shape.Kind)
             {
                 case BasicShapeGrammar.BasicShapeKind.Polygon:
                     useEvenOdd = shape.PolygonFillRule == BasicShapeGrammar.FillRule.Evenodd;
-                    BuildPolygon(path, shape, referenceBox, box);
+                    BuildPolygon(path, shape, referenceBox, box, ppp);
                     break;
                 case BasicShapeGrammar.BasicShapeKind.Inset:
-                    BuildInset(path, shape, referenceBox, box);
+                    BuildInset(path, shape, referenceBox, box, ppp);
                     break;
                 case BasicShapeGrammar.BasicShapeKind.Circle:
-                    BuildCircle(path, shape, referenceBox, box);
+                    BuildCircle(path, shape, referenceBox, box, ppp);
                     break;
                 case BasicShapeGrammar.BasicShapeKind.Ellipse:
-                    BuildEllipse(path, shape, referenceBox, box);
+                    BuildEllipse(path, shape, referenceBox, box, ppp);
                     break;
                 default:
                     path.Dispose();
@@ -64,14 +71,14 @@ namespace PeachPDF.Html.Core.Utils
             return true;
         }
 
-        private static void BuildPolygon(RGraphicsPath path, BasicShapeGrammar.ParsedBasicShape shape, RRect referenceBox, CssBox box)
+        private static void BuildPolygon(RGraphicsPath path, BasicShapeGrammar.ParsedBasicShape shape, RRect referenceBox, CssBox box, double ppp)
         {
             var points = shape.PolygonPoints;
 
             for (var i = 0; i < points.Count; i++)
             {
-                var x = referenceBox.X + CssValueParser.ParseLength(points[i].X, referenceBox.Width, box);
-                var y = referenceBox.Y + CssValueParser.ParseLength(points[i].Y, referenceBox.Height, box);
+                var x = (referenceBox.X + CssValueParser.ParseLength(points[i].X, referenceBox.Width, box)) / ppp;
+                var y = (referenceBox.Y + CssValueParser.ParseLength(points[i].Y, referenceBox.Height, box)) / ppp;
 
                 if (i == 0)
                     path.Start(x, y);
@@ -82,7 +89,7 @@ namespace PeachPDF.Html.Core.Utils
             path.CloseFigure();
         }
 
-        private static void BuildInset(RGraphicsPath path, BasicShapeGrammar.ParsedBasicShape shape, RRect referenceBox, CssBox box)
+        private static void BuildInset(RGraphicsPath path, BasicShapeGrammar.ParsedBasicShape shape, RRect referenceBox, CssBox box, double ppp)
         {
             var edges = shape.InsetEdges;
             var top = CssValueParser.ParseLength(edges[0], referenceBox.Height, box);
@@ -90,10 +97,10 @@ namespace PeachPDF.Html.Core.Utils
             var bottom = CssValueParser.ParseLength(edges[2], referenceBox.Height, box);
             var left = CssValueParser.ParseLength(edges[3], referenceBox.Width, box);
 
-            var x0 = referenceBox.X + left;
-            var y0 = referenceBox.Y + top;
-            var x1 = referenceBox.Right - right;
-            var y1 = referenceBox.Bottom - bottom;
+            var x0 = (referenceBox.X + left) / ppp;
+            var y0 = (referenceBox.Y + top) / ppp;
+            var x1 = (referenceBox.Right - right) / ppp;
+            var y1 = (referenceBox.Bottom - bottom) / ppp;
 
             // A rounded inset (inset(... round <radius>)) is captured by the grammar but rendered as a
             // plain rectangle here - the corner radius is not applied (documented limitation).
@@ -104,17 +111,17 @@ namespace PeachPDF.Html.Core.Utils
             path.CloseFigure();
         }
 
-        private static void BuildCircle(RGraphicsPath path, BasicShapeGrammar.ParsedBasicShape shape, RRect referenceBox, CssBox box)
+        private static void BuildCircle(RGraphicsPath path, BasicShapeGrammar.ParsedBasicShape shape, RRect referenceBox, CssBox box, double ppp)
         {
             var cx = referenceBox.X + CssValueParser.ParseLength(shape.CenterX, referenceBox.Width, box);
             var cy = referenceBox.Y + CssValueParser.ParseLength(shape.CenterY, referenceBox.Height, box);
 
             var r = ResolveCircleRadius(shape.RadiusX, cx, cy, referenceBox, box);
 
-            AppendEllipse(path, cx, cy, r, r);
+            AppendEllipse(path, cx / ppp, cy / ppp, r / ppp, r / ppp);
         }
 
-        private static void BuildEllipse(RGraphicsPath path, BasicShapeGrammar.ParsedBasicShape shape, RRect referenceBox, CssBox box)
+        private static void BuildEllipse(RGraphicsPath path, BasicShapeGrammar.ParsedBasicShape shape, RRect referenceBox, CssBox box, double ppp)
         {
             var cx = referenceBox.X + CssValueParser.ParseLength(shape.CenterX, referenceBox.Width, box);
             var cy = referenceBox.Y + CssValueParser.ParseLength(shape.CenterY, referenceBox.Height, box);
@@ -122,7 +129,7 @@ namespace PeachPDF.Html.Core.Utils
             var rx = ResolveAxisRadius(shape.RadiusX, cx - referenceBox.X, referenceBox.Width, referenceBox.Width, box);
             var ry = ResolveAxisRadius(shape.RadiusY, cy - referenceBox.Y, referenceBox.Height, referenceBox.Height, box);
 
-            AppendEllipse(path, cx, cy, rx, ry);
+            AppendEllipse(path, cx / ppp, cy / ppp, rx / ppp, ry / ppp);
         }
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Utils/RenderUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/RenderUtils.cs
@@ -172,10 +172,27 @@ namespace PeachPDF.Html.Core.Utils
         /// SW-----SE
         /// </code>
         /// </summary>
+        /// <remarks>
+        /// <paramref name="rect"/> and every radius are in the caller's layout-space units (the same
+        /// <c>PixelsPerInch</c>-inflated space as <see cref="Dom.CssBox"/> geometry) — unlike every other
+        /// <see cref="RGraphics"/> draw primitive (<c>DrawLine</c>, <c>DrawRectangle</c>,
+        /// <c>PushClip(RRect)</c>), neither <c>RGraphics.PushClip(RGraphicsPath)</c> nor <c>DrawPath</c>
+        /// ever divides a path's coordinates by <see cref="RGraphics.PixelsPerPoint"/> before handing them
+        /// to the backend (that division is left to whichever ambient <c>PushTransform</c> is active for
+        /// SVG/glyph-outline paths, the other consumers of an <see cref="RGraphicsPath"/> — see
+        /// <c>Adapters.GraphicsPathAdapter.Transform</c>'s own comment). A box-geometry path has no such
+        /// ambient transform, so this method divides by <see cref="RGraphics.PixelsPerPoint"/> itself,
+        /// once, before building the path (issue #812).
+        /// </remarks>
         public static RGraphicsPath GetRoundRect(RGraphics g, RRect rect,
             double nwX, double nwY, double neX, double neY,
             double seX, double seY, double swX, double swY)
         {
+            var ppp = g.PixelsPerPoint;
+            rect = new RRect(rect.Left / ppp, rect.Top / ppp, rect.Width / ppp, rect.Height / ppp);
+            nwX /= ppp; nwY /= ppp; neX /= ppp; neY /= ppp;
+            seX /= ppp; seY /= ppp; swX /= ppp; swY /= ppp;
+
             var path = g.GetGraphicsPath();
 
             // Top edge: start after NW corner, end before NE corner.


### PR DESCRIPTION
## Summary

The original #812 fix (PR #818) corrected the reported rounded-clip/border-leak symptoms, but only tested at the library's default `PdfGenerateConfig.PixelsPerInch` of 72. The reporter's re-test at their production config, `PixelsPerInch = 96`, showed both symptoms had returned plus a new one (text vanishing). This PR fixes the actual root cause: `PdfSharpAdapter.PixelsPerPoint = PixelsPerInch / 72` inflates the internal CSS layout coordinate space, and every draw primitive is individually responsible for dividing its own coordinates back down before reaching the PDF backend — but four independent `RGraphicsPath` box-geometry builders never did:

- `RenderUtils.GetRoundRect` — shared by the `overflow: hidden` clip curve, rounded background fills (`background-clip: padding-box`/`content-box`), and rounded form-field/list-marker chrome.
- `BordersDrawHandler.GetRoundedBorderPath` — a separate, independent builder for the rounded border **stroke** (explains the reported border-leak symptom reproducing from `border-radius` alone).
- `CssClipPathResolver.TryBuildClipPath` — `clip-path: polygon()/inset()/circle()/ellipse()`. Found during this PR's own post-change review, not in the original report; confirmed with a `clip-path: circle(50%)` repro that rendered as a mangled quarter-shape at `PixelsPerInch = 96`.
- `FragmentPainter.Decorations.BuildRingPath` — the concentric ring fills approximating a blurred *inset* `box-shadow`'s falloff. Also found during review; confirmed with a repro whose shadow ring visibly detached from its box at `PixelsPerInch = 96`.

At the default `PixelsPerInch = 72` (`PixelsPerPoint = 1.0`) a missing division is invisible, which is why the original fix's own thorough two-renderer verification never caught this — it also predates the commit (later the same day) that made absolute lengths like `border-radius: 999px` actually `PixelsPerPoint`-scaled in the first place.

`RGraphicsPath` has a second, legitimate consumer — SVG shapes and glyph/COLR outlines — which paint under an active `PushTransform` that already performs this conversion; fixing at the four box-geometry path-*building* call sites (rather than the shared `GraphicsAdapter.PushClip`/`DrawPath`) avoids double-scaling those. A full `grep` sweep of every `GetGraphicsPath()` call site after the fact confirmed no fifth box-geometry consumer was missed.

## Deliberately out of scope (tracked separately)

- Rounded border stroke **width** (thickness, not position) still ignores `PixelsPerInch` — #851
- Box-shadow blur approximation **band count** varies with `PixelsPerInch` (a smoothness difference, not a wrong position) — #852
- A pre-existing, unrelated typo in `GetRoundedBorderPath`'s `Border.Right` case (uses the left border's width instead of the right's for one corner) — #853

## Test plan

- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 9291 passed, 0 failed, 9 pre-existing skips
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings
- [x] 100% diff coverage on changed source lines
- [x] Every new/extended test verified to fail against the pre-fix source (stashed each fix individually, reran, confirmed failure with the predicted un-divided-by-`ppp` magnitude, then restored)
- [x] Both of the issue's own repros, a grid-card variant from the reporter's follow-up comments, a `clip-path: circle()` repro, and an inset-shadow repro all rendered at `PixelsPerInch = 96` via a direct `PdfGenerator` call, rasterized with both PDFium and MuPDF, and pixel-diffed against the `PixelsPerInch = 72` render of the same HTML — all showed real defects before their fix and were pixel-identical (modulo anti-aliasing) after
- [x] New `border_radius_96dpi` TestHarness showcase, visually confirmed in both renderers

Fixes #812