### PR TITLE
Fix resumed-pass residuals in CssLayoutEngine.FlowBox

### DIFF
--- a/.claude/recent-fixes/2026-09-07-resumed-pass-residuals-in-csslayoutengine.md
+++ b/.claude/recent-fixes/2026-09-07-resumed-pass-residuals-in-csslayoutengine.md
@@ -1,0 +1,92 @@
+# Resumed-pass residuals in CssLayoutEngine.FlowBox (#341, #342, #343)
+
+Closes #341, #342, #343. (#340 investigated and closed separately as already-resolved — see below.)
+
+## What was wrong
+
+Three residuals left by earlier fixes (#336 and predecessors) to `CssLayoutEngine.FlowBox`'s
+one-pass-per-fragmentainer, resumable inline layout:
+
+1. **#341** — `PrepareFlowBoxEntry` calls `CssNamedStringEngine.ApplyStringSet(box)` for a `string-set`
+   box, which seeds `NamedString.Y` from `box.Location.Y` — meaningless for a plain inline box (only its
+   words are ever positioned, never the box itself). `FinalizeFlowBoxExit`'s own later correction is
+   gated on `opensHere`, but a box whose own content straddles a fragmentainer boundary never reaches
+   `FinalizeFlowBoxExit` at all on the pass that opens it: `FlowBox`'s recursive call returns as soon as
+   `coordinates.Break` is set, before its own exit bookkeeping runs — and on the pass that finally
+   completes the box, `opensHere` is false (it already opened earlier), so that gate never fires either.
+   The value was left at the meaningless seed forever, corrupting `MarginBoxRenderer.ResolveNamedString`'s
+   page attribution for `string(name, first/start/...)`.
+2. **#342** — `BubbleRectangles` compensated for a box whose leading spacing (border+padding) was applied
+   on the line it was entered on, when that box's own first word then wrapped to a new line — by
+   subtracting the box's full `margin + border + padding` from the rectangle. This double-counted margin
+   (the cursor already excludes margin from `word.Left`) and, more fundamentally, was compensating for a
+   stale `CssBox.FirstHostingLineBox` (stamped at the box's entry, before the wrap was known) rather than
+   correcting it.
+3. **#343** — `ApplyAtomicInlineVerticalInsets` (an inline-block's top/bottom border+padding, applied by
+   shifting the words it flows) only ever applied once, matching `box-decoration-break: slice` — under
+   `clone` (css-break-3 §6.2), every fragment of a straddling inline-block should re-open with its own top
+   border/padding and re-close with its own bottom border/padding, and this never happened for a
+   continuation page at all.
+
+`#340`'s own described mechanism (`CreateLineBoxes`'s `if (blockBox.ActualRight >= 90999)` branch, fed by
+`CssLineBoxCoordinates.MaxRight`) was investigated and found **unreachable in current code**: instrumenting
+that branch and running the full suite (9897 tests) never triggered it once. Every shrink-to-fit width
+resolution path checked (`float`, `table-cell`, absolutely-positioned auto-width) now resolves width via
+`CssLayoutEngine.GetFitContentWidth`/`GetBoxWidth`'s own intrinsic-width measurement *before* `CreateLineBoxes`
+runs, not via this runtime accumulation. No fix was made; #340 is closed as already-superseded.
+
+## The fix
+
+1. **#341**: right after `ApplyStringSet(box)` in `PrepareFlowBoxEntry`, stamp
+   `namedString.Y = coordinates.CurrentY` for every named string the box just registered — the flow's own
+   cursor at the exact moment the box opens, always correct regardless of how far the box's content later
+   continues.
+2. **#342**: correct `CssBox.FirstHostingLineBox` at the wrap site itself (`FlowBox`'s wrap branch), for
+   every inline ancestor whose content genuinely begins with the wrapping word — the wrapping box itself
+   (self-iteration) or, transitively, every ancestor that is in turn its own parent's first child (a new
+   `IsFirstChildOfItsParent` helper). `CssLineBox.UpdateRectangle`'s own pre-existing leading-spacing
+   subtraction (keyed on this same field) then fires correctly on its own; the old `BubbleRectangles`
+   compensation was deleted. A second gap surfaced by code review: when the wrapping box (`b`) is not the
+   corrected ancestor itself (e.g. `b` is an anonymous run box holding an ancestor span's words), only
+   `b`'s own leading spacing was ever reserved on the cursor — the ancestor's real spacing was never added
+   at all. The fix now also adds each corrected ancestor's own margin/border/padding-left to the cursor at
+   the wrap, mirroring what `FlowBox`'s normal `childOpensHere` path would have added had the wrap not
+   pre-empted it. The same cascade also re-stamps `NamedStrings.Y` for a `string-set` ancestor, mirroring
+   #341's entry-side fix for the "own first word wraps" case.
+3. **#343**: a new `clonesAtomicDecorations` local widens the top-inset pre-shift condition from
+   `childOpensHere` alone to `childOpensHere || clonesAtomicDecorations`, and adds
+   `ApplyAtomicInlineVerticalInsets(b, coordinates, atomicBottomInset)` calls (gated on
+   `clonesAtomicDecorations`) at both existing `if (coordinates.Break is not null) return;` sites, which
+   previously returned without ever applying the bottom inset. A pass that merely walks through a box
+   already fully finished earlier takes the same widened pre-shift branch but places nothing new (every
+   word ordinal is skipped), so `coordinates.Line` never changes and the shift is cancelled by the existing
+   post-dispatch "undo" with no effect — verified by tracing the ordinal-skip path, not just asserted.
+
+## What was found by running it, not by reading it
+
+- #340's own branch was confirmed dead by instrumentation (a file-append probe on
+  `blockBox.ActualRight >= 90999`) across the full 9897-test suite — zero hits. Reading the code alone
+  suggested the branch was live; running it proved otherwise.
+- The #342 fix's first version (correcting only `FirstHostingLineBox`, matching the issue's own literal
+  description) passed the full suite but was **incomplete** — code review (two independent agents, one
+  verifying empirically) found and reproduced a case (`width:25pt`, span padding, anonymous run box holding
+  the words) where the rectangle still computed outside the block, because the ancestor's own leading
+  spacing was never added to the cursor. Fixed by extending the same cascade to also add each corrected
+  ancestor's own spacing.
+- The naive "widen `IsFirstChildOfItsParent`'s cascade to also start from `b.ParentBox` when `b != box`"
+  first attempt broke the pre-existing `Slice_BreakFallingAtAnInlinesFirstWord_PadsItOnce` regression test;
+  the correct cascade starts from `box` (the box whose own `FlowBox` recursion this is), not `b.ParentBox`,
+  with `ReferenceEquals(b, box)` as the alternate self-iteration entry condition.
+
+## Evidence
+
+- `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0`: 9903 passed, 0 failed, 9 skipped
+  (pre-existing platform-gated skips).
+- `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings, 0 errors.
+- Diff coverage (`diff-cover` against `main`): 91.2% on the one changed production file (three lines in a
+  narrow branch — the first break-return site's clone-bottom-inset call for a box holding words directly —
+  not exercised by the fixtures used; above the 90% gate).
+- New/updated tests: `ResumedInlineNamedStringLayoutIntegrationTests.cs` (straddling and same-pass-wrap
+  `string-set` position tests), `ResumedInlineDecorationLayoutIntegrationTests.cs` (rectangle-inside-block
+  tests for both the self-iteration and anonymous-run-box wrap shapes, and the `clone` top-inset-repeats
+  test) — each confirmed to fail against the pre-fix code before being confirmed passing against the fix.

--- a/src/PeachPDF.Tests/Integration/ResumedInlineDecorationLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/ResumedInlineDecorationLayoutIntegrationTests.cs
@@ -312,6 +312,71 @@ namespace PeachPDF.Tests.Integration
             Assert.All(laterPageWords, w => Assert.Equal(p.ClientLeft, w.Left, 2));
         }
 
+        [Fact]
+        public async Task Slice_SpanWhoseOwnFirstWordWrapsOntoALine_KeepsItsRectangleInsideTheBlock()
+        {
+            // The plain, single-page shape of the same wrap-branch code Slice_BreakFallingAtAnInlinesFirstWord_PadsItOnce
+            // exercises for a resumed pass - no pagination at all here, just an ordinary overflow wrap.
+            // BubbleRectangles used to compensate by subtracting the span's full leading set (margin +
+            // border + padding) from a rectangle already sitting at the block's content edge, landing it
+            // outside the block entirely (#342). It no longer needs to: FirstHostingLineBox is corrected
+            // at the wrap itself, so CssLineBox.UpdateRectangle's own subtraction never fires for this
+            // (non-opening) line in the first place.
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<p id='p' style='margin:0;width:70pt;font:10pt Arial'>" +
+                "<span id='s' style='padding-left:20pt'>Wordzero VeryLongWordThatWraps</span></p>"));
+
+            var p = LayoutHarness.FindById(root, "p")!;
+            var s = LayoutHarness.FindById(root, "s")!;
+
+            Assert.True(s.Rectangles.Count >= 2, $"fixture must wrap the span's own content onto a second line, got {s.Rectangles.Count} rectangle(s)");
+
+            var continuation = s.Rectangles.Values.OrderBy(r => r.Y).Last();
+
+            Assert.True(continuation.Left >= p.ClientLeft,
+                $"continuation line's rectangle (left={continuation.Left:F1}) starts before the block's own content edge ({p.ClientLeft:F1})");
+        }
+
+        [Fact]
+        public async Task Slice_SpanHeldByAnAnonymousRun_FirstWordWrapsOntoALine_KeepsItsRectangleInsideTheBlock()
+        {
+            // The shape Slice_SpanWhoseOwnFirstWordWrapsOntoALine covers has the span hold its own single
+            // text run directly (self-iteration in FlowBox: b == box). Here the span's word instead lives
+            // in a separate anonymous run box (b != box, the span's own Boxes[0]) - correcting
+            // FirstHostingLineBox alone is not enough for this shape, since only the wrapping box's own
+            // leading spacing (zero, for a bare anonymous run) was being reserved on the cursor; the
+            // span's real 20pt padding was never added at all, so the rectangle still landed outside the
+            // block after the FirstHostingLineBox-only fix.
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<p id='p' style='margin:0;width:25pt;font:10pt Arial'>" +
+                "<span id='s' style='padding-left:20pt'>Wordzero VeryLongWordThatWraps</span></p>"));
+
+            var p = LayoutHarness.FindById(root, "p")!;
+            var s = LayoutHarness.FindById(root, "s")!;
+
+            Assert.True(s.Rectangles.Count >= 1, "fixture must place the span's content somewhere");
+            Assert.All(s.Rectangles.Values, rect => Assert.True(rect.Left >= p.ClientLeft,
+                $"rectangle left ({rect.Left:F1}) starts before the block's own content edge ({p.ClientLeft:F1})"));
+        }
+
+        [Fact]
+        public async Task Slice_SpanAsAWholeWrapsAfterPrecedingText_KeepsItsRectangleInsideTheBlock()
+        {
+            // A further variant of the same gap: the span isn't the line's first content at all - plain
+            // text precedes it - so the whole span (its one anonymous run) wraps onto a new line as a
+            // unit, rather than the span itself opening a line and then immediately overflowing.
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                "<p id='p' style='margin:0;width:100pt;font:10pt Arial'>Filler words here now " +
+                "<span id='s' style='padding-left:20pt'>Spantext</span></p>"));
+
+            var p = LayoutHarness.FindById(root, "p")!;
+            var s = LayoutHarness.FindById(root, "s")!;
+
+            Assert.True(s.Rectangles.Count >= 1, "fixture must place the span's content somewhere");
+            Assert.All(s.Rectangles.Values, rect => Assert.True(rect.Left >= p.ClientLeft,
+                $"rectangle left ({rect.Left:F1}) starts before the block's own content edge ({p.ClientLeft:F1})"));
+        }
+
         // ── clone (the control) ──────────────────────────────────────────────────────────────────────
 
         [Fact]
@@ -335,6 +400,41 @@ namespace PeachPDF.Tests.Integration
 
             Assert.All(span.Rectangles.Values,
                 r => Assert.Equal(p.ClientLeft + MarginLeftOf(span), r.Left, 2));
+        }
+
+        [Fact]
+        public async Task Clone_InlineBlockCrossingSeveralPageBreaks_ReopensItsTopInsetOnEveryPage()
+        {
+            // An inline-block's own top border/padding is applied by shifting the words it flows,
+            // gated (by default, box-decoration-break: slice) to the pass that opens it - a straddling
+            // box's later pages correctly get none. Under clone (css-break-3 §6.2) every fragment
+            // re-opens with its own top border/padding instead, which used to never happen at all for a
+            // continuation page (#343).
+            const int topInset = 8; // 3pt border-top + 5pt padding-top
+            var html = LayoutHarness.Wrap(
+                "<p id='p' style='margin:0;line-height:22pt;font-size:10pt'>" +
+                "<span id='ib' style='display:inline-block;box-decoration-break:clone;" +
+                "padding:5pt 0;border-top:3pt solid #000;border-bottom:3pt solid #000'>" +
+                string.Join("<br>", Enumerable.Range(0, 20).Select(i => $"Line{i}")) +
+                "</span></p>");
+
+            var (root, container) = await LayoutHarness.LayoutAsync(html, pageHeight: PageHeight, margin: Margin);
+
+            AssertPaginated(container);
+
+            var ib = LayoutHarness.FindById(root, "ib")!;
+            var byPage = AllWords(ib).Where(w => !w.IsLineBreak)
+                .GroupBy(w => container.PageIndexOf(w.Top))
+                .OrderBy(g => g.Key)
+                .ToList();
+
+            Assert.True(byPage.Count > 1, $"fixture must straddle several pages, got {byPage.Count}");
+
+            foreach (var page in byPage)
+            {
+                var expectedTop = container.PageTopOf(page.Key) + topInset;
+                Assert.Equal(expectedTop, page.Min(w => w.Top), 2);
+            }
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/ResumedInlineNamedStringLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/ResumedInlineNamedStringLayoutIntegrationTests.cs
@@ -43,6 +43,68 @@ namespace PeachPDF.Tests.Integration
             Assert.Equal(trueY, namedString.Y, 1);
         }
 
+        [Fact]
+        public async Task NamedString_InlineTargetStraddlingAPageBreak_KeepsItsOwnOpeningPosition()
+        {
+            // Unlike the fixture above, "term" itself is long enough to straddle the break its own
+            // content falls across - CssLayoutEngine.FlowBox's recursive call for "term" hits the break
+            // and returns before reaching its own FinalizeFlowBoxExit, on every pass that touches it, so
+            // nothing after ApplyStringSet's own (otherwise wrong, box.Location.Y-seeded) registration
+            // ever corrects it unless the fix records the box's real opening position up front (#341).
+            var html = LayoutHarness.Wrap(
+                "<p id='p' style='margin:0;line-height:22pt;font-size:10pt'>" +
+                "<span id='term' style='string-set: entry content(text)'>" +
+                string.Join("<br>", Enumerable.Range(0, 20).Select(i => $"Line{i}")) +
+                "</span></p>");
+
+            var (root, container) = await LayoutHarness.LayoutAsync(html, pageHeight: 200, margin: 20);
+
+            Assert.True(container.FragmentainerPasses > 1,
+                $"fixture must paginate, but layout took {container.FragmentainerPasses} pass(es)");
+
+            var term = LayoutHarness.FindById(root, "term")!;
+            var words = AllWords(term).ToList();
+            var openingY = words.Min(w => w.Top);
+            var closingY = words.Max(w => w.Top);
+
+            // The fixture must actually straddle a break, or the assertion below is vacuous.
+            Assert.NotEqual(container.PageIndexOf(openingY), container.PageIndexOf(closingY));
+
+            var namedString = Assert.Single(container.NamedStrings, ns => ns.Name == "entry");
+            Assert.Equal(container.PageIndexOf(openingY), container.PageIndexOf(namedString.Y));
+            Assert.Equal(openingY, namedString.Y, 1);
+        }
+
+        [Fact]
+        public async Task NamedString_InlineTargetWhoseOwnFirstWordOverflowsOntoALine_KeepsThatLinesPageAttribution()
+        {
+            // No pagination needed to reach this: "term" opens PrepareFlowBoxEntry with the seed line's
+            // own Y (stamped before any of its content is known), but its own first word then overflows
+            // onto a second line - the same wrap FlowBox's own FirstHostingLineBox correction handles
+            // (#342) needs the mirror correction for a string-set box's NamedStrings.Y too, or it is left
+            // naming the line "term" was entered on rather than one its content actually starts on. Only
+            // the page attribution is pinned here (not the exact line): FinalizeFlowBoxExit's own,
+            // separate exit-side update (unaffected by this fix) still re-stamps Y from wherever "term"'s
+            // flow ends up by the time it fully closes, which is a different, pre-existing imprecision
+            // that happens not to matter while every line involved shares one page.
+            var html = LayoutHarness.Wrap(
+                "<p id='p' style='margin:0;width:25pt;font:10pt Arial'>" +
+                "<span id='term' style='string-set: entry content(text)'>Wordzero VeryLongWordThatWraps</span></p>");
+
+            var (root, container) = await LayoutHarness.LayoutAsync(html);
+
+            var term = LayoutHarness.FindById(root, "term")!;
+            var words = AllWords(term).ToList();
+
+            // The fixture must actually wrap the span's own content onto more than one line, or the
+            // assertion below is vacuous.
+            Assert.True(words.Select(w => w.Top).Distinct().Count() > 1,
+                "fixture must wrap the span's own content onto more than one line");
+
+            var namedString = Assert.Single(container.NamedStrings, ns => ns.Name == "entry");
+            Assert.Equal(0, container.PageIndexOf(namedString.Y));
+        }
+
         // 200 short words, comfortably enough to push this paragraph across a page break at PageHeight.
         private static readonly string Filler = string.Join(" ", Enumerable.Repeat("word", 200));
 

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -2216,6 +2216,21 @@ namespace PeachPDF.Html.Core.Dom
                 }
 
                 CssNamedStringEngine.ApplyStringSet(box);
+
+                // ApplyStringSet seeds each NamedString.Y from box.Location.Y, which is meaningless for
+                // a plain inline box (only its words get a position; the box itself never does) - it
+                // stays at whatever default the box happened to carry, corrupting the page attribution
+                // MarginBoxRenderer.ResolveNamedString relies on. coordinates.CurrentY, read here at the
+                // exact moment this box opens, is always correct regardless of how far its content later
+                // continues - unlike the exit-side correction below (FinalizeFlowBoxExit), which a break
+                // inside this box's own content (on this pass or the one that finally completes it, since
+                // an in-progress ancestor's own FlowBox call returns before reaching its exit bookkeeping
+                // whenever a break occurs anywhere in its recursion - #341) can skip forever, leaving this
+                // the only assignment a straddling box is guaranteed to get.
+                foreach (var namedString in box.NamedStrings.Values)
+                {
+                    namedString.Y = coordinates.CurrentY;
+                }
             }
 
             return opensHere;
@@ -2447,11 +2462,19 @@ namespace PeachPDF.Html.Core.Dom
                 // assumed, since a display:inline-block box acquiring direct words in the future would
                 // silently double the shift here rather than fail loudly. Only on the pass that opens b's
                 // own content (childOpensHere): a continuation must not re-push a box's later lines down
-                // by a padding it already paid on an earlier fragmentainer.
+                // by a padding it already paid on an earlier fragmentainer - unless it re-opens with its
+                // own top border/padding on every fragment by declaration (box-decoration-break: clone,
+                // css-break-3 §6.2), in which case a pass continuing b's own straddling content applies
+                // it again too (#343). A pass that walks through a b already fully finished earlier takes
+                // this same branch but places nothing new (every word ordinal is skipped below), so
+                // coordinates.Line never changes and the "undo" after this dispatch cancels the shift
+                // with no effect - safe to pre-shift unconditionally for clone rather than having to tell
+                // "still straddling" apart from "already done" up front.
                 var appliesAtomicInset = b.DerivedStyle.ActualDisplay is Keywords.InlineBlock && !ReferenceEquals(b, box);
+                var clonesAtomicDecorations = appliesAtomicInset && b.BoxDecorationBreak.Value == BoxDecorationBreakMode.Clone;
                 var atomicTopInset = appliesAtomicInset ? b.ActualBorderTopWidth + b.ActualPaddingTop : 0;
                 var atomicBottomInset = appliesAtomicInset ? b.ActualBorderBottomWidth + b.ActualPaddingBottom : 0;
-                var preShiftedForAtomicInset = childOpensHere && atomicTopInset > 0;
+                var preShiftedForAtomicInset = atomicTopInset > 0 && (childOpensHere || clonesAtomicDecorations);
                 var lineBeforeChild = coordinates.Line;
 
                 if (preShiftedForAtomicInset)
@@ -2679,6 +2702,54 @@ namespace PeachPDF.Html.Core.Dom
                                 if (clonesDecorations)
                                     coordinates.CurrentX += DomUtils.ClonedInlineStart(b.ParentBox, blockBox);
                             }
+
+                            // b's own first word wrapped onto this new line, so box - the box whose own
+                            // recursive FlowBox call this is, which stamped its FirstHostingLineBox at
+                            // entry, before any of this was known - does not really start on the line it
+                            // was entered on when b is what its content genuinely begins with: either b
+                            // IS box (self-iteration - a leaf holding its own words directly), or b is
+                            // box's own first child (its words are read here without a nested FlowBox
+                            // call, see the self-iteration remark above). The same then cascades up
+                            // through every further inline ancestor that is, in turn, its own parent's
+                            // first child. CssLineBox.UpdateRectangle's own leading-spacing subtraction
+                            // walks this same inline-ancestor chain checking this field, so correcting it
+                            // at the source is what lets that subtraction fire correctly on its own,
+                            // without BubbleRectangles compensating for its absence afterward (#342).
+                            //
+                            // b == box (self-iteration) already got its own leading spacing added above,
+                            // via `leftSpacing`, computed for b. When b != box, b's own leading spacing
+                            // is real and already reserved the same way - but box's own (and every
+                            // cascaded ancestor's) is not: FlowBox's normal "childOpensHere" path adds an
+                            // ancestor's leading spacing only when that ancestor's own per-child dispatch
+                            // runs, which this wrap pre-empted by placing b's word without ever reaching
+                            // it. Adding it here, for exactly the ancestors this cascade corrects, is what
+                            // keeps the word position itself (not just the rectangle) agreeing with the
+                            // corrected FirstHostingLineBox.
+                            if (word.Equals(b.FirstWord) && (ReferenceEquals(b, box) || IsFirstChildOfItsParent(b)))
+                            {
+                                for (var ancestor = box; ancestor is { IsInline: true }; ancestor = ancestor.ParentBox)
+                                {
+                                    if (!ReferenceEquals(ancestor, b))
+                                    {
+                                        coordinates.CurrentX += ancestor.Position.Value is not (PositionMode.Absolute or PositionMode.Fixed)
+                                            ? ancestor.ActualMarginLeft + ancestor.ActualBorderLeftWidth + ancestor.ActualPaddingLeft
+                                            : 0;
+                                    }
+
+                                    ancestor.FirstHostingLineBox = coordinates.Line;
+
+                                    // Same correction as PrepareFlowBoxEntry's own entry-side stamp
+                                    // (#341) for a string-set ancestor whose recorded Y was seeded before
+                                    // this wrap was known about - a page attribution this ancestor's
+                                    // opening line, not the seed line PrepareFlowBoxEntry stamped it with.
+                                    foreach (var namedString in ancestor.NamedStrings.Values)
+                                    {
+                                        namedString.Y = coordinates.CurrentY;
+                                    }
+
+                                    if (!IsFirstChildOfItsParent(ancestor)) break;
+                                }
+                            }
                             else if (clonesDecorations)
                             {
                                 // The break fell inside b: every cloning box it is part of, itself included,
@@ -2812,7 +2883,14 @@ namespace PeachPDF.Html.Core.Dom
                         word.Top += box.ActualMarginTop;
                     }
 
-                    if (coordinates.Break is not null) return;
+                    if (coordinates.Break is not null)
+                    {
+                        // Under clone this pass's own portion of b closes here with its own bottom
+                        // border/padding (css-break-3 §6.2), same as the true-final-pass case below -
+                        // the break just means it isn't that pass (#343).
+                        if (clonesAtomicDecorations) ApplyAtomicInlineVerticalInsets(b, coordinates, atomicBottomInset);
+                        return;
+                    }
 
                     // A box holding its words directly (e.g. a ::before/::after pseudo-element,
                     // whose generated text lives on the box itself rather than an anonymous
@@ -2848,7 +2926,15 @@ namespace PeachPDF.Html.Core.Dom
                 else
                 {
                     await FlowBox(g, blockBox, b, lineSpacing, lineStartX, coordinates, childClonedResumeStart);
-                    if (coordinates.Break is not null) return;
+
+                    if (coordinates.Break is not null)
+                    {
+                        // Same as the branch above: under clone this pass's own portion of b closes here
+                        // with its own bottom border/padding, same as the true-final-pass case below - the
+                        // break just means it isn't that pass (#343).
+                        if (clonesAtomicDecorations) ApplyAtomicInlineVerticalInsets(b, coordinates, atomicBottomInset);
+                        return;
+                    }
 
                     // Same as the branch above: an inset applies to the words this pass placed, and a
                     // box it placed none for has already had it.
@@ -3221,6 +3307,16 @@ namespace PeachPDF.Html.Core.Dom
         }
 
         /// <summary>
+        /// Whether <paramref name="box"/> is the first of <see cref="CssBox.Boxes"/> on its own parent -
+        /// i.e. its parent's content genuinely begins with it. Shared by the wrap branch in
+        /// <see cref="FlowBox"/> (which corrects an inline ancestor chain's stale
+        /// <see cref="CssBox.FirstHostingLineBox"/> when this box's own first word wraps to a new line)
+        /// and, historically, <see cref="BubbleRectangles"/>'s own compensation for the same case.
+        /// </summary>
+        private static bool IsFirstChildOfItsParent(CssBox box) =>
+            box.ParentBox is { } parent && parent.Boxes.Count > 0 && ReferenceEquals(parent.Boxes[0], box);
+
+        /// <summary>
         /// Recursively creates the rectangles of the blockBox, by bubbling from deep to outside the boxes
         /// in the rectangle structure
         /// </summary>
@@ -3235,23 +3331,7 @@ namespace PeachPDF.Html.Core.Dom
 
                 foreach (var word in words)
                 {
-                    // handle if line is wrapped for the first text element where parent has left margin\padding
-                    //
-                    // This exists for the one case FirstHostingLineBox cannot express: a parent entered
-                    // on one line whose first word wraps to the next, so the leading spacing was applied
-                    // on a line the parent does not really start on. Not when the parent genuinely opens
-                    // on this line - there the spacing is real, it was applied to the words, and
-                    // UpdateRectangle takes it off the rectangle itself. Doing both takes it off twice,
-                    // which is what a resumed pass hit: its opening line is never LineBoxes[0], since
-                    // earlier fragmentainers' lines are kept.
-                    var left = word.Left;
-
-                    if (box == box.ParentBox!.Boxes[0] && word == box.Words[0] && word == line.Words[0] && line != line.OwnerBox.LineBoxes[0] && !word.IsLineBreak
-                        && !ReferenceEquals(box.ParentBox.FirstHostingLineBox, line))
-                        left -= box.ParentBox.ActualMarginLeft + box.ParentBox.ActualBorderLeftWidth + box.ParentBox.ActualPaddingLeft;
-
-
-                    x = Math.Min(x, left);
+                    x = Math.Min(x, word.Left);
                     r = Math.Max(r, word.Right);
                     y = Math.Min(y, word.Top);
                     b = Math.Max(b, word.Bottom);


### PR DESCRIPTION
## Summary
Three related defects in `CssLayoutEngine.FlowBox`'s one-pass-per-fragmentainer, resumable inline layout — all residuals of earlier fixes (#336 and predecessors) to the same mechanism:

- **#341** — A `string-set` box's `NamedString.Y` was seeded from `box.Location.Y` (meaningless for a plain inline box, which never gets its own `.Location`), and `FinalizeFlowBoxExit`'s later correction is unreachable for a box whose own content straddles a fragmentainer boundary (`FlowBox`'s recursion returns before reaching its exit bookkeeping whenever a break occurs anywhere inside it). Fixed by stamping `NamedString.Y` from the flow's own cursor at the box's entry, which is always correct regardless of how far the content later continues.
- **#342** — `BubbleRectangles` compensated for a box whose leading spacing landed on a line its content then wrapped off, by subtracting `margin + border + padding` from the rectangle — double-counting margin, and compensating for a stale `CssBox.FirstHostingLineBox` rather than correcting it. Fixed by correcting `FirstHostingLineBox` at the wrap site itself, cascading through every inline ancestor whose content genuinely begins with the wrapping word, so `CssLineBox.UpdateRectangle`'s own existing subtraction fires correctly on its own (the old compensation is deleted). A second gap found by review: when the wrapping box isn't the corrected ancestor itself (e.g. an anonymous run box holding a styled ancestor's words), only its own — zero — leading spacing was ever reserved on the cursor; the fix now also reserves each corrected ancestor's own spacing.
- **#343** — `box-decoration-break: clone` never repeated an inline-block's top/bottom border and padding across the pages a straddling box spans, applying them only once (matching `slice`, the default). Fixed by widening the top-inset pre-shift condition and adding the bottom-inset application at both pass-break sites, gated on `clone`.

**#340** was investigated and found to already be resolved: its own described mechanism (`CreateLineBoxes`'s `>= 90999` unrestricted-width branch) is unreachable in current code — confirmed by instrumenting it and running the full test suite with zero hits. Every shrink-to-fit width path now resolves via `GetFitContentWidth`'s own intrinsic-width measurement before that branch would ever run. No code change was needed; closing separately with an explanation rather than via this PR.

Fixes #341
Fixes #342
Fixes #343

## Test plan
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 9903 passed, 0 failed
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings, 0 errors
- [x] Diff coverage against `main` (`diff-cover`) — 91.2% (above the 90% gate)
- [x] New/updated tests for all three fixes, each confirmed to fail against the pre-fix code and pass against the fix
- [x] Post-change review pass (two independent passes across 8 angles) — found and fixed a duplicated comment block and an incomplete case in the #342 fix (ancestor's own leading spacing wasn't being reserved when the wrapping box itself held none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)