### PR TITLE
Fix outside marker border-top gap and inside marker baseline shift

### DIFF
--- a/src/PeachPDF.Tests/Integration/MarkerPseudoElementIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/MarkerPseudoElementIntegrationTests.cs
@@ -100,6 +100,52 @@ namespace PeachPDF.Tests.Integration
             Assert.Equal(liWithout.ActualRight, liWith.ActualRight);
         }
 
+        [Fact]
+        public async Task OutsideMarker_AccountsForOwnersBorderTopWidth()
+        {
+            // CssBoxMarker.PerformLayoutImp's top calculation omitted ActualBorderTopWidth (unlike
+            // ClientTop's own definition), so a bordered <li>/<ul>/<ol> sat its marker too high by
+            // exactly the border width. Uses a decimal (<ol>) marker to skip the MarkerShape centering
+            // branch entirely, isolating just this one term.
+            var withBorder = await BuildAndLayout(Wrap("<ol><li id='li' style='border-top:4pt solid black'>text</li></ol>"));
+            var withoutBorder = await BuildAndLayout(Wrap("<ol><li id='li'>text</li></ol>"));
+
+            var markerWith = li(withBorder.root);
+            var markerWithout = li(withoutBorder.root);
+
+            Assert.Equal(4, markerWith.Location.Y - markerWithout.Location.Y, 1);
+
+            static CssBoxMarker li(CssBox root) =>
+                (CssBoxMarker)FindById(root, "li")!.Boxes.Single(b => b.IsMarkerPseudoElement);
+        }
+
+        [Fact]
+        public async Task InsideMarkerShape_IsCenteredWithinTheLine_NotBaselineAligned()
+        {
+            // An outside marker's shape is explicitly centered within the owner's line box
+            // (PerformLayoutImp's own MarkerShape branch). An "inside" marker never reaches that code -
+            // it flows as an ordinary inline box, positioned by CssLayoutEngine's line-box vertical-align
+            // pass, which defaults every box to baseline - sitting a small vector shape noticeably high
+            // relative to the adjacent text. CssBoxMarker.ResolveDefaultContent now sets VerticalAlign:
+            // middle for a shape marker, and CssLayoutEngine's ancestor walk stops at a marker box
+            // instead of reading its owning <li>'s (unset) vertical-align.
+            var (root, container) = await BuildAndLayout(Wrap(
+                "<ul style='list-style-position:inside'><li id='li'>text</li></ul>"));
+            var li = FindById(root, "li")!;
+
+            var marker = (CssBoxMarker)li.Boxes.Single(b => b.IsMarkerPseudoElement);
+            Assert.Equal(VerticalAlignment.Middle, marker.VerticalAlign.Value!.Keyword);
+
+            var markerWord = marker.Words.Single();
+            var textWord = AllWords(li).First(w => w != markerWord);
+
+            // The shape's vertical center should fall within the adjacent text word's own vertical
+            // extent - "roughly level with the text", not sitting entirely above or below it the way
+            // baseline alignment (bottom of a 0.35x-font-height shape pinned to the text baseline) does.
+            var markerCenter = markerWord.Top + markerWord.Height / 2;
+            Assert.InRange(markerCenter, textWord.Top, textWord.Top + textWord.Height);
+        }
+
         // ─── Helpers ─────────────────────────────────────────────────────────────
 
         private static string Wrap(string body) =>
@@ -135,6 +181,14 @@ namespace PeachPDF.Tests.Integration
                 if (found != null) return found;
             }
             return null;
+        }
+
+        private static System.Collections.Generic.IEnumerable<CssRect> AllWords(CssBox box)
+        {
+            foreach (var word in box.Words) yield return word;
+            foreach (var child in box.Boxes)
+                foreach (var word in AllWords(child))
+                    yield return word;
         }
     }
 }

--- a/src/PeachPDF/Html/Core/Dom/CssBoxMarker.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBoxMarker.cs
@@ -85,6 +85,15 @@ namespace PeachPDF.Html.Core.Dom
                 listStyleType.Equals(Keywords.Square, System.StringComparison.OrdinalIgnoreCase))
             {
                 MarkerShape = listStyleType.ToLowerInvariant();
+
+                // An outside marker's shape is explicitly centered within the owner's line box
+                // (PerformLayoutImp's own MarkerShape branch below). An inside marker never reaches
+                // that code - it's positioned by the ordinary inline vertical-align algorithm instead
+                // (CssLayoutEngine's own line-box pass), which defaults every box to baseline. A small
+                // vector shape baseline-aligned like a text glyph sits noticeably high relative to the
+                // adjacent text; middle-align it against the line the same way the outside path does.
+                VerticalAlign = CssProperty<CssKeywordOrValue<VerticalAlignment, LengthOrCalc>>.FromValue(
+                    Keywords.Middle, new CssKeywordOrValue<VerticalAlignment, LengthOrCalc>(VerticalAlignment.Middle, null));
                 return;
             }
 
@@ -178,7 +187,7 @@ namespace PeachPDF.Html.Core.Dom
             var width = word?.Width ?? 0;
             var height = word?.Height ?? owner.ActualFont.Height;
 
-            var top = owner.Location.Y + owner.ActualPaddingTop;
+            var top = owner.Location.Y + owner.ActualBorderTopWidth + owner.ActualPaddingTop;
             if (MarkerShape is not null)
             {
                 // Text is drawn top-aligned; center the (much smaller) shape within the owner's line

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -3564,9 +3564,14 @@ namespace PeachPDF.Html.Core.Dom
                 // own VerticalAlign always stays at the initial "baseline" regardless of what its
                 // originating element declared. Walk up to the nearest ancestor that has an HtmlTag
                 // (the same walk TextTop/TextBottom below already needs, for the same reason) to read
-                // the value the author actually declared.
+                // the value the author actually declared. A synthesized ::marker box stops the walk at
+                // itself instead of continuing to its owning <li> - unlike an anonymous text-node
+                // wrapper, it IS the thing vertical-align should apply to (CssBoxMarker sets its own
+                // VerticalAlign for a list-style-position: inside shape marker, to center it in the
+                // line the way an outside marker's own hand-computed position already does).
                 var styledBoxForVerticalAlign = box;
-                while (styledBoxForVerticalAlign.HtmlTag is null && styledBoxForVerticalAlign.ParentBox is not null)
+                while (styledBoxForVerticalAlign.HtmlTag is null && !styledBoxForVerticalAlign.IsMarkerPseudoElement
+                       && styledBoxForVerticalAlign.ParentBox is not null)
                     styledBoxForVerticalAlign = styledBoxForVerticalAlign.ParentBox;
                 var effectiveVerticalAlign = firstLineVerticalAlign ?? styledBoxForVerticalAlign.VerticalAlign;
 


### PR DESCRIPTION
## Summary

Two small, independent defects found while investigating issue #850, which turned out to already be fixed by #812/PR #854 - see that issue for the bisection. Not related to #850's own symptom, but real regardless:

- `CssBoxMarker`'s outside-marker `top` calculation omitted `ActualBorderTopWidth` (unlike `ClientTop`'s own definition), sitting the marker too high by the border width on a bordered `<li>`/`<ul>`/`<ol>`.
- An inside marker (`list-style-position: inside`) never reaches `CssBoxMarker`'s own positioning code - it flows as an ordinary inline box, positioned by the generic vertical-align pass, which defaults every box to `baseline`. A small vector shape marker baseline-aligned like a text glyph sits noticeably high relative to the adjacent text. `CssBoxMarker` now sets `VerticalAlign: middle` for a shape marker, and the vertical-align ancestor walk stops at a marker box instead of reading its owning `<li>`'s (unset) value.

No issue closed by this PR - both defects are unrelated to any currently-open issue.

## Test plan
- [x] Added `OutsideMarker_AccountsForOwnersBorderTopWidth` and `InsideMarkerShape_IsCenteredWithinTheLine_NotBaselineAligned`
- [x] Verified both new tests fail without their respective fix
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - 9299 passed, 0 failed (including the full suite, to check the shared `CssLayoutEngine.cs` vertical-align change didn't regress anything)
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` - 0 warnings
- [x] Visually verified the inside-marker fix by rendering and rasterizing before/after