### PR TITLE
Resolve position:fixed percentage width/height against the page area

### DIFF
--- a/src/PeachPDF.Tests/Integration/FixedPositionPercentageSizeIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FixedPositionPercentageSizeIntegrationTests.cs
@@ -1,0 +1,113 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore.Drawing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Layer K (Tier 0) of mixed page orientation/size support: a <c>position: fixed</c> box's own
+    /// percentage width/height must resolve against the page area (CSS2.1 §10.1: the initial
+    /// containing block), the same basis <c>CssBox.CommitBlockChildOffset</c>'s fixed branch already
+    /// uses for <c>left</c>/<c>top</c> - previously it fell through to the ordinary DOM
+    /// <c>ContainingBlock</c> chain, exactly like a <c>position: static</c> box, which is wrong
+    /// independent of anything to do with mixed page sizes (a pre-existing bug found while designing
+    /// that feature). Same harness convention as <see cref="AbsolutePositioningIntegrationTests"/>,
+    /// whose analogous absolute-positioning fix this mirrors.
+    /// </summary>
+    public class FixedPositionPercentageSizeIntegrationTests
+    {
+        [Fact]
+        public async Task FixedPercentWidth_ResolvesAgainstPageArea_NotItsNarrowStaticAncestor()
+        {
+            // The fixed box's ContainingBlock (nearest in-flow block ancestor) is a 120pt-wide div -
+            // before the fix, `width: 50%` resolved against that (60pt). It must resolve against the
+            // 595pt-wide page instead (297.5pt).
+            var (root, _) = await BuildAndLayout(Wrap(
+                "<div style='width:120pt;'>" +
+                "<div id='fixed' style='position:fixed; width:50%;'></div>" +
+                "</div>"));
+
+            var fixedBox = FindById(root, "fixed")!;
+            Assert.Equal(297.5, fixedBox.Size.Width, 1.5);
+        }
+
+        [Fact]
+        public async Task FixedPercentHeight_ResolvesAgainstPageArea_NotItsShortStaticAncestor()
+        {
+            // Same for height: the ancestor's 80pt height must not be the basis - the 842pt page is.
+            var (root, _) = await BuildAndLayout(Wrap(
+                "<div style='height:80pt;'>" +
+                "<div id='fixed' style='position:fixed; height:50%;'></div>" +
+                "</div>"));
+
+            var fixedBox = FindById(root, "fixed")!;
+            Assert.Equal(421, fixedBox.ActualHeight, 1.5);
+        }
+
+        [Fact]
+        public async Task FixedPercentWidthAndHeight_MatchTheBoxsOwnPercentageOffsetBasis()
+        {
+            // Regression guard tying the two together: left/top (already page-area-based) and
+            // width/height (newly fixed) must now agree on the same basis for the same box.
+            var (root, _) = await BuildAndLayout(Wrap(
+                "<div id='fixed' style='position:fixed; left:10%; top:10%; width:20%; height:20%;'></div>"));
+
+            var fixedBox = FindById(root, "fixed")!;
+            Assert.Equal(59.5, fixedBox.Location.X, 1.5);  // 10% of 595
+            Assert.Equal(84.2, fixedBox.Location.Y, 1.5);  // 10% of 842
+            Assert.Equal(119, fixedBox.Size.Width, 1.5);   // 20% of 595
+            Assert.Equal(168.4, fixedBox.ActualHeight, 1.5); // 20% of 842
+        }
+
+        [Fact]
+        public async Task StaticPercentWidth_StillResolvesAgainstItsOwnContainingBlock()
+        {
+            // Regression guard: an ordinary (non-fixed) box's percentage resolution is unaffected.
+            var (root, _) = await BuildAndLayout(Wrap(
+                "<div style='width:120pt;'>" +
+                "<div id='block' style='width:50%;'></div>" +
+                "</div>"));
+
+            var block = FindById(root, "block")!;
+            Assert.Equal(60, block.Size.Width, 1.5);
+        }
+
+        private static string Wrap(string body) =>
+            $"<!DOCTYPE html><html><head><style>body,div{{margin:0}}</style></head><body>{body}</body></html>";
+
+        private static CssBox? FindById(CssBox box, string id)
+        {
+            if (string.Equals(box.HtmlTag?.TryGetAttribute("id", ""), id, System.StringComparison.OrdinalIgnoreCase))
+                return box;
+
+            foreach (var child in box.Boxes)
+            {
+                var found = FindById(child, id);
+                if (found != null) return found;
+            }
+
+            return null;
+        }
+
+        private static async Task<(CssBox root, HtmlContainerInt container)> BuildAndLayout(string html)
+        {
+            var adapter = new PdfSharpAdapter { PixelsPerPoint = 1.0 };
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            var size = new XSize(595, 842);
+            container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+            container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+            var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            return (container.Root!, container);
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -1507,8 +1507,15 @@ namespace PeachPDF.Html.Core.Dom
                 && !(box.DerivedStyle.ActualDisplay == Keywords.Inline && box.Words.Count == 0))
             {
                 // Absolute boxes resolve a percentage width against their nearest positioned ancestor
-                // (CSS 2.1 §10.1), consistent with GetBoxHeight and the left/top positioning code.
-                width = CssValueParser.ParseLength(box.Width, PercentageBase(box).Size.Width, box);
+                // (CSS 2.1 §10.1), consistent with GetBoxHeight and the left/top positioning code. Fixed
+                // boxes resolve against the page area (CSS2.1 §10.1: the initial containing block), the
+                // same basis CommitBlockChildOffset already uses for a fixed box's left/top - previously
+                // missed here, so a fixed box's own percentage width fell through to the ordinary DOM
+                // ContainingBlock chain instead.
+                var widthBasis = box.Position.Value is PositionMode.Fixed && box.HtmlContainer is { } wfc
+                    ? wfc.PageSize.Width
+                    : PercentageBase(box).Size.Width;
+                width = CssValueParser.ParseLength(box.Width, widthBasis, box);
             }
 
             if (box is { Width: Keywords.Auto, Position.Value: not PositionMode.Absolute })
@@ -1594,8 +1601,13 @@ namespace PeachPDF.Html.Core.Dom
             // container that ContainingBlock returns. (Positioning already uses GetNearestPositionedAncestor;
             // this keeps % height resolution consistent, so e.g. a Charts.css pie slice `td { position:
             // absolute; height: 100% }` fills its position:relative tbody even though its parent <tr> is
-            // static and zero-height.)
+            // static and zero-height.) A fixed box resolves against the page area instead (CSS2.1 §10.1:
+            // the initial containing block, the same basis CommitBlockChildOffset already uses for a fixed
+            // box's left/top) - always definite, since the page always has a real height.
             var heightCb = PercentageBase(box);
+            var isFixedToPage = box.Position.Value is PositionMode.Fixed && box.HtmlContainer is not null;
+            var heightBasisIsCalculated = isFixedToPage || heightCb.IsHeightCalculated;
+            var heightBasis = isFixedToPage ? box.HtmlContainer!.PageSize.Height : heightCb.Size.Height;
 
             // CSS 2.1 §10.6.3: a definite (non-auto) `height` is the used height regardless of
             // content - content taller than it overflows past ActualBottom (clipped or not per
@@ -1603,7 +1615,7 @@ namespace PeachPDF.Html.Core.Dom
             // the previous order here had it), so min-height can still win on conflict per §10.7.
             if (CssValueParser.IsValidLength(box.Height))
             {
-                if (!heightCb.IsHeightCalculated && box.Height.EndsWith('%'))
+                if (!heightBasisIsCalculated && box.Height.EndsWith('%'))
                 {
                     // An indefinite percentage height behaves as automatic (CSS Box Sizing 4 §5): a
                     // preferred aspect ratio sizes the height from the (definite) width if there is one;
@@ -1615,21 +1627,21 @@ namespace PeachPDF.Html.Core.Dom
                 }
                 else
                 {
-                    height = CssValueParser.ParseLength(box.Height, heightCb.Size.Height, box) + box.ActualBoxSizeIncludedHeight;
+                    height = CssValueParser.ParseLength(box.Height, heightBasis, box) + box.ActualBoxSizeIncludedHeight;
                 }
             }
             else if (box.Position.Value is PositionMode.Absolute
                      && box.Top.Value.IsValue && box.Bottom.Value.IsValue
-                     && heightCb.IsHeightCalculated)
+                     && heightBasisIsCalculated)
             {
                 // CSS 2.1 §10.6.4: an absolutely-positioned box with auto height but both `top` and `bottom`
                 // set fills the space between them in the containing block. The counterpart of the §10.3.7
                 // width rule above; sizes a Charts.css area/line `td::before` (auto height, `inset: 0`) to
                 // its cell's height.
-                var top = CssValueParser.ParseLength(box.Top.Value.Value!.Value, heightCb.Size.Height, box);
-                var bottom = CssValueParser.ParseLength(box.Bottom.Value.Value!.Value, heightCb.Size.Height, box);
+                var top = CssValueParser.ParseLength(box.Top.Value.Value!.Value, heightBasis, box);
+                var bottom = CssValueParser.ParseLength(box.Bottom.Value.Value!.Value, heightBasis, box);
                 // Over-constrained fill clamps to 0 (a used height is never negative), per CSS 2.1 §10.6.4.
-                height = Math.Max(0, heightCb.Size.Height - top - bottom - box.ActualMarginTop - box.ActualMarginBottom);
+                height = Math.Max(0, heightBasis - top - bottom - box.ActualMarginTop - box.ActualMarginBottom);
             }
             else if (TryGetAspectRatioHeight(box, out var ratioHeight))
             {
@@ -1640,9 +1652,9 @@ namespace PeachPDF.Html.Core.Dom
             }
 
             if (CssValueParser.IsValidLength(box.MinHeight) &&
-                (heightCb.IsHeightCalculated || !box.MinHeight.EndsWith('%')))
+                (heightBasisIsCalculated || !box.MinHeight.EndsWith('%')))
             {
-                var minHeight = CssValueParser.ParseLength(box.MinHeight, heightCb.Size.Height, box) + box.ActualBoxSizeIncludedHeight;
+                var minHeight = CssValueParser.ParseLength(box.MinHeight, heightBasis, box) + box.ActualBoxSizeIncludedHeight;
 
                 if (minHeight > height)
                 {
@@ -1682,7 +1694,13 @@ namespace PeachPDF.Html.Core.Dom
         internal static bool HasDefiniteHeight(CssBox box)
         {
             if (!CssValueParser.IsValidLength(box.Height)) return false;
-            if (box.Height.EndsWith('%')) return PercentageBase(box).IsHeightCalculated;
+            if (box.Height.EndsWith('%'))
+            {
+                // A fixed box's percentage height resolves against the page area (always definite),
+                // mirroring GetBoxHeight's own isFixedToPage treatment.
+                if (box.Position.Value is PositionMode.Fixed && box.HtmlContainer is not null) return true;
+                return PercentageBase(box).IsHeightCalculated;
+            }
             return true;
         }
 

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -1693,14 +1693,12 @@ namespace PeachPDF.Html.Core.Dom
         /// </summary>
         internal static bool HasDefiniteHeight(CssBox box)
         {
+            // Its one caller, TryGetAspectRatioWidth, only runs for PositionMode.Absolute boxes (see
+            // GetBoxWidth's auto-width branch), so - unlike GetBoxHeight's own isFixedToPage treatment -
+            // there is no reachable Fixed case here to special-case; PercentageBase(box) already covers
+            // every box this function is actually called for.
             if (!CssValueParser.IsValidLength(box.Height)) return false;
-            if (box.Height.EndsWith('%'))
-            {
-                // A fixed box's percentage height resolves against the page area (always definite),
-                // mirroring GetBoxHeight's own isFixedToPage treatment.
-                if (box.Position.Value is PositionMode.Fixed && box.HtmlContainer is not null) return true;
-                return PercentageBase(box).IsHeightCalculated;
-            }
+            if (box.Height.EndsWith('%')) return PercentageBase(box).IsHeightCalculated;
             return true;
         }
 


### PR DESCRIPTION
## Summary
`CssLayoutEngine.GetBoxWidth`/`GetBoxHeight` resolved a `position: fixed` box's percentage width/height against the ordinary DOM `ContainingBlock` chain — the same treatment a `position: static` box gets — instead of the page area (CSS2.1 §10.1), which `CommitBlockChildOffset`'s fixed branch already uses for `left`/`top`. A fixed box nested inside a narrow/short static ancestor sized its percentage width/height against that ancestor instead of the page.

This is a genuine pre-existing bug, independent of the mixed page orientation/size work — found while designing that larger feature (Layer K Tier 0 in the tracked plan) but not dependent on any of it, so it's landing standalone off `main`.

## Test plan
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (9348 passed)
- [x] New `FixedPositionPercentageSizeIntegrationTests.cs`: percentage width/height now resolve against the page area rather than a narrow/short static ancestor, position/size basis agreement, and a regression guard confirming ordinary (non-fixed) percentage resolution is unaffected