### PR TITLE
Fix rounded border-radius top-right corner using left border width

### DIFF
--- a/src/PeachPDF.Tests/Integration/RoundedBorderStrokePixelsPerPointIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/RoundedBorderStrokePixelsPerPointIntegrationTests.cs
@@ -82,6 +82,43 @@ namespace PeachPDF.Tests.Integration
             AssertPathsMatch(defaultPaths, scaledPaths);
         }
 
+        /// <summary>
+        /// Issue #853: <c>GetRoundedBorderPath</c>'s <c>Border.Right</c> case offset the top-right arc's
+        /// endpoint by half the <b>left</b> border's width instead of the right border's own - a
+        /// copy-paste typo unrelated to <c>PixelsPerInch</c>, only visible when the left and right border
+        /// widths differ. Asymmetric widths plus <c>border-top: none</c> (the <c>noTop</c> branch that
+        /// reaches the buggy line) isolate exactly the arc endpoint the fix changes.
+        /// </summary>
+        [Fact]
+        public async Task RoundedBorderStroke_TopRightArcEndpoint_UsesRightBorderOwnWidth()
+        {
+            const string html = "<div id='box' style='width:100pt;height:100pt;border-radius:14pt;" +
+                                 "border-left:10pt solid black;border-right:2pt solid black;" +
+                                 "border-top:none;border-bottom:6pt solid black;'></div>";
+
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(html));
+            var box = LayoutHarness.FindById(root, "box");
+            Assert.NotNull(box);
+
+            var recording = new RecordingGraphics(new PdfSharpAdapter()) { PixelsPerPointOverride = 1.0 };
+            FragmentPaintHarness.PaintBox(container, box!, recording);
+
+            // Paint order (DrawBoxBorders) is Top/Left/Bottom/Right; Top is suppressed (none), so the
+            // right border's path is the third one recorded.
+            Assert.Equal(3, recording.StrokedPaths.Count);
+            var rightBorderPath = recording.StrokedPaths[2];
+
+            // Start, then the top-right ArcTo endpoint (noTop is true here), then a LineTo - no
+            // bottom-right arc, since the bottom border is present (noBottom is false).
+            Assert.Equal(3, rightBorderPath.Points.Count);
+            var topRightArcEndpoint = rightBorderPath.Points[1];
+
+            var expectedX = box!.ActualRight - box.ActualBorderRightWidth / 2;
+            var wrongX = box.ActualRight - box.ActualBorderLeftWidth / 2;
+            Assert.NotEqual(wrongX, expectedX, 3);
+            Assert.Equal(expectedX, topRightArcEndpoint.X, 3);
+        }
+
         // ── Helpers ───────────────────────────────────────────────────────────────
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Handlers/BordersDrawHandler.cs
+++ b/src/PeachPDF/Html/Core/Handlers/BordersDrawHandler.cs
@@ -473,7 +473,7 @@ namespace PeachPDF.Html.Core.Handlers
                         bool noBottom = b.BorderBottomStyle.Value is LineStyle.None or LineStyle.Hidden;
                         path.Start(right - brw / 2 - (noTop ? radTRX : 0), top + btw / 2 + (noTop ? 0 : radTRY));
                         if ((radTRX > 0 || radTRY > 0) && noTop)
-                            path.ArcTo(right - blw / 2, top + btw / 2 + radTRY, radTRX, radTRY, RGraphicsPath.Corner.TopRight);
+                            path.ArcTo(right - brw / 2, top + btw / 2 + radTRY, radTRX, radTRY, RGraphicsPath.Corner.TopRight);
                         path.LineTo(right - brw / 2, bottom - bbw / 2 - radBRY);
                         if ((radBRX > 0 || radBRY > 0) && noBottom)
                             path.ArcTo(right - brw / 2 - radBRX, bottom - bbw / 2, radBRX, radBRY, RGraphicsPath.Corner.BottomRight);


### PR DESCRIPTION
## Summary
- `BordersDrawHandler.GetRoundedBorderPath`'s `Border.Right` case offset the top-right corner's arc endpoint using the left border's width (`blw`) instead of the right border's own width (`brw`) - every other coordinate in that case, and the symmetric `Border.Left` case, correctly use the edge's own width.
- Fixes the mispositioned corner segment for a box with a rounded top-right corner and asymmetric left/right border widths.

Fixes #853

## Test plan
- [x] Added `RoundedBorderStroke_TopRightArcEndpoint_UsesRightBorderOwnWidth`, isolating the buggy line with asymmetric border widths and `border-top: none`
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - 9292 passed, 0 failed
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` - 0 warnings