### PR TITLE
Resolve @page size per matching rule; fix bare orientation keyword

### DIFF
--- a/src/PeachPDF.Tests/Html/Core/PageRuleResolverTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/PageRuleResolverTests.cs
@@ -1,6 +1,9 @@
+using PeachPDF.CSS;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Entities;
+using PeachPDF.PdfSharpCore.Drawing;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace PeachPDF.Tests.Html.Core
 {
@@ -70,6 +73,92 @@ namespace PeachPDF.Tests.Html.Core
             // At/after the reversion Y: reverted to the empty (default) name, NOT "chapter".
             Assert.Equal(string.Empty, PageRuleResolver.ActiveNameAtSlotStart(elements, slotTop: 1600));
             Assert.Equal(string.Empty, PageRuleResolver.ActiveNameAtPageEnd(elements, pageY: 1600, pageHeight: 800));
+        }
+
+        // ── ResolvePageSize ──────────────────────────────────────────────────────
+
+        private static readonly XSize BasePortrait = new(612, 792);
+        private static readonly PageLengthContext DefaultContext = new(EmPt: 12, RemPt: 12, HundredPercentPt: 612);
+
+        private static PageRule ParsePageRule(string css) =>
+            new StylesheetParser().Parse(css).Rules.OfType<PageRule>().First();
+
+        [Fact]
+        public void ResolvePageSize_NullRule_ReturnsBaseSize()
+        {
+            Assert.Equal(BasePortrait, PageRuleResolver.ResolvePageSize(null, BasePortrait, DefaultContext));
+        }
+
+        [Fact]
+        public void ResolvePageSize_RuleWithNoSizeDeclared_ReturnsBaseSize()
+        {
+            var rule = ParsePageRule("@page chapter { margin: 10mm; }");
+
+            Assert.Equal(BasePortrait, PageRuleResolver.ResolvePageSize(rule, BasePortrait, DefaultContext));
+        }
+
+        [Fact]
+        public void ResolvePageSize_NamedKeywordWithOrientation_Resolves()
+        {
+            var rule = ParsePageRule("@page landscape-table { size: a4 landscape; }");
+
+            var size = PageRuleResolver.ResolvePageSize(rule, BasePortrait, DefaultContext);
+
+            Assert.True(size.Width > size.Height);
+            Assert.Equal(841.89, size.Width, 2);
+            Assert.Equal(595.28, size.Height, 2);
+        }
+
+        [Fact]
+        public void ResolvePageSize_ExplicitLengths_Resolve()
+        {
+            var rule = ParsePageRule("@page wide { size: 400pt 300pt; }");
+
+            Assert.Equal(new XSize(400, 300), PageRuleResolver.ResolvePageSize(rule, BasePortrait, DefaultContext));
+        }
+
+        [Fact]
+        public void ResolvePageSize_BareOrientationKeyword_RotatesBaseSizePt()
+        {
+            var rule = ParsePageRule("@page landscape-table { size: landscape; }");
+
+            Assert.Equal(new XSize(792, 612), PageRuleResolver.ResolvePageSize(rule, BasePortrait, DefaultContext));
+        }
+
+        [Fact]
+        public void ResolvePageSize_BareOrientationKeyword_MatchingBaseOrientation_IsANoOp()
+        {
+            var rule = ParsePageRule("@page portrait-table { size: portrait; }");
+
+            Assert.Equal(BasePortrait, PageRuleResolver.ResolvePageSize(rule, BasePortrait, DefaultContext));
+        }
+
+        [Fact]
+        public void ResolvePageSize_PercentageValue_FallsBackToBaseSize()
+        {
+            // Not a <length> for `size` (sheet geometry has no percentage basis, css-page-3 §7.1) -
+            // ParsePageSizeToPdfPoints returns null, so the base size is kept.
+            var rule = ParsePageRule("@page wide { size: 50%; }");
+
+            Assert.Equal(BasePortrait, PageRuleResolver.ResolvePageSize(rule, BasePortrait, DefaultContext));
+        }
+
+        [Fact]
+        public void ResolvePageSize_NoContext_FallsBackToBaseSize()
+        {
+            var rule = ParsePageRule("@page wide { size: a4 landscape; }");
+
+            Assert.Equal(BasePortrait, PageRuleResolver.ResolvePageSize(rule, BasePortrait, context: null));
+        }
+
+        [Fact]
+        public void ResolvePageSize_EmDimension_RebasesOnTheWinningRulesOwnFontSize()
+        {
+            var rule = ParsePageRule("@page wide { font-size: 30pt; size: 10em; }");
+
+            var size = PageRuleResolver.ResolvePageSize(rule, BasePortrait, DefaultContext);
+
+            Assert.Equal(new XSize(300, 300), size);
         }
     }
 }

--- a/src/PeachPDF.Tests/Integration/PageSizeUnitIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/PageSizeUnitIntegrationTests.cs
@@ -164,12 +164,79 @@ namespace PeachPDF.Tests.Integration
             Assert.NotEqual(300, container.CssPageSize!.Value.Width, 3); // not the 30pt page font
         }
 
-        private static async Task<HtmlContainerInt> BuildAsync(string html)
+        [Fact]
+        public async Task Size_OrientationAlone_RotatesConfiguredPortraitPageSize()
+        {
+            // A bare orientation keyword now rotates whatever size would otherwise apply, rather than
+            // being a silent no-op (docs/html-css-support.md already claimed this - the code now
+            // matches). Configured 612x792 (portrait) rotates to 792x612 (landscape).
+            var container = await BuildAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { size: landscape; }
+                </style></head><body><p>content</p></body></html>
+                """);
+
+            Assert.NotNull(container.CssPageSize);
+            Assert.Equal(SheetH, container.CssPageSize!.Value.Width, 3);
+            Assert.Equal(SheetW, container.CssPageSize!.Value.Height, 3);
+        }
+
+        [Fact]
+        public async Task Size_OrientationAlone_OnAlreadyMatchingOrientation_IsANoOp()
+        {
+            // `landscape` on an already-landscape configured size must not rotate a second time - this
+            // is also what keeps CascadeApplyPageStyles's own two-pass retry idempotent, since the
+            // retry re-enters with PageSize already rotated from the first pass.
+            var container = await BuildAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { size: landscape; }
+                </style></head><body><p>content</p></body></html>
+                """, configuredWidth: SheetH, configuredHeight: SheetW);
+
+            Assert.NotNull(container.CssPageSize);
+            Assert.Equal(SheetH, container.CssPageSize!.Value.Width, 3);
+            Assert.Equal(SheetW, container.CssPageSize!.Value.Height, 3);
+        }
+
+        [Fact]
+        public async Task Size_PortraitAlone_OnLandscapeConfiguredSize_Rotates()
+        {
+            var container = await BuildAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { size: portrait; }
+                </style></head><body><p>content</p></body></html>
+                """, configuredWidth: SheetH, configuredHeight: SheetW);
+
+            Assert.NotNull(container.CssPageSize);
+            Assert.Equal(SheetW, container.CssPageSize!.Value.Width, 3);
+            Assert.Equal(SheetH, container.CssPageSize!.Value.Height, 3);
+        }
+
+        [Fact]
+        public async Task Size_OrientationAlone_SurvivesApplyPageStylesOnceRetryPass()
+        {
+            // The base rule also sets a percentage margin, forcing CascadeApplyPageStyles's own
+            // "resolve once more in place" retry (issue #582) once the rotated size differs from the
+            // pre-resolution configured size. The final resolved size must still be rotated exactly
+            // once, not twice (which would silently un-rotate it back to portrait).
+            var container = await BuildAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { size: landscape; margin-left: 10%; }
+                </style></head><body><p>content</p></body></html>
+                """);
+
+            Assert.NotNull(container.CssPageSize);
+            Assert.Equal(SheetH, container.CssPageSize!.Value.Width, 3);
+            Assert.Equal(SheetW, container.CssPageSize!.Value.Height, 3);
+        }
+
+        private static async Task<HtmlContainerInt> BuildAsync(
+            string html, double configuredWidth = SheetW, double configuredHeight = SheetH)
         {
             var adapter = new PdfSharpAdapter { PixelsPerPoint = 1.0 };
             var container = new HtmlContainerInt(adapter)
             {
-                PageSize = new RSize(SheetW, SheetH)
+                PageSize = new RSize(configuredWidth, configuredHeight)
             };
             await container.SetHtml(html, null);
             return container;

--- a/src/PeachPDF/Html/Core/Dom/PageRuleResolver.cs
+++ b/src/PeachPDF/Html/Core/Dom/PageRuleResolver.cs
@@ -1,6 +1,7 @@
 using PeachPDF.CSS;
 using PeachPDF.Html.Core.Entities;
 using PeachPDF.Html.Core.Parse;
+using PeachPDF.PdfSharpCore.Drawing;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -167,6 +168,30 @@ namespace PeachPDF.Html.Core.Dom
             double? Resolve(string value) => ctx is { } c
                 ? DomParser.ParseLengthToPdfPoints(value, c)
                 : DomParser.ParseLengthToPdfPoints(value);
+        }
+
+        /// <summary>
+        /// Resolves the physical sheet size for the winning rule, in true PDF points, falling back to
+        /// <paramref name="baseSizePt"/> when the rule declares no <c>size</c>, or declares one that
+        /// can't be resolved here (percentages/viewport units have no sheet-relative basis, css-page-3
+        /// §7.1) - <see cref="DomParser.ParsePageSizeToPdfPoints"/> already returns null for exactly
+        /// those cases. A bare orientation keyword rotates <paramref name="baseSizePt"/> itself (see
+        /// that method), so a named/pseudo rule's <c>size: landscape</c> rotates whichever size this
+        /// rule would otherwise fall back to - the same base-vs-per-page relationship
+        /// <see cref="ResolvePageMargins"/> already has with its own base-margin parameters, just for
+        /// one property instead of four.
+        /// </summary>
+        internal static XSize ResolvePageSize(PageRule? rule, XSize baseSizePt, PageLengthContext? context = null)
+        {
+            if (rule?.Style.Size is not { Length: > 0 } sizeValue) return baseSizePt;
+
+            // Re-base the em/ex length basis on the winning rule's own font-size, mirroring
+            // ResolvePageMargins's identical treatment (css-page-3 §7.1 / issue #162).
+            var ctx = context;
+            if (context is { } c0 && rule.Style.FontSize.Length > 0)
+                ctx = c0 with { EmPt = MarginBoxRenderer.ResolveFontSizePt(rule.Style.FontSize) };
+
+            return ctx is { } c ? DomParser.ParsePageSizeToPdfPoints(sizeValue, c, baseSizePt) ?? baseSizePt : baseSizePt;
         }
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -420,8 +420,12 @@ namespace PeachPDF.Html.Core.Parse
                 {
                     // CssPageSize is documented/consumed as true PDF points (PdfGenerator.AddPdfPages
                     // assigns it straight to orgPageSize), not internal pixel space - unlike the
-                    // margins above, this one deliberately stays unscaled.
-                    htmlContainer.CssPageSize = ParsePageSizeToPdfPoints(pageRule.Style.Size, lengthContext);
+                    // margins above, this one deliberately stays unscaled. The base rule's own
+                    // "otherwise-configured size" (for a bare orientation keyword to rotate) is the
+                    // caller-configured PdfGenerateConfig size, reconstructed the same way the retry
+                    // check above does.
+                    var baseSizePt = PeachPDF.Utilities.Utils.Convert(htmlContainer.PageSize, pixelsPerPoint);
+                    htmlContainer.CssPageSize = ParsePageSizeToPdfPoints(pageRule.Style.Size, lengthContext, baseSizePt);
                 }
             }
         }
@@ -443,7 +447,15 @@ namespace PeachPDF.Html.Core.Parse
             { "tabloid", new XSize(792,      1224)   },
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
-        private static XSize? ParsePageSizeToPdfPoints(string sizeValue, PageLengthContext context)
+        /// <summary>
+        /// Resolves an <c>@page { size: ... }</c> value to true PDF points, for the winning rule of
+        /// ANY selector kind (base, <c>:first</c>/<c>:left</c>/<c>:right</c>, or named) -
+        /// <paramref name="baseSizePt"/> is whichever size this rule would otherwise fall back to (the
+        /// document's configured/base size for a base rule; a named/pseudo rule's own base-rule
+        /// fallback via <see cref="Dom.PageRuleResolver.ResolvePageSize"/>), used both as the "no size
+        /// declared" fallback and as the size a bare orientation keyword rotates.
+        /// </summary>
+        internal static XSize? ParsePageSizeToPdfPoints(string sizeValue, PageLengthContext context, XSize baseSizePt)
         {
             var parts = sizeValue.Trim().Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries);
             if (parts.Length == 0)
@@ -511,10 +523,27 @@ namespace PeachPDF.Html.Core.Parse
             if (firstLength.HasValue)
                 return new XSize(firstLength.Value, secondLength ?? firstLength.Value);
 
-            // Reached for an orientation keyword alone — no explicit size, so the configured page size
-            // is kept. (`auto` and any other unrecognized single token fall into the invalid branch
-            // above and also return null here, which is the same "keep the configured size" outcome
-            // `auto` calls for.)
+            if (landscape.HasValue)
+            {
+                // An orientation keyword alone (no <page-size>): css-page-3 §7.1 only defines this as
+                // "the size of the page sheet is chosen by the UA" - it does not itself mandate rotating
+                // an otherwise-configured size, but doing so is a common, defensible UA choice (Prince/
+                // WeasyPrint-style) and is what this codebase's own docs already (and, until this fix,
+                // incorrectly) claimed. Rotate baseSizePt only when the keyword's implied orientation
+                // actually differs from its current one - `landscape` on an already-landscape size is a
+                // no-op, not a second rotation. This also keeps CascadeApplyPageStyles's own two-pass
+                // retry idempotent: the retry re-enters with PageSize already rotated, so the second call
+                // correctly does nothing.
+                var size = baseSizePt;
+                if (landscape.Value && size.Width < size.Height)
+                    size = new XSize(size.Height, size.Width);
+                else if (!landscape.Value && size.Width > size.Height)
+                    size = new XSize(size.Height, size.Width);
+                return size;
+            }
+
+            // `auto` and any other unrecognized single token fall into the invalid branch above and
+            // return null here too - "keep whatever this rule would otherwise fall back to".
             return null;
         }
 


### PR DESCRIPTION
## Summary
- Adds `PageRuleResolver.ResolvePageSize`, resolving `size` for any `@page` rule (base, pseudo-selector, or named) instead of only the base rule — the first layer of mixed page orientation/size support (per-page `@page { size: ... }`).
- Fixes a real, independent bug: a bare orientation keyword (`size: landscape` with no page-size keyword) was a silent no-op. It now rotates the otherwise-configured size, matching what `docs/html-css-support.md` already (incorrectly) claimed.

## Test plan
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (9357 passed)
- [x] New unit tests for `PageRuleResolver.ResolvePageSize` (named/explicit/bare-orientation/percentage-fallback/em-rebasing)
- [x] New integration tests for the orientation-keyword fix, including idempotency across the two-pass `@page` retry