### PR TITLE
Document the :left/:right page-geometry-vs-numbering gap precisely

### DIFF
--- a/.claude/accepted-gaps/left-right-page-geometry-vs-materialized-numbering.md
+++ b/.claude/accepted-gaps/left-right-page-geometry-vs-materialized-numbering.md
@@ -1,0 +1,22 @@
+# A `:left`/`:right` page's own geometry can be numbered differently than its materialized content
+
+`PageGeometryTable.Compute` resolves each pagination slot's own margins/sheet size (what a `:left`/
+`:right` gutter-margin `@page` rule shapes) from the raw, un-skipped grid slot index (`pageIndex + 1`),
+built forward-incrementally as layout proceeds. Content-emptiness — and so the final *materialized* page
+number a reader actually sees — is only known later, at `FragmentEmitter.Finish` (see
+[Content-empty page slots are not materialized](content-empty-page-slots.md), a related but distinct
+mechanism: that gap is about *whether* a slot is skipped at all, this one is about a *kept* slot's own
+geometry disagreeing with its final page number). The paint-side margin-box **content**/page-style
+selection (`PdfGenerator.cs`'s page loop, `HtmlContainerInt.LayoutMarginBoxes`) already uses the
+materialized number correctly via `PageRuleResolver.SelectApplicableMarginRules`/
+`SelectApplicablePageStyle` — only the earlier-resolved **geometry** can disagree with it. So once a
+content-empty page has been skipped somewhere earlier in the document, a later kept page can render
+`:right` margin-box content (correctly materialized-numbered) inside margins that were actually sized by
+the `:left` rule (grid-numbered), or vice versa.
+
+Reconciling this would need either a second geometry pass once emptiness is fully known (expensive, and
+risks its own convergence questions — see
+[A named-page run spanning several physical pages has a convergence loop that is bounded, not guaranteed](named-page-run-convergence-loop-is-bounded-not-guaranteed.md))
+or continuing to accept the gap. Narrow in practice: needs both a multi-page content-empty gap *and* a
+parity-dependent (`:left`/`:right`) margin override in the same document. Tracked as
+[issue #148](https://github.com/jhaygood86/PeachPDF/issues/148).


### PR DESCRIPTION
## Summary
Records the exact root cause found while investigating #148: page geometry resolves against the raw grid slot index while materialized page numbering (which the paint-side margin-box selection already uses correctly) is only known after content-empty slots are skipped. No code change - narrow, forward-vs-final numbering ordering problem that would need a second geometry pass to close.

## Test plan
- [x] Docs-only change, no production code touched
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - full suite green