### PR TITLE
Fix a crash on a malformed GSUB/GPOS contextual rule with glyphCount 0

### DIFF
--- a/.claude/recent-fixes/2026-09-05-gsub-gpos-malformed-contextual-rule-crash.md
+++ b/.claude/recent-fixes/2026-09-05-gsub-gpos-malformed-contextual-rule-crash.md
@@ -1,0 +1,50 @@
+# Fix a crash on a malformed GSUB/GPOS contextual-rule `glyphCount`/`inputGlyphCount` of 0
+
+Found by a code-review pass (line-by-line diff scan) against the recently-merged Arabic/Indic
+complex-script joining work, not by a real font reproducing it - a defensive robustness fix, not a
+behavior change for any well-formed font.
+
+## The bug
+
+`GsubTable.ReadSequenceRule`/`ReadChainedSequenceRule` (and the byte-for-byte identical `GposTable`
+readers for Lookup Types 7/8) computed a rule's `Input` array as `new ushort[glyphCount - 1]` /
+`new ushort[inputGlyphCount - 1]`. Per the OpenType spec, a `SequenceRule`/`ChainedSequenceRule`'s own
+`glyphCount`/`inputGlyphCount` field always includes the first glyph (already matched via the
+subtable's own `Coverage` table), so a spec-conformant font always has this field `>= 1`. Nothing
+validated that assumption: a malformed or adversarially-crafted font claiming `glyphCount == 0` computed
+`new ushort[-1]`, throwing `OverflowException` and crashing the entire render - not confined to the one
+malformed lookup, and not caught anywhere upstream.
+
+## Load-bearing idea
+
+**Clamp, don't validate-and-throw.** The surrounding code already has a house style for malformed input
+in this exact family of readers (`IndexOfGlyph` bounds checks, `TryGetAlternate`'s range checks) of
+degrading to "this can never match" rather than raising - a `Coverage`-matched glyph should still be
+recognized as such, but a rule that can never actually complete a match (an empty `Input` beyond the
+already-matched first glyph) is a safe, silent no-op consistent with how the rest of this codebase
+already treats out-of-spec table data. `Math.Max(0, glyphCount - 1)` is the minimal fix that preserves
+this: a well-formed font's `glyphCount >= 1` computes the exact same array length as before (no
+behavior change for any real font), and a malformed `glyphCount == 0` degrades to an empty array instead
+of throwing.
+
+## What was deliberately not done
+
+- No attempt to reject the whole subtable/lookup/font on a malformed rule, or to log/report it - this
+  codebase's own convention for malformed-but-parseable table data throughout `GsubTable`/`GposTable` is
+  silent graceful degradation (see `IndexOfGlyph`, `TryGetAlternate`), not validation errors, and this
+  fix follows that precedent rather than introducing a new policy for one corner case.
+- The identical `Math.Max` guard was applied to all four call sites (GSUB `ReadSequenceRule`/
+  `ReadChainedSequenceRule`, GPOS's own two) in one pass, since they are the exact same duplicated code
+  this codebase already runs at parallel, per this repo's own established GSUB/GPOS convention (see each
+  file's own header comment) - not a partial fix to only the file the review happened to name.
+
+## Evidence
+
+- New `GsubGposMalformedContextualRuleSyntheticTests.cs`: three synthetic-byte-blob tests (GSUB
+  Contextual Format 1, GSUB Chaining Format 1, GPOS Context Positioning Format 1), each building a
+  minimal table with a rule whose `glyphCount`/`inputGlyphCount` is 0. Confirmed to reproduce the exact
+  `OverflowException` (temporarily reverting the `Math.Max` guard) before restoring the fix, then
+  asserting the read succeeds with an empty `Input` array.
+- `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings, 0 errors.
+- `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0`: 9807 passed, 9 pre-existing
+  platform-specific skips, 0 failed (full suite).

--- a/src/PeachPDF.Tests/PdfSharpCore/Fonts/GsubGposMalformedContextualRuleSyntheticTests.cs
+++ b/src/PeachPDF.Tests/PdfSharpCore/Fonts/GsubGposMalformedContextualRuleSyntheticTests.cs
@@ -1,0 +1,237 @@
+using System.IO;
+using PeachPDF.Fonts.OpenType;
+using PeachPDF.PdfSharpCore.Drawing;
+using PeachPDF.Tests.TestSupport;
+using Xunit;
+
+namespace PeachPDF.Tests.PdfSharpCoreTests.Fonts
+{
+    /// <summary>
+    /// Regression coverage for a real crash risk in <see cref="GsubTable.ReadSequenceRule"/>/
+    /// <see cref="GsubTable.ReadChainedSequenceRule"/> and their <see cref="GposTable"/> twins: per
+    /// the OpenType spec a Contextual/Chained-Context Substitution/Positioning rule's own
+    /// <c>glyphCount</c>/<c>inputGlyphCount</c> field always includes the first glyph (already matched
+    /// via the subtable's own <c>Coverage</c> table), so the remaining <c>Input</c> array is sized
+    /// <c>glyphCount - 1</c> - a spec-conformant font always has <c>glyphCount &gt;= 1</c>, but nothing
+    /// stopped a malformed/corrupt font from claiming <c>glyphCount == 0</c>, which computed a negative
+    /// array length and crashed the whole render with an <see cref="System.OverflowException"/> instead
+    /// of degrading gracefully. Fixed by clamping to zero.
+    /// </summary>
+    public class GsubGposMalformedContextualRuleSyntheticTests
+    {
+        // Coverage {50}; one ruleSet with one rule: glyphCount=0 (malformed - spec requires >= 1),
+        // seqLookupCount=0.
+        private static byte[] BuildSyntheticGsubWithMalformedRule()
+        {
+            var b = new SfntByteBuilder();
+
+            b.U16(1); b.U16(0);
+            int scriptListOffsetAt = b.PlaceholderU16();
+            int featureListOffsetAt = b.PlaceholderU16();
+            int lookupListOffsetAt = b.PlaceholderU16();
+
+            int scriptListStart = b.Position;
+            b.PatchU16(scriptListOffsetAt, scriptListStart);
+            b.U16(0); // scriptCount
+
+            int featureListStart = b.Position;
+            b.PatchU16(featureListOffsetAt, featureListStart);
+            b.U16(0); // featureCount
+
+            int lookupListStart = b.Position;
+            b.PatchU16(lookupListOffsetAt, lookupListStart);
+            b.U16(1); // lookupCount
+            int lookup0At = b.PlaceholderU16();
+
+            int lookup0Start = b.Position;
+            b.PatchU16(lookup0At, lookup0Start - lookupListStart);
+            b.U16(5); b.U16(0); b.U16(1); // lookupType 5 (Contextual), lookupFlag, subtableCount
+            int lookup0SubAt = b.PlaceholderU16();
+            int lookup0SubStart = b.Position;
+            b.PatchU16(lookup0SubAt, lookup0SubStart - lookup0Start);
+            {
+                int subtableStart = b.Position;
+                b.U16(1); // format 1
+                int coverageOffsetAt = b.PlaceholderU16();
+                b.U16(1); // seqRuleSetCount
+                int ruleSetOffsetAt = b.PlaceholderU16();
+                int ruleSetStart = b.Position;
+                b.PatchU16(ruleSetOffsetAt, ruleSetStart - subtableStart);
+                b.U16(1); // seqRuleCount
+                int ruleOffsetAt = b.PlaceholderU16();
+                int ruleStart = b.Position;
+                b.PatchU16(ruleOffsetAt, ruleStart - ruleSetStart);
+                b.U16(0); // glyphCount - malformed: spec requires >= 1
+                b.U16(0); // seqLookupCount
+                int coverageStart = b.Position;
+                b.PatchU16(coverageOffsetAt, coverageStart - subtableStart);
+                b.U16(1); b.U16(1); b.U16(50); // coverage format 1, 1 glyph, glyph 50
+            }
+
+            return b.ToArray();
+        }
+
+        private static byte[] Concat(byte[] a, byte[] b)
+        {
+            var combined = new byte[a.Length + b.Length];
+            a.CopyTo(combined, 0);
+            b.CopyTo(combined, a.Length);
+            return combined;
+        }
+
+        [Fact]
+        public void Gsub_ContextualFormat1_MalformedZeroGlyphCountRule_DoesNotThrow()
+        {
+            byte[] fontBytes = File.ReadAllBytes(BundledFonts.Ttf);
+            int tableStart = fontBytes.Length;
+            byte[] combined = Concat(fontBytes, BuildSyntheticGsubWithMalformedRule());
+            var face = XFontSource.GetOrCreateFrom(combined).Fontface;
+
+            var gsub = new GsubTable(face, tableStart);
+            var lookup = gsub.GetContextualLookup(0);
+
+            Assert.NotNull(lookup);
+            var rule = Assert.Single(Assert.Single(lookup!.Subtables).RuleSets![0]);
+            // A malformed glyphCount=0 degrades to an empty (never able to match beyond its own
+            // coverage-matched first glyph) Input array rather than throwing.
+            Assert.Empty(rule.Input);
+        }
+
+        // Coverage {50}; backtrack=[], one ruleSet with one rule: inputGlyphCount=0 (malformed),
+        // lookahead=[], seqLookupCount=0.
+        private static byte[] BuildSyntheticGsubWithMalformedChainedRule()
+        {
+            var b = new SfntByteBuilder();
+
+            b.U16(1); b.U16(0);
+            int scriptListOffsetAt = b.PlaceholderU16();
+            int featureListOffsetAt = b.PlaceholderU16();
+            int lookupListOffsetAt = b.PlaceholderU16();
+
+            int scriptListStart = b.Position;
+            b.PatchU16(scriptListOffsetAt, scriptListStart);
+            b.U16(0);
+
+            int featureListStart = b.Position;
+            b.PatchU16(featureListOffsetAt, featureListStart);
+            b.U16(0);
+
+            int lookupListStart = b.Position;
+            b.PatchU16(lookupListOffsetAt, lookupListStart);
+            b.U16(1);
+            int lookup0At = b.PlaceholderU16();
+
+            int lookup0Start = b.Position;
+            b.PatchU16(lookup0At, lookup0Start - lookupListStart);
+            b.U16(6); b.U16(0); b.U16(1); // lookupType 6 (Chaining Context)
+            int lookup0SubAt = b.PlaceholderU16();
+            int lookup0SubStart = b.Position;
+            b.PatchU16(lookup0SubAt, lookup0SubStart - lookup0Start);
+            {
+                int subtableStart = b.Position;
+                b.U16(1); // format 1
+                int coverageOffsetAt = b.PlaceholderU16();
+                b.U16(1); // chainSeqRuleSetCount
+                int ruleSetOffsetAt = b.PlaceholderU16();
+                int ruleSetStart = b.Position;
+                b.PatchU16(ruleSetOffsetAt, ruleSetStart - subtableStart);
+                b.U16(1); // chainSeqRuleCount
+                int ruleOffsetAt = b.PlaceholderU16();
+                int ruleStart = b.Position;
+                b.PatchU16(ruleOffsetAt, ruleStart - ruleSetStart);
+                b.U16(0); // backtrackGlyphCount
+                b.U16(0); // inputGlyphCount - malformed: spec requires >= 1
+                b.U16(0); // lookaheadGlyphCount
+                b.U16(0); // seqLookupCount
+                int coverageStart = b.Position;
+                b.PatchU16(coverageOffsetAt, coverageStart - subtableStart);
+                b.U16(1); b.U16(1); b.U16(50); // coverage format 1, 1 glyph, glyph 50
+            }
+
+            return b.ToArray();
+        }
+
+        [Fact]
+        public void Gsub_ChainingFormat1_MalformedZeroInputGlyphCountRule_DoesNotThrow()
+        {
+            byte[] fontBytes = File.ReadAllBytes(BundledFonts.Ttf);
+            int tableStart = fontBytes.Length;
+            byte[] combined = Concat(fontBytes, BuildSyntheticGsubWithMalformedChainedRule());
+            var face = XFontSource.GetOrCreateFrom(combined).Fontface;
+
+            var gsub = new GsubTable(face, tableStart);
+            var lookup = gsub.GetChainingContextLookup(0);
+
+            Assert.NotNull(lookup);
+            var rule = Assert.Single(Assert.Single(lookup!.Subtables).RuleSets![0]);
+            Assert.Empty(rule.Input);
+        }
+
+        // The GPOS reader shares the identical rule format/bug - same fixture shape, GposTable instead.
+        private static byte[] BuildSyntheticGposWithMalformedRule()
+        {
+            var b = new SfntByteBuilder();
+
+            b.U16(1); b.U16(0);
+            int scriptListOffsetAt = b.PlaceholderU16();
+            int featureListOffsetAt = b.PlaceholderU16();
+            int lookupListOffsetAt = b.PlaceholderU16();
+
+            int scriptListStart = b.Position;
+            b.PatchU16(scriptListOffsetAt, scriptListStart);
+            b.U16(0);
+
+            int featureListStart = b.Position;
+            b.PatchU16(featureListOffsetAt, featureListStart);
+            b.U16(0);
+
+            int lookupListStart = b.Position;
+            b.PatchU16(lookupListOffsetAt, lookupListStart);
+            b.U16(1);
+            int lookup0At = b.PlaceholderU16();
+
+            int lookup0Start = b.Position;
+            b.PatchU16(lookup0At, lookup0Start - lookupListStart);
+            b.U16(7); b.U16(0); b.U16(1); // lookupType 7 (Context Positioning)
+            int lookup0SubAt = b.PlaceholderU16();
+            int lookup0SubStart = b.Position;
+            b.PatchU16(lookup0SubAt, lookup0SubStart - lookup0Start);
+            {
+                int subtableStart = b.Position;
+                b.U16(1); // format 1
+                int coverageOffsetAt = b.PlaceholderU16();
+                b.U16(1); // seqRuleSetCount
+                int ruleSetOffsetAt = b.PlaceholderU16();
+                int ruleSetStart = b.Position;
+                b.PatchU16(ruleSetOffsetAt, ruleSetStart - subtableStart);
+                b.U16(1); // seqRuleCount
+                int ruleOffsetAt = b.PlaceholderU16();
+                int ruleStart = b.Position;
+                b.PatchU16(ruleOffsetAt, ruleStart - ruleSetStart);
+                b.U16(0); // glyphCount - malformed: spec requires >= 1
+                b.U16(0); // seqLookupCount
+                int coverageStart = b.Position;
+                b.PatchU16(coverageOffsetAt, coverageStart - subtableStart);
+                b.U16(1); b.U16(1); b.U16(50); // coverage format 1, 1 glyph, glyph 50
+            }
+
+            return b.ToArray();
+        }
+
+        [Fact]
+        public void Gpos_ContextualFormat1_MalformedZeroGlyphCountRule_DoesNotThrow()
+        {
+            byte[] fontBytes = File.ReadAllBytes(BundledFonts.Ttf);
+            int tableStart = fontBytes.Length;
+            byte[] combined = Concat(fontBytes, BuildSyntheticGposWithMalformedRule());
+            var face = XFontSource.GetOrCreateFrom(combined).Fontface;
+
+            var gpos = new GposTable(face, tableStart);
+            var lookup = gpos.GetContextualLookup(0);
+
+            Assert.NotNull(lookup);
+            var rule = Assert.Single(Assert.Single(lookup!.Subtables).RuleSets![0]);
+            Assert.Empty(rule.Input);
+        }
+    }
+}

--- a/src/PeachPDF/Fonts/OpenType/GposTable.cs
+++ b/src/PeachPDF/Fonts/OpenType/GposTable.cs
@@ -36,6 +36,7 @@
 //
 #endregion
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
@@ -1207,7 +1208,12 @@ namespace PeachPDF.Fonts.OpenType
             _face.Position = ruleOffset;
             int glyphCount = _face.ReadUShort();
             int seqLookupCount = _face.ReadUShort();
-            var input = new ushort[glyphCount - 1];
+            // glyphCount includes the first glyph (already matched via this rule's own Coverage
+            // entry), so Input holds glyphCount - 1 more - a spec-conformant font always has
+            // glyphCount >= 1, but a malformed/corrupt font could claim 0; Math.Max keeps that case a
+            // harmless empty (never-matching) rule instead of an OverflowException from a negative
+            // array length.
+            var input = new ushort[Math.Max(0, glyphCount - 1)];
             for (int i = 0; i < input.Length; i++)
                 input[i] = _face.ReadUShort();
             var records = new GposSequenceLookupRecord[seqLookupCount];
@@ -1245,7 +1251,8 @@ namespace PeachPDF.Fonts.OpenType
                 backtrack[i] = _face.ReadUShort();
 
             int inputGlyphCount = _face.ReadUShort();
-            var input = new ushort[inputGlyphCount - 1];
+            // See ReadSequenceRule's own remarks on the Math.Max guard.
+            var input = new ushort[Math.Max(0, inputGlyphCount - 1)];
             for (int i = 0; i < input.Length; i++)
                 input[i] = _face.ReadUShort();
 

--- a/src/PeachPDF/Fonts/OpenType/GsubTable.cs
+++ b/src/PeachPDF/Fonts/OpenType/GsubTable.cs
@@ -26,6 +26,7 @@
 //
 #endregion
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
@@ -1124,7 +1125,12 @@ namespace PeachPDF.Fonts.OpenType
             _face.Position = ruleOffset;
             int glyphCount = _face.ReadUShort();
             int seqLookupCount = _face.ReadUShort();
-            var input = new ushort[glyphCount - 1];
+            // glyphCount includes the first glyph (already matched via this rule's own Coverage
+            // entry), so Input holds glyphCount - 1 more - a spec-conformant font always has
+            // glyphCount >= 1, but a malformed/corrupt font could claim 0; Math.Max keeps that case a
+            // harmless empty (never-matching) rule instead of an OverflowException from a negative
+            // array length.
+            var input = new ushort[Math.Max(0, glyphCount - 1)];
             for (int i = 0; i < input.Length; i++)
                 input[i] = _face.ReadUShort();
             var records = new GsubSequenceLookupRecord[seqLookupCount];
@@ -1162,7 +1168,8 @@ namespace PeachPDF.Fonts.OpenType
                 backtrack[i] = _face.ReadUShort();
 
             int inputGlyphCount = _face.ReadUShort();
-            var input = new ushort[inputGlyphCount - 1];
+            // See ReadSequenceRule's own remarks on the Math.Max guard.
+            var input = new ushort[Math.Max(0, inputGlyphCount - 1)];
             for (int i = 0; i < input.Length; i++)
                 input[i] = _face.ReadUShort();
 


### PR DESCRIPTION
## Summary

A `SequenceRule`/`ChainedSequenceRule`'s `glyphCount`/`inputGlyphCount` always includes the first (Coverage-matched) glyph per the OpenType spec, so a spec-conformant font always has this field `>= 1`. Nothing validated that assumption: `GsubTable`/`GposTable`'s Contextual/Chaining-Context Substitution/Positioning readers computed `new ushort[glyphCount - 1]`, so a malformed or adversarially-crafted font claiming `glyphCount == 0` would compute a negative array length and crash the whole render with an `OverflowException`.

Fixed by clamping to zero (`Math.Max(0, glyphCount - 1)`), matching this codebase's existing convention elsewhere in the same file family (`IndexOfGlyph`, `TryGetAlternate`) of degrading malformed table data to a safe, never-matching no-op rather than throwing. No behavior change for any well-formed font.

Found via a code-review pass against the recently-merged Arabic/Indic complex-script joining work (#888); no real font has been observed triggering this.

## Test plan

- [x] New `GsubGposMalformedContextualRuleSyntheticTests.cs`: three synthetic-byte-blob tests (GSUB Contextual Format 1, GSUB Chaining Format 1, GPOS Context Positioning Format 1) with a malformed `glyphCount`/`inputGlyphCount` of 0 - confirmed to reproduce the exact `OverflowException` with the fix temporarily reverted, then pass with it restored
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` - 0 warnings, 0 errors
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - full suite green (9807 passed, 9 pre-existing platform-specific skips, 0 failed)