### PR TITLE
Fix outline stroke width ignoring non-default PixelsPerInch

### DIFF
--- a/src/PeachPDF.Tests/Integration/OutlineStylePaintIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/OutlineStylePaintIntegrationTests.cs
@@ -466,6 +466,58 @@ namespace PeachPDF.Tests.Integration
             Assert.Equal(bWithout.Size, bWith.Size);
         }
 
+        // ─── issue #856: pen stroke width ignores non-default PixelsPerInch ────────
+
+        [Fact]
+        public async Task OutlineStyleDotted_PenWidth_IsInvariantUnderNonDefaultPixelsPerInch()
+        {
+            const string html = "<div id='b' style='width:20pt; height:20pt; outline: 8pt dotted rgb(3,3,3)'>x</div>";
+
+            var (rootDefault, containerDefault) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(html));
+            var divDefault = LayoutHarness.FindById(rootDefault, "b")!;
+            var gDefault = new TestRecordingGraphics { PixelsPerPointOverride = 1.0 };
+            FragmentPaintHarness.PaintBox(containerDefault, divDefault, gDefault);
+            var widthsDefault = gDefault.Log.OfType<TestRecordingGraphics.DrawLineCall>().Select(l => l.Width).ToList();
+
+            var (rootScaled, containerScaled) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(html), pixelsPerPoint: 2.0);
+            var divScaled = LayoutHarness.FindById(rootScaled, "b")!;
+            var gScaled = new TestRecordingGraphics { PixelsPerPointOverride = 2.0 };
+            FragmentPaintHarness.PaintBox(containerScaled, divScaled, gScaled);
+            var widthsScaled = gScaled.Log.OfType<TestRecordingGraphics.DrawLineCall>().Select(l => l.Width).ToList();
+
+            Assert.NotEmpty(widthsDefault);
+            Assert.Equal(widthsDefault.Count, widthsScaled.Count);
+            for (var i = 0; i < widthsDefault.Count; i++)
+                Assert.Equal(widthsDefault[i], widthsScaled[i], 3);
+
+            // Sanity: the pen width should actually equal the declared 8pt outline width.
+            Assert.All(widthsDefault, w => Assert.Equal(8, w, 1));
+        }
+
+        [Fact]
+        public async Task OutlineStyleDoubleAndGroove_StripeWidths_AreInvariantUnderNonDefaultPixelsPerInch()
+        {
+            const string html = "<div id='b' style='width:20pt; height:20pt; outline: 12pt double rgb(51,51,51)'>x</div>";
+
+            var (rootDefault, containerDefault) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(html));
+            var divDefault = LayoutHarness.FindById(rootDefault, "b")!;
+            var gDefault = new TestRecordingGraphics { PixelsPerPointOverride = 1.0 };
+            FragmentPaintHarness.PaintBox(containerDefault, divDefault, gDefault);
+            var widthsDefault = gDefault.Log.OfType<TestRecordingGraphics.DrawLineCall>().Select(l => l.Width).ToList();
+
+            var (rootScaled, containerScaled) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(html), pixelsPerPoint: 2.0);
+            var divScaled = LayoutHarness.FindById(rootScaled, "b")!;
+            var gScaled = new TestRecordingGraphics { PixelsPerPointOverride = 2.0 };
+            FragmentPaintHarness.PaintBox(containerScaled, divScaled, gScaled);
+            var widthsScaled = gScaled.Log.OfType<TestRecordingGraphics.DrawLineCall>().Select(l => l.Width).ToList();
+
+            // double contributes 2 stripes per side, 4 sides.
+            Assert.Equal(8, widthsDefault.Count);
+            Assert.Equal(widthsDefault.Count, widthsScaled.Count);
+            for (var i = 0; i < widthsDefault.Count; i++)
+                Assert.Equal(widthsDefault[i], widthsScaled[i], 3);
+        }
+
         // ─── Helpers ─────────────────────────────────────────────────────────────
 
         private static bool IsVerticalEdge(System.Collections.Generic.IReadOnlyList<RPoint> points)

--- a/src/PeachPDF/Html/Core/Handlers/OutlineDrawHandler.cs
+++ b/src/PeachPDF/Html/Core/Handlers/OutlineDrawHandler.cs
@@ -187,12 +187,15 @@ namespace PeachPDF.Html.Core.Handlers
                 innerColor = style == OutlineStyle.Groove ? color : BordersDrawHandler.Darken(color);
             }
 
+            // outerWidth/innerWidth stay in the caller's raw, un-divided layout-space units below (used
+            // for nearBand/farBand position math, paired with the still-raw rect) - only the pen's own
+            // stroke width needs the PixelsPerPoint correction, same reason as GetPen's.
             var outerPen = g.GetPen(outerColor);
-            outerPen.Width = outerWidth;
+            outerPen.Width = outerWidth / g.PixelsPerPoint;
             outerPen.DashStyle = RDashStyle.Solid;
 
             var innerPen = g.GetPen(innerColor);
-            innerPen.Width = innerWidth;
+            innerPen.Width = innerWidth / g.PixelsPerPoint;
             innerPen.DashStyle = RDashStyle.Solid;
 
             // "outer"/"inner" name the stripe's position within the ring band (nearest the box edge vs.
@@ -247,7 +250,11 @@ namespace PeachPDF.Html.Core.Handlers
         private static RPen GetPen(RGraphics g, OutlineStyle style, RColor color, double width)
         {
             var p = g.GetPen(color);
-            p.Width = width;
+            // width is the caller's raw, un-divided layout-space (PixelsPerInch-inflated) outline
+            // width - every outline *position* is already built from correctly-scaled coordinates (see
+            // DrawRing/DrawDottedOrDashedLine), but a pen's own stroke width bypasses those and needs
+            // the same PixelsPerPoint correction here (mirrors BordersDrawHandler.GetPen, issue #851).
+            p.Width = width / g.PixelsPerPoint;
             p.DashStyle = style switch
             {
                 OutlineStyle.Dotted => RDashStyle.Dot,


### PR DESCRIPTION
## Summary
- `OutlineDrawHandler.GetPen` set `RPen.Width` directly from a raw, un-divided layout-space (`PixelsPerInch`-inflated) value - the same defect fixed for `BordersDrawHandler` in #851, in the parallel `outline` draw handler. At the default `PixelsPerInch = 72` this was invisible; at any other value, an outline rendered visibly thicker than declared, though correctly positioned.
- Also fixed `DrawDoubleOrGrooveRidge`'s `double`/`groove`/`ridge` stripe pens, same defect.

Fixes #856

## Test plan
- [x] Added `OutlineStyleDotted_PenWidth_IsInvariantUnderNonDefaultPixelsPerInch` and `OutlineStyleDoubleAndGroove_StripeWidths_AreInvariantUnderNonDefaultPixelsPerInch`
- [x] Verified both new tests fail (showing exactly 2x the expected width) with the fix reverted
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - 9299 passed, 0 failed
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` - 0 warnings
- [x] Diff coverage: 100%