### PR TITLE
Resolve per-slot physical sheet size in PageGeometryTable

### DIFF
--- a/src/PeachPDF.Tests/Integration/PerPageSizeGeometryLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/PerPageSizeGeometryLayoutIntegrationTests.cs
@@ -1,0 +1,179 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Adapters.Entities;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore.Drawing;
+using System;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Layer B of mixed page orientation/size support: <see cref="PageGeometryTable"/> resolving a
+    /// per-slot physical sheet size (<see cref="PageBandGeometry.SheetWidthPt"/>/
+    /// <see cref="PageBandGeometry.SheetHeightPt"/>) from a named/pseudo <c>@page</c> rule's own
+    /// <c>size</c>, via <see cref="PageRuleResolver.ResolvePageSize"/>, mirroring exactly how margins
+    /// already resolve per slot. Same harness convention as
+    /// <see cref="NamedPageGeometryAttributionTests"/>/<see cref="PerPageGeometryLayoutIntegrationTests"/>.
+    /// </summary>
+    public class PerPageSizeGeometryLayoutIntegrationTests
+    {
+        private const double SheetW = 612;
+        private const double SheetH = 792;
+        private const double BaseMt = 60;
+        private const double BaseMb = 60;
+
+        [Fact]
+        public async Task UniformDocument_NoSizeOverride_HasSizeOverridesIsFalse_AndEverySlotUsesBaseSheetSize()
+        {
+            var container = await BuildLayoutAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { margin: 60pt 50pt; }
+                div, p { margin: 0; }
+                </style></head><body>
+                <div style="height: 2000pt">tall content spanning several pages</div>
+                </body></html>
+                """);
+
+            Assert.False(container.PageGeometry.HasSizeOverrides);
+
+            for (var slot = 0; slot < 3; slot++)
+            {
+                var geom = container.PageGeometry.GetPage(slot);
+                Assert.Equal(SheetW, geom.SheetWidthPt, 3);
+                Assert.Equal(SheetH, geom.SheetHeightPt, 3);
+            }
+        }
+
+        [Fact]
+        public async Task NamedPageWithExplicitSize_SlotGetsItsOwnSheetDimensions_OtherSlotsStayBase()
+        {
+            var container = await BuildLayoutAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { margin: 60pt 50pt; }
+                @page wide { size: 900pt 400pt; margin: 20pt; }
+                div, p { margin: 0; }
+                </style></head><body>
+                <p>default page one</p>
+                <div style="page: wide; height: 50pt">wide section</div>
+                <p>default page three</p>
+                </body></html>
+                """);
+
+            Assert.True(container.PageGeometry.HasSizeOverrides);
+
+            // Slot 0: default page, base sheet size.
+            var slot0 = container.PageGeometry.GetPage(0);
+            Assert.Equal(SheetW, slot0.SheetWidthPt, 3);
+            Assert.Equal(SheetH, slot0.SheetHeightPt, 3);
+
+            // Slot 1: the named page's own forced break lands it here, carrying its own sheet size.
+            var slot1 = container.PageGeometry.GetPage(1);
+            Assert.Equal(900, slot1.SheetWidthPt, 3);
+            Assert.Equal(400, slot1.SheetHeightPt, 3);
+            Assert.Equal(20, slot1.MarginLeftPt, 3);
+            Assert.Equal(20, slot1.MarginTopPt, 3);
+
+            // Slot 2: reverted to the default name - base sheet size restored.
+            var slot2 = container.PageGeometry.GetPage(2);
+            Assert.Equal(SheetW, slot2.SheetWidthPt, 3);
+            Assert.Equal(SheetH, slot2.SheetHeightPt, 3);
+        }
+
+        [Fact]
+        public async Task NamedPageWithNamedSizeAndOrientation_ResolvesIndependentlyOfTheBaseSheet()
+        {
+            // A4 landscape via the named-size keyword table - independent of the base Letter sheet,
+            // confirming ResolvePageSize's named-size branch is reached (not just explicit lengths).
+            var container = await BuildLayoutAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { margin: 60pt 50pt; }
+                @page landscape-table { size: a4 landscape; margin: 15mm; }
+                div, p { margin: 0; }
+                </style></head><body>
+                <p>default page one</p>
+                <div style="page: landscape-table; height: 50pt">landscape section</div>
+                </body></html>
+                """);
+
+            var slot1 = container.PageGeometry.GetPage(1);
+            Assert.True(slot1.SheetWidthPt > slot1.SheetHeightPt);
+            Assert.Equal(841.89, slot1.SheetWidthPt, 2);
+            Assert.Equal(595.28, slot1.SheetHeightPt, 2);
+        }
+
+        [Fact]
+        public async Task NamedPageSizeWithDegenerateMargins_KeepsTheResolvedSheetSize_MarginsFallBackToBase()
+        {
+            // The named rule's own top+bottom margins (300+300=600) consume more than its own resolved
+            // 300pt-tall sheet - band-height purposes discard the margins and fall back to the base
+            // document margins (60+60=120, which DOES fit the 300pt sheet), but the SHEET SIZE ITSELF
+            // stays the named override (400x300), not the base (612x792): only the degenerate margin is
+            // discarded, per PageGeometryTable.Compute's remarks.
+            var container = await BuildLayoutAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { margin: 60pt 50pt; }
+                @page tiny { size: 400pt 300pt; margin: 300pt 20pt; }
+                div, p { margin: 0; }
+                </style></head><body>
+                <p>default page one</p>
+                <div style="page: tiny; height: 50pt">tiny section</div>
+                </body></html>
+                """);
+
+            var slot1 = container.PageGeometry.GetPage(1);
+            Assert.Equal(400, slot1.SheetWidthPt, 3);
+            Assert.Equal(300, slot1.SheetHeightPt, 3);
+            Assert.Equal(300 - BaseMt - BaseMb, slot1.BandHeight, 3); // resolved sheet's own band under base margins
+            Assert.Equal(BaseMt, slot1.MarginTopPt, 3);
+            Assert.Equal(BaseMb, slot1.MarginBottomPt, 3);
+        }
+
+        [Fact]
+        public async Task NamedPageSizeSmallerThanBaseMargins_DiscardsMarginsEntirely_ReclaimsFullResolvedSheet()
+        {
+            // A resolved sheet so small even the BASE margins (60+60=120) don't fit its own 100pt
+            // height - the second-level fallback discards margins entirely rather than let pagination
+            // stall, reclaiming the full resolved sheet as the band (mirrors the base-sheet-only
+            // "margin: 0" full-bleed pattern, but reached via a too-small size override instead).
+            var container = await BuildLayoutAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { margin: 60pt 50pt; }
+                @page tiny { size: 400pt 100pt; margin: 300pt 20pt; }
+                div, p { margin: 0; }
+                </style></head><body>
+                <p>default page one</p>
+                <div style="page: tiny; height: 50pt">tiny section</div>
+                </body></html>
+                """);
+
+            var slot1 = container.PageGeometry.GetPage(1);
+            Assert.Equal(400, slot1.SheetWidthPt, 3);
+            Assert.Equal(100, slot1.SheetHeightPt, 3);
+            Assert.Equal(100, slot1.BandHeight, 3);
+            Assert.Equal(0, slot1.MarginTopPt, 3);
+            Assert.Equal(0, slot1.MarginBottomPt, 3);
+        }
+
+        private static async Task<HtmlContainerInt> BuildLayoutAsync(string html, double ppp = 1.0)
+        {
+            var adapter = new PdfSharpAdapter { PixelsPerPoint = ppp };
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            container.PageSize = new RSize(
+                SheetW * ppp - container.MarginLeft - container.MarginRight,
+                SheetH * ppp - container.MarginTop - container.MarginBottom);
+            container.Location = new RPoint(container.MarginLeft, container.MarginTop);
+            container.MaxSize = new RSize(container.PageSize.Width, 0);
+
+            var measure = XGraphics.CreateMeasureContext(
+                new XSize(container.PageSize.Width, container.PageSize.Height), XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, ppp);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            return container;
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/PageGeometryTable.cs
+++ b/src/PeachPDF/Html/Core/PageGeometryTable.cs
@@ -1,5 +1,6 @@
 using PeachPDF.Adapters;
 using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore.Drawing;
 using System;
 using System.Collections.Generic;
 
@@ -7,8 +8,11 @@ namespace PeachPDF.Html.Core
 {
     /// <summary>
     /// One pagination slot's resolved geometry: its document-space band top and height (internal
-    /// pixel space, the same space all layout coordinates use) plus its four resolved page margins in
-    /// true PDF points (the space the paint loop's clip/translate and the margin-box renderer use).
+    /// pixel space, the same space all layout coordinates use) plus its four resolved page margins and
+    /// its resolved physical sheet width/height, all in true PDF points (the space the paint loop's
+    /// clip/translate and the margin-box renderer use). <see cref="SheetWidthPt"/>/
+    /// <see cref="SheetHeightPt"/> are always populated - the base/configured sheet size for a slot no
+    /// <c>@page</c> rule overrides, this slot's own resolved <c>size</c> otherwise.
     /// </summary>
     internal readonly record struct PageBandGeometry(
         int PageIndex,
@@ -17,7 +21,9 @@ namespace PeachPDF.Html.Core
         double MarginLeftPt,
         double MarginTopPt,
         double MarginRightPt,
-        double MarginBottomPt);
+        double MarginBottomPt,
+        double SheetWidthPt,
+        double SheetHeightPt);
 
     /// <summary>
     /// The per-page geometry table behind CSS Paged Media's page-box model: when per-page
@@ -41,6 +47,7 @@ namespace PeachPDF.Html.Core
         private readonly List<PageBandGeometry> _pages = [];
         private bool? _hasVerticalOverrides;
         private bool? _hasHorizontalOverrides;
+        private bool? _hasSizeOverrides;
 
         /// <summary>
         /// Whether any selector-carrying <c>@page</c> rule declares a top or bottom margin — the only
@@ -98,6 +105,35 @@ namespace PeachPDF.Html.Core
             return false;
         }
 
+        /// <summary>
+        /// Whether any selector-carrying <c>@page</c> rule declares a physical <c>size</c> - when true,
+        /// a pagination slot's sheet width/height can differ from the document's base/configured size
+        /// (e.g. a named page in a different orientation), so <see cref="Compute"/> resolves it per
+        /// slot via <see cref="PageRuleResolver.ResolvePageSize"/> instead of the cheap global
+        /// reconstruction. When false (the overwhelming majority of documents), sheet size stays the
+        /// single base value for every slot and no per-slot resolution runs at all.
+        /// </summary>
+        internal bool HasSizeOverrides
+        {
+            get
+            {
+                _hasSizeOverrides ??= ComputeHasSizeOverrides();
+                return _hasSizeOverrides.Value;
+            }
+        }
+
+        private bool ComputeHasSizeOverrides()
+        {
+            foreach (var rule in container.PageRules)
+            {
+                if (rule.Selector is null) continue;
+                if (rule.Style.Size.Length > 0)
+                    return true;
+            }
+
+            return false;
+        }
+
         /// <summary>Drops every cached slot and re-evaluates the override scan — called at the start
         /// of every layout pass (and via <c>Clear</c>/<c>SetHtml</c>) so a fresh pass never sees the
         /// previous pass's geometry.</summary>
@@ -106,6 +142,7 @@ namespace PeachPDF.Html.Core
             _pages.Clear();
             _hasVerticalOverrides = null;
             _hasHorizontalOverrides = null;
+            _hasSizeOverrides = null;
         }
 
         /// <summary>
@@ -173,28 +210,62 @@ namespace PeachPDF.Html.Core
             var baseTPt = container.MarginTop / ppp;
             var baseRPt = container.MarginRight / ppp;
             var baseBPt = container.MarginBottom / ppp;
-            // The raw sheet height in layout px, recovered by construction: PdfGenerator.SetContent
+            // The raw sheet width/height in layout px, recovered by construction: PdfGenerator.SetContent
             // subtracts both point-space margins from the point-space sheet, and the public wrappers
             // scale PageSize and margins by the same PixelsPerPoint.
-            var sheetPx = container.PageSize.Height + container.MarginTop + container.MarginBottom;
+            var baseSheetPxWidth = container.PageSize.Width + container.MarginLeft + container.MarginRight;
+            var baseSheetPxHeight = container.PageSize.Height + container.MarginTop + container.MarginBottom;
 
             var activeName = PageRuleResolver.ActiveNameAtSlotStart(container.NamedPageElements, top);
             var rule = PageRuleResolver.SelectPageRule(container.PageRules, pageIndex + 1, activeName);
             var (mL, mT, mR, mB) = PageRuleResolver.ResolvePageMargins(
                 rule, baseLPt, baseTPt, baseRPt, baseBPt, container.PageLengthContext);
 
-            var bandHeight = sheetPx - (mT + mB) * ppp;
+            // Only resolve a per-slot sheet size when some rule in the document actually declares one -
+            // the cheap, overwhelmingly common case (including every slot of a document that HAS a size
+            // override elsewhere, but not on the rule that won here) stays the plain base reconstruction,
+            // with no PageRuleResolver.ResolvePageSize call/allocation at all.
+            double sheetPxHeight, sheetWidthPt, sheetHeightPt;
+            if (HasSizeOverrides)
+            {
+                var baseSizePt = new XSize(baseSheetPxWidth / ppp, baseSheetPxHeight / ppp);
+                var resolved = PageRuleResolver.ResolvePageSize(rule, baseSizePt, container.PageLengthContext);
+                sheetWidthPt = resolved.Width;
+                sheetHeightPt = resolved.Height;
+                sheetPxHeight = resolved.Height * ppp;
+            }
+            else
+            {
+                sheetWidthPt = baseSheetPxWidth / ppp;
+                sheetHeightPt = baseSheetPxHeight / ppp;
+                sheetPxHeight = baseSheetPxHeight;
+            }
+
+            var bandHeight = sheetPxHeight - (mT + mB) * ppp;
             if (bandHeight < 1.0)
             {
                 // Degenerate override (top+bottom margins consume the whole sheet): discard it for
-                // band purposes and fall back to the base band, so the pagination walk always
-                // advances and paint/clip stay consistent with the band actually used.
+                // band purposes and fall back to the base document margins against the SAME resolved
+                // sheet (not just the base one - only the margins are discarded, per the class doc
+                // comment), so the pagination walk always advances and paint/clip stay consistent with
+                // the band actually used.
                 mT = baseTPt;
                 mB = baseBPt;
-                bandHeight = container.PageSize.Height;
+                bandHeight = sheetPxHeight - (mT + mB) * ppp;
+
+                if (bandHeight < 1.0)
+                {
+                    // Still degenerate - the resolved sheet itself is smaller than even the base
+                    // margins allow (only reachable once a per-slot size override can make the sheet
+                    // arbitrarily small, e.g. a tiny named page). Discard margins entirely rather than
+                    // let pagination stall.
+                    mT = 0;
+                    mB = 0;
+                    bandHeight = sheetPxHeight;
+                }
             }
 
-            return new PageBandGeometry(pageIndex, top, bandHeight, mL, mT, mR, mB);
+            return new PageBandGeometry(pageIndex, top, bandHeight, mL, mT, mR, mB, sheetWidthPt, sheetHeightPt);
         }
     }
 }


### PR DESCRIPTION
## Summary
Stacked on #869 (per-rule `size` resolution). `PageBandGeometry` gains `SheetWidthPt`/`SheetHeightPt`, resolved per pagination slot via `PageRuleResolver.ResolvePageSize` — the same winning `@page` rule margins already use. A new table-level `HasSizeOverrides` flag mirrors `HasHorizontalMarginOverrides`/`HasVerticalMarginOverrides` exactly, keeping the zero-override fast path byte-identical for the overwhelming majority of documents (no `ResolvePageSize` call at all unless some rule in the document actually declares `size`).

Also fixes a latent bug the new code path surfaced: the existing degenerate-margin clamp (a rule's own top+bottom margins consuming the whole sheet) fell back to the base document margins but used the *full* reclaimed sheet height as the band rather than that sheet's own content band under the base margins — harmless when there was only ever one sheet size, but wrong once a per-slot sheet size can differ from the base. Fixed, plus a second-level fallback for the (now newly possible) case where even the base margins don't fit a sufficiently small resolved sheet.

Layer B of mixed page orientation/size support (see the project's own tracked plan for the full sequence — this and #869 together let a later layer make the actual PDF page physically differently-sized/oriented).

## Test plan
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (9362 passed)
- [x] New `PerPageSizeGeometryLayoutIntegrationTests.cs`: fast-path guard, a named page's own explicit/named-keyword size, and both levels of the degenerate-margin fallback