### PR TITLE
Honor named-page reversion inside table rows and cells

### DIFF
--- a/.claude/accepted-gaps/named-page-reversion-outside-block-flow.md
+++ b/.claude/accepted-gaps/named-page-reversion-outside-block-flow.md
@@ -1,5 +1,27 @@
-# Named-page activation and reversion outside normal block flow
+# Named-page activation and reversion outside normal block flow (flex/multicol only)
 
-Named-page (`page: <name>`) activation and **reversion** are honored only for normal block-flow content. The used value of `page` is now tree-based (CSS Paged Media Level 3 §3) and reverts for content leaving a named subtree — fixed for the block-flow forced-break path in `CssBox.PerformLayoutImp` (issue #126), but *not* for children positioned independently by `CssLayoutEngineFlex`/`CssLayoutEngineTable`/`CssLayoutEngineColumns`, which don't route through that path (same engine-independence family as the CSS Fragmentation §5.2 margin-truncation gap, see [Margins adjoining an unforced break](margin-truncation-remaining-gaps.md)). A `page` change/reversion among flex items, table cells, or multicol children may not begin/revert on a fresh page. Filed as [issue #166](https://github.com/jhaygood86/PeachPDF/issues/166). See `NamedPageLayoutIntegrationTests`/`NamedPageGeometryAttributionTests` for the fixed block-flow behavior (used-value reversion, band restoration, margin-box suppression no longer leaking).
+Tracked as [issue #902](https://github.com/jhaygood86/PeachPDF/issues/902), narrowed from #166 (closed -
+the table case is fixed).
 
-**Confirmed to leak past the table's own subtree, not just within it** (found building the mixed-page-orientation showcase): a plain block sibling *after* a named-page section that merely *contains* a `<table>` (anywhere in its descendants, not the reverting box itself) also fails to revert — the table's own registration apparently isn't withdrawn when its containing section's content finishes, so the name stays active for whatever ordinary block-flow content comes next, even though that later content never touches the table engine itself. Reproduced with a single-cell table; unrelated to page-break placement, fixed-position content, or the number of block-level siblings inside the named section. Same tracked issue (#166) — this is the same underlying mechanism (the table engine's own registration bypassing the withdraw-on-exit path `CssBox.PerformLayoutImp`'s forced-break path already has), just a wider-reaching symptom of it than "content is still open." Until closed, avoid a `<table>` as the last piece of content in a named-page section that a later section needs to revert away from.
+Named-page (`page: <name>`) activation and **reversion** are honored only for normal block-flow content
+and, since issue #166's table fix, for table rows/cells too. The used value of `page` is tree-based (CSS
+Paged Media Level 3 §3) and reverts for content leaving a named subtree — fixed for the block-flow
+forced-break path in `CssBox.PerformLayoutImp` (issue #126) and for `CssLayoutEngineTable` (issue #166:
+`CssLayoutEngineTable.ForcedBreakFallsBeforeRow` now forces a break on a row's own used-name transition,
+and `LayoutBodyRow` now sets each row's `UsedPageName` from its own ancestor chain before any cell lays
+out — a `<tr>` is never itself given a `PerformLayoutPrologue` call the way an ordinary block box is, so
+without this a cell inheriting from its row's never-set `UsedPageName` registered a spurious reversion
+mid-table, corrupting `ActivePageName` for whatever ordinary content followed the table even when that
+content never touched the table engine at all) — but *not* for children positioned independently by
+`CssLayoutEngineFlex`/`CssLayoutEngineColumns`, which don't route through either fixed path (same
+engine-independence family as the CSS Fragmentation §5.2 margin-truncation gap, see
+[Margins adjoining an unforced break](margin-truncation-remaining-gaps.md)). A `page` change/reversion
+among flex items or multicol children may not begin/revert on a fresh page, and — mirroring the table
+symptom above before its fix — a flex/multicol container's own registration bypassing the correct
+inheritance/withdraw path could plausibly leak a name past its own subtree the same way. No equivalent
+per-child break hook exists in either engine at all yet (`CssLayoutEngineFlex`'s
+`RelocateLinesAcrossFragmentainers` only handles `break-inside`/monolithic content), so closing this
+needs new plumbing built from scratch in each, not a small extension of an existing hook the way the
+table fix was. See `NamedPageLayoutIntegrationTests`/`NamedPageGeometryAttributionTests` for the fixed
+block-flow and table behavior (used-value reversion, band restoration, margin-box suppression no longer
+leaking, mid-table name transitions, and reversion past a table's own subtree).

--- a/.claude/recent-fixes/2026-09-06-named-page-reversion-in-tables.md
+++ b/.claude/recent-fixes/2026-09-06-named-page-reversion-in-tables.md
@@ -1,0 +1,76 @@
+# Named-page reversion now honored inside tables (#166, table case)
+
+`CssLayoutEngineFlex`/`CssLayoutEngineTable`/`CssLayoutEngineColumns` position their children directly,
+bypassing the block-flow forced-break path (`CssBox.PerformLayoutImp`/`CommitBlockChildOffset`) that
+already honors a `page` name's used-value transition/reversion (issue #126). Closed for the table case;
+flex/multicol remain open under a narrower follow-up (see the rewritten accepted-gap file).
+
+## Load-bearing idea
+
+Two independent bugs, both inside `CssLayoutEngineTable`, needed fixing together - the first alone
+still left the second's symptom reproducible.
+
+**1. No break on a row's own name transition.** `ForcedBreakFallsBeforeRow` decided a page break only
+from `break-before`/`break-after` values. Extended it to also force a break when a row's *prospective*
+used page name differs from `HtmlContainerInt.ActivePageName` - the same `pageNameChanged` rule
+`CssBox.PerformLayoutImp`'s prologue already applies to ordinary block flow. Can't reuse
+`CssBox.UsedPageName` directly for this, though: it's not populated yet at the point this decision has
+to be made (only set inside a box's own `PerformLayoutPrologue`, which for a table row never runs before
+this - see bug 2). `ProspectiveUsedPageNameFor` recomputes the same css-page-3 §3 used-value rule by
+walking the row's own ancestor chain, grounded at `_tableBox.UsedPageName` (the table itself is an
+ordinary block-flow box whose prologue has already run by this point). Once the break is decided, the
+target slot's own geometry has to be resolvable immediately - mirroring block-flow's own "register the
+used name before any child lays out" rule - so `PreRegisterPageNameTransition` registers the row's name
+at the target slot's top *before* `TakeBreakBeforeRow` queries that slot's band height, setting
+`row.RegisteredNamedPageElement` so the row's own later tail-fallback registration re-syncs against it
+rather than duplicating it (exactly the pattern issue #149's table-relocation fix already established).
+
+**2. A `<tr>` never gets `PerformLayoutPrologue` called on it at all** - only its cells do
+(`LayoutBodyRow`'s own per-cell `cell.PerformLayout(g)` loop). `UsedPageName` therefore stays at
+`CssBox`'s compile-time default (empty string) on every row, forever, regardless of the table's own
+name. A cell then inherits from its row (`ParentBox?.UsedPageName`) exactly as the used-value rule says
+it should - correctly by that rule, but wrongly in outcome, since it inherits the row's *never-set* empty
+name instead of the table's real one. The cell's own prologue then computes a spurious
+`pageNameChanged` (`"" != "wide"`) and registers a bogus reversion **mid-table**, corrupting
+`ActivePageName` for whatever ordinary block-flow content came after the table - even content that never
+touches the table engine at all. This is the "leaks past the table's own subtree" symptom the accepted-gap
+doc had already isolated, and it reproduced independently of bug 1 (no row-level name transition needed
+to trigger it - a single, unnamed row inside a named section was enough). Fixed by setting
+`row.UsedPageName` from the same `ProspectiveUsedPageNameFor` walk at the top of `LayoutBodyRow`, before
+any cell lays out, for *every* row (not just ones a break decision touches) - since every cell needs a
+correct value to inherit from, not just cells on a transitioning row.
+
+## What running it (not just reading it) confirmed
+
+- A regression test for bug 1 alone (`NamedPageTransition_MidTable_ForcesABreakBetweenRows`) initially
+  failed on `PageBandHeightOf(1)` (expected the named page's own full-sheet band, got the base band) even
+  after the break-decision fix landed - the row DID move to the next slot, but that slot's geometry had
+  already been resolved (and, per `PageGeometryTable`'s own forward-incremental/lazy design, effectively
+  fixed) against the *previous* active name, because `TakeBreakBeforeRow`'s own `cursor.MoveToSlot` query
+  ran before anything registered the new name. Confirmed by toggling the pre-registration call via
+  `git stash` on just that one file: the test fails with exactly the wrong (previous-name) band height
+  without it, passes with it.
+- The subtree-leak fix (bug 2) was found by dumping every box's own `PageName`/`UsedPageName` after
+  layout for the failing fixture (a temporary scratch test, removed before landing) - `<tr>`'s
+  `UsedPageName` read as empty while `<table>`'s own correctly read the active name, immediately pointing
+  at the missing per-row assignment rather than at anything in the registration/withdrawal logic the
+  accepted-gap doc had originally guessed at ("the table engine's own registration bypassing the
+  withdraw-on-exit path").
+- Toggled bug 2's one-line fix (`row.UsedPageName = ProspectiveUsedPageNameFor(row);`) via a temporary
+  comment-out and rebuild: the subtree-leak regression test fails with exactly the pre-fix (leaked) band
+  height without it, passes with it - confirmed independently of bug 1's own fix.
+
+## Deliberately not done
+
+- Flex and multicol remain open (no equivalent per-child break hook exists in either engine to extend the
+  way `ForcedBreakFallsBeforeRow` already existed for tables) - narrowed into its own follow-up issue,
+  referenced from the rewritten `named-page-reversion-outside-block-flow.md`.
+
+## Evidence
+
+- New regression tests, each individually confirmed to fail pre-fix:
+  `NamedPageGeometryAttributionTests.NamedPageTransition_MidTable_ForcesABreakBetweenRows` (bug 1) and
+  `NamedPageGeometryAttributionTests.ReversionAfterNamedPage_TableInsideTheSection_StillReverts` (bug 2).
+- `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - full suite green (9897 passed, 9
+  pre-existing platform-gated skips).
+- `dotnet build PeachPDF.slnx -t:Rebuild` - 0 warnings.

--- a/src/PeachPDF.Tests/Integration/NamedPageGeometryAttributionTests.cs
+++ b/src/PeachPDF.Tests/Integration/NamedPageGeometryAttributionTests.cs
@@ -208,6 +208,75 @@ namespace PeachPDF.Tests.Integration
         }
 
         [Fact]
+        public async Task NamedPageTransition_MidTable_ForcesABreakBetweenRows()
+        {
+            // Issue #166: a table row's own used `page` name transition must force a break before it,
+            // exactly like an equivalent block-level sibling already does - CssLayoutEngineTable
+            // positions rows directly, bypassing the block-flow path that check normally lives on
+            // (CssBox.PerformLayoutImp's pageNameChanged). Before this fix, both rows landed on the
+            // same (default) page, and "wide"'s own margin:0 band never took effect for row two.
+            var container = await BuildLayoutAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { margin: 60pt 50pt; }
+                @page wide { margin: 0; }
+                body, table, tr, td { margin: 0; }
+                </style></head><body>
+                <table>
+                <tr id='r1'><td>row one</td></tr>
+                <tr id='r2' style='page: wide'><td>row two</td></tr>
+                </table>
+                </body></html>
+                """);
+
+            var r1 = FindById(container.Root!, "r1");
+            var r2 = FindById(container.Root!, "r2");
+            Assert.NotNull(r1);
+            Assert.NotNull(r2);
+
+            Assert.Equal(0, container.PageIndexOf(r1!.Location.Y + HtmlContainerInt.PageBoundaryEpsilon));
+            Assert.Equal(1, container.PageIndexOf(r2!.Location.Y + HtmlContainerInt.PageBoundaryEpsilon));
+            Assert.Equal(BaseBand, container.PageBandHeightOf(0));
+            Assert.Equal(SheetH, container.PageBandHeightOf(1));
+
+            var registered = Assert.Single(container.NamedPageElements, e => e.Name == "wide");
+            Assert.Equal(container.PageTopOf(1), registered.Y, 1);
+        }
+
+        [Fact]
+        public async Task ReversionAfterNamedPage_TableInsideTheSection_StillReverts()
+        {
+            // Issue #166's "leaks past the table's own subtree" symptom (see
+            // .claude/accepted-gaps/named-page-reversion-outside-block-flow.md): a plain block sibling
+            // AFTER a named-page section that merely CONTAINS a table anywhere in its descendants - not
+            // the reverting box itself - must still revert to the default page, exactly like
+            // ReversionAfterNamedPage_RestoresDefaultBand_DoesNotLeakMargins above (which uses a table-free
+            // section). Before the fix, the table's own registration wasn't withdrawn when its containing
+            // section's content finished, leaking "wide" onto whatever ordinary block-flow content came
+            // next even though that content never touches the table engine itself.
+            var container = await BuildLayoutAsync("""
+                <!DOCTYPE html><html><head><style>
+                @page { margin: 60pt 50pt; }
+                @page wide { margin: 0; }
+                body, table, tr, td, div { margin: 0; }
+                </style></head><body>
+                <div id='d1'>default one</div>
+                <div id='section' style='page: wide'>
+                <table><tr><td>single cell</td></tr></table>
+                </div>
+                <div id='after'>default again</div>
+                </body></html>
+                """);
+
+            var after = FindById(container.Root!, "after");
+            Assert.NotNull(after);
+
+            Assert.Equal(BaseBand, container.PageBandHeightOf(0));   // default page
+            Assert.Equal(SheetH, container.PageBandHeightOf(1));     // wide page (margin: 0)
+            Assert.Equal(BaseBand, container.PageBandHeightOf(2));   // reverted - base band restored
+            Assert.Equal(2, container.PageIndexOf(after!.Location.Y + HtmlContainerInt.PageBoundaryEpsilon));
+        }
+
+        [Fact]
         public async Task ReversionAfterNamedPage_RestoresDefaultMarginBox_DoesNotLeakSuppression()
         {
             // Second symptom from issue #126: a named page that suppresses a margin box

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
@@ -3387,6 +3387,17 @@ namespace PeachPDF.Html.Core.Dom
                     && (ForcedBreakFallsBeforeRow(i)
                         || WillCrossPageBoundary(container, cursor.CurrentY + estimatedRowHeight, availableHeight, slot, pageHeight)))
                 {
+                    // If this break is a used-name transition (issue #166), the row's own name must be
+                    // registered at the target slot's top BEFORE TakeBreakBeforeRow queries that slot's
+                    // geometry (cursor.MoveToSlot -> container.PageTopOf/PageBandHeightOf) - mirroring
+                    // the block-flow rule (CssBox.CommitBlockChildOffset's own remarks: "register the
+                    // used page name BEFORE any child lays out") that a named page's own band must be
+                    // resolvable from the moment anything asks about it. The row's own later
+                    // prologue/epilogue registration (PerformLayoutImp's tail, the only registration path
+                    // a table-engine-positioned row reaches) re-syncs against this rather than
+                    // duplicating it, exactly as it already does for CssLayoutEngineTable's whole-table
+                    // relocation pre-check (#149).
+                    PreRegisterPageNameTransition(container, row, slot + 1);
                     slot = await TakeBreakBeforeRow(g, container, cursor, slot);
                 }
 
@@ -4256,8 +4267,80 @@ namespace PeachPDF.Html.Core.Dom
             var before = BreakPropagation.AnchorForBreakBefore(_bodyRows[index]);
             var after = BreakPropagation.AnchorForBreakAfter(_bodyRows[index - 1]);
 
-            return BreakPropagation.ForcedBreakBeforeAt(before, FragmentationContext.Page) is not null
-                   || BreakPropagation.ForcedBreakAfterAt(after, FragmentationContext.Page) is not null;
+            if (BreakPropagation.ForcedBreakBeforeAt(before, FragmentationContext.Page) is not null
+                || BreakPropagation.ForcedBreakAfterAt(after, FragmentationContext.Page) is not null)
+            {
+                return true;
+            }
+
+            // Issue #166: a used `page` name transition forces a break here too, mirroring
+            // CssBox.PerformLayoutImp's own pageNameChanged check for ordinary block flow
+            // (css-page-3 §3's used-value transition rule). The table engine positions rows directly
+            // rather than through that block-flow path, so named-page activation/reversion among rows
+            // was previously silently ignored - a `page`-carrying row (or one reverting away from an
+            // outer one) never actually began a fresh page the way an equivalent block-level sibling
+            // would. Once this forces the break, the row's own (unmodified) PerformLayoutPrologue -
+            // which every row already goes through regardless of which engine positions it - registers
+            // its used name and updates HtmlContainer.ActivePageName exactly as it would for a plain
+            // block box; this only supplies the missing relocation decision, not a second registration
+            // mechanism.
+            if (_tableBox.HtmlContainer is { } container
+                && ProspectiveUsedPageNameFor(_bodyRows[index]) != container.ActivePageName)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// The `page` name row <paramref name="row"/> would use per css-page-3 §3's used-value rule
+        /// (its own explicit, non-"auto" <c>PageName</c>, or else the nearest ancestor's), computed
+        /// without relying on <c>CssBox.UsedPageName</c> - which for <paramref name="row"/> itself is
+        /// not populated yet at the point <see cref="ForcedBreakFallsBeforeRow"/> needs this (a row's
+        /// own prologue, where that property is set, only runs once <see cref="LayoutBodyRows"/> lays it
+        /// out - after this break decision). Grounds the walk at <see cref="_tableBox"/>'s own
+        /// <c>UsedPageName</c> rather than continuing through it, since the table itself is an ordinary
+        /// block-flow box whose prologue has already run by this point (unlike an intermediate row
+        /// group, e.g. a <c>&lt;tbody&gt;</c>, which - like a row - is positioned directly by this engine
+        /// and so cannot be relied on to have one either).
+        /// </summary>
+        private string ProspectiveUsedPageNameFor(CssBox row)
+        {
+            var candidate = row;
+            while (candidate != null && candidate != _tableBox)
+            {
+                if (!string.IsNullOrEmpty(candidate.PageName) && candidate.PageName != Keywords.Auto)
+                    return candidate.PageName;
+
+                candidate = candidate.ParentBox;
+            }
+
+            return _tableBox.UsedPageName;
+        }
+
+        /// <summary>
+        /// Registers <paramref name="row"/>'s prospective used page name at <paramref name="targetSlot"/>'s
+        /// own top, if it's actually a transition away from the currently active name - a no-op
+        /// otherwise (the break instead came from <c>WillCrossPageBoundary</c>'s own space estimate,
+        /// not a name change). Withdraws any earlier registration first, the same re-entry guard every
+        /// other registration site in this codebase uses. Setting <c>row.RegisteredNamedPageElement</c>
+        /// here (rather than only calling <c>RegisterNamedPageElement</c> and discarding the result)
+        /// is what makes the row's own later prologue/epilogue registration re-sync against this entry
+        /// instead of adding a second one - see <see cref="ForcedBreakFallsBeforeRow"/>'s own remarks
+        /// for why this needs to happen before the break is taken at all.
+        /// </summary>
+        private void PreRegisterPageNameTransition(HtmlContainerInt container, CssBox row, int targetSlot)
+        {
+            var prospectiveName = ProspectiveUsedPageNameFor(row);
+            if (prospectiveName == container.ActivePageName) return;
+
+            if (row.RegisteredNamedPageElement is { } stale)
+            {
+                container.UnregisterNamedPageElement(stale);
+            }
+
+            row.RegisteredNamedPageElement = container.RegisterNamedPageElement(prospectiveName, container.PageTopOf(targetSlot));
         }
 
         /// <summary>
@@ -4891,6 +4974,19 @@ namespace PeachPDF.Html.Core.Dom
         /// <param name="cursor">where the row loop has got to; read and advanced</param>
         private async ValueTask LayoutBodyRow(RGraphics g, CssBox row, double startX, TableRowCursor cursor)
         {
+            // Issue #166's "leaks past the table's own subtree" symptom: a <tr> is never itself given a
+            // PerformLayout/PerformLayoutPrologue call (only its cells are, in the loop below) - only
+            // this engine ever positions a row, so nothing else ever sets its UsedPageName either, and
+            // it stays at CssBox's own compile-time default (empty) forever. A cell then inherits from
+            // its row (ParentBox?.UsedPageName) exactly as PerformLayoutPrologue's own inheritance rule
+            // says it should, correctly per that rule but WRONGLY in outcome: it inherits the row's
+            // never-set empty name instead of the table's real one, computes a spurious pageNameChanged,
+            // and registers a bogus reversion mid-table - which is what corrupted ActivePageName for
+            // whatever ordinary block-flow content came after the table. Setting it here, from the same
+            // ancestor-chain walk ForcedBreakFallsBeforeRow's own break decision already uses, gives
+            // every cell the correct value to inherit before any of them lay out.
+            row.UsedPageName = ProspectiveUsedPageNameFor(row);
+
             var currentY = cursor.CurrentY;
             var rowIndex = cursor.RowIndex;
             var rowSpannedBoxes = cursor.RowSpannedBoxes;


### PR DESCRIPTION
## Summary
`CssLayoutEngineFlex`/`CssLayoutEngineTable`/`CssLayoutEngineColumns` position their children directly, bypassing the block-flow forced-break path that already honors a `page` name's used-value transition and reversion. Closes the gap for tables:

- `ForcedBreakFallsBeforeRow` now also forces a break when a row's own used page name differs from the currently active one, mirroring the block-flow `pageNameChanged` rule. The target slot's geometry is pre-registered before it's queried, so the new page's own band takes effect immediately rather than one pass late.
- A `<tr>` is never itself given a layout-prologue call (only its cells are), so its `UsedPageName` silently stayed at its unset default forever, and a cell inheriting from it computed a spurious reversion mid-table - corrupting the active page name for whatever ordinary content followed, even content that never touched a table. Each row now gets its own correct used name before any cell lays out.

Flex and multicol remain open, narrowed to #902.

## Test plan
- [x] New regression tests for both fixes, each individually confirmed to fail pre-fix and pass post-fix
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - full suite green
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` - 0 warnings

Fixes #166