### PR TITLE
Fix named-page registration timing and remove inline page registration

### DIFF
--- a/.claude/recent-fixes/2026-09-06-named-page-registration-table-relocation-and-inline-removal.md
+++ b/.claude/recent-fixes/2026-09-06-named-page-registration-table-relocation-and-inline-removal.md
@@ -1,0 +1,62 @@
+# Named-page registration cleanup: table relocation via OffsetTop, inline `page` removed (#149)
+
+Two independent residuals in named-page (`page: <name>`) registration.
+
+## Load-bearing idea
+
+**Table relocation.** `CssLayoutEngineTable.LayoutBodyRows` has two whole-table relocation pre-checks
+(headerless and header-present) that used to assign `_tableBox.Location` directly, then manually
+`OffsetTop` the top captions (and, in the header-present case, the header box) to match. Direct
+`Location` assignment bypasses `CssBox.OffsetTop`'s own `RegisteredNamedPageElement`/`MoveNamedPageElement`
+re-sync, deferring it to `PerformLayoutImp`'s tail fallback - which runs *after* the row loop below has
+already paginated against the pre-relocation geometry. Replaced both direct assignments with
+`_tableBox.OffsetTop(pageBreakOffset)`, which re-syncs the registration immediately. Top captions are
+`_tableBox`'s own DOM children (`AssignBoxKinds`'s `foreach (var box in _tableBox.Boxes)` walk populates
+`_captionBoxes` from exactly that collection), so `OffsetTop`'s own recursion into `Boxes` already moves
+them - the separate per-caption loop was doing (and, if kept alongside the new call, would have
+double-applied) work `OffsetTop` now does on its own. The header box is genuinely detached
+(`_headerBox.ParentBox = null` before this runs) precisely so it can repeat across pages, so it stays
+outside that recursion and keeps its own explicit `OffsetTop` call.
+
+**Inline `page` removed.** Per CSS Paged Media 3 §7.2, `page` applies only to boxes that create class-A
+break points - block-level boxes, by definition. `CssLayoutEngine.FlowBox`'s two inline registration
+sites (plain-inline exit, inline-flex) registered a `NamedPageElement` for an inline box anyway, at its
+own raw (unsnapped, mid-line) Y - spec-marginal to begin with, and (per
+`.claude/recent-fixes/2026-08-02-inline-string-set-and-named-page-corruption-across-reflow.md`) a real,
+independent source of registration corruption across re-layout/resumed continuations. Removed both
+registration blocks entirely rather than snapping them to `CssBox.NamedPageRegistrationY()` (the
+alternative, more conservative fix) - a snapped-but-present inline registration would still be
+spec-incorrect, just less visibly so. The sibling `NamedStrings` (string-set) finalization at both sites
+is untouched; it's a different feature with no equivalent spec restriction.
+
+## What running it (not just reading it) confirmed
+
+- Removing inline `page` registration broke five existing tests that had used an inline `page` element
+  purely as the *vehicle* for exercising two shared FlowBox mechanisms (unregister-before-register across
+  re-layout; the `opensHere` gate across a resumed continuation) that also apply to `NamedStrings`. Three
+  of the five (`MulticolLayoutIntegrationTests.NamedPageElement_InlineTarget_DoesNotAccumulateStaleEntriesAcrossReflow`,
+  its InlineFlex sibling, and `ResumedInlineNamedStringLayoutIntegrationTests.NamedPageElement_InlineTarget_KeepsTruePositionAcrossResumedContinuation`)
+  were deleted outright rather than adapted - each had an exact `NamedString`-based sibling test already
+  exercising the identical shared mechanism, so keeping a now-permanently-empty-collection assertion
+  alongside it would add nothing. The other two (`NamedPageLayoutIntegrationTests`' plain-inline and
+  inline-flex "Registers" tests) were rewritten to assert the new no-op instead of deleted, since they
+  have no `NamedString`-based sibling proving the same ground.
+- `TableRelocatedByPreCheck_TailResyncMovesRegistrationToNewPage` (an existing test written to describe
+  the *old* tail-fallback re-sync) still passes unchanged against the new `OffsetTop`-based mechanism -
+  the final registered position is identical either way, only the timing differs (immediate vs.
+  epilogue-tail) - confirming the tail fallback's own conditional re-sync (`PerformLayoutImp`'s
+  `Math.Abs(RegisteredNamedPageElement.Y - registrationY) > PageBoundaryEpsilon` guard) correctly becomes
+  a no-op rather than double-moving the registration.
+
+## Deliberately not done
+
+- Did not attempt the harder, "not observed in any real fixture" half of the original issue (a named-page
+  table relocation whose *rows* fragment against pre-relocation bands) - the fix here closes the
+  registration-timing gap that would enable it, but no repro fixture was constructed to prove the
+  downstream row-fragmentation symptom itself no longer occurs.
+
+## Evidence
+
+- `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - full suite green (9895 passed,
+  9 pre-existing platform-gated skips - net decrease of 3 from the deleted redundant tests).
+- `dotnet build PeachPDF.slnx -t:Rebuild` - 0 warnings.

--- a/src/PeachPDF.Tests/Integration/MulticolLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/MulticolLayoutIntegrationTests.cs
@@ -493,33 +493,6 @@ namespace PeachPDF.Tests.Integration
         }
 
         [Fact]
-        public async Task NamedPageElement_InlineTarget_DoesNotAccumulateStaleEntriesAcrossReflow()
-        {
-            // Same re-banding fixture as NamedString_InlineTarget_DoesNotAccumulateStaleEntriesAcrossReflow,
-            // exercising the `page` registration's twin unregister-before-register gap in the same
-            // FlowBox code path. (Unlike the block-level page property, an inline target's `page`
-            // value does not force a break of its own - css2.1 §13.2's page-transition break check
-            // runs against block-level boxes - so this only asserts against re-registration, not a
-            // page transition.)
-            var html = Wrap(@"
-                <div id='mc' style='columns:2; column-gap:0; width:200px'>
-                    <div class='item' id='i1' style='height:80px'>one</div>
-                    <div class='item' id='i2' style='height:10px'><b id='b2' style='page:chapter'>two</b></div>
-                    <div class='item' id='i3' style='height:10px'>three</div>
-                </div>");
-            var (root, container) = await BuildAndLayout(html, pageHeight: 100);
-            var mc = FindById(root, "mc")!;
-            var i2 = FindById(root, "i2")!;
-
-            // Confirm the fixture actually forces re-banding before trusting the assertion below.
-            Assert.True(i2.Location.X > mc.ClientLeft + 50, "expected i2 to be re-banded into column 2");
-
-            // Exactly one entry is the regression guard - the inline path used to leave one orphaned
-            // NamedPageElement behind per re-layout instead of withdrawing the earlier one first.
-            Assert.Single(container.NamedPageElements, e => e.Name == "chapter");
-        }
-
-        [Fact]
         public async Task NamedString_InlineFlexTarget_DoesNotAccumulateStaleEntriesAcrossReflow()
         {
             // Same re-banding fixture as NamedString_InlineTarget_DoesNotAccumulateStaleEntriesAcrossReflow,
@@ -543,28 +516,6 @@ namespace PeachPDF.Tests.Integration
             // The regression guard: without unregistering a stale entry before re-registering, this
             // accumulates one orphaned "entry"/"two" per re-layout instead of staying at exactly one.
             Assert.Single(container.NamedStrings, ns => ns.Name == "entry" && ns.Value == "two");
-        }
-
-        [Fact]
-        public async Task NamedPageElement_InlineFlexTarget_DoesNotAccumulateStaleEntriesAcrossReflow()
-        {
-            // Same re-banding fixture, exercising the `page` registration's twin gap in the same
-            // InlineFlex branch of FlowBox.
-            var html = Wrap(@"
-                <div id='mc' style='columns:2; column-gap:0; width:200px'>
-                    <div class='item' id='i1' style='height:80px'>one</div>
-                    <div class='item' id='i2' style='height:10px'><span id='b2' style='display:inline-flex; page:chapter'>two</span></div>
-                    <div class='item' id='i3' style='height:10px'>three</div>
-                </div>");
-            var (root, container) = await BuildAndLayout(html, pageHeight: 100);
-            var mc = FindById(root, "mc")!;
-            var i2 = FindById(root, "i2")!;
-
-            Assert.True(i2.Location.X > mc.ClientLeft + 50, "expected i2 to be re-banded into column 2");
-
-            // Exactly one entry is the regression guard - the InlineFlex branch used to leave one
-            // orphaned NamedPageElement behind per re-layout instead of withdrawing the earlier one first.
-            Assert.Single(container.NamedPageElements, e => e.Name == "chapter");
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/NamedPageGeometryAttributionTests.cs
+++ b/src/PeachPDF.Tests/Integration/NamedPageGeometryAttributionTests.cs
@@ -117,14 +117,17 @@ namespace PeachPDF.Tests.Integration
         [Fact]
         public async Task TableRelocatedByPreCheck_TailResyncMovesRegistrationToNewPage()
         {
-            // CssLayoutEngineTable's whole-table pre-check assigns the table's Location directly
-            // (bypassing OffsetTop's MoveNamedPageElement sync), so the tail of
-            // CssBox.PerformLayoutImp must re-sync the early registration to the slot the table
-            // actually ended up on. Every element here carries the same explicit `page: tbl`, so the
-            // table itself doesn't force a break (its used name equals the already-active one, which
-            // would otherwise land it at a slot top and mask the move) while still registering (a box
-            // with its own explicit name always registers, so the relocated table has an entry to
-            // re-sync). The leading 660pt named div pushes the table's top near the slot-0 boundary.
+            // Issue #149: CssLayoutEngineTable's whole-table pre-check now routes the relocation through
+            // CssBox.OffsetTop (instead of assigning the table's Location directly), so the early
+            // registration re-syncs to the table's new slot immediately - before the row loop below
+            // paginates against this table's own named-page geometry, rather than only afterward at
+            // CssBox.PerformLayoutImp's tail (which stays as a no-op safety net here, since the
+            // registration already matches by the time it runs). Every element here carries the same
+            // explicit `page: tbl`, so the table itself doesn't force a break (its used name equals the
+            // already-active one, which would otherwise land it at a slot top and mask the move) while
+            // still registering (a box with its own explicit name always registers, so the relocated
+            // table has an entry to re-sync). The leading 660pt named div pushes the table's top near
+            // the slot-0 boundary.
             var container = await BuildLayoutAsync("""
                 <!DOCTYPE html><html><head><style>
                 @page { margin: 60pt 50pt; }

--- a/src/PeachPDF.Tests/Integration/NamedPageLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/NamedPageLayoutIntegrationTests.cs
@@ -92,35 +92,34 @@ namespace PeachPDF.Tests.Integration
         }
 
         [Fact]
-        public async Task NamedPageElement_InlineElement_Registers()
+        public async Task NamedPageElement_InlineElement_DoesNotRegister()
         {
-            // Regression coverage for the inline-element gap shared with string-set: an inline element
-            // inside a text-flow container (ContainsInlinesOnly, laid out via CssLayoutEngine.FlowBox)
-            // never got its own PerformLayoutImp call, so RegisterNamedPageElement never ran for it -
-            // previously this would have registered zero NamedPageElements, failing Assert.Single below.
+            // Issue #149: `page` is a class-A-break-point property (css-page-3 §7.2), and an inline-level
+            // box never creates one, so an inline element's own `page` declaration is now a no-op -
+            // registration only ever happens at the nearest block-level ancestor (here, <p>#para itself
+            // carries no `page`, so nothing registers at all). Previously this registered an entry at the
+            // <b>'s own (unsnapped, mid-line) Y, a real source of corruption (see
+            // .claude/recent-fixes/2026-08-02-inline-string-set-and-named-page-corruption-across-reflow.md).
             var html = Wrap("""<p id="para"><b id="chapter" style="page:chapter">Chapter 2</b> starts here.</p>""");
 
-            var (root, container) = await BuildAndLayout(html);
-            var paraBox = FindById(root, "para")!;
+            var (_, container) = await BuildAndLayout(html);
 
-            var registered = Assert.Single(container.NamedPageElements, e => e.Name == "chapter");
-            // <b> is the paragraph's first inline content on its first line, so it should land at the
-            // same Y as the paragraph's own top (no padding/border in this fixture).
-            Assert.Equal(paraBox.Location.Y, registered.Y, 1);
+            Assert.DoesNotContain(container.NamedPageElements, e => e.Name == "chapter");
         }
 
         [Fact]
-        public async Task NamedPageElement_InlineElement_RegistersActualLocationY_NotZero()
+        public async Task NamedPageElement_InlineElement_StillDoesNotRegister_EvenWellIntoTheFlow()
         {
+            // Companion to the no-registration test above with a non-trivial Y (well past a filler div),
+            // confirming the no-op holds regardless of where in the flow the inline element lands.
             var html = Wrap("""
                 <div style="height:500px"></div>
                 <p><b id="chapter" style="page:chapter">Chapter 3</b> starts here.</p>
                 """);
 
-            var (root, container) = await BuildAndLayout(html);
+            var (_, container) = await BuildAndLayout(html);
 
-            var registered = Assert.Single(container.NamedPageElements, e => e.Name == "chapter");
-            Assert.True(registered.Y > 100, $"expected a Y well past the filler div, got {registered.Y}");
+            Assert.DoesNotContain(container.NamedPageElements, e => e.Name == "chapter");
         }
 
         [Fact]
@@ -142,19 +141,17 @@ namespace PeachPDF.Tests.Integration
         }
 
         [Fact]
-        public async Task NamedPageElement_InlineFlexElement_Registers()
+        public async Task NamedPageElement_InlineFlexElement_DoesNotRegister()
         {
-            // display:inline-flex inside a text-flow container is treated as an atomic inline element
-            // (CssLayoutEngine.FlowBox's dedicated InlineFlex branch), a separate code path from the
-            // plain-inline case above - it finalizes its own Location eagerly rather than deferring to
-            // FlowBox's generic "box != blockBox" late correction, so needs its own regression coverage.
+            // Issue #149: display:inline-flex inside a text-flow container is treated as an atomic
+            // inline element (CssLayoutEngine.FlowBox's dedicated InlineFlex branch) - still inline-level
+            // per css-page-3 §7.2, so its own `page` declaration is a no-op too, the same as the
+            // plain-inline case above.
             var html = Wrap("""<p id="para"><span id="chapter" style="display:inline-flex; page:chapter">Chapter 2</span> starts here.</p>""");
 
-            var (root, container) = await BuildAndLayout(html);
-            var chapterBox = FindById(root, "chapter")!;
+            var (_, container) = await BuildAndLayout(html);
 
-            var registered = Assert.Single(container.NamedPageElements, e => e.Name == "chapter");
-            Assert.Equal(chapterBox.Location.Y, registered.Y, 1);
+            Assert.DoesNotContain(container.NamedPageElements, e => e.Name == "chapter");
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/ResumedInlineNamedStringLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/ResumedInlineNamedStringLayoutIntegrationTests.cs
@@ -8,15 +8,18 @@ namespace PeachPDF.Tests.Integration
 {
     /// <summary>
     /// The real-world shape behind the css4.pub Icelandic dictionary running-header bug: a <c>&lt;b&gt;</c>
-    /// carrying <c>string-set</c>/<c>page</c> opens on one page, but its containing paragraph is long
-    /// enough that a later page break falls inside the *same* paragraph. Layout fills one fragmentainer
-    /// per pass (see <see cref="ResumedInlineDecorationLayoutIntegrationTests"/>), so the pass that
-    /// resumes the paragraph on the next page walks its inline content from the top again - reaching the
+    /// carrying <c>string-set</c> opens on one page, but its containing paragraph is long enough that a
+    /// later page break falls inside the *same* paragraph. Layout fills one fragmentainer per pass (see
+    /// <see cref="ResumedInlineDecorationLayoutIntegrationTests"/>), so the pass that resumes the
+    /// paragraph on the next page walks its inline content from the top again - reaching the
     /// already-placed <c>&lt;b&gt;</c> a second time even though it did not open on this pass. Without
-    /// gating <c>CssLayoutEngine.FlowBox</c>'s string-set/named-page application on <c>opensHere</c>, that
-    /// second visit re-stamps the box's <c>NamedString</c>/<c>NamedPageElement</c> using *this* pass's
-    /// cursor - which sits at the resumed page's own top, since the walk has not yet advanced past the
-    /// already-placed word - discarding the box's true first-page position.
+    /// gating <c>CssLayoutEngine.FlowBox</c>'s string-set application on <c>opensHere</c>, that second
+    /// visit re-stamps the box's <c>NamedString</c> using *this* pass's cursor - which sits at the
+    /// resumed page's own top, since the walk has not yet advanced past the already-placed word -
+    /// discarding the box's true first-page position. This same <c>opensHere</c> gate originally also
+    /// covered an inline target's <c>page</c> (named-page) registration - removed entirely since (issue
+    /// #149), as an inline-level box never creates the class-A break points css-page-3 §7.2 scopes
+    /// <c>page</c> to.
     /// </summary>
     public class ResumedInlineNamedStringLayoutIntegrationTests
     {
@@ -40,27 +43,15 @@ namespace PeachPDF.Tests.Integration
             Assert.Equal(trueY, namedString.Y, 1);
         }
 
-        [Fact]
-        public async Task NamedPageElement_InlineTarget_KeepsTruePositionAcrossResumedContinuation()
-        {
-            var html = Wrap($"<p id='p'><b id='term'>first</b> {Filler}</p>", stringSet: false);
-            var (root, container) = await LayoutHarness.LayoutAsync(html, pageWidth: 200, pageHeight: PageHeight);
-
-            AssertPaginated(container);
-
-            var term = LayoutHarness.FindById(root, "term")!;
-            var trueY = AllWords(term).Single().Top;
-
-            var registered = Assert.Single(container.NamedPageElements, e => e.Name == "chapter");
-            Assert.Equal(0, container.PageIndexOf(registered.Y));
-            Assert.Equal(trueY, registered.Y, 1);
-        }
-
         // 200 short words, comfortably enough to push this paragraph across a page break at PageHeight.
         private static readonly string Filler = string.Join(" ", Enumerable.Repeat("word", 200));
 
         private static string Wrap(string body, bool stringSet)
         {
+            // `page` is no longer registered for an inline target at all (issue #149 - inline-level
+            // boxes never create the class-A break points css-page-3 §7.2 scopes `page` to), so this
+            // helper's only remaining caller always passes stringSet: true; kept as a parameter rather
+            // than inlined in case a future inline-target regression needs the same fixture shape again.
             var declaration = stringSet ? "string-set: entry content(text)" : "page: chapter";
             return $"<!DOCTYPE html><html><head><style>#term {{ {declaration} }}</style></head><body>{body}</body></html>";
         }

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -5772,11 +5772,14 @@ namespace PeachPDF.Html.Core.Dom
             // (see the early registration above the layout-engine dispatch); everything else (e.g. a
             // box that never entered the block branch) registers here, after every branch above that
             // can still move this box's own Location. For an already-registered box this is a re-sync
-            // for movers that bypass OffsetTop (CssLayoutEngineTable's whole-table pre-check assigns
-            // Location directly). A *later* reposition by an ancestor's layout engine after this
-            // box's own PerformLayoutImp has returned (e.g. CssLayoutEngineColumns re-banding a
-            // column child via OffsetTop) is handled by retaining the registered element on
-            // RegisteredNamedPageElement, which OffsetTop keeps in sync.
+            // safety net for any remaining mover that bypasses OffsetTop - CssLayoutEngineTable's
+            // whole-table pre-check now routes through OffsetTop itself (issue #149), so this branch is
+            // a no-op for that specific case (RegisteredNamedPageElement.Y already matches), but stays
+            // in place for whatever else might still move a box's Location directly in the future. A
+            // *later* reposition by an ancestor's layout engine after this box's own PerformLayoutImp
+            // has returned (e.g. CssLayoutEngineColumns re-banding a column child via OffsetTop) is
+            // handled by retaining the registered element on RegisteredNamedPageElement, which OffsetTop
+            // keeps in sync.
             // Reuse the shouldRegisterPage boolean computed near the top of this method - it must NOT
             // be re-derived here: the early registration above mutates HtmlContainer.ActivePageName,
             // so a fresh UsedPageName != ActivePageName comparison would now read false for an

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -2294,36 +2294,26 @@ namespace PeachPDF.Html.Core.Dom
 
             // Finalize what was captured at entry, now that this box's content has actually been placed
             // and coordinates.CurrentY reflects where it landed - mirrors CssBox.PerformLayoutImp's own
-            // late-stage Y-correction/named-page registration (done there once Location is final), which
-            // a plain inline box never gets a Location for in the first place. Gated on opensHere for the
-            // same reason as the entry-side guard in PrepareFlowBoxEntry: a pass merely resuming this
-            // box's already-placed content into a later fragmentainer must not re-stamp its
-            // NamedStrings/named-page Y to wherever *this* pass's cursor happens to sit (typically the
-            // resumed fragmentainer's own top, since the walk hasn't advanced past already-placed words
-            // yet) - that both discards the box's true position from when it actually opened and, for
-            // named-page, would corrupt ActivePageName for content after it.
-            if (opensHere && box != blockBox)
+            // late-stage Y-correction (done there once Location is final), which a plain inline box
+            // never gets a Location for in the first place. Gated on opensHere for the same reason as
+            // the entry-side guard in PrepareFlowBoxEntry: a pass merely resuming this box's
+            // already-placed content into a later fragmentainer must not re-stamp its NamedStrings' Y
+            // to wherever *this* pass's cursor happens to sit (typically the resumed fragmentainer's own
+            // top, since the walk hasn't advanced past already-placed words yet) - that would discard
+            // the box's true position from when it actually opened.
+            //
+            // `page` is deliberately NOT registered for an inline box here (issue #149): per css-page-3
+            // §7.2, `page` only applies to boxes that create class-A break points, which are block-level
+            // by definition - an inline box is not one, so registering it was already spec-marginal, and
+            // doing so at its own (unsnapped, mid-line) Y made it a real source of corruption on its own
+            // (see .claude/recent-fixes/2026-08-02-inline-string-set-and-named-page-corruption-across-reflow.md,
+            // whose unregister-before-register/opensHere fixes protected this dead-end registration
+            // along with the still-needed NamedStrings one above).
+            if (opensHere && box != blockBox && box.NamedStrings.Count > 0)
             {
-                if (box.NamedStrings.Count > 0)
+                foreach (var namedString in box.NamedStrings.Values)
                 {
-                    foreach (var namedString in box.NamedStrings.Values)
-                    {
-                        namedString.Y = coordinates.CurrentY;
-                    }
-                }
-
-                if (!string.IsNullOrEmpty(box.PageName) && box.PageName != "auto")
-                {
-                    // Same re-entry hazard as the string-set guard in PrepareFlowBoxEntry: without
-                    // withdrawing a stale registration first, a re-banding re-layout or column-fill retry
-                    // leaves an orphaned NamedPageElement behind, corrupting ActivePageName for whatever
-                    // comes after it.
-                    if (box.RegisteredNamedPageElement is { } stalePageElement)
-                    {
-                        box.HtmlContainer?.UnregisterNamedPageElement(stalePageElement);
-                    }
-
-                    box.RegisteredNamedPageElement = box.HtmlContainer?.RegisterNamedPageElement(box.PageName, coordinates.CurrentY);
+                    namedString.Y = coordinates.CurrentY;
                 }
             }
 
@@ -2352,8 +2342,11 @@ namespace PeachPDF.Html.Core.Dom
             b.FirstHostingLineBox = coordinates.Line;
             b.LastHostingLineBox = coordinates.Line;
 
-            // Unlike a plain inline box, b.Location is already final here, so string-set/named-page can
-            // be applied and finalized together rather than split across entry/exit like plain inlines.
+            // Unlike a plain inline box, b.Location is already final here, so string-set can be applied
+            // and finalized in one step rather than split across entry/exit like plain inlines. `page`
+            // is deliberately NOT registered for an inline-flex box (issue #149) - see the plain-inline
+            // exit path above (FlowBox) for why: an inline-level box never creates a class-A break point,
+            // so `page` doesn't apply to it per css-page-3 §7.2.
             if (!string.IsNullOrEmpty(b.StringSet) && b.StringSet != Keywords.None)
             {
                 if (b.NamedStrings.Count > 0)
@@ -2367,16 +2360,6 @@ namespace PeachPDF.Html.Core.Dom
                 {
                     namedString.Y = b.Location.Y;
                 }
-            }
-
-            if (!string.IsNullOrEmpty(b.PageName) && b.PageName != "auto")
-            {
-                if (b.RegisteredNamedPageElement is { } staleFlexPageElement)
-                {
-                    b.HtmlContainer?.UnregisterNamedPageElement(staleFlexPageElement);
-                }
-
-                b.RegisteredNamedPageElement = b.HtmlContainer?.RegisterNamedPageElement(b.PageName, b.Location.Y);
             }
 
             await CssLayoutEngineFlex.PerformLayout(g, b);

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
@@ -3212,8 +3212,14 @@ namespace PeachPDF.Html.Core.Dom
                     pageBreakOffset = PullKeepWithNextRun(container, cursor.CurrentY, pageBreakOffset,
                         slot, availableHeight, estimatedBodyHeight);
 
-                    _tableBox.Location = _tableBox.Location with { Y = _tableBox.Location.Y + pageBreakOffset };
-                    foreach (var caption in _topCaptions) caption.OffsetTop(pageBreakOffset);
+                    // Routes through OffsetTop rather than a direct Location assignment (issue #149) so
+                    // RegisteredNamedPageElement re-syncs immediately, before the row loop below
+                    // paginates against this table's named-page geometry - a direct Location write left
+                    // that re-sync to PerformLayoutEpilogue's tail, after rows had already fragmented
+                    // against the pre-relocation bands. Captions are _tableBox's own DOM children
+                    // (AssignBoxKinds's `foreach (var box in _tableBox.Boxes)` walk), so OffsetTop's own
+                    // recursion into Boxes already moves them - no separate per-caption loop needed here.
+                    _tableBox.OffsetTop(pageBreakOffset);
                     startY = Math.Max(_tableBox.ClientTop + _topCaptionsHeight + StartYSpacing(), 0);
                     // startY is a fresh restart point at the table's own content-top edge on the new
                     // page, not an arbitrary interior coordinate - the same "top edge flush on a
@@ -3253,9 +3259,13 @@ namespace PeachPDF.Html.Core.Dom
                     pageBreakOffset = PullKeepWithNextRun(container, startY, pageBreakOffset,
                         slot, availableHeight, _headerHeight + firstRowHeight);
 
-                    _tableBox.Location = _tableBox.Location with { Y = _tableBox.Location.Y + pageBreakOffset };
+                    // Routes through OffsetTop rather than a direct Location assignment (issue #149) -
+                    // see the identical rationale on the headerless pre-check above. _headerBox is
+                    // detached (ParentBox set null before this runs) so _tableBox's own recursion into
+                    // Boxes can't reach it - it keeps its own explicit OffsetTop call; captions, as
+                    // _tableBox's own DOM children, are already covered by that recursion.
+                    _tableBox.OffsetTop(pageBreakOffset);
                     _headerBox.OffsetTop(pageBreakOffset);
-                    foreach (var caption in _topCaptions) caption.OffsetTop(pageBreakOffset);
 
                     startY = Math.Max(_tableBox.ClientTop + _topCaptionsHeight + StartYSpacing(), 0);
                     // startY is a fresh restart point at the table's own content-top edge on the new


### PR DESCRIPTION
## Summary
Two independent residuals in named-page (`page: <name>`) registration:
- `CssLayoutEngineTable`'s whole-table relocation pre-checks now route through `CssBox.OffsetTop` instead of assigning `Location` directly, so the registration re-syncs before the row loop paginates against this table's own geometry rather than only afterward at the layout tail
- `CssLayoutEngine.FlowBox` no longer registers `page` for an inline box at all: per css-page-3 §7.2, `page` only applies to boxes that create class-A break points, which are block-level by definition. The prior registration was already spec-marginal and a real source of corruption across re-layout/resumed continuations

## Test plan
- [x] Existing table-relocation registration test still passes unchanged against the new mechanism
- [x] Updated/removed tests that pinned the old inline-registration behavior
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - full suite green
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` - 0 warnings

Fixes #149