### PR TITLE
Detect named-page identity, not just page index, in the reflow fixpoint

### DIFF
--- a/.claude/accepted-gaps/named-page-run-convergence-loop-is-bounded-not-guaranteed.md
+++ b/.claude/accepted-gaps/named-page-run-convergence-loop-is-bounded-not-guaranteed.md
@@ -1,0 +1,29 @@
+# A named-page run spanning several physical pages has a convergence loop that is bounded, not guaranteed
+
+`HtmlContainerInt.PerformLayout`'s per-page horizontal reflow loop (`UseVariableInlineMeasure`'s own
+3-iteration cap) detects a fixpoint by comparing `PageAssignmentSignature()` — each box's numeric page
+index paired with that page's own active named page (`PageGeometryTable.PageBandGeometry.ActiveName`) —
+pass over pass. Pairing the name in, not just the index, closes the specific blind spot issue #202
+originally named: two passes that agree on which physical page a box landed on but disagree on which
+named-page rule was active there (because a width change shifted where a name-transition boundary falls)
+are now correctly told apart rather than being wrongly accepted as "already converged."
+
+What this does not do is *prove* the loop converges for every document. A named page whose `@page`
+left/right margin or `size` override spans **several physical pages** under one continuously-active name
+has a genuine width→height→page-name feedback: the content width affects box heights, which affects which
+page-number boundary falls where, which can — in principle — affect which name is active there. Proving a
+bound on the number of iterations such a feedback loop needs (e.g. a `1 + T`-transition-count formula)
+would need either that formula or a different algorithm entirely; neither is attempted here. The loop
+instead stays at the flat 3-iteration cap this repo's `@container` convergence loop already established as
+an acceptable "bounded, not guaranteed" stance (see
+[container-query-convergence-loop-is-bounded-not-guaranteed.md](container-query-convergence-loop-is-bounded-not-guaranteed.md)).
+
+No known real-world or test-suite fixture needs more than one re-pass to settle a named-page run spanning
+multiple physical pages — every fixture this repo exercises, including a run deliberately constructed to
+span 3+ physical pages under one active name, converges on the loop's very first iteration once the
+signature fix above is in place. On cap exceeded, the last pass's result is accepted silently, the same
+tradeoff `@container`'s own loop already makes. Tracked as
+[#202](https://github.com/jhaygood86/PeachPDF/issues/202), narrowed to this specific remaining question —
+the original issue's own within-pass named-page registration race (a box measured against its own name's
+geometry *before* its own registration invalidated the stale slot) is already fixed, independently of the
+signature change here, via `CssBox._measureResolvedAgainst`/`InlineSizeCameFromAnotherPagesMeasure`.

--- a/.claude/accepted-gaps/per-page-horizontal-reflow-scope.md
+++ b/.claude/accepted-gaps/per-page-horizontal-reflow-scope.md
@@ -51,12 +51,19 @@ page's own content from re-wrapping at all — a box that opens a named page is 
 geometry — is fixed: `CssBox._measureResolvedAgainst` records the measure actually used at resolve time,
 and `InlineSizeCameFromAnotherPagesMeasure` compares a fresh lookup against *that* (not a second fresh
 lookup, which agreed with the first because both ran after the registration that invalidated the slot) to
-catch and correct it within the same pass. What #202 still names and this does not close: a named-page
-run that spans *several physical pages* under one continuously-active name has a genuine
-width→height→page-name fixpoint (the content width affects box heights, which affects which page-number
-boundary falls where, which can affect which name is active at that boundary) that the bounded reflow
-loop does not *formally* prove converges — only empirically observed, on this repo's own fixtures, to
-settle on the loop's first iteration once the two fixes above are in place.
+catch and correct it within the same pass. `PageAssignmentSignature`'s own fixpoint comparison closes a
+further blind spot: it now pairs each box's page index with that page's own active name
+(`PageGeometryTable.PageBandGeometry.ActiveName`), so two passes that agree on numeric page index but
+disagree on which named-page rule is active there (because a width change shifted a name-transition
+boundary onto a different physical page) are correctly told apart rather than wrongly accepted as
+converged. What #202 still names and none of this closes: a named-page run that spans *several physical
+pages* under one continuously-active name has a genuine width→height→page-name fixpoint (the content
+width affects box heights, which affects which page-number boundary falls where, which can affect which
+name is active at that boundary) that the bounded reflow loop does not *formally* prove converges — only
+empirically observed, on this repo's own fixtures, to settle on the loop's first iteration once all three
+fixes above are in place. See
+[named-page-run-convergence-loop-is-bounded-not-guaranteed.md](named-page-run-convergence-loop-is-bounded-not-guaranteed.md)
+for the accepted, narrowed remainder.
 
 **Also no longer a gap** (#199, #200, #201): three related restrictions on which boxes participate in
 per-page reflow at all have closed together, via one generalized eligibility rule.

--- a/.claude/migration-notes/2026-09-06-named-page-reflow-convergence-detection-improved.md
+++ b/.claude/migration-notes/2026-09-06-named-page-reflow-convergence-detection-improved.md
@@ -1,0 +1,13 @@
+# Named-page reflow convergence detection now accounts for which name is active, not just which page
+
+Previously, the per-page horizontal reflow loop's fixpoint check (`HtmlContainerInt.PageAssignmentSignature`)
+compared only each box's numeric page index across re-passes. A document where a width change between
+passes shifted a named-page transition onto a different physical page — while a box's numeric page index
+happened to stay the same — could have been silently accepted as "converged" one pass early, before the
+new page's own (different) named-page margins had actually been applied to that content.
+
+The signature now pairs each box's page index with that page's own active named page, so such a case is
+correctly detected as not yet settled and the loop takes the additional pass it needs (still capped at 3
+iterations, same as before). No known document in this project's own test suite is affected by this in
+practice — every fixture already converges on the loop's first iteration — so this is a robustness fix
+for a case not previously known to be exercised, not an expected behavior change for existing documents.

--- a/src/PeachPDF.Tests/Integration/PerPageHorizontalReflowLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/PerPageHorizontalReflowLayoutIntegrationTests.cs
@@ -840,6 +840,65 @@ namespace PeachPDF.Tests.Integration
             Assert.Equal(BaseRightEdge, container.PageContentRightOf(p.Location.Y), 0.5);
         }
 
+        [Fact]
+        public async Task NamedPageRun_SpanningThreePhysicalPages_EachPageOwnMeasureConverges()
+        {
+            // #202's remaining narrowed scope: a named page whose L/R margin override spans SEVERAL
+            // physical pages under one continuously-active name. Every physical page the run crosses
+            // must get that name's own measure - not silently fall back to a stale one - and the bounded
+            // reflow loop's own fixpoint detection (HtmlContainerInt.PageAssignmentSignature, now pairing
+            // each box's numeric page index with that page's own active name) must not mistake two
+            // different pages sharing the same name for "already converged" before anything has actually
+            // settled.
+            var words = string.Join(" ", Enumerable.Range(0, 3000).Select(i => $"word{i}"));
+            var container = await BuildLayoutAsync($$"""
+                <!DOCTYPE html><html><head><style>
+                @page { margin: 60pt 50pt; }
+                @page wide { margin: 60pt 10pt; }
+                body { margin: 0; }
+                p { margin: 0; }
+                </style></head><body>
+                <p id='run' style='page: wide'>{{words}}</p>
+                </body></html>
+                """);
+
+            var run = FindById(container.Root!, "run")!;
+            var runWords = new List<CssRect>();
+            CollectWords(run, runWords);
+
+            var pagesSpanned = runWords.Where(w => w.Width > 0)
+                .Select(w => container.PageIndexOf(w.Top)).Distinct().OrderBy(p => p).ToList();
+
+            Assert.True(pagesSpanned.Count >= 3,
+                $"expected the named-page run to span at least 3 physical pages, got {pagesSpanned.Count}");
+
+            foreach (var pageIndex in pagesSpanned)
+            {
+                // Every physical page the run crosses is still attributed to the SAME active name -
+                // the name never actually changes mid-run, only which physical page is showing it.
+                Assert.Equal("wide", container.PageGeometry.GetPage(pageIndex).ActiveName);
+
+                // A wrapped line's last word naturally lands a little short of the measure it wrapped
+                // against (whatever slack that word left), so the page's own edge is a ceiling, not an
+                // exact target - the same relaxed shape this file's own straddling-paragraph tests use
+                // elsewhere. What matters is that it never OVERRUNS this page's own (wide) measure, and
+                // that it lands meaningfully past the base measure rather than the stale one.
+                var pageContentRight = container.PageContentRightOf(container.PageTopOf(pageIndex));
+                var pageWords = runWords.Where(w => w.Width > 0 && container.PageIndexOf(w.Top) == pageIndex).ToList();
+                var wrapRight = pageWords.Max(w => w.Right);
+
+                Assert.True(wrapRight <= pageContentRight + 0.5,
+                    $"page {pageIndex}: wrapped right edge {wrapRight} overran its own measure {pageContentRight}");
+                Assert.True(wrapRight > BaseRightEdge,
+                    $"page {pageIndex}: wrapped right edge {wrapRight} did not reflect the wide named page's measure");
+            }
+
+            // The empirically-observed bound this repo's own fixtures settle on (issue #202's remaining,
+            // accepted-but-monitored scope, mirrored from WidthFromTheSpaceNotTheLocationTests) - a
+            // genuine further re-pass this fixture needed would show up here as a larger count.
+            Assert.Equal(3, container.LayoutGeneration);
+        }
+
         [Theory]
         [InlineData(1.0)]
         [InlineData(1.5)]

--- a/src/PeachPDF/Html/Core/HtmlContainerInt.cs
+++ b/src/PeachPDF/Html/Core/HtmlContainerInt.cs
@@ -2183,24 +2183,31 @@ namespace PeachPDF.Html.Core
         }
 
         /// <summary>
-        /// A snapshot of every box's pagination-slot assignment (<see cref="PageIndexOf"/> of its
-        /// laid-out top) in a fixed tree-walk order, used by <see cref="PerformLayout"/>'s per-page
-        /// horizontal-reflow loop to detect a fixpoint: once a re-pass leaves every box on the same page
-        /// it was on before, the per-page widths it resolved against are self-consistent and the loop
-        /// stops. Rebuilt from scratch each call — the loop runs at most a few iterations, and only for
-        /// the rare document that carries a per-page left/right <c>@page</c> margin override.
+        /// A snapshot of every box's pagination-slot assignment — <see cref="PageIndexOf"/> of its
+        /// laid-out top, paired with that slot's own active named page (<see cref="PageBandGeometry.ActiveName"/>)
+        /// — in a fixed tree-walk order, used by <see cref="PerformLayout"/>'s per-page horizontal-reflow
+        /// loop to detect a fixpoint: once a re-pass leaves every box on the same page (AND that page
+        /// still carries the same active name) it was on before, the per-page widths it resolved against
+        /// are self-consistent and the loop stops. The name is paired with the index, not just checked
+        /// alongside it, so two passes that agree on numeric page index but disagree on which named-page
+        /// rule is active there (issue #202: a named run whose own width→height feedback shifts which
+        /// physical page a later name-transition boundary falls on) are correctly told apart rather than
+        /// wrongly accepted as converged. Rebuilt from scratch each call — the loop runs at most a few
+        /// iterations, and only for the rare document that carries a per-page left/right <c>@page</c>
+        /// margin override.
         /// </summary>
-        private List<int> PageAssignmentSignature()
+        private List<(int PageIndex, string? ActiveName)> PageAssignmentSignature()
         {
-            List<int> signature = [];
+            List<(int, string?)> signature = [];
             if (Root is not null)
                 CollectPageAssignments(Root, signature);
             return signature;
         }
 
-        private void CollectPageAssignments(CssBox box, List<int> signature)
+        private void CollectPageAssignments(CssBox box, List<(int PageIndex, string? ActiveName)> signature)
         {
-            signature.Add(PageIndexOf(box.Location.Y));
+            var pageIndex = PageIndexOf(box.Location.Y);
+            signature.Add((pageIndex, PageGeometry.GetPage(pageIndex).ActiveName));
             foreach (var childBox in box.Boxes)
                 CollectPageAssignments(childBox, signature);
         }

--- a/src/PeachPDF/Html/Core/PageGeometryTable.cs
+++ b/src/PeachPDF/Html/Core/PageGeometryTable.cs
@@ -17,7 +17,9 @@ namespace PeachPDF.Html.Core
     /// layout px - so <see cref="Dom.CssLayoutEngine.GetBoxHeight"/>'s existing pin of the initial
     /// containing block's height to <c>GetPage(0).BandHeight</c> has a width counterpart to pin to (issue
     /// #201) without duplicating <see cref="HtmlContainerInt.PageContentRightOf"/>'s degenerate-override
-    /// fallback a second time.
+    /// fallback a second time. <see cref="ActiveName"/> is the named page active at this slot's own
+    /// start (<c>null</c> for the un-named default) - exposed so <see cref="HtmlContainerInt.PageAssignmentSignature"/>
+    /// can tell two slots with the same numeric index but different active geometry apart (issue #202).
     /// </summary>
     internal readonly record struct PageBandGeometry(
         int PageIndex,
@@ -29,7 +31,8 @@ namespace PeachPDF.Html.Core
         double MarginRightPt,
         double MarginBottomPt,
         double SheetWidthPt,
-        double SheetHeightPt);
+        double SheetHeightPt,
+        string? ActiveName);
 
     /// <summary>
     /// The per-page geometry table behind CSS Paged Media's page-box model: when per-page
@@ -41,10 +44,18 @@ namespace PeachPDF.Html.Core
     /// name always forces a break onto a fresh page (<c>CssBox.PerformLayoutImp</c>), with the
     /// registration snapped to that page's slot top (<c>CssBox.NamedPageRegistrationY</c>) and made
     /// BEFORE the named box's children lay out, that name is fully determined by content laid out
-    /// before the slot, so no fixpoint relayout is ever needed. A
+    /// before the slot for a SINGLE pass. A
     /// named-page registration only invalidates cached slots at/after its own Y
     /// (<see cref="InvalidateFrom"/>); boxes that consumed those entries are inside those slots and
-    /// lay out at/after the registering box.
+    /// lay out at/after the registering box. What this does NOT rule out on its own: a named page whose
+    /// L/R margin or <c>size</c> override spans several physical pages has a genuine
+    /// width→height→page-name feedback (content width affects box height, which affects which page a
+    /// later boundary falls on, which can affect which name is active there) that
+    /// <see cref="HtmlContainerInt.PerformLayout"/>'s own bounded reflow loop, not this table, is
+    /// responsible for driving to a fixpoint across MULTIPLE passes - see
+    /// <see cref="HtmlContainerInt.PageAssignmentSignature"/> and
+    /// <c>.claude/accepted-gaps/named-page-run-convergence-loop-is-bounded-not-guaranteed.md</c> (issue
+    /// #202).
     /// All values scale per the issue-#113 discipline: margins resolve in true points, then scale by
     /// <c>PixelsPerPoint</c> exactly once into layout space.
     /// </summary>
@@ -289,7 +300,7 @@ namespace PeachPDF.Html.Core
                     bandWidth = sheetPxWidth;
             }
 
-            return new PageBandGeometry(pageIndex, top, bandHeight, bandWidth, mL, mT, mR, mB, sheetWidthPt, sheetHeightPt);
+            return new PageBandGeometry(pageIndex, top, bandHeight, bandWidth, mL, mT, mR, mB, sheetWidthPt, sheetHeightPt, activeName);
         }
     }
 }


### PR DESCRIPTION
## Summary

Phase 4 (final phase) of closing the per-page-horizontal-reflow follow-up cluster (#196-#202), building on #896/#897/#899 (Phases 1-3).

- `HtmlContainerInt.PageAssignmentSignature` (the fixpoint check the per-page-reflow loop uses to decide it has settled) compared only each box's numeric page index across re-passes. Two passes that agree on page index but disagree on which named-page rule is active there - because a width change between passes shifted a name-transition boundary onto a different physical page - could be silently accepted as "converged" one pass early, before that page's own (different) named-page geometry had actually been applied.
- `PageGeometryTable.PageBandGeometry` gains an `ActiveName` field (populated from `Compute`'s already-resolved value, no new lookup), and the signature now pairs each box's page index with that page's own active name.
- The iteration cap stays at a flat 3 - no evidence any real document needs more, and this repo's own multi-physical-page named-page fixtures (including a new one added here, spanning 3 physical pages under one continuously-active name) still converge on the loop's first iteration with the fix in place.

**This narrows #202 rather than closing it.** The issue's original centerpiece - a box measured against its own named page's geometry *before* its own registration invalidated the stale slot - was already fixed independently of this PR (`CssBox._measureResolvedAgainst`/`InlineSizeCameFromAnotherPagesMeasure`). What remains, and what this PR does not attempt to formally prove, is whether the bounded reflow loop provably converges for *every* document with a named-page run spanning several physical pages - a genuine width→height→page-name feedback that could in principle need more than one re-pass. This PR documents that remainder as an accepted, monitored gap (mirroring this repo's existing precedent for the `@container` convergence loop, #614) rather than attempting a formal bound or proof. `#202` stays open, tracking that narrowed remainder.

## Test plan

- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (9891 passed, 9 skipped, 0 failed), including `WidthFromTheSpaceNotTheLocationTests` (which pins exact `LayoutGeneration` counts) unchanged
- [x] Diff coverage 100% on the changed lines (`diff-cover` against `main`)
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] New integration test `NamedPageRun_SpanningThreePhysicalPages_EachPageOwnMeasureConverges` - a named page spanning 3 physical pages under one active name, asserting each page reflows to that name's own measure and that the pass count stays at the documented value (3)
- [x] `.claude/accepted-gaps/per-page-horizontal-reflow-scope.md` updated, new accepted-gap file `named-page-run-convergence-loop-is-bounded-not-guaranteed.md` added, `PageGeometryTable`'s own class doc corrected, and a migration note added in the same change