### PR TITLE
Fix PDF gradients ignoring stop positions not at the domain edges

### DIFF
--- a/.claude/migration-notes/2026-09-06-gradient-stops-not-at-edges-now-hold-solid-color.md
+++ b/.claude/migration-notes/2026-09-06-gradient-stops-not-at-edges-now-hold-solid-color.md
@@ -1,0 +1,19 @@
+# Gradient stops not at 0%/100% now hold solid color outside their range, instead of the whole gradient stretching to fit
+
+Previously: a `linear-gradient()`/`radial-gradient()` whose first color stop wasn't at position 0%
+and/or whose last color stop wasn't at 100% rendered as if those stops *were* at the domain's
+edges — the color transition stretched to fill the entire gradient box. For example,
+`linear-gradient(red 20%, blue 80%)` rendered identically to `linear-gradient(red, blue)`: a smooth
+red-to-blue fade across the whole box, instead of solid red for the first 20%, a fade from 20%-80%,
+and solid blue for the last 20% (the CSS Images 4 §3.5.5-correct result). The same applied to a
+gradient's alpha channel when its colors carried varying opacity.
+
+This was most visible for a gradient whose first and last stop share the *same* position — a common
+"hairline" idiom (`linear-gradient(color <width>, transparent <width>)` tiled via `background-size`
+to draw a crisp line without extra markup, used by libraries like Charts.css for chart gridlines):
+it rendered as a soft wash spanning the whole background tile instead of a crisp line.
+
+Now: colors hold solid outside the first/last stop's position, matching every other renderer. A
+document that was relying on the old (incorrect) stretch-to-fit behavior — intentionally or not —
+will see its gradient's visible color transition become narrower, confined to the actual
+first-stop-to-last-stop range instead of spanning the whole gradient box.

--- a/.claude/recent-fixes/2026-09-06-gradient-stop-position-domain-edges.md
+++ b/.claude/recent-fixes/2026-09-06-gradient-stop-position-domain-edges.md
@@ -1,0 +1,91 @@
+# Fix PDF gradient shading functions ignoring a first/last stop that isn't at 0%/100%
+
+Reported as visual artifacts on the Charts.css showcase's "Columns" chart: gray gradient washes
+below where a horizontal gridline should be, and a spurious vertical line between columns - neither
+visible when the same HTML is opened in a browser.
+
+## The bug
+
+Charts.css draws its secondary-axis gridlines with no extra DOM elements: each column's own
+`tbody tr` gets `background-image: linear-gradient(color <w>, transparent <w>)` (both stops at the
+*same* small offset, e.g. 1px) tiled via `background-size: 100% calc(100% / N)`. A spec-correct
+renderer paints a crisp hairline at the top of each tile.
+
+`src/PeachPDF/Html/Core/Handlers/CssImagePainter.cs`'s `NormalizeGradientStops` already resolves
+each stop's true fractional position correctly (including when it isn't 0 or 1), and that value
+flows untouched into `XLinearGradientBrush._positions`/`XRadialGradientBrush._positions` - the
+position *data* was never wrong. The bug was entirely in
+`src/PeachPDF/PdfSharpCore/Pdf.Advanced/PdfShading.cs` turning that into a PDF shading dictionary.
+The `/Coords` are always the gradient's *full* geometric line (`ComputeGradientLine`, no knowledge
+of stop positions), so `/Domain [0 1]` genuinely means "0 = start of the box, 1 = end of the box"
+- but every function-construction path assumed the first stop sits at domain 0 and the last at
+domain 1, regardless of where they actually were:
+
+- Exactly-2-color gradients (`SetupFromBrush(XLinearGradientBrush,...)`, `SetupRadialMultiStop`,
+  and their two `*AlphaExtGStateIfNeeded` soft-mask mirrors) took a shortcut: a single
+  `/FunctionType 2` interpolating C0→C1 across the *whole* `[0,1]` domain, discarding
+  `_positions` completely.
+- 3+-color gradients (`BuildStitchingFunction`/`BuildAlphaStitchingFunction`) built `/Bounds` only
+  from *interior* stops (`positions[1..n-2]`); the first sub-function's domain was implicitly
+  `[0, positions[1]]` and the last implicitly `[positions[n-2], 1]` - `positions[0]` and
+  `positions[n-1]` were never consulted.
+
+For the Charts.css hairline (both stops at ~2-5% of the tile height) this stretched what should
+be a solid-then-instant-transparent step into a smooth fade spanning the *entire* tile - the
+"gradient below the line". That wash is painted per-column (the CSS rule targets each data
+column's own `tr`, not the whole chart), so the sharp edge where one column's wash met the
+transparent gap beside it read as the reported vertical line.
+
+Confirmed by rasterizing the actual showcase PDF with both PDFium and MuPDF before the fix (visible
+gray wash bands, and a distinct vertical seam between columns 2 and 3) and after (crisp hairlines,
+seam gone, both renderers agree) - see [Testing conventions](../../CLAUDE.md#testing-conventions).
+
+## Load-bearing idea
+
+**A gradient's colors must hold solid outside its first/last stop position (CSS Images 4 §3.5.5)
+- the PDF representation has to say so explicitly, because the shading's `/Domain` is anchored to
+the geometric gradient line, not to the stops.** Fixed by generalizing the segment model
+`BuildStitchingFunction`/`BuildAlphaStitchingFunction` already used for interior stops to also
+cover the two ends:
+
+- New `BuildStitchSegments(double[] positions)`: splits the domain into an optional leading
+  constant-`colors[0]` pad (`[0, positions[0]]`, only when `positions[0] > 0`), one interpolating
+  segment per adjacent real-stop pair, and an optional trailing constant-`colors[^1]` pad
+  (`[positions[^1], 1]`, only when `positions[^1] < 1`). A pad segment is just an interpolating
+  segment whose `LeftIndex == RightIndex` - both builders read `colors[seg.LeftIndex]`/
+  `colors[seg.RightIndex]` uniformly, no separate pad-vs-interpolate branch needed downstream.
+- `RequiresStitchingFunction(positions)`: true when there are more than 2 stops, or the first/last
+  isn't already at the domain edge (small epsilon). The four call sites that used to gate on
+  `colors.Length > 2` now gate on this instead - when `positions == [0, 1]` exactly (the common
+  case: no explicit stop positions, or the classic `linear-gradient(red, blue)`), this is `false`
+  and the cheap plain `/FunctionType 2` shortcut is kept, unchanged from before. This was a
+  deliberate choice over always using the stitching function: avoids PDF size bloat for the
+  overwhelmingly common case, and keeps the fix's behavioral footprint limited to gradients that
+  were actually wrong.
+
+## What was deliberately not done, and why
+
+- No changes to `CssImagePainter.cs`, `BackgroundLayerResolver.cs`, or
+  `BackgroundImageDrawHandler.cs` - the `background-size`/`-position`/`-repeat` tiling machinery and
+  the stop-position *resolution* were already correct; only the PDF function construction from
+  already-correct positions was wrong.
+- Conic gradients (`BuildConicMeshData`) are unaffected - a Type 4 mesh is built from explicit
+  per-vertex angles, not a stitched `/Domain [0,1]` function, so this class of bug doesn't apply
+  to them.
+
+## Evidence
+
+- New tests in `LinearGradientIntegrationTests.cs`/`RadialGradientIntegrationTests.cs`: the
+  Charts.css hairline shape itself (two stops at the same non-edge position), an ordinary
+  `red 20%, blue 80%` (asserting the actual `/Bounds` values, not just "a `/FunctionType` is
+  present somewhere" - matching this repo's existing `HardStopShorthand_ExpandsToTwoStops`
+  convention), a regression guard proving the default-edges case still emits the cheap
+  `/FunctionType 2` (no `/FunctionType 3`), and a combined color+alpha case proving both
+  `BuildStitchingFunction` and `BuildAlphaStitchingFunction` got the fix.
+- Rasterized the regenerated Charts.css showcase's "Columns" chart with both PDFium and MuPDF;
+  gridlines are crisp with no wash and no vertical seam in either, matching a browser rendering of
+  the same HTML.
+- `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0`: 9883 passed, 9
+  pre-existing platform-specific skips, 0 failed (full suite).
+- `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings, 0 errors.
+- `diff-cover` against `main`: 100% diff coverage on the changed lines.

--- a/src/PeachPDF.Tests/Integration/LinearGradientIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/LinearGradientIntegrationTests.cs
@@ -2,6 +2,7 @@ using PeachPDF;
 using PeachPDF.PdfSharpCore;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -129,6 +130,63 @@ namespace PeachPDF.Tests.Integration
 
             Assert.Contains("/ShadingType", pdfText);
             Assert.Contains("/FunctionType", pdfText);
+        }
+
+        // ── Bug fix: stops not anchored at the domain edges (0%/100%) ─────
+        //
+        // A gradient's colors must hold solid outside its first/last stop rather than the
+        // interpolation stretching to fill the shading's whole [0,1] /Domain (CSS Images 4 §3.5.5).
+        // These pin the Charts.css gridline idiom that surfaced the bug: a hairline drawn with two
+        // stops at the *same* small offset (e.g. `color 1px, transparent 1px`) - which, before the
+        // fix, rendered as a smooth solid-to-transparent wash spanning the entire background tile
+        // instead of a crisp line, because the ≤2-stop path ignored stop positions entirely.
+
+        [Fact]
+        public async Task TwoStopsAtSameNonEdgePosition_ProducesHardEdgeAtThatPosition()
+        {
+            // The Charts.css gridline shape itself: both stops at 5%, not 0%/100%.
+            var pdfText = await GetPdfText(GradientHtml("background-image: linear-gradient(black 5%, transparent 5%);"));
+
+            Assert.Contains("/FunctionType 3", pdfText);
+            Assert.Matches(@"/Bounds\s*\[\s*0\.05\s+0\.05\s*\]", pdfText);
+        }
+
+        [Fact]
+        public async Task TwoStopsNotAtEdges_HoldsSolidColorOutsideStopRange()
+        {
+            // red 20%, blue 80% - solid red from 0-20% and solid blue from 80-100%, per CSS Images 4.
+            // Before the fix this collapsed to a single Type 2 function spanning the whole [0,1]
+            // domain, so red was already fading toward blue starting at 0% instead of 20%.
+            var pdfText = await GetPdfText(GradientHtml("background-image: linear-gradient(to right, red 20%, blue 80%);"));
+
+            Assert.Contains("/FunctionType 3", pdfText);
+            Assert.Matches(@"/Bounds\s*\[\s*0\.2\s+0\.8\s*\]", pdfText);
+        }
+
+        [Fact]
+        public async Task TwoStopsAtDefaultEdges_StillUsesThePlainType2Shortcut()
+        {
+            // Regression guard for the fast path: a plain 2-color gradient with no explicit stop
+            // positions (implicitly 0%/100%) must keep using the cheap single Type 2 function rather
+            // than the fix growing every gradient into a stitching function.
+            var pdfText = await GetPdfText(GradientHtml("background-image: linear-gradient(red, blue);"));
+
+            Assert.Contains("/FunctionType 2", pdfText);
+            Assert.DoesNotContain("/FunctionType 3", pdfText);
+        }
+
+        [Fact]
+        public async Task TwoStopsNotAtEdgesWithAlpha_PadsBothColorAndAlphaStitchingFunctions()
+        {
+            // Combines the position bug with a soft mask: BuildStitchingFunction (color) and
+            // BuildAlphaStitchingFunction (alpha) are separate code paths that both needed the fix.
+            var pdfText = await GetPdfText(GradientHtml(
+                "background-image: linear-gradient(to right, rgba(255,0,0,1) 20%, rgba(0,0,255,0.2) 80%);"));
+
+            Assert.Contains("/SMask", pdfText);
+            var boundsMatches = Regex.Matches(pdfText, @"/Bounds\s*\[\s*0\.2\s+0\.8\s*\]");
+            Assert.True(boundsMatches.Count >= 2,
+                $"expected both the color and alpha stitching functions to pad to [0.2 0.8], found {boundsMatches.Count} occurrence(s)");
         }
     }
 }

--- a/src/PeachPDF.Tests/Integration/RadialGradientIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/RadialGradientIntegrationTests.cs
@@ -125,6 +125,30 @@ namespace PeachPDF.Tests.Integration
             Assert.Contains("/ShadingType", pdfText);
         }
 
+        // ── Bug fix: stops not anchored at the domain edges (0%/100%) ─────
+        //
+        // Mirrors the linear-gradient fix: a gradient's colors must hold solid outside its first/last
+        // stop rather than the interpolation stretching to fill the shading's whole [0,1] /Domain
+        // (CSS Images 4 §3.5.5). See LinearGradientIntegrationTests for the Charts.css motivation.
+
+        [Fact]
+        public async Task TwoStopsNotAtEdges_HoldsSolidColorOutsideStopRange()
+        {
+            var pdfText = await GetPdfText(GradientHtml("background-image: radial-gradient(circle, red 20%, blue 80%);"));
+
+            Assert.Contains("/FunctionType 3", pdfText);
+            Assert.Matches(@"/Bounds\s*\[\s*0\.2\s+0\.8\s*\]", pdfText);
+        }
+
+        [Fact]
+        public async Task TwoStopsAtDefaultEdges_StillUsesThePlainType2Shortcut()
+        {
+            var pdfText = await GetPdfText(GradientHtml("background-image: radial-gradient(red, blue);"));
+
+            Assert.Contains("/FunctionType 2", pdfText);
+            Assert.DoesNotContain("/FunctionType 3", pdfText);
+        }
+
         // ── Alpha / transparency ───────────────────────────────────────────
 
         [Fact]

--- a/src/PeachPDF/PdfSharpCore/Pdf.Advanced/PdfShading.cs
+++ b/src/PeachPDF/PdfSharpCore/Pdf.Advanced/PdfShading.cs
@@ -31,6 +31,9 @@ using PeachPDF.PdfSharpCore.Drawing;
 using PeachPDF.PdfSharpCore.Drawing.Pdf;
 using PeachPDF.PdfSharpCore.Pdf.Internal;
 using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
 
 namespace PeachPDF.PdfSharpCore.Pdf.Advanced
 {
@@ -156,7 +159,7 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
             XColor[] colors = brush._colors!;
             double[]? positions = brush._positions;
 
-            if (colors.Length > 2 && positions != null)
+            if (positions != null && RequiresStitchingFunction(positions))
                 Elements[Keys.Function] = BuildStitchingFunction(colors, positions, colorMode);
             else
             {
@@ -186,7 +189,7 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
             if (!hasVaryingAlpha) return;
 
             PdfDictionary alphaFn;
-            if (positions != null && colors.Length > 2)
+            if (positions != null && RequiresStitchingFunction(positions))
                 alphaFn = BuildAlphaStitchingFunction(colors, positions);
             else
             {
@@ -337,7 +340,7 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
             XColor[] allColors = brush._colors ?? new[] { brush._color1, brush._color2 };
             double[]? allPositions = brush._positions;
 
-            if (brush._colors != null && brush._colors.Length > 2 && brush._positions != null)
+            if (brush._colors != null && brush._positions != null && RequiresStitchingFunction(brush._positions))
             {
                 Elements[Keys.Function] = BuildStitchingFunction(brush._colors, brush._positions, colorMode);
             }
@@ -372,7 +375,7 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
 
             // Build DeviceGray alpha interpolation function
             PdfDictionary alphaFn;
-            if (positions != null && colors.Length > 2)
+            if (positions != null && RequiresStitchingFunction(positions))
                 alphaFn = BuildAlphaStitchingFunction(colors, positions);
             else
             {
@@ -431,39 +434,93 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
             AlphaExtGState = extGState;
         }
 
-        private static PdfDictionary BuildAlphaStitchingFunction(XColor[] colors, double[] positions)
-        {
-            int n = colors.Length;
-            var stitching = new PdfDictionary();
-            stitching.Elements["/FunctionType"] = new PdfInteger(3);
-            stitching.Elements["/Domain"] = new PdfLiteral("[0 1]");
+        /// <summary>
+        /// One slice of a PDF Type 3 stitching function's domain: a plain Type 2 function
+        /// interpolating between <paramref name="LeftIndex"/> and <paramref name="RightIndex"/>
+        /// (the same index for both is a solid-color pad segment, see <see cref="BuildStitchSegments"/>).
+        /// </summary>
+        private readonly record struct StitchSegment(double Lo, double Hi, int LeftIndex, int RightIndex);
 
-            var bounds = new System.Text.StringBuilder("[");
-            for (int i = 1; i < n - 1; i++)
+        /// <summary>
+        /// A gradient's colors interpolate strictly between its first and last stop positions; CSS
+        /// requires the color at (and beyond) each end stop to hold solid outside that range (CSS
+        /// Images 4 §3.5.5) rather than the interpolation stretching to fill the shading's whole
+        /// [0,1] domain. Splits <paramref name="positions"/> into the segments a Type 3 stitching
+        /// function needs to reproduce that: an optional leading solid-<c>colors[0]</c> pad when
+        /// <c>positions[0] &gt; 0</c>, one interpolating segment per adjacent stop pair, and an
+        /// optional trailing solid-<c>colors[^1]</c> pad when <c>positions[^1] &lt; 1</c>.
+        /// </summary>
+        private static List<StitchSegment> BuildStitchSegments(double[] positions)
+        {
+            const double eps = 1e-6;
+            int n = positions.Length;
+            var segments = new List<StitchSegment>(n + 1);
+
+            if (positions[0] > eps)
+                segments.Add(new StitchSegment(0.0, positions[0], 0, 0));
+
+            for (int i = 0; i < n - 1; i++)
+                segments.Add(new StitchSegment(positions[i], positions[i + 1], i, i + 1));
+
+            if (positions[n - 1] < 1.0 - eps)
+                segments.Add(new StitchSegment(positions[n - 1], 1.0, n - 1, n - 1));
+
+            return segments;
+        }
+
+        /// <summary>
+        /// Whether a gradient's stops need the full Type 3 stitching-function machinery rather than
+        /// the cheaper plain Type 2 (single C0-to-C1 interpolation across the whole [0,1] domain)
+        /// shortcut - true whenever there are more than 2 stops, or the first/last stop isn't
+        /// already sitting at the domain edge (0/1) where the shortcut is exact.
+        /// </summary>
+        private static bool RequiresStitchingFunction(double[] positions)
+        {
+            const double eps = 1e-6;
+            return positions.Length > 2 || positions[0] > eps || positions[^1] < 1.0 - eps;
+        }
+
+        private static string BuildBoundsLiteral(IReadOnlyList<StitchSegment> segments)
+        {
+            var bounds = new StringBuilder("[");
+            for (int i = 0; i < segments.Count - 1; i++)
             {
-                if (i > 1) bounds.Append(' ');
-                bounds.Append(positions[i].ToString("G6", System.Globalization.CultureInfo.InvariantCulture));
+                if (i > 0) bounds.Append(' ');
+                bounds.Append(segments[i].Hi.ToString("G6", CultureInfo.InvariantCulture));
             }
             bounds.Append(']');
-            stitching.Elements["/Bounds"] = new PdfLiteral(bounds.ToString());
+            return bounds.ToString();
+        }
 
-            var encode = new System.Text.StringBuilder("[");
-            for (int i = 0; i < n - 1; i++)
+        private static string BuildEncodeLiteral(int segmentCount)
+        {
+            var encode = new StringBuilder("[");
+            for (int i = 0; i < segmentCount; i++)
             {
                 if (i > 0) encode.Append(' ');
                 encode.Append("0 1");
             }
             encode.Append(']');
-            stitching.Elements["/Encode"] = new PdfLiteral(encode.ToString());
+            return encode.ToString();
+        }
+
+        private static PdfDictionary BuildAlphaStitchingFunction(XColor[] colors, double[] positions)
+        {
+            var segments = BuildStitchSegments(positions);
+            var stitching = new PdfDictionary();
+            stitching.Elements["/FunctionType"] = new PdfInteger(3);
+            stitching.Elements["/Domain"] = new PdfLiteral("[0 1]");
+            stitching.Elements["/Bounds"] = new PdfLiteral(BuildBoundsLiteral(segments));
+            stitching.Elements["/Encode"] = new PdfLiteral(BuildEncodeLiteral(segments.Count));
 
             var functions = new PdfArray();
-            for (int i = 0; i < n - 1; i++)
+            foreach (var seg in segments)
             {
                 var fn = new PdfDictionary();
                 fn.Elements["/FunctionType"] = new PdfInteger(2);
                 fn.Elements["/Domain"] = new PdfLiteral("[0 1]");
-                fn.Elements["/C0"] = new PdfLiteral("[" + AlphaToString(colors[i].A) + "]");
-                fn.Elements["/C1"] = new PdfLiteral("[" + AlphaToString(colors[i + 1].A) + "]");
+                fn.Elements["/C0"] = new PdfLiteral("[" + AlphaToString(colors[seg.LeftIndex].A) + "]");
+                fn.Elements["/C1"] = new PdfLiteral("[" + AlphaToString(colors[seg.RightIndex].A) + "]");
                 fn.Elements["/N"] = new PdfInteger(1);
                 functions.Elements.Add(fn);
             }
@@ -472,41 +529,24 @@ namespace PeachPDF.PdfSharpCore.Pdf.Advanced
         }
 
         private static string AlphaToString(double a) =>
-            a.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture);
+            a.ToString("0.###", CultureInfo.InvariantCulture);
 
         private static PdfDictionary BuildStitchingFunction(XColor[] colors, double[] positions, PdfColorMode colorMode)
         {
-            int n = colors.Length;
+            var segments = BuildStitchSegments(positions);
             var stitching = new PdfDictionary();
             stitching.Elements["/FunctionType"] = new PdfInteger(3);
             stitching.Elements["/Domain"] = new PdfLiteral("[0 1]");
+            stitching.Elements["/Bounds"] = new PdfLiteral(BuildBoundsLiteral(segments));
+            stitching.Elements["/Encode"] = new PdfLiteral(BuildEncodeLiteral(segments.Count));
 
-            // Bounds: intermediate stop positions (all except first and last)
-            var boundsBuilder = new System.Text.StringBuilder("[");
-            for (int i = 1; i < n - 1; i++)
-            {
-                if (i > 1) boundsBuilder.Append(' ');
-                boundsBuilder.Append(positions[i].ToString("G6", System.Globalization.CultureInfo.InvariantCulture));
-            }
-            boundsBuilder.Append(']');
-            stitching.Elements["/Bounds"] = new PdfLiteral(boundsBuilder.ToString());
-
-            // Encode: each sub-function maps its slice to [0 1]
-            var encodeBuilder = new System.Text.StringBuilder("[");
-            for (int i = 0; i < n - 1; i++)
-            {
-                if (i > 0) encodeBuilder.Append(' ');
-                encodeBuilder.Append("0 1");
-            }
-            encodeBuilder.Append(']');
-            stitching.Elements["/Encode"] = new PdfLiteral(encodeBuilder.ToString());
-
-            // Sub-functions: one Type 2 for each adjacent pair of stops
+            // Sub-functions: one Type 2 per segment (interpolating between two real stops, or a
+            // solid-color pad at either end - see BuildStitchSegments).
             var functions = new PdfArray();
-            for (int i = 0; i < n - 1; i++)
+            foreach (var seg in segments)
             {
-                XColor c0 = ColorSpaceHelper.EnsureColorMode(colorMode, colors[i]);
-                XColor c1 = ColorSpaceHelper.EnsureColorMode(colorMode, colors[i + 1]);
+                XColor c0 = ColorSpaceHelper.EnsureColorMode(colorMode, colors[seg.LeftIndex]);
+                XColor c1 = ColorSpaceHelper.EnsureColorMode(colorMode, colors[seg.RightIndex]);
                 var fn = new PdfDictionary();
                 fn.Elements["/FunctionType"] = new PdfInteger(2);
                 fn.Elements["/Domain"] = new PdfLiteral("[0 1]");


### PR DESCRIPTION
## Summary
- `linear-gradient()`/`radial-gradient()` stops whose first stop wasn't at 0% and/or last stop wasn't at 100% rendered as if they were - the color transition stretched across the whole gradient box instead of holding solid outside the stop range (CSS Images 4 §3.5.5).
- Root cause: `PdfShading`'s PDF shading-function construction (both the plain 2-color shortcut and the `BuildStitchingFunction`/`BuildAlphaStitchingFunction` machinery) only ever accounted for *interior* stop positions, silently anchoring the first/last stop to the PDF shading's `/Domain` edges (0 and 1) regardless of where they actually were.
- This was reported as visual artifacts on the Charts.css showcase's "Columns" chart: gray wash bands below where a horizontal gridline should be, and a spurious vertical line between columns - Charts.css draws gridlines with a 2-stop "hairline" gradient (both stops at the same small offset), which is exactly the case the bug mishandled.
- Fix: generalized the stitching-function segment model (`BuildStitchSegments`) to pad the domain edges with solid color whenever the first/last stop isn't already there, applied uniformly across linear/radial and color/alpha soft-mask paths. The cheap plain-`FunctionType 2` shortcut is kept for the common case (stops already at 0%/100%) to avoid PDF size bloat.

## Test plan
- [x] New structural tests in `LinearGradientIntegrationTests.cs`/`RadialGradientIntegrationTests.cs` (Charts.css-style hairline, an ordinary off-edge gradient asserting actual `/Bounds` values, a fast-path regression guard, and a combined color+alpha case)
- [x] Rasterized the actual Charts.css showcase's "Columns" chart before/after with both PDFium and MuPDF - wash bands and vertical seam gone, gridlines crisp, matching a browser
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - 9883 passed, 0 failed (full suite)
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` - 0 warnings, 0 errors
- [x] `diff-cover` against `main` - 100% diff coverage on changed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)