### PR TITLE
Resolve hoisted stacking participant overflow clips from the fragment tree

### DIFF
--- a/.claude/recent-fixes/2026-09-06-hoisted-stacking-participant-overflow-clip-from-fragment-not-live-box.md
+++ b/.claude/recent-fixes/2026-09-06-hoisted-stacking-participant-overflow-clip-from-fragment-not-live-box.md
@@ -1,0 +1,73 @@
+# A hoisted stacking participant's ancestor overflow clip now comes from the fragment tree, not the live box tree
+
+Closes #345.
+
+## What was wrong
+
+`RenderUtils.PushAncestorOverflowClips` re-applies an `overflow: hidden` ancestor's clip when painting a
+box that `StackingOrder.Flatten` hoisted past one or more plain ancestors for stacking-context z-order
+purposes (it paints via the claiming stacking context's own paint loop, bypassing those ancestors' own
+nested paint calls, so their clipping never gets picked up "for free"). It resolved each ancestor's clip
+rectangle from the ancestor's *live* `CssBox.Bounds`, offset by the participant's own fragment's `OriginY`.
+That's wrong for an ancestor shown at more than one place in the document — a hoisted participant inside a
+repeated table `<thead>`/`<tfoot>`, whose shared source subtree's live boxes carry only whichever page
+positioned them last, exactly the class of bug `FragmentEmitter.OverflowClipOf`/`ClipOf` already fixed for
+the *nearest*-ancestor case (#325).
+
+## The fix
+
+`StackingOrder.SearchForHoistableDescendants` already walks the *fragment* tree (`fragment.Children`) and
+has the right `childFragment` in hand at the exact point it recorded `childBox` into `ancestorPath` — it
+was discarding the fragment and keeping only the live box. Changed `StackingParticipant.ClipAncestors` and
+`ancestorPath` from `IReadOnlyList<CssBox>`/`List<CssBox>` to `IReadOnlyList<BoxFragment>`/`List<BoxFragment>`,
+storing `childFragment` instead. `RenderUtils.TryPushOverflowClip`/`PushAncestorOverflowClips` now read the
+clip rectangle from `ancestor.Rect` (already fragmentainer-local, since both the participant's own fragment
+and its ancestor fragments come from the same page's fragment tree) instead of `overflowBox.Bounds`, which
+also removes the need for the `originY` translation parameter entirely — there was nothing to map, the two
+were already in the same coordinate space once both come from fragments. Style-only facts (`Overflow.Value`,
+border widths, `IsRounded`, `ComputeInnerRadii`) still read off `ancestor.Box` live, mirroring how
+`FragmentEmitter.OverflowClipOf` already separates position facts (fragment) from style facts (box).
+
+## What was found by running it, not by reading it
+
+Building a natural end-to-end repro (a stacking-hoisted participant — `position:relative;z-index` or
+`opacity<1` — inside a repeated table header, clipped by an `overflow:hidden` ancestor) turned up a
+separate, pre-existing, more severe bug that made the scenario unreachable: `HtmlContainerInt.ComputeFlowFlags`
+computes the document-wide `HasStackingHoistCandidates` flag by walking `box.Boxes` from `Root`, but
+`CssProxyBox` (the per-page stand-in for a repeated `<thead>`/`<tfoot>`) doesn't expose its `SourceBox`'s
+children through `.Boxes` — so a stacking context that exists *only* inside a repeated header/footer's
+detached subtree is invisible to that scan, `HasStackingHoistCandidates` comes out false, and
+`StackingOrder.Flatten` (which gates its entire hoisting search on that one boolean) never finds or paints
+the box at all, anywhere in the document. This is strictly worse than a mis-resolved clip and is *why* #345
+itself was "exotic enough that no fixture in the suite reaches it" — the fix here is correct and verified
+independently of that bug (see Evidence below), but the natural integration-level repro is blocked on it.
+Flagged as a separate follow-up rather than folded into this change, since it's a different mechanism
+(`ComputeFlowFlags`/candidate detection, not clip resolution) and unrelated to what this fix touches.
+
+## What was deliberately not done
+
+No new geometry/build-time snapshot machinery was added — unlike `OverflowClipOf` (which resolves an
+arbitrary-distance containing-block-chain ancestor at *build* time via a `BoxGeometrySnapshot`, because that
+ancestor isn't necessarily reachable as an already-materialized fragment when the builder runs),
+`SearchForHoistableDescendants` already walks a fully-materialized per-page fragment tree at *paint* time,
+so the exact ancestor fragment for this page's own pass is already in hand — no snapshot, no build-time
+bookkeeping, just stop discarding what was already there.
+
+## Evidence
+
+- `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0`: 9900 passed, 0 failed, 9 skipped
+  (pre-existing platform-gated skips, unrelated).
+- `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings, 0 errors.
+- Diff coverage (`diff-cover` against `main`): 100% on the three changed production files.
+- New tests in `src/PeachPDF.Tests/Html/Core/Utils/PushAncestorOverflowClipsTests.cs`:
+  - `PushesClip_FromAncestorsOwnFragmentRect_NotFromItsLiveBoxBounds` — proves `TryPushOverflowClip` reads
+    the ancestor's fragment rect, not its live bounds, by handing it a fragment whose `Rect` deliberately
+    disagrees with the live box's current position.
+  - `Flatten_SameAncestorBoxShownAtDifferentFragmentRects_CapturesEachTreesOwnInstance` — proves
+    `StackingOrder.Flatten`/`SearchForHoistableDescendants` itself (not just `RenderUtils` in isolation)
+    captures each fragment tree's own ancestor instance when the same live `CssBox` stands in for two
+    different fragment-tree positions, the actual repeated-header shape.
+  - `PushesNoClip_WhenAncestorIsNotOverflowHidden` — the early-return path still holds under the new
+    `BoxFragment` parameter type.
+  - All three fail to compile against the pre-fix signature (`PushAncestorOverflowClips(RGraphics,
+    IReadOnlyList<CssBox>, double)`), confirming the API change is load-bearing for what they test.

--- a/src/PeachPDF.Tests/Html/Core/Utils/PushAncestorOverflowClipsTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Utils/PushAncestorOverflowClipsTests.cs
@@ -1,0 +1,112 @@
+using PeachPDF.Html.Adapters.Entities;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Fragments;
+using PeachPDF.Html.Core.Paint;
+using PeachPDF.Html.Core.Utils;
+using PeachPDF.Tests.TestSupport;
+using System.Linq;
+using System.Threading.Tasks;
+using static PeachPDF.Tests.TestSupport.TestRecordingGraphics;
+
+namespace PeachPDF.Tests.Html.Core.Utils
+{
+    using DomUtils = PeachPDF.Html.Core.Utils.DomUtils;
+
+    /// <summary>
+    /// <see cref="RenderUtils.PushAncestorOverflowClips"/> re-applies an ancestor's <c>overflow: hidden</c>
+    /// clip for a stacking-hoisted participant, which paints outside that ancestor's own nested paint
+    /// call. The ancestor can be shown at more than one place in the document (a hoisted participant
+    /// inside a repeated table header), so its live <see cref="Dom.CssBox"/> geometry only ever reflects
+    /// whichever place last positioned it — the clip has to come from the ancestor's own fragment for the
+    /// page being painted instead (#345).
+    /// </summary>
+    public class PushAncestorOverflowClipsTests
+    {
+        [Fact]
+        public async Task PushesClip_FromAncestorsOwnFragmentRect_NotFromItsLiveBoxBounds()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='h' style='overflow:hidden;width:50pt;height:20pt'>" +
+                "<div id='hoisted' style='position:relative;z-index:0'><span>TEXT</span></div></div>"));
+
+            var hBox = DomUtils.GetBoxById(root, "h")!;
+            var liveBounds = hBox.Bounds;
+
+            // Simulate the repeated-header shape: an ancestor whose fragment on the page being painted
+            // sits somewhere quite different from wherever its live box happens to be positioned right
+            // now (e.g. a shared source subtree a later page's layout pass has since moved on).
+            var movedRect = hBox.Bounds;
+            movedRect.Offset(0, 1000);
+            var movedAncestor = FragmentPaintHarness.FragmentOf(container, hBox) with { Rect = movedRect };
+
+            var recording = new TestRecordingGraphics();
+            RenderUtils.PushAncestorOverflowClips(recording, [movedAncestor]);
+
+            var pushed = Assert.Single(recording.Log.OfType<PushClipCall>());
+            var expected = RenderUtils.PaddingEdgeOf(hBox, movedRect);
+
+            Assert.Equal(expected.Top, pushed.Rect.Top, 3);
+            Assert.Equal(expected.Left, pushed.Rect.Left, 3);
+
+            // Sanity: the fragment we passed really does disagree with the live box, so this actually
+            // exercises the fragment-vs-live-box distinction rather than the two happening to coincide.
+            Assert.NotEqual(liveBounds.Top, movedRect.Top);
+        }
+
+        [Fact]
+        public async Task PushesNoClip_WhenAncestorIsNotOverflowHidden()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='plain' style='width:50pt;height:20pt'>" +
+                "<div id='hoisted' style='position:relative;z-index:0'><span>TEXT</span></div></div>"));
+
+            var plainBox = DomUtils.GetBoxById(root, "plain")!;
+            var ancestor = FragmentPaintHarness.FragmentOf(container, plainBox);
+
+            var recording = new TestRecordingGraphics();
+            var pushed = RenderUtils.PushAncestorOverflowClips(recording, [ancestor]);
+
+            Assert.Equal(0, pushed);
+            Assert.Empty(recording.Log.OfType<PushClipCall>());
+        }
+
+        [Fact]
+        public async Task Flatten_SameAncestorBoxShownAtDifferentFragmentRects_CapturesEachTreesOwnInstance()
+        {
+            // The same live CssBox standing in for two different pages' own fragment of it — exactly
+            // the shape a repeated table header's shared source subtree produces. StackingOrder's own
+            // discovery walk (SearchForHoistableDescendants), not just RenderUtils in isolation, must
+            // record each tree's own ancestor fragment rather than always the same one.
+            var (root, container) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<div id='h' style='overflow:hidden;width:50pt;height:20pt'>" +
+                "<div id='hoisted' style='position:relative;z-index:0'><span>TEXT</span></div></div>"));
+
+            var hBox = DomUtils.GetBoxById(root, "h")!;
+            var rootFragmentA = FragmentPaintHarness.FragmentOf(container, root);
+
+            var movedRect = FragmentPaintHarness.FragmentOf(container, hBox).Rect;
+            movedRect.Offset(0, 1000);
+            var rootFragmentB = WithReplacedRect(rootFragmentA, hBox, movedRect);
+
+            var hoistedBox = DomUtils.GetBoxById(root, "hoisted")!;
+            var participantA = StackingOrder.Flatten(rootFragmentA).Single(p => p.Box == hoistedBox);
+            var participantB = StackingOrder.Flatten(rootFragmentB).Single(p => p.Box == hoistedBox);
+
+            var ancestorA = participantA.ClipAncestors.Single(a => a.Box == hBox);
+            var ancestorB = participantB.ClipAncestors.Single(a => a.Box == hBox);
+
+            Assert.NotEqual(ancestorA.Rect.Top, ancestorB.Rect.Top);
+            Assert.Equal(movedRect.Top, ancestorB.Rect.Top, 3);
+        }
+
+        private static BoxFragment WithReplacedRect(BoxFragment fragment, CssBox target, RRect newRect) =>
+            ReferenceEquals(fragment.Box, target)
+                ? fragment with { Rect = newRect }
+                : fragment with
+                {
+                    Children = fragment.Children
+                        .Select(child => WithReplacedRect(child, target, newRect))
+                        .ToList()
+                };
+    }
+}

--- a/src/PeachPDF/Html/Core/Paint/FragmentPainter.cs
+++ b/src/PeachPDF/Html/Core/Paint/FragmentPainter.cs
@@ -612,7 +612,7 @@ namespace PeachPDF.Html.Core.Paint
         private void PaintStackingParticipant(RGraphics g, StackingOrder.StackingParticipant participant)
         {
             var fragment = participant.Fragment;
-            var pushedClips = RenderUtils.PushAncestorOverflowClips(g, participant.ClipAncestors, fragment.OriginY);
+            var pushedClips = RenderUtils.PushAncestorOverflowClips(g, participant.ClipAncestors);
 
             PaintFragment(g, fragment);
 

--- a/src/PeachPDF/Html/Core/Paint/StackingOrder.cs
+++ b/src/PeachPDF/Html/Core/Paint/StackingOrder.cs
@@ -22,15 +22,18 @@ namespace PeachPDF.Html.Core.Paint
     /// </remarks>
     internal static class StackingOrder
     {
-        // One box to paint as part of a stacking context's own layer ordering, plus the chain of DOM
-        // ancestor boxes (outer to inner, between the claiming stacking context and Box itself) that
-        // Box was hoisted past. Empty for a direct plain child - it paints via ordinary nested
+        // One box to paint as part of a stacking context's own layer ordering, plus the chain of
+        // ancestor fragments (outer to inner, between the claiming stacking context and Box itself)
+        // that Box was hoisted past. Empty for a direct plain child - it paints via ordinary nested
         // recursion, so its ancestors' own overflow clipping is already correctly active on the
         // graphics clip stack from their own (still-running) paint calls. Non-empty for a hoisted
         // participant - it paints via the claiming stacking context's own paint loop instead, bypassing
         // those ancestors' paint calls entirely, so their overflow clipping must be reapplied
-        // explicitly (see RenderUtils.PushAncestorOverflowClips) around its own paint call.
-        internal readonly record struct StackingParticipant(BoxFragment Fragment, IReadOnlyList<CssBox> ClipAncestors)
+        // explicitly (see RenderUtils.PushAncestorOverflowClips) around its own paint call. Carrying
+        // the ancestors' own fragments, rather than their live boxes, is what makes this correct for a
+        // box shown at more than one place at once - a hoisted participant inside a repeated table
+        // header - since a live CssBox only ever carries whichever page positioned it last (#345).
+        internal readonly record struct StackingParticipant(BoxFragment Fragment, IReadOnlyList<BoxFragment> ClipAncestors)
         {
             /// <summary>The box whose style and stacking role decide where this participant paints.</summary>
             internal CssBox Box => Fragment.Box;
@@ -132,15 +135,16 @@ namespace PeachPDF.Html.Core.Paint
         //   outer search claiming them too, which would both double-paint them and order them relative
         //   to the wrong (too-distant) box's siblings.
         //
-        // `ancestorPath` accumulates every DOM ancestor walked through along the way (both plain
-        // pass-through wrappers and hoisted-but-not-yet-fully-resolved boxes like a merely-positioned
-        // box) - each yielded participant snapshots it as its ClipAncestors, so the caller can re-apply
-        // those ancestors' own overflow clipping (which it never picks up naturally, having been hoisted
-        // past their own paint calls). Mutating one shared list via add-before-recurse/remove-after is
-        // safe here: the whole sequence is drained eagerly and synchronously by Flatten's caller before
-        // anything else touches it.
+        // `ancestorPath` accumulates the fragment of every ancestor walked through along the way (both
+        // plain pass-through wrappers and hoisted-but-not-yet-fully-resolved boxes like a
+        // merely-positioned box) - each yielded participant snapshots it as its ClipAncestors, so the
+        // caller can re-apply those ancestors' own overflow clipping (which it never picks up
+        // naturally, having been hoisted past their own paint calls) resolved against the exact
+        // instance of each ancestor this walk actually went through, not just its live box. Mutating
+        // one shared list via add-before-recurse/remove-after is safe here: the whole sequence is
+        // drained eagerly and synchronously by Flatten's caller before anything else touches it.
         private static IEnumerable<StackingParticipant> SearchForHoistableDescendants(
-            BoxFragment fragment, List<CssBox> ancestorPath, bool claimFloatsHere = true)
+            BoxFragment fragment, List<BoxFragment> ancestorPath, bool claimFloatsHere = true)
         {
             foreach (var childFragment in fragment.Children)
             {
@@ -163,7 +167,7 @@ namespace PeachPDF.Html.Core.Paint
                 // only genuine stacking contexts still need to keep escaping past it.
                 var claimBeyond = !isLocalOrderingScope && claimFloatsHere;
 
-                ancestorPath.Add(childBox);
+                ancestorPath.Add(childFragment);
                 foreach (var descendant in SearchForHoistableDescendants(childFragment, ancestorPath, claimBeyond))
                 {
                     yield return descendant;

--- a/src/PeachPDF/Html/Core/Utils/RenderUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/RenderUtils.cs
@@ -66,33 +66,34 @@ namespace PeachPDF.Html.Core.Utils
         }
 
         /// <summary>
-        /// Pushes <paramref name="overflowBox"/>'s own clip (padding-edge rect, per CSS spec, plus its
-        /// rounded-corner curve if it has a <c>border-radius</c>) if it has <c>overflow: hidden</c>,
-        /// mapped into the coordinate space of the fragment being painted by subtracting its
-        /// <paramref name="originY"/> (zero for a fixed fragment, which does not move with the page).
+        /// Pushes <paramref name="ancestor"/>'s own clip (padding-edge rect, per CSS spec, plus its
+        /// rounded-corner curve if it has a <c>border-radius</c>) if it has <c>overflow: hidden</c>.
+        /// Resolved from the ancestor's own fragment rectangle - already in the fragment-local space of
+        /// the participant being painted, since both come from the same page's fragment tree - rather
+        /// than the live box's <see cref="CssBox.Bounds"/>, so this is correct for a box shown at more
+        /// than one place at once (a hoisted participant inside a repeated table header), where the
+        /// live box only ever carries whichever page positioned it last.
         /// </summary>
         /// <returns>the number of clips actually pushed (callers must pop exactly this many afterward)</returns>
-        private static int TryPushOverflowClip(RGraphics g, CssBox overflowBox, double originY)
+        private static int TryPushOverflowClip(RGraphics g, BoxFragment ancestor)
         {
+            var overflowBox = ancestor.Box;
             if (overflowBox.Overflow.Value != Overflow.Hidden) return 0;
 
             var prevClip = g.GetClip();
-            var paddingRect = PaddingEdgeOf(overflowBox, overflowBox.Bounds);
+            var paddingRect = PaddingEdgeOf(overflowBox, ancestor.Rect);
 
             var rect = paddingRect;
-            rect.Offset(0, -originY);
             rect.Intersect(prevClip);
             g.PushClip(rect);
             var pushed = 1;
 
             if (overflowBox.IsRounded)
             {
-                var curveRect = paddingRect;
-                curveRect.Offset(0, -originY);
-                var radii = overflowBox.ComputeInnerRadii(overflowBox.Bounds, paddingRect,
+                var radii = overflowBox.ComputeInnerRadii(ancestor.Rect, paddingRect,
                     overflowBox.ActualBorderLeftWidth, overflowBox.ActualBorderTopWidth,
                     overflowBox.ActualBorderRightWidth, overflowBox.ActualBorderBottomWidth);
-                pushed += PushRoundedClipIfRounded(g, curveRect, radii);
+                pushed += PushRoundedClipIfRounded(g, paddingRect, radii);
             }
 
             return pushed;
@@ -134,30 +135,27 @@ namespace PeachPDF.Html.Core.Utils
             borderBox.Bottom - box.ActualBorderBottomWidth);
 
         /// <summary>
-        /// Pushes the <c>overflow: hidden</c> clip of every box in <paramref name="ancestors"/> that has
-        /// one, in order. Used when painting a box that <see cref="Paint.StackingOrder.Flatten"/>
+        /// Pushes the <c>overflow: hidden</c> clip of every fragment in <paramref name="ancestors"/> that
+        /// has one, in order. Used when painting a box that <see cref="Paint.StackingOrder.Flatten"/>
         /// hoisted past one or more plain ancestor boxes for stacking-context z-order purposes - since it
         /// paints via the claiming stacking context's own paint loop rather than those ancestors' own
         /// (nested) paint calls, their overflow clipping isn't already active on the graphics
         /// clip stack the way it would be for normally-painted content, and must be applied explicitly
-        /// here instead. <paramref name="ancestors"/> is the exact, already-known chain of DOM ancestors
-        /// between the claiming stacking context and the box being painted (see
+        /// here instead. <paramref name="ancestors"/> is the exact, already-known chain of ancestor
+        /// fragments between the claiming stacking context and the box being painted (see
         /// <see cref="Paint.StackingOrder.StackingParticipant"/>), so no walk is needed; each ancestor is
-        /// checked directly.
+        /// checked directly. Each ancestor's rectangle comes from its own fragment rather than its live
+        /// box, so this is correct even for a box shown at more than one place at once - a hoisted
+        /// participant inside a repeated table header - whose live box only ever carries whichever page
+        /// positioned it last (#345).
         /// </summary>
-        /// <remarks>
-        /// This one still reads the live boxes, because the chain is discovered during the paint walk
-        /// and so is not available to the builder. That is only wrong for a box shown at several places
-        /// at once — a hoisted stacking participant inside a repeated table header — which is exotic
-        /// enough that no fixture in the suite reaches it.
-        /// </remarks>
         /// <returns>the number of clips actually pushed (callers must pop exactly this many afterward)</returns>
-        public static int PushAncestorOverflowClips(RGraphics g, IReadOnlyList<CssBox> ancestors, double originY)
+        public static int PushAncestorOverflowClips(RGraphics g, IReadOnlyList<BoxFragment> ancestors)
         {
             var pushed = 0;
             foreach (var ancestor in ancestors)
             {
-                pushed += TryPushOverflowClip(g, ancestor, originY);
+                pushed += TryPushOverflowClip(g, ancestor);
             }
             return pushed;
         }


### PR DESCRIPTION
## Summary
- `RenderUtils.PushAncestorOverflowClips` re-applies an `overflow: hidden` ancestor's clip when painting a stacking-hoisted participant (a box `StackingOrder.Flatten` hoisted past plain ancestors for z-order purposes, bypassing their own nested paint calls). It resolved each ancestor's clip rectangle from the ancestor's *live* `CssBox.Bounds`, which only reflects whichever page positioned it last for a box shown at more than one place at once — a hoisted participant inside a repeated table `<thead>`/`<tfoot>`.
- `StackingOrder.SearchForHoistableDescendants` already walks the fragment tree and has the correct per-ancestor `BoxFragment` in hand at the point it built `ancestorPath` — it was discarding the fragment in favor of the live box. This threads `BoxFragment` through `StackingParticipant.ClipAncestors` and `RenderUtils.TryPushOverflowClip`/`PushAncestorOverflowClips` instead, resolving the clip rectangle from the ancestor's own fragment (already fragmentainer-local), which also removes the need for the `originY` translation parameter entirely.
- Style-only facts (`Overflow.Value`, border widths, `IsRounded`, radii) still read off the live `CssBox`, mirroring the existing `FragmentEmitter.OverflowClipOf` pattern of separating position facts (fragment) from style facts (box).

Fixes #345

## Test plan
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 9900 passed, 0 failed
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings, 0 errors
- [x] Diff coverage against `main` (`diff-cover`) — 100% on the three changed production files
- [x] New tests in `PushAncestorOverflowClipsTests.cs` prove `TryPushOverflowClip` reads the ancestor's fragment rect (not live bounds), and that `StackingOrder.Flatten`/`SearchForHoistableDescendants` itself captures each fragment tree's own ancestor instance when the same live box stands in for two different fragment-tree positions (the actual repeated-header shape)
- [x] Post-change review pass (correctness, cleanup, altitude, CLAUDE.md conventions) — one test-coverage gap found and fixed before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)