### PR TITLE
Cache parsed inline style="" rules by attribute text

### DIFF
--- a/src/PeachPDF.Tests/Html/Core/Parse/CssValueParserGetOrParseInlineStyleRuleTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Parse/CssValueParserGetOrParseInlineStyleRuleTests.cs
@@ -1,0 +1,50 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core.Parse;
+
+namespace PeachPDF.Tests.Html.Core.Parse
+{
+    /// <summary>
+    /// Direct unit tests for <see cref="CssValueParser.GetOrParseInlineStyleRule"/> (issue #912):
+    /// machine-generated markup often repeats the exact same <c>style="..."</c> attribute text across
+    /// many elements, so the parsed rule is cached by that text instead of being re-tokenized per box.
+    /// </summary>
+    public class CssValueParserGetOrParseInlineStyleRuleTests
+    {
+        [Fact]
+        public void SameAttributeText_ReturnsCachedInstance()
+        {
+            var parser = new CssValueParser(new PdfSharpAdapter());
+
+            var first = parser.GetOrParseInlineStyleRule("color: red; font-size: 12pt");
+            var second = parser.GetOrParseInlineStyleRule("color: red; font-size: 12pt");
+
+            Assert.Same(first, second);
+        }
+
+        [Fact]
+        public void DifferentAttributeText_ReturnsDistinctInstancesWithCorrectDeclarations()
+        {
+            var parser = new CssValueParser(new PdfSharpAdapter());
+
+            var red = parser.GetOrParseInlineStyleRule("color: red");
+            var blue = parser.GetOrParseInlineStyleRule("color: blue");
+
+            Assert.NotSame(red, blue);
+            Assert.Equal("rgb(255, 0, 0)", red.Style.GetPropertyValue("color"));
+            Assert.Equal("rgb(0, 0, 255)", blue.Style.GetPropertyValue("color"));
+        }
+
+        [Fact]
+        public void SeparateParserInstances_DoNotShareCache()
+        {
+            var first = new CssValueParser(new PdfSharpAdapter());
+            var second = new CssValueParser(new PdfSharpAdapter());
+
+            var firstRule = first.GetOrParseInlineStyleRule("color: red");
+            var secondRule = second.GetOrParseInlineStyleRule("color: red");
+
+            Assert.NotSame(firstRule, secondRule);
+            Assert.Equal("rgb(255, 0, 0)", secondRule.Style.GetPropertyValue("color"));
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Parse/CssValueParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/CssValueParser.cs
@@ -35,9 +35,15 @@ namespace PeachPDF.Html.Core.Parse
         #region Fields and Consts
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         private readonly RAdapter _adapter;
+
+        /// <summary>
+        /// Caches parsed inline <c>style=""</c> rules by their raw attribute text, since machine-generated
+        /// markup often repeats the same attribute text across many elements.
+        /// </summary>
+        private readonly Dictionary<string, StyleRule> _inlineStyleRuleCache = new();
 
         #endregion
 
@@ -50,6 +56,23 @@ namespace PeachPDF.Html.Core.Parse
             ArgumentNullException.ThrowIfNull(adapter, "global");
 
             _adapter = adapter;
+        }
+
+        /// <summary>
+        /// Get the parsed <see cref="StyleRule"/> for an inline <c>style=""</c> attribute's text, parsing
+        /// and caching it on first use so identical attribute text across boxes is only parsed once.
+        /// </summary>
+        internal StyleRule GetOrParseInlineStyleRule(string styleAttributeText)
+        {
+            if (_inlineStyleRuleCache.TryGetValue(styleAttributeText, out var cached))
+            {
+                return cached;
+            }
+
+            var rule = new StyleRule(StylesheetParser.Default);
+            StylesheetParser.Default.AppendDeclarations(rule.Style, styleAttributeText);
+            _inlineStyleRuleCache[styleAttributeText] = rule;
+            return rule;
         }
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -723,9 +723,10 @@ namespace PeachPDF.Html.Core.Parse
             if (box.HtmlTag != null && box.HtmlTag.HasAttribute("style"))
             {
                 var styleAttributeText = box.HtmlTag.TryGetAttribute("style")!;
-                var rule = new StyleRule(StylesheetParser.Default);
-                StylesheetParser.Default.AppendDeclarations(rule.Style, styleAttributeText);
-                inlineRule = rule;
+                // Machine-generated markup often repeats the same style="..." text across many
+                // elements (e.g. every cell in a table), so the parsed rule is cached by its raw
+                // attribute text on valueParser rather than re-tokenized per box.
+                inlineRule = valueParser.GetOrParseInlineStyleRule(styleAttributeText);
             }
 
             // The relatively expensive property/custom-property snapshots below are only ever read


### PR DESCRIPTION
## Summary

- `DomParser.CascadeApplyStyles` re-parsed a box's `style=""` attribute text into a fresh `StyleRule` on every visit, even when many boxes share the exact same attribute text (e.g. machine-generated table markup repeating the same inline style on every row).
- The parsed rule is only ever read afterward (`AssignCssBlock`/`RulesUseRevertKeyword` just `foreach` over it), so it's safe to memoize the built `StyleRule` by its raw attribute text.
- Added `CssValueParser.GetOrParseInlineStyleRule(string)`, backed by an instance-level `Dictionary<string, StyleRule>`, since `CssValueParser` already flows through the whole cascade and is constructed fresh per cascade pass — matching the scope/lifetime the issue proposed.

## Test plan

- [x] Added `CssValueParserGetOrParseInlineStyleRuleTests.cs`: identical attribute text returns the cached (same) `StyleRule` instance, different text produces distinct correctly-parsed rules, and separate `CssValueParser` instances don't share caches.
- [x] Full `PeachPDF.Tests` suite (`dotnet test --framework net8.0`): 9900 passed, 9 skipped (pre-existing platform-specific skips), 0 failed.
- [x] `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings, 0 errors.
- [x] Diff coverage vs `main`: 100%.

Fixes #912