### PR TITLE
Make float displacement page-width-aware

### DIFF
--- a/src/PeachPDF.Tests/Integration/FloatPerPageMeasureIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FloatPerPageMeasureIntegrationTests.cs
@@ -112,6 +112,63 @@ namespace PeachPDF.Tests.Integration
             Assert.Equal(BaseMargin, f1.Location.X, 0.5);
         }
 
+        [Fact]
+        public async Task ClearedFloatLeft_ReplacedAtTheLandingPage_ViaTheLeftReplacementBranch()
+        {
+            // Mirrors ClearedFloatRight_ReplacedAtTheLandingPagesRightEdge for the Floating.Left half of
+            // FloatBox's post-clear re-placement (the two are separate branches - a float:right sibling
+            // contributes to clear:right's clearance per CSS 2.1 §9.5.2, pushing this float well past the
+            // page boundary; the base-anchored left edge doesn't itself vary by page, but the
+            // re-placement call must still run for the Left direction too).
+            var container = await BuildLayoutAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { margin: 60pt 50pt; }
+                @page :first { margin-left: 0; }
+                body { margin: 0; }
+                div, p { margin: 0; }
+                </style></head><body>
+                <div id='tallRight' style='float:right; width:50pt; height:700pt;'></div>
+                <div id='clearedLeft' style='float:left; clear:right; width:100pt; height:20pt;'></div>
+                </body></html>
+                """);
+
+            var clearedLeft = FindById(container.Root!, "clearedLeft")!;
+
+            Assert.Equal(1, container.PageIndexOf(clearedLeft.Location.Y));
+            Assert.Equal(BaseMargin, clearedLeft.Location.X, 0.5);
+        }
+
+        [Fact]
+        public async Task FloatRight_DroppedByANarrowedScanBoundary_RederivesAtTheLandingPage()
+        {
+            // Exercises FloatBoxRight's own mid-scan re-derivation (inside the drop branch, not the
+            // simpler "re-run from scratch after clear" path above). `ghost` is a float:right box with a
+            // (valid, if unusual) negative margin-left - IsFloatIntersecting's Floating.Right case reads
+            // an existing candidate's own margin-left-adjusted left edge, so a small negative value is
+            // what makes an already-in-bounds box register as "intersecting" at all under that formula,
+            // which is the only way this branch is reachable through DomUtils.GetFirstIntersectingFloatBox
+            // as it exists today. Once found, `ghost`'s height carries the drop's MaxBottom well past the
+            // page-0/page-1 boundary, and f2's own width (wider than either page's own remaining room
+            // once narrowed) forces the drop that must re-derive the boundary at the Y it lands on.
+            var container = await BuildLayoutAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { margin: 60pt 50pt; }
+                @page :first { margin-left: 0; }
+                body { margin: 0; }
+                div, p { margin: 0; }
+                </style></head><body>
+                <div id='ghost' style='float:right; width:10pt; margin-left:-20pt; height:700pt;'></div>
+                <div id='f2' style='float:right; width:560pt; height:20pt;'></div>
+                </body></html>
+                """);
+
+            var f2 = FindById(container.Root!, "f2")!;
+
+            Assert.Equal(1, container.PageIndexOf(f2.Location.Y));
+            Assert.Equal(BaseRightEdge, f2.ActualRight, 0.5);
+            Assert.Equal(container.PageContentRightOf(f2.Location.Y), f2.ActualRight, 0.5);
+        }
+
         private static async Task<HtmlContainerInt> BuildLayoutAsync(string html, double ppp = 1.0)
         {
             var adapter = new PdfSharpAdapter { PixelsPerPoint = ppp };

--- a/src/PeachPDF.Tests/Integration/FloatPerPageMeasureIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FloatPerPageMeasureIntegrationTests.cs
@@ -1,0 +1,150 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Adapters.Entities;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore.Drawing;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Layer J (floats) of mixed page orientation/size support: a float's own displacement scan
+    /// (<see cref="CssLayoutEngine.FloatBox"/>/<c>FloatBoxLeft</c>/<c>FloatBoxRight</c>) captured its
+    /// page-area boundary ONCE, before the scan's own drop-and-retry loop could carry the float onto a
+    /// different page - so a <c>float: right</c> on any page whose per-page measure differs from its
+    /// containing block's own (fixed-once) measure placed against the WRONG page's right edge. A
+    /// float's own auto/percentage width already resolved correctly per landing page (issue #320/#540);
+    /// only its position was wrong. Same <c>@page :first</c> mirror-margin harness convention as
+    /// <see cref="PerPageHorizontalReflowLayoutIntegrationTests"/>, whose fix this mirrors for floats.
+    /// </summary>
+    public class FloatPerPageMeasureIntegrationTests
+    {
+        private const double SheetW = 612;
+        private const double SheetH = 792;
+        private const double BaseMargin = 50;
+        private const double BaseRightEdge = SheetW - BaseMargin; // 562
+        private const double WideFirstPageRightEdge = SheetW; // 612 (margin-left: 0 on page 0 only)
+
+        [Fact]
+        public async Task FloatRight_OnAWiderFirstPage_ReachesThatPagesOwnRightEdge()
+        {
+            // The containing block (body) itself is placed once, against page 0's wide measure - before
+            // the fix, ANY float:right anywhere in the document used that single stale value. f1 (on the
+            // base-measure page 1) must reach 562, not the page-0 measure (612) its containing block's
+            // own ClientRight would report.
+            var container = await BuildLayoutAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { margin: 60pt 50pt; }
+                @page :first { margin-left: 0; }
+                body { margin: 0; }
+                div, p { margin: 0; }
+                </style></head><body>
+                <div id='f0' style='float:right; width:100pt; height:20pt;'></div>
+                <p id='p0'>page zero</p>
+                <p id='p1' style='page-break-before: always'>page one</p>
+                <div id='f1' style='float:right; width:100pt; height:20pt;'></div>
+                </body></html>
+                """);
+
+            var f0 = FindById(container.Root!, "f0")!;
+            var f1 = FindById(container.Root!, "f1")!;
+
+            Assert.Equal(0, container.PageIndexOf(f0.Location.Y));
+            Assert.Equal(1, container.PageIndexOf(f1.Location.Y));
+
+            Assert.Equal(WideFirstPageRightEdge, f0.ActualRight, 0.5);
+            Assert.Equal(BaseRightEdge, f1.ActualRight, 0.5);
+            Assert.Equal(container.PageContentRightOf(f0.Location.Y), f0.ActualRight, 0.5);
+            Assert.Equal(container.PageContentRightOf(f1.Location.Y), f1.ActualRight, 0.5);
+        }
+
+        [Fact]
+        public async Task ClearedFloatRight_ReplacedAtTheLandingPagesRightEdge()
+        {
+            // clearedRight's OWN initial placement (before clear resolves) is against page 0's wide
+            // measure; clearance (from the tall preceding float:left) then pushes it well into page 1.
+            // The re-placement after ClearBox must use page 1's own (narrower) right edge.
+            var container = await BuildLayoutAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { margin: 60pt 50pt; }
+                @page :first { margin-left: 0; }
+                body { margin: 0; }
+                div, p { margin: 0; }
+                </style></head><body>
+                <div id='tallLeft' style='float:left; width:50pt; height:700pt;'></div>
+                <div id='clearedRight' style='float:right; clear:left; width:100pt; height:20pt;'></div>
+                </body></html>
+                """);
+
+            var clearedRight = FindById(container.Root!, "clearedRight")!;
+
+            Assert.Equal(1, container.PageIndexOf(clearedRight.Location.Y));
+            Assert.Equal(BaseRightEdge, clearedRight.ActualRight, 0.5);
+            Assert.Equal(container.PageContentRightOf(clearedRight.Location.Y), clearedRight.ActualRight, 0.5);
+        }
+
+        [Fact]
+        public async Task FloatLeft_KeepsTheBaseLeftOrigin_OnEveryPage()
+        {
+            // Contrast/regression guard: a float's left edge is already page-independent (document space
+            // is anchored at the base left origin; the painter's per-page deltaX handles the shift), on
+            // every page - not just the base-measure ones.
+            var container = await BuildLayoutAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { margin: 60pt 50pt; }
+                @page :first { margin-left: 0; }
+                body { margin: 0; }
+                div, p { margin: 0; }
+                </style></head><body>
+                <div id='f0' style='float:left; width:80pt; height:20pt;'></div>
+                <p id='p0'>page zero</p>
+                <p id='p1' style='page-break-before: always'>page one</p>
+                <div id='f1' style='float:left; width:80pt; height:20pt;'></div>
+                </body></html>
+                """);
+
+            var f0 = FindById(container.Root!, "f0")!;
+            var f1 = FindById(container.Root!, "f1")!;
+
+            Assert.Equal(0, container.PageIndexOf(f0.Location.Y));
+            Assert.Equal(1, container.PageIndexOf(f1.Location.Y));
+            Assert.Equal(BaseMargin, f0.Location.X, 0.5);
+            Assert.Equal(BaseMargin, f1.Location.X, 0.5);
+        }
+
+        private static async Task<HtmlContainerInt> BuildLayoutAsync(string html, double ppp = 1.0)
+        {
+            var adapter = new PdfSharpAdapter { PixelsPerPoint = ppp };
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            container.PageSize = new RSize(
+                SheetW * ppp - container.MarginLeft - container.MarginRight,
+                SheetH * ppp - container.MarginTop - container.MarginBottom);
+            container.Location = new RPoint(container.MarginLeft, container.MarginTop);
+            container.MaxSize = new RSize(container.PageSize.Width, 0);
+
+            var measure = XGraphics.CreateMeasureContext(
+                new XSize(container.PageSize.Width, container.PageSize.Height), XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, ppp);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            return container;
+        }
+
+        private static CssBox? FindById(CssBox box, string id)
+        {
+            if (string.Equals(box.HtmlTag?.TryGetAttribute("id", ""), id, System.StringComparison.OrdinalIgnoreCase))
+                return box;
+
+            foreach (var child in box.Boxes)
+            {
+                var found = FindById(child, id);
+                if (found != null) return found;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -1227,8 +1227,6 @@ namespace PeachPDF.Html.Core.Dom
 
             var containingBox = box.ContainingBlock!;
 
-            var limitRight = containingBox.ClientRight;
-
             //Get the start x and y of the blockBox
             var startX = containingBox.ClientLeft;
             var startY = box.Location.Y;
@@ -1238,16 +1236,26 @@ namespace PeachPDF.Html.Core.Dom
             switch (box.Float.Value)
             {
                 case Floating.Left:
-                    FloatBoxLeft(box, startX, startY, limitRight);
+                    FloatBoxLeft(box, containingBox, startX, startY);
                     break;
                 case Floating.Right:
-                    FloatBoxRight(box, startX, startY, limitRight);
+                    FloatBoxRight(box, containingBox, startX, startY);
                     break;
             }
 
             if (box.Clear.Value is not ClearMode.None)
             {
                 ClearBox(box, currentBoxIdx, containingBox);
+
+                // css-break-3 §5.1: clearance can carry the float several bands down, onto a
+                // fragmentainer whose inline-end edge differs from the one the scan above placed it
+                // against - and ClearBox rewrites Location wholesale, so a right float has lost its
+                // inline-end placement entirely by this point. Re-place it, once, at the clearance it
+                // landed on. Bounded by construction: ClearBox itself is not re-run.
+                if (box.Float.Value is Floating.Right)
+                    FloatBoxRight(box, containingBox, startX, box.Location.Y);
+                else if (box.Float.Value is Floating.Left)
+                    FloatBoxLeft(box, containingBox, startX, box.Location.Y);
             }
         }
 
@@ -1451,6 +1459,32 @@ namespace PeachPDF.Html.Core.Dom
         }
 
         /// <summary>
+        /// The inline-end content edge of <paramref name="containingBlock"/> on the fragmentainer whose
+        /// band contains document Y <paramref name="blockTop"/> - per-page horizontal reflow (issue
+        /// #143): when a per-page <c>@page</c> rule overrides left/right margins (or, for a mixed
+        /// page-size document, the sheet width itself), content laid out on a page whose measure differs
+        /// from the base uses THAT page's own content-box width (CSS Paged Media 3: "the edges of the
+        /// page area act as a containing block for layout that occurs between page breaks" / css-break-3
+        /// §5.1: "recalculating sizes and positions using its own size"). Falls back to
+        /// <paramref name="containingBlock"/>'s own <see cref="CssBox.ClientRight"/> wherever per-page
+        /// measure does not apply (no <see cref="HtmlContainerInt"/>, <see cref="HtmlContainerInt.UseVariablePageWidth"/>
+        /// is off, or the containing block isn't an unconstrained main column - issue #143's own scope,
+        /// deferred further nesting as #199-#201), so callers may invoke it unconditionally. Shared by
+        /// <see cref="GetBoxWidth"/>'s own box-width resolution and <see cref="FloatBox"/>'s displacement
+        /// scan, rather than each re-deriving the same page-area-minus-inset expression independently.
+        /// </summary>
+        private static double ContentRightOf(CssBox containingBlock, double blockTop)
+        {
+            if (containingBlock.HtmlContainer is { UseVariablePageWidth: true } htmlContainer
+                && IsUnconstrainedMainColumn(containingBlock))
+            {
+                return htmlContainer.PageContentRightOf(blockTop) - MainColumnRightInset(containingBlock);
+            }
+
+            return containingBlock.ClientRight;
+        }
+
+        /// <summary>
         /// The used inline size of <paramref name="box"/>.
         /// </summary>
         /// <param name="g">the device context</param>
@@ -1463,30 +1497,13 @@ namespace PeachPDF.Html.Core.Dom
         /// </param>
         public static async ValueTask<double> GetBoxWidth(RGraphics g, CssBox box, double? blockTop = null)
         {
-            // Per-page horizontal reflow (issue #143). When a per-page @page rule overrides left/right
-            // margins, content laid out on a page whose margins differ from the base uses THAT page's own
-            // content-box width as its measure (CSS Paged Media 3: "the edges of the page area act as a
-            // containing block for layout that occurs between page breaks"). Content stays anchored at the
-            // base left origin, so the painter's existing per-page deltaX translate moves the (already
-            // page-width) content to the page's true left edge. The available right edge is the page's own
-            // area right MINUS the containing block's right inset (mirroring ContainingBlock.ClientLeft on
-            // the left), so a margined body/html doesn't get overrun. Scoped to the unconstrained main
-            // column (containing block chain is auto-width root/html/body): a box nested inside some other
-            // (or constrained) block resolves against that block instead - deferred as an accepted gap
-            // (#199-#201), since only the auto-width main column is guaranteed to span the page area.
             // Keyed off `blockTop` - the border-box top the frame placing this box has just decided on, not
             // the box's own Location.Y, which on the pass that places it still holds whatever position an
             // earlier layout generation left there (page 0's measure, on the first). The frame's offset is
             // settled before this runs precisely so the measure can come from the page the box lands on;
             // where no frame is placing the box (an engine measuring its own container), the box's
             // Location.Y has already been written and is the same answer.
-            var availableRight = box.ContainingBlock.ClientRight;
-            if (box.HtmlContainer is { } htmlContainer && htmlContainer.UseVariablePageWidth
-                && IsUnconstrainedMainColumn(box.ContainingBlock))
-            {
-                availableRight = htmlContainer.PageContentRightOf(blockTop ?? box.Location.Y)
-                                 - MainColumnRightInset(box.ContainingBlock);
-            }
+            var availableRight = ContentRightOf(box.ContainingBlock, blockTop ?? box.Location.Y);
 
             var width = availableRight - box.ContainingBlock.ClientLeft - box.ActualMarginLeft - box.ActualMarginRight;
 
@@ -1890,8 +1907,10 @@ namespace PeachPDF.Html.Core.Dom
             return clearance;
         }
 
-        private static void FloatBoxLeft(CssBox box, double startX, double startY, double limitRight)
+        private static void FloatBoxLeft(CssBox box, CssBox containingBox, double startX, double startY)
         {
+            var limitRight = ContentRightOf(containingBox, startY);
+
             CssFloatCoordinates coordinates = new()
             {
                 Left = startX + box.ActualMarginLeft,
@@ -1928,6 +1947,13 @@ namespace PeachPDF.Html.Core.Dom
                 {
                     coordinates.Top = coordinates.MaxBottom + box.ActualMarginTop;
                     coordinates.Left = startX + box.ActualMarginLeft;
+
+                    // css-break-3 §5.1: this drop may have carried the float onto a fragmentainer of a
+                    // different inline size, so the boundary later iterations test against is re-derived
+                    // at the Y it reached, rather than kept from the band the scan opened in. A
+                    // uniform-width document re-derives the same number, so nothing changes for it.
+                    limitRight = ContentRightOf(containingBox, coordinates.Top);
+                    coordinates.Right = limitRight;
                 }
             } while (true);
 
@@ -1935,8 +1961,10 @@ namespace PeachPDF.Html.Core.Dom
 
         }
 
-        private static void FloatBoxRight(CssBox box, double startX, double startY, double limitRight)
+        private static void FloatBoxRight(CssBox box, CssBox containingBox, double startX, double startY)
         {
+            var limitRight = ContentRightOf(containingBox, startY);
+
             CssFloatCoordinates coordinates = new()
             {
                 Left = startX,
@@ -1970,8 +1998,11 @@ namespace PeachPDF.Html.Core.Dom
 
                 if (coordinates.Left > coordinates.FloatRightStartX)
                 {
-                    coordinates.Right = limitRight - box.ActualMarginRight;
                     coordinates.Top = coordinates.MaxBottom;
+
+                    // Re-derive at the band the drop reached (css-break-3 §5.1), mirroring FloatBoxLeft.
+                    limitRight = ContentRightOf(containingBox, coordinates.Top);
+                    coordinates.Right = limitRight - box.ActualMarginRight;
                 }
             } while (true);
 


### PR DESCRIPTION
## Summary
`FloatBox`'s displacement scan (`FloatBoxLeft`/`FloatBoxRight`) captured its page-area right boundary once, from the containing block's own (fixed-once) `ClientRight`, before the scan's own drop-and-retry loop or a `clear`-triggered relocation could carry the float onto a different page. A `float: right` on any page whose per-page measure differs from its containing block's single measure placed against the *wrong* page's right edge — this is live under the already-shipped per-page-margin reflow (#143), not just the mixed-page-size work in progress.

Extracts a shared `ContentRightOf(containingBlock, y)` helper (also now used by `GetBoxWidth`, replacing its own inline duplicate of the same expression — one shared resolver rather than two independently-maintained copies) and re-derives it wherever the scan crosses a band: inside the drop loop, and again after `ClearBox` (which rewrites `Location` wholesale and previously discarded the scan's own right-edge placement entirely).

A float's own auto/percentage width already resolved correctly per landing page (existing machinery); only its *position* was wrong. The change is algebraically a no-op for any document without per-page `@page` overrides — confirmed by the full suite passing unchanged.

Layer J (floats half) of mixed page orientation/size support (multicol is a separate PR, gated behind other work still in progress).

## Test plan
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (9360 passed)
- [x] New `FloatPerPageMeasureIntegrationTests.cs`: a float's position now varies correctly per page (was previously stuck at the containing block's own page-0 measure), a cleared float's re-placement after clearance uses the page it actually landed on, and a contrast test confirming `float: left`'s already-correct base-anchored position is unaffected