### PR TITLE
Fix nested bidi override nesting order for boxes sharing a start index

### DIFF
--- a/.claude/recent-fixes/2026-09-01-bidi-nested-override-start-index-ordering.md
+++ b/.claude/recent-fixes/2026-09-01-bidi-nested-override-start-index-ordering.md
@@ -1,0 +1,47 @@
+## Nested/sibling CSS bidi overrides sharing a start index pushed in the wrong nesting order
+
+Fixes GitHub issue #575.
+
+**Load-bearing idea:** `CssBidiParagraphResolver.Flatten` builds the shared `overrides` list
+`BidiResolver.ResolveExplicitLevels` consumes for CSS `unicode-bidi` boxes, and that consumer relies
+entirely on **list order** to know which of two overrides sharing a `Start` index is the outer one (it
+pushes same-start overrides in list order, so whichever is last in the list ends up on top of the
+explicit-level stack). The old code appended a box's own override only *after* recursing into its
+children, so whenever a child box's override shared the exact same `Start` as its parent (parent has no
+text of its own before the child begins - the overwhelmingly common shape for a `dir`-bearing wrapper
+around another `dir`-bearing element), the child's override landed in the list before the parent's:
+backwards from the real DOM nesting.
+
+**What running it showed, not just reading it:** for two opposite-direction spans sharing a start
+index, this isn't just a misordering that happens to still look right - it computes a numerically
+different embedding level. Built a probe test rendering `<p>A<span dir="ltr"><span
+dir="rtl">B</span>C</span></p>` and read `CssBox.BidiLevels` directly: pre-fix gave levels `A=0 B=2
+C=2`, post-fix gives `A=0 B=4 C=2`. Pre-fix, "B" and "C" collapse onto the identical level 2, erasing
+the isolate boundary between them; post-fix "B" correctly lands one level-3 (odd/RTL) scope deeper,
+which UAX#9 I2 then bumps to 4 for being strong-L at an odd level. This matters practically because
+`CssLayoutEngine`'s word-splitting relies on level *value* changes (not just parity) to place run
+boundaries even with no intervening whitespace - see `CssLayoutEngineBidiTests.RtlParagraph_...SplitsIntoItsOwnWord`
+for the same mechanism firing on digit runs.
+
+**The fix:** record `insertAt = overrides.Count` *before* recursing into the child, then
+`overrides.Insert(insertAt + i, ...)` the box's own override(s) there once its `length` is known (after
+recursion returns). This keeps every earlier sibling's overrides before `insertAt` (unaffected) while
+guaranteeing this box's own override sits ahead of anything a nested descendant added during the
+recursive call - list order now tracks DOM nesting depth exactly, regardless of whether the box has any
+text of its own before its children.
+
+**Deliberately not done:** the `List<T>.Insert` is O(n) from shifting elements, but the overrides list
+only grows with boxes that have a non-normal `unicode-bidi` (rare relative to total paragraph text), so
+this isn't worth a different data structure.
+
+**Evidence:** `PeachPDF.Tests/Html/Core/Dom/CssBidiParagraphResolverTests.cs`
+(`NestedOppositeDirectionSpans_SharingStartIndex_ResolveOuterToInnerLevels`) asserts the exact byte
+levels above; confirmed it fails on the pre-fix code (`A=0 B=2 C=2`, `Assert.Equal(4, ...)` fails
+`Actual: 2`) and passes post-fix. Full suite: 9411 passed, 0 failed, 9 skipped (unrelated
+platform-specific MIME tests). `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings. Diff coverage
+against `main`: 100% (3/3 changed lines in `CssBidiParagraphResolver.cs`).
+
+**Related but out of scope:** issue #576 (BD13 chaining for isolates nested 3+ deep that all close at
+the identical index) is a separate, already-documented gap this fix does not touch - it concerns the
+X10/BD13 isolating-run-sequence chaining logic in `BidiResolver.ComputeIsolatingRunSequences`, not the
+override-list construction this fix corrects.

--- a/src/PeachPDF.Tests/Html/Core/Dom/CssBidiParagraphResolverTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/CssBidiParagraphResolverTests.cs
@@ -1,0 +1,61 @@
+using PeachPDF.Tests.TestSupport;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Html.Core.Dom
+{
+    /// <summary>
+    /// Regression coverage for issue #575: <c>CssBidiParagraphResolver.Flatten</c> used to append a box's
+    /// own <c>BidiIsolateOverride</c> to the shared overrides list only after recursing into that box's
+    /// children, so when a nested box's override shared its parent's exact <c>Start</c> index (no
+    /// character of the parent's own preceding the child), the child's override landed *before* its
+    /// parent's in the list <c>BidiResolver.ResolveExplicitLevels</c> pushes in order. For two boxes with
+    /// opposite directions, that pushed the wrong override on top of the stack while the shared index's
+    /// character was processed, computing a numerically wrong embedding level rather than merely a
+    /// misordered one.
+    /// </summary>
+    public class CssBidiParagraphResolverTests
+    {
+        [Fact]
+        public async Task NestedOppositeDirectionSpans_SharingStartIndex_ResolveOuterToInnerLevels()
+        {
+            // <span id="outer" dir="ltr"> has no text of its own before <span id="inner" dir="rtl">, so
+            // both spans' synthetic isolate overrides share the exact same Start index (right after "A") -
+            // the precise shape #575 was filed for. "outer"'s override still ends two characters later
+            // (after "C"), so only the *opening* order is exercised here, not the closing order.
+            var html = LayoutHarness.Wrap(
+                """<p id="p">A<span id="outer" dir="ltr"><span id="inner" dir="rtl">B</span>C</span></p>""");
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+
+            var textA = LayoutHarness.Descendants(root).First(b => b.Text == "A");
+            var textB = LayoutHarness.Descendants(root).First(b => b.Text == "B");
+            var textC = LayoutHarness.Descendants(root).First(b => b.Text == "C");
+
+            Assert.NotNull(textA.BidiLevels);
+            Assert.NotNull(textB.BidiLevels);
+            Assert.NotNull(textC.BidiLevels);
+
+            // "A" sits outside both spans, at the paragraph's own (LTR) base level.
+            Assert.Equal(0, textA.BidiLevels![0]);
+
+            // With the outer LTR isolate correctly pushed first and the inner RTL isolate pushed on top
+            // of it, "B" resolves inside a level-3 (odd, RTL) scope; UAX#9 I2 then bumps its own strong-L
+            // type up by one for being at an odd level, landing it at level 4. The pre-fix bug pushed the
+            // inner RTL override first and the outer LTR override second (backwards), so "B" resolved
+            // inside a level-2 (even, LTR) scope instead and never got the I2 bump, staying at level 2 -
+            // colliding with "C"'s own level below instead of standing apart from it.
+            Assert.Equal(4, textB.BidiLevels![0]);
+
+            // "C" sits back in the outer span's own (LTR isolate) scope, one level deeper than "A".
+            Assert.Equal(2, textC.BidiLevels![0]);
+
+            // The isolate boundary between "B" and "C" must produce a level change - the collapse of both
+            // onto the same level (2) is exactly the symptom a real UA would never show for two elements
+            // of opposite `direction`, since it erases the isolate boundary layout/line-breaking logic
+            // relies on to tell the two runs apart.
+            Assert.NotEqual(textB.BidiLevels![0], textC.BidiLevels![0]);
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssBidiParagraphResolver.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBidiParagraphResolver.cs
@@ -109,17 +109,23 @@ namespace PeachPDF.Html.Core.Dom
                     else
                     {
                         var start = text.Length;
+
+                        // Recorded before recursing so this box's own override(s) can be inserted here -
+                        // ahead of any overrides a nested box contributes while sharing the same Start (a
+                        // nested box with no preceding sibling text of its own) - rather than appended
+                        // after recursion returns, which would put a child's override before its
+                        // parent's for any index the two happen to share. BidiResolver.Resolve pushes
+                        // overrides sharing a start in list order and (deliberately) pops overrides
+                        // sharing an end in the reverse order, so outer-to-inner list order is what makes
+                        // both same-index nesting and a multi-push box's own two pushes resolve correctly.
+                        var insertAt = overrides.Count;
                         Flatten(child, text, ranges, overrides);
                         var length = text.Length - start;
 
-                        // Added in outer-to-inner order (e.g. isolate-override's LRI before its nested
-                        // LRO) - BidiResolver.Resolve pushes overrides sharing a start in that same
-                        // order and (deliberately) pops overrides sharing an end in the reverse order,
-                        // so this list order is what makes both ends of a multi-push box nest correctly.
                         if (length > 0)
                         {
-                            foreach (var push in pushes)
-                                overrides.Add(new BidiIsolateOverride(start, length, push));
+                            for (var i = 0; i < pushes.Count; i++)
+                                overrides.Insert(insertAt + i, new BidiIsolateOverride(start, length, pushes[i]));
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

- `CssBidiParagraphResolver.Flatten` appended a plain inline box's own `BidiIsolateOverride` to the shared overrides list only after recursing into that box's children, so a nested box's override landed before its parent's in the list whenever both shared the exact same real-text `Start` index (the parent has no text of its own before the nested box begins) - `BidiResolver.ResolveExplicitLevels` pushes same-start overrides in list order, so this put the wrong override on top of the explicit-level stack for the shared index's character.
- For two boxes with opposite `direction`, this computed a numerically wrong embedding level rather than merely a misordered one (verified empirically: `<p>A<span dir="ltr"><span dir="rtl">B</span>C</span></p>` resolved "B" to level 2 instead of level 4, colliding with "C"'s own level and erasing the isolate boundary between them).
- Fixed by recording the insertion point before recursing into a child, then inserting that child's own override(s) there once its length is known - so list order always reflects DOM nesting depth instead of relying on append order.

Fixes #575

## Test plan

- [x] Added `CssBidiParagraphResolverTests.NestedOppositeDirectionSpans_SharingStartIndex_ResolveOuterToInnerLevels`, which asserts the exact resolved `BidiLevels` for the repro shape; confirmed it fails against the pre-fix code (`Actual: 2` where `Expected: 4`) and passes post-fix.
- [x] Full suite: `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - 9411 passed, 0 failed, 9 skipped (unrelated platform-specific MIME tests).
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` - 0 warnings, 0 errors.
- [x] Diff coverage against `main` - 100% (3/3 changed lines in `CssBidiParagraphResolver.cs`).