### PR TITLE
Resolve position:fixed and background-attachment:fixed against each page's own area

### DIFF
--- a/.claude/recent-fixes/2026-09-06-fixed-position-per-slot-basis.md
+++ b/.claude/recent-fixes/2026-09-06-fixed-position-per-slot-basis.md
@@ -1,0 +1,69 @@
+# `position: fixed` and `background-attachment: fixed` now resolve against each page's own area (#146)
+
+Four sites all resolved a fixed-positioned/fixed-attachment box against the document's single, base
+page geometry instead of the current page's own (possibly `:first`/named/margin-overridden) area.
+
+## Load-bearing idea
+
+`CssBox.CommitBlockChildOffset`'s Fixed branch and `CssLayoutEngine.GetBoxHeight`'s `isFixedToPage`
+branch resolve a fixed box's canonical `left`/`top`/`height` percentage basis exactly once, before its
+own page is known - mirroring the existing ICB convention (`GetBoxHeight`'s `box == box.ContainingBlock`
+branch, #145/#201): pinned to **page 1's own resolved band** (`PageGeometry.GetPage(0).BandWidth`/
+`BandHeight`), not the document's base configured `PageSize`. `GetBoxWidth`'s own Fixed branch already
+did this correctly (via `PageContentRightOf(resolvedBlockTop)`, which defaults to `box.Location.Y` - `0`
+before the box is placed, i.e. page 0) - `GetBoxHeight` and `CommitBlockChildOffset` were the two
+asymmetric holdouts.
+
+`FragmentEmitter.ComputeFixedPageOffset`/`ComputeFixedSizeOverride` then correct that single canonical
+value into a **per-slot delta** for every later page a fixed box repeats onto - but both gated
+exclusively on `PageGeometryTable.HasSizeOverrides`, so a document with only a *margin* override (no
+`size` override at all - the common `@page :first { margin: 0 }` case) never ran the correction, even
+though the same content-area basis those methods reconstruct depends on margins just as much as on
+sheet size. Widened both gates to also fire on `HasVerticalMarginOverrides`/`HasHorizontalMarginOverrides`.
+
+`FragmentPainter.Decorations.cs`'s `PaintBackground` read `HtmlContainerInt.PageBoxRect` unconditionally
+for a `background-attachment: fixed` layer's positioning area - the one call site that hadn't adopted
+the `PageClipOverride ?? PageBoxRect` fallback `FragmentPainter.Paint`'s own `PushClip` and
+`PdfGenerator.HandleLinks` already use for the per-slot window `PdfGenerator.AddPdfPages` sets before
+painting each page.
+
+## What running it (not just reading it) confirmed
+
+- A full-`PdfGenerator`-pipeline test comparing raw PDF content-stream `cm` matrices across two
+  differently-margined pages is **not** reliable for this bug: `PdfGenerator.AddPdfPages` emits the
+  per-page margin-override translate as a *separate, earlier* `cm` operator (only present when that
+  page's own margins differ from the base), so two pages' `cm ... /I0 Do` matrices, compared in
+  isolation, are expressed in two different coordinate frames - a raw equality/inequality check on them
+  proves nothing about this fix either way (confirmed both directions: an early draft's assertion passed
+  identically with and without the production fix applied, for unrelated reasons - a size-only override
+  changes `HtmlContainerInt.PageSize`/`MaxSize` per page through an already-correct, pre-existing
+  mechanism unrelated to this bug, and a margin-only override's Y-axis difference is dominated by the
+  paint-time translate itself, not by `viewportRect`).
+- `HtmlContainerInt.PageClipOverride` is **also** the page's own content clip (pushed around all
+  painting, not just backgrounds) - a test that sets it to a rect not containing the test box's own
+  position clips that box out of the fragment entirely (zero draws recorded, not a wrong position),
+  which is what an early draft of the isolated `RecordingGraphics` test hit before choosing a same-origin,
+  smaller override instead of a shifted one.
+- The reliable way to isolate this specific fix: extend the shared `RecordingGraphics` mock
+  (`PeachPDF.Tests/TestSupport/RecordingGraphics.cs`) to record `DrawImage` destination rects (previously
+  a no-op there), call `HtmlContainerInt.PerformPaint` directly with `PageClipOverride` set/unset, and
+  assert the recorded rect - sidesteps PDF content-stream Y-flip and per-page-translate composition
+  entirely, since `RGraphics` destination rects are in the same top-down layout space `PaintBackground`
+  itself computes in.
+- Confirmed each new/changed regression test fails against the pre-fix source with the exact wrong
+  (base-page-basis) value the bug predicts, then passes against the fix, for all four sites independently
+  (toggled via `git stash` on each touched production file in turn).
+
+## Deliberately not done
+
+- Did not attempt to make `background-attachment: fixed`'s positioning area reach into the page's own
+  margins on every axis - `PageBoxRect`'s own pre-existing formula (unchanged here) already doesn't
+  reach the bottom margin (only the right, via its `+ MarginRight` term), a pre-existing, untouched
+  asymmetry this fix's per-slot correction (`PageClipOverride`, which mirrors that same shape) faithfully
+  preserves rather than "corrects" - out of scope for a per-page-basis fix.
+
+## Evidence
+
+- New/updated regression tests, each independently confirmed to fail pre-fix: `FixedPositionPerPageOffsetLayoutIntegrationTests.FixedPercentOffset_ResolvesToEachPagesOwnArea_OnAMarginOnlyOverrideDocument`, `FixedPositionPerPageSizeLayoutIntegrationTests.FixedPercentSize_ResolvesToEachPagesOwnArea_OnAMarginOnlyOverrideDocument`, `BackgroundAttachmentFixedIntegrationTests.FixedAttachment_ViewportReflectsThePerSlotPageClipOverride_NotTheBasePageBoxRect`.
+- `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - full suite green (9898 passed, 9 pre-existing platform-gated skips).
+- `dotnet build PeachPDF.slnx -t:Rebuild` - 0 warnings.

--- a/src/PeachPDF.Tests/Integration/BackgroundAttachmentFixedIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/BackgroundAttachmentFixedIntegrationTests.cs
@@ -1,5 +1,10 @@
 using PeachPDF;
+using PeachPDF.Adapters;
+using PeachPDF.Html.Adapters.Entities;
+using PeachPDF.Html.Core;
 using PeachPDF.PdfSharpCore;
+using PeachPDF.PdfSharpCore.Drawing;
+using PeachPDF.Tests.TestSupport;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -45,6 +50,67 @@ namespace PeachPDF.Tests.Integration
             var matrixAtMargin20 = await GetImageCmMatrix(marginTop: 20, attachment: "scroll");
 
             Assert.NotEqual(matrixAtMargin50, matrixAtMargin20);
+        }
+
+        [Fact]
+        public async Task FixedAttachment_ViewportReflectsThePerSlotPageClipOverride_NotTheBasePageBoxRect()
+        {
+            // Issue #146: FragmentPainter.PaintBackground's viewportRect (the positioning area a
+            // background-attachment:fixed layer resolves its position against) must prefer
+            // HtmlContainerInt.PageClipOverride - the per-slot window PdfGenerator.AddPdfPages sets
+            // before painting each page, already used the same way by FragmentPainter's own PushClip
+            // and PdfGenerator.HandleLinks - over the single, page-independent PageBoxRect. Isolated at
+            // the RGraphics boundary (RecordingGraphics.DrawnImageRects), not by parsing PDF content
+            // streams: PageClipOverride is set directly, sidestepping PdfGenerator.AddPdfPages' own
+            // per-page paint-time translate entirely, since that translate is a separate, orthogonal
+            // mechanism (correcting WHERE the whole page's content lands physically) from this ("what
+            // rect does a percentage position resolve against").
+            // No PageClipOverride: falls back to the base PageBoxRect - here (0, 0, 500, 500), since
+            // MarginLeft/Top/Right are all 0 and PageSize is 500x500. "100% 100%" with a 10x10 image
+            // lands its top-left corner at the far corner minus the image size: (490, 490).
+            var withoutOverride = await PaintFixedBackground(pageClipOverride: null);
+            Assert.Single(withoutOverride.DrawnImageRects);
+            Assert.Equal(490, withoutOverride.DrawnImageRects[0].X, 0.01);
+            Assert.Equal(490, withoutOverride.DrawnImageRects[0].Y, 0.01);
+
+            // A per-slot override - same origin as the div's own content (PageClipOverride is also the
+            // page's content clip, so shifting the origin away would clip the div itself out entirely),
+            // but a genuinely smaller window, as a `:first`/margin-overridden page's own content band
+            // could be - must be what "100% 100%" resolves against instead: (0, 0, 200, 200) puts the
+            // far corner at (200, 200), so the image's top-left lands at (190, 190).
+            var withOverride = await PaintFixedBackground(pageClipOverride: new RRect(0, 0, 200, 200));
+            Assert.Single(withOverride.DrawnImageRects);
+            Assert.Equal(190, withOverride.DrawnImageRects[0].X, 0.01);
+            Assert.Equal(190, withOverride.DrawnImageRects[0].Y, 0.01);
+        }
+
+        private static async Task<RecordingGraphics> PaintFixedBackground(RRect? pageClipOverride)
+        {
+            var html = "<!DOCTYPE html><html><body>"
+                + "<div id='bg' style=\"width:20pt;height:20pt;"
+                + "background-image:url(" + PngDataUri + ");background-repeat:no-repeat;"
+                + "background-attachment:fixed;background-position:100% 100%;background-size:10pt 10pt;\">"
+                + "</div></body></html>";
+
+            var adapter = new PdfSharpAdapter { PixelsPerPoint = 1.0 };
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            container.PageSize = new RSize(500, 500);
+            container.Location = new RPoint(0, 0);
+            container.MaxSize = new RSize(500, 0);
+
+            var measure = XGraphics.CreateMeasureContext(new XSize(500, 500), XGraphicsUnit.Point, XPageDirection.Downwards);
+            using (var measureGraphics = new GraphicsAdapter(adapter, measure, 1.0))
+            {
+                await container.PerformLayout(measureGraphics);
+            }
+
+            container.PageClipOverride = pageClipOverride;
+
+            var recorder = new RecordingGraphics(adapter);
+            FragmentPaintHarness.PaintPage(container, recorder);
+            return recorder;
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/FixedPositionPerPageOffsetLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FixedPositionPerPageOffsetLayoutIntegrationTests.cs
@@ -99,6 +99,47 @@ namespace PeachPDF.Tests.Integration
         }
 
         [Fact]
+        public async Task FixedPercentOffset_ResolvesToEachPagesOwnArea_OnAMarginOnlyOverrideDocument()
+        {
+            // Issue #146: a margin-only override (no `size` override anywhere in the document) must
+            // also drive ComputeFixedPageOffset - its gate previously only checked HasSizeOverrides,
+            // so a plain `@page :first { margin: 0 }` document (no named page, no size override at
+            // all) wrongly left every page sharing page 0's single global offset.
+            var container = await BuildLayoutAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { margin: 60pt 50pt; }
+                @page :first { margin: 0; }
+                body, div, p { margin: 0; }
+                .fixedBox { position: fixed; left: 50%; top: 50%; width: 10pt; height: 10pt; }
+                </style></head><body>
+                <div class="fixedBox" id="fixed"></div>
+                <p>page zero</p>
+                <p style="page-break-before: always">page one</p>
+                </body></html>
+                """);
+
+            var fixedBox = FindById(container.Root!, "fixed")!;
+            var tree = container.FragmentTree!;
+            Assert.Equal(2, tree.Fragmentainers.Count);
+
+            var page0Fragment = FindBoxFragment(tree.Fragmentainers[0].Root, fixedBox);
+            var page1Fragment = FindBoxFragment(tree.Fragmentainers[1].Root, fixedBox);
+            Assert.NotNull(page0Fragment);
+            Assert.NotNull(page1Fragment);
+
+            // Page 0 (`:first`, margin 0, full 612x792 sheet as its own content area): 50% => (306, 396).
+            Assert.Equal(SheetW / 2, page0Fragment!.WholeBoxRect.X, 0.5);
+            Assert.Equal(SheetH / 2, page0Fragment.WholeBoxRect.Y, 0.5);
+
+            // Page 1 (base margins, 512x672 content area): 50% => (256, 336) - genuinely different.
+            Assert.Equal(BaseContentWidth / 2, page1Fragment!.WholeBoxRect.X, 0.5);
+            Assert.Equal(BaseContentHeight / 2, page1Fragment.WholeBoxRect.Y, 0.5);
+
+            Assert.NotEqual(page0Fragment.WholeBoxRect.X, page1Fragment.WholeBoxRect.X);
+            Assert.NotEqual(page0Fragment.WholeBoxRect.Y, page1Fragment.WholeBoxRect.Y);
+        }
+
+        [Fact]
         public async Task FixedPercentOffset_NoSizeOverridesInDocument_StaysIdenticalAcrossPages()
         {
             // Regression guard: HasSizeOverrides is false for a uniform document, so

--- a/src/PeachPDF.Tests/Integration/FixedPositionPerPageSizeLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FixedPositionPerPageSizeLayoutIntegrationTests.cs
@@ -290,6 +290,47 @@ namespace PeachPDF.Tests.Integration
         }
 
         [Fact]
+        public async Task FixedPercentSize_ResolvesToEachPagesOwnArea_OnAMarginOnlyOverrideDocument()
+        {
+            // Issue #146: a margin-only override (no `size` override anywhere) must also drive
+            // ComputeFixedSizeOverride - its gate previously only checked HasSizeOverrides, so a plain
+            // `@page :first { margin: 0 }` document wrongly left every page sharing page 0's single
+            // global size.
+            var container = await BuildLayoutAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { margin: 60pt 50pt; }
+                @page :first { margin: 0; }
+                body, div, p { margin: 0; }
+                .fixedBox { position: fixed; left: 0; top: 0; width: 50%; height: 50%; }
+                </style></head><body>
+                <div class="fixedBox" id="fixed"></div>
+                <p>page zero</p>
+                <p style="page-break-before: always">page one</p>
+                </body></html>
+                """);
+
+            var fixedBox = FindById(container.Root!, "fixed")!;
+            var tree = container.FragmentTree!;
+            Assert.Equal(2, tree.Fragmentainers.Count);
+
+            var page0Fragment = FindBoxFragment(tree.Fragmentainers[0].Root, fixedBox);
+            var page1Fragment = FindBoxFragment(tree.Fragmentainers[1].Root, fixedBox);
+            Assert.NotNull(page0Fragment);
+            Assert.NotNull(page1Fragment);
+
+            // Page 0 (`:first`, margin 0, full 612x792 sheet as its own content area): 50% => 306x396.
+            Assert.Equal(SheetW / 2, page0Fragment!.WholeBoxRect.Width, 0.5);
+            Assert.Equal(SheetH / 2, page0Fragment.WholeBoxRect.Height, 0.5);
+
+            // Page 1 (base margins, 512x672 content area): 50% => 256x336 - genuinely different.
+            Assert.Equal(BaseContentWidth / 2, page1Fragment!.WholeBoxRect.Width, 0.5);
+            Assert.Equal(BaseContentHeight / 2, page1Fragment.WholeBoxRect.Height, 0.5);
+
+            Assert.NotEqual(page0Fragment.WholeBoxRect.Width, page1Fragment.WholeBoxRect.Width);
+            Assert.NotEqual(page0Fragment.WholeBoxRect.Height, page1Fragment.WholeBoxRect.Height);
+        }
+
+        [Fact]
         public async Task FixedPercentSize_NoSizeOverridesInDocument_StaysIdenticalAcrossPages()
         {
             // Regression guard: HasSizeOverrides is false for a uniform document, so

--- a/src/PeachPDF.Tests/TestSupport/RecordingGraphics.cs
+++ b/src/PeachPDF.Tests/TestSupport/RecordingGraphics.cs
@@ -77,6 +77,11 @@ namespace PeachPDF.Tests.TestSupport
         /// <summary>Every word string passed to DrawString during this paint pass, with the Y it was drawn at.</summary>
         public List<(string Text, double Y)> DrawnStrings { get; } = [];
 
+        /// <summary>Every destination rect passed to <see cref="DrawImage(RImage, RRect, RRect)"/>/
+        /// <see cref="DrawImage(RImage, RRect)"/>, in order - e.g. to confirm a
+        /// <c>background-attachment: fixed</c> layer's positioning area actually reached the image draw.</summary>
+        public List<RRect> DrawnImageRects { get; } = [];
+
         /// <summary>
         /// Settable so a test can exercise a non-default <c>PixelsPerPoint</c> (issue #814) without a
         /// full <c>GraphicsAdapter</c>/PDF stack - defaults to the base <see cref="RGraphics.PixelsPerPoint"/>
@@ -198,8 +203,8 @@ namespace PeachPDF.Tests.TestSupport
         public override void DrawRectangle(RBrush brush, double x, double y, double width, double height) =>
             Log.Add(new PaintOp(PaintOpKind.FillRect, new RRect(x, y, width, height)));
 
-        public override void DrawImage(RImage image, RRect destRect, RRect srcRect) { }
-        public override void DrawImage(RImage image, RRect destRect) { }
+        public override void DrawImage(RImage image, RRect destRect, RRect srcRect) => DrawnImageRects.Add(destRect);
+        public override void DrawImage(RImage image, RRect destRect) => DrawnImageRects.Add(destRect);
         public override void DrawPath(RPen pen, RGraphicsPath path)
         {
             if (path is not RecordingGraphicsPath recordingPath) return;

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -5428,9 +5428,15 @@ namespace PeachPDF.Html.Core.Dom
                     // one's own fixed black bar. Percentages resolve against the page/viewport size
                     // (CSS2.1 §10.1: the initial containing block), not ScrollOffset (a scroll
                     // position, not a size) - not exercised by this fixture (uses em, not %) but
-                    // wrong regardless.
-                    var left = child.ActualMarginLeft + ResolveOffsetOrZero(child.Left, child.HtmlContainer!.PageSize.Width, child);
-                    var top = child.ActualMarginTop + ResolveOffsetOrZero(child.Top, child.HtmlContainer!.PageSize.Height, child);
+                    // wrong regardless. Pinned to page 1's own resolved band (PageGeometry.GetPage(0)),
+                    // not the document's base configured PageSize - the same "always page 1" ICB
+                    // convention GetBoxHeight's own ICB branch already follows, since a `@page :first`
+                    // margin/size override changes what this canonical resolution should be relative to
+                    // (issue #146); FragmentEmitter.ComputeFixedPageOffset corrects the delta for every
+                    // LATER page relative to whatever this establishes here.
+                    var pageZero = child.HtmlContainer!.PageGeometry.GetPage(0);
+                    var left = child.ActualMarginLeft + ResolveOffsetOrZero(child.Left, pageZero.BandWidth, child);
+                    var top = child.ActualMarginTop + ResolveOffsetOrZero(child.Top, pageZero.BandHeight, child);
                     child.Location = new RPoint(left, top);
                 }
             }

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -1763,11 +1763,16 @@ namespace PeachPDF.Html.Core.Dom
             // absolute; height: 100% }` fills its position:relative tbody even though its parent <tr> is
             // static and zero-height.) A fixed box resolves against the page area instead (CSS2.1 §10.1:
             // the initial containing block, the same basis CommitBlockChildOffset already uses for a fixed
-            // box's left/top) - always definite, since the page always has a real height.
+            // box's left/top) - always definite, since the page always has a real height. Like the true
+            // ICB itself (this method's own box == box.ContainingBlock branch above), this is pinned to
+            // page 1's own resolved band, not the document's base configured PageSize - a `@page :first`
+            // margin/size override changes what a fixed box's own canonical height resolves against (issue
+            // #146); FragmentEmitter.ComputeFixedSizeOverride corrects the delta for every LATER page
+            // relative to whatever this establishes here.
             var heightCb = PercentageBase(box);
             var isFixedToPage = box.Position.Value is PositionMode.Fixed && box.HtmlContainer is not null;
             var heightBasisIsCalculated = isFixedToPage || heightCb.IsHeightCalculated;
-            var heightBasis = isFixedToPage ? box.HtmlContainer!.PageSize.Height : heightCb.Size.Height;
+            var heightBasis = isFixedToPage ? box.HtmlContainer!.PageGeometry.GetPage(0).BandHeight : heightCb.Size.Height;
 
             // CSS 2.1 §10.6.3: a definite (non-auto) `height` is the used height regardless of
             // content - content taller than it overflows past ActualBottom (clipped or not per

--- a/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
@@ -2519,12 +2519,16 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// (whose resolution doesn't depend on the basis at all) always yields a zero delta - the
         /// existing per-page paint-time margin translate already positions those correctly, and this is
         /// purely the correction a percentage offset needs on top of it. Zero whenever the document has
-        /// no <c>@page size</c> overrides at all (<see cref="PageGeometryTable.HasSizeOverrides"/>), so
-        /// this never even runs for the overwhelming majority of documents.
+        /// no <c>@page size</c> override AND no vertical/horizontal margin override at all (issue #146 -
+        /// a margin-only override, e.g. plain <c>@page :first { margin: 0 }</c>, changes this exact same
+        /// content-area basis just as a <c>size</c> override does, so it must not be excluded from this
+        /// gate), so this never even runs for the overwhelming majority of documents.
         /// </summary>
         private (double Dx, double Dy) ComputeFixedPageOffset(CssBox box, Slot slot)
         {
-            if (!container.PageGeometry.HasSizeOverrides) return (0, 0);
+            var geometry = container.PageGeometry;
+            if (!geometry.HasSizeOverrides && !geometry.HasVerticalMarginOverrides && !geometry.HasHorizontalMarginOverrides)
+                return (0, 0);
 
             var ppp = (container.Adapter as PdfSharpAdapter)?.PixelsPerPoint ?? 1.0;
             var geom = slot.Geometry;
@@ -2546,13 +2550,16 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// or <c>auto</c>, always yields a zero delta for that dimension, since the box's own content isn't
         /// re-measured per slot (see <see cref="Draft.FixedSizeDeltaWidth"/>'s own remarks on why: doing so
         /// would require re-flowing the box's content, which css-position-3 explicitly does not require of
-        /// a fixed box). Zero whenever the document has no <c>@page size</c> overrides at all
-        /// (<see cref="PageGeometryTable.HasSizeOverrides"/>), so this never even runs for the overwhelming
-        /// majority of documents.
+        /// a fixed box). Zero whenever the document has no <c>@page size</c> override AND no vertical/
+        /// horizontal margin override at all (issue #146 - same reasoning as <see cref="ComputeFixedPageOffset"/>'s
+        /// own gate: a margin-only override changes this same content-area basis a percentage width/height
+        /// resolves against), so this never even runs for the overwhelming majority of documents.
         /// </summary>
         private (double DeltaWidth, double DeltaHeight) ComputeFixedSizeOverride(CssBox box, Slot slot)
         {
-            if (!container.PageGeometry.HasSizeOverrides) return (0, 0);
+            var geometry = container.PageGeometry;
+            if (!geometry.HasSizeOverrides && !geometry.HasVerticalMarginOverrides && !geometry.HasHorizontalMarginOverrides)
+                return (0, 0);
 
             // Mirrors CssLayoutEngine.GetBoxWidth's own percentage-width gate exactly (a fixed box always
             // computes to display:block per CSS2.1 §9.7, so GetBoxWidth's inline-with-no-words exclusion

--- a/src/PeachPDF/Html/Core/Paint/FragmentPainter.Decorations.cs
+++ b/src/PeachPDF/Html/Core/Paint/FragmentPainter.Decorations.cs
@@ -91,7 +91,11 @@ namespace PeachPDF.Html.Core.Paint
             // not once for the whole box.
             var originLayers = BackgroundLayerResolver.SplitLayers(box.BackgroundOrigin);
             var clipLayers   = BackgroundLayerResolver.SplitLayers(box.BackgroundClip);
-            var viewportRect = box.HtmlContainer!.PageBoxRect;
+            // background-attachment:fixed's positioning area is this page's own window, not the base
+            // page box - PageClipOverride is set per-slot by PdfGenerator.AddPdfPages (the same override
+            // FragmentPainter's own PushClip and PdfGenerator.HandleLinks already prefer over PageBoxRect)
+            // and reflects a `@page :first`/named/margin-overridden page's own area; issue #146.
+            var viewportRect = box.HtmlContainer!.PageClipOverride ?? box.HtmlContainer!.PageBoxRect;
 
             var actualBackgroundColor = firstLineStyle?.ActualBackgroundColor ?? box.ActualBackgroundColor;
             RBrush? solidBrush = RenderUtils.IsColorVisible(actualBackgroundColor)


### PR DESCRIPTION
## Summary
Four sites resolved fixed-positioned/fixed-attachment content against the document's single base page geometry instead of the current page's own (possibly `:first`/named/margin-overridden) area:
- `CssBox.CommitBlockChildOffset` and `CssLayoutEngine.GetBoxHeight`'s fixed-position branches now pin to page 1's own resolved band, mirroring the existing initial-containing-block convention
- `FragmentEmitter.ComputeFixedPageOffset`/`ComputeFixedSizeOverride`'s per-slot correction only ran for a `@page size` override; widened to also cover a margin-only override, which changes the same basis
- `FragmentPainter.PaintBackground` now prefers the per-slot `PageClipOverride` over the single base `PageBoxRect` for a `background-attachment:fixed` layer's positioning area, matching every other paint-time consumer of that override

## Test plan
- [x] New regression tests for all 4 sites, each individually confirmed to fail pre-fix and pass post-fix
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - full suite green
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` - 0 warnings

Fixes #146