### PR TITLE
Skip ::first-line candidate gathering when the document has no such rule

### DIFF
--- a/.claude/recent-fixes/2026-09-07-first-line-rule-check-skips-candidate-gathering.md
+++ b/.claude/recent-fixes/2026-09-07-first-line-rule-check-skips-candidate-gathering.md
@@ -1,0 +1,49 @@
+# ResolveFirstLineStyle skips both candidate-gathering passes when no ::first-line rule exists
+
+Closes #911.
+
+## What was wrong
+
+`DomParser.ResolveFirstLineStyle` runs once per box, for every box in the document, and opened with two
+full candidate gathers (`CssData.GetFirstLineStyleRules` for UA and author rules), each immediately
+materialized with `.ToList()` - *before* the check (`firstLineUaRules.Count == 0 && firstLineAuthorRules.Count
+== 0`) that makes the whole method a no-op. On a document that declares no `::first-line` rule anywhere
+(the overwhelming majority of real documents), every single box still paid for two selector-index walks
+and two list allocations just to learn there was nothing to do.
+
+## The fix
+
+Added `CssData.HasFirstLineRules`, a document-level flag computed once in `EnsureIndex` (beside the
+existing `HasCascadeLayers`) by threading a `ref bool hasFirstLineRules` accumulator through the
+recursive `IndexRules` walk and setting it when a style rule's selector passes the new
+`CouldMatchAsFirstLineSelector` predicate. That predicate is a deliberate **superset** of the existing
+`MatchesAsFirstLineSelector`: same selector-shape switch (`ListSelector`/`ComplexSelector`/
+`CompoundSelector`), but the `CompoundSelector` case omits the per-box
+`compound.Where(...).All(s => DoesSelectorMatch(s, box))` conjunct, since no box exists yet when this
+runs once at index-build time. It can therefore return `true` for a selector that ends up matching no
+box, but can never return `false` for one that would have matched some box - so `false` from every rule
+in the document proves both of `ResolveFirstLineStyle`'s gathers would always return empty.
+`ResolveFirstLineStyle` now opens with `if (!cssData.HasFirstLineRules) return;`, before either
+`GetFirstLineStyleRules` call.
+
+## What was deliberately not done
+
+No change to `MatchesAsFirstLineSelector`, `GetFirstLineStyleRules`, or the per-box matching path at all
+- the fix is purely an early-exit gate in front of unchanged per-box logic, so the box-level matching
+semantics (including its own documented simplifications around ancestor-combinator selectors and mixed
+`ListSelector` alternatives) are untouched.
+
+## Evidence
+
+- `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0`: 9908 passed, 0 failed, 9 skipped
+  (pre-existing platform-gated skips, unrelated), including the full pre-existing
+  `FirstLinePseudoElementIntegrationTests` suite (all 7 implemented `::first-line` properties plus the
+  structural/straddling-box/bidi cases) unchanged.
+- `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings, 0 errors.
+- Diff coverage (`diff-cover` against `main`): 100% on the two changed production files.
+- New tests in `src/PeachPDF.Tests/CSS/FirstLineRulesFlagTests.cs` (`FirstLineRulesFlagTests`) exercise
+  `CssData.HasFirstLineRules` directly: no stylesheet, ordinary non-first-line rules, a same-pseudo-family
+  distractor (`::before`), a plain tag selector, a class-compound selector, an ancestor-combinator
+  selector, a `::first-line` alternative inside a `ListSelector`, and a rule nested inside `@media` - the
+  false cases prove the flag doesn't false-positive on ordinary CSS, and the true cases cover every
+  selector shape `CouldMatchAsFirstLineSelector`'s switch handles.

--- a/src/PeachPDF.Tests/CSS/FirstLineRulesFlagTests.cs
+++ b/src/PeachPDF.Tests/CSS/FirstLineRulesFlagTests.cs
@@ -1,0 +1,89 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+
+namespace PeachPDF.Tests.CSS;
+
+/// <summary>
+/// Regression tests for <c>CssData.HasFirstLineRules</c> (issue #911): a document-level flag,
+/// computed once in <c>CssData.EnsureIndex</c> via <c>CouldMatchAsFirstLineSelector</c>, that lets
+/// <c>DomParser.ResolveFirstLineStyle</c> skip its two per-box candidate-gathering passes entirely on
+/// documents (the overwhelming majority) that declare no <c>::first-line</c> rule at all. The flag
+/// must stay false whenever nothing in the document could ever match via <c>::first-line</c>, and true
+/// whenever something could - <c>CouldMatchAsFirstLineSelector</c> is a deliberate superset of
+/// <c>MatchesAsFirstLineSelector</c> (same selector-shape switch, minus the per-box conjunct), so it
+/// can never wrongly report false when a box would actually have matched.
+/// </summary>
+public class FirstLineRulesFlagTests
+{
+    [Fact]
+    public async Task NoStylesheetRules_FlagStaysFalse()
+    {
+        var cssData = await BuildCssData("<p>text</p>");
+        Assert.False(cssData.HasFirstLineRules);
+    }
+
+    [Fact]
+    public async Task OrdinaryRulesWithNoFirstLine_FlagStaysFalse()
+    {
+        var cssData = await BuildCssData("<style>p { color: red; } .a { color: blue; } #b { color: green; }</style><p class='a' id='b'>text</p>");
+        Assert.False(cssData.HasFirstLineRules);
+    }
+
+    [Fact]
+    public async Task OtherPseudoElement_DoesNotSetFlag()
+    {
+        // ::before is a different pseudo-element entirely - must not be conflated with ::first-line.
+        var cssData = await BuildCssData("<style>p::before { content: 'X'; }</style><p>text</p>");
+        Assert.False(cssData.HasFirstLineRules);
+    }
+
+    [Fact]
+    public async Task SimpleTagFirstLineRule_SetsFlag()
+    {
+        var cssData = await BuildCssData("<style>p::first-line { color: red; }</style><p>text</p>");
+        Assert.True(cssData.HasFirstLineRules);
+    }
+
+    [Fact]
+    public async Task ClassCompoundFirstLineRule_SetsFlag()
+    {
+        var cssData = await BuildCssData("<style>.a::first-line { color: red; }</style><p class='a'>text</p>");
+        Assert.True(cssData.HasFirstLineRules);
+    }
+
+    [Fact]
+    public async Task AncestorCombinatorFirstLineRule_SetsFlag()
+    {
+        var cssData = await BuildCssData("<style>article p::first-line { color: red; }</style><article><p>text</p></article>");
+        Assert.True(cssData.HasFirstLineRules);
+    }
+
+    [Fact]
+    public async Task ListSelectorWithFirstLineAlternative_SetsFlag()
+    {
+        // Only the second alternative is ::first-line - the flag must still be set (ListSelector's
+        // Any() short-circuits true on the first matching alternative).
+        var cssData = await BuildCssData("<style>div, p::first-line { color: red; }</style><p>text</p>");
+        Assert.True(cssData.HasFirstLineRules);
+    }
+
+    [Fact]
+    public async Task FirstLineRuleNestedInMediaQuery_SetsFlag()
+    {
+        // The flag is computed while indexing (which descends into @media/@layer/@supports/@container
+        // the same way normal rule gathering does), so a first-line rule nested inside a grouping
+        // at-rule must still be found - regardless of whether that media query would ever match.
+        var cssData = await BuildCssData("<style>@media print { p::first-line { color: red; } }</style><p>text</p>");
+        Assert.True(cssData.HasFirstLineRules);
+    }
+
+    private static async Task<CssData> BuildCssData(string body)
+    {
+        var adapter = new PdfSharpAdapter();
+        var container = new HtmlContainerInt(adapter);
+        await container.SetHtml($"<!DOCTYPE html><html><head></head><body>{body}</body></html>", null);
+
+        Assert.NotNull(container.CssData);
+        return container.CssData!;
+    }
+}

--- a/src/PeachPDF/Html/Core/CssData.cs
+++ b/src/PeachPDF/Html/Core/CssData.cs
@@ -97,6 +97,20 @@ namespace PeachPDF.Html.Core
         /// <summary>True when the document declares any <c>@layer</c> cascade layer.</summary>
         internal bool HasCascadeLayers { get; private set; }
 
+        /// <summary>
+        /// True when the document declares any rule whose selector could possibly match via
+        /// <see cref="MatchesAsFirstLineSelector"/> - i.e. a deliberate superset computed once, up
+        /// front, by <see cref="CouldMatchAsFirstLineSelector"/> (same selector-shape switch, minus the
+        /// per-box <see cref="DoesSelectorMatch(ISelector, ICssDomNode?)"/> conjunct
+        /// <see cref="MatchesAsFirstLineSelector"/> applies in its <see cref="CompoundSelector"/> case).
+        /// False here proves no box can have any <c>::first-line</c> rules, so
+        /// <see cref="GetFirstLineStyleRules"/> would always return empty; true does not prove the
+        /// converse. See <c>DomParser.ResolveFirstLineStyle</c>, which uses this to skip its two
+        /// candidate-gathering passes entirely on the (overwhelmingly common) documents with no
+        /// <c>::first-line</c> rule at all.
+        /// </summary>
+        internal bool HasFirstLineRules { get; private set; }
+
         private int RankOf(string? layerName) =>
             layerName is not null && _layerRanks!.TryGetValue(layerName, out var rank) ? rank : UnlayeredRank;
 
@@ -111,14 +125,16 @@ namespace PeachPDF.Html.Core
             var keys = new List<(SelectorBucketKind Kind, string Key)>();
             var layerRegistry = new LayerRegistry();
             var order = 0;
+            var hasFirstLineRules = false;
 
             foreach (var stylesheet in Stylesheets)
             {
-                IndexRules(stylesheet.Rules, stylesheet.IsUserAgent, null, null, null, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order);
+                IndexRules(stylesheet.Rules, stylesheet.IsUserAgent, null, null, null, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order, ref hasFirstLineRules);
             }
 
             _layerRanks = layerRegistry.ComputeRanks();
             HasCascadeLayers = _layerRanks.Count > 0;
+            HasFirstLineRules = hasFirstLineRules;
             _tagIndex = tagIndex;
             _classIndex = classIndex;
             _idIndex = idIndex;
@@ -237,7 +253,8 @@ namespace PeachPDF.Html.Core
             List<IndexedRule> universal,
             List<(SelectorBucketKind Kind, string Key)> keys,
             LayerRegistry layerRegistry,
-            ref int order)
+            ref int order,
+            ref bool hasFirstLineRules)
         {
             foreach (var rule in rules)
             {
@@ -245,6 +262,9 @@ namespace PeachPDF.Html.Core
                 {
                     case IStyleRule styleRule:
                         var indexedRule = new IndexedRule(styleRule, isUserAgent, order++, enclosingMedia, enclosingContainers, currentLayer);
+
+                        if (!hasFirstLineRules && CouldMatchAsFirstLineSelector(styleRule.Selector))
+                            hasFirstLineRules = true;
 
                         keys.Clear();
                         CollectIndexKeys(styleRule.Selector, keys);
@@ -276,14 +296,14 @@ namespace PeachPDF.Html.Core
                         // media/@layer context and right after the parent in document order (so it wins
                         // ties by source order, matching its textual position after the parent).
                         if (styleRule.NestedRules.Count > 0)
-                            IndexRules(styleRule.NestedRules, isUserAgent, enclosingMedia, enclosingContainers, currentLayer, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order);
+                            IndexRules(styleRule.NestedRules, isUserAgent, enclosingMedia, enclosingContainers, currentLayer, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order, ref hasFirstLineRules);
                         break;
 
                     case IMediaRule mediaRule:
                         var nestedMedia = enclosingMedia is null
                             ? [mediaRule.Media]
                             : (MediaList[])[.. enclosingMedia, mediaRule.Media];
-                        IndexRules(mediaRule.Rules, isUserAgent, nestedMedia, enclosingContainers, currentLayer, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order);
+                        IndexRules(mediaRule.Rules, isUserAgent, nestedMedia, enclosingContainers, currentLayer, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order, ref hasFirstLineRules);
                         break;
 
                     // @layer statement (`@layer a, b, c;`) only declares layer order — register each
@@ -301,7 +321,7 @@ namespace PeachPDF.Html.Core
                             : QualifyLayer(currentLayer, layerRule.Name);
                         if (!string.IsNullOrEmpty(layerRule.Name))
                             layerRegistry.Register(qualified);
-                        IndexRules(layerRule.Rules, isUserAgent, enclosingMedia, enclosingContainers, qualified, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order);
+                        IndexRules(layerRule.Rules, isUserAgent, enclosingMedia, enclosingContainers, qualified, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order, ref hasFirstLineRules);
                         break;
 
                     // @supports: the condition is invariant (IConditionFunction.Check() takes no
@@ -314,7 +334,7 @@ namespace PeachPDF.Html.Core
                     // up, just decided by the real condition now instead of unconditionally.
                     case ISupportsRule supportsRule:
                         if (supportsRule.Condition.Check())
-                            IndexRules(supportsRule.Rules, isUserAgent, enclosingMedia, enclosingContainers, currentLayer, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order);
+                            IndexRules(supportsRule.Rules, isUserAgent, enclosingMedia, enclosingContainers, currentLayer, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order, ref hasFirstLineRules);
                         break;
 
                     // @container: truthiness depends on the nearest matched element's own container
@@ -334,7 +354,7 @@ namespace PeachPDF.Html.Core
                         var nestedContainers = enclosingContainers is null
                             ? [condition]
                             : (ContainerCondition[])[.. enclosingContainers, condition];
-                        IndexRules(containerRule.Rules, isUserAgent, enclosingMedia, nestedContainers, currentLayer, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order);
+                        IndexRules(containerRule.Rules, isUserAgent, enclosingMedia, nestedContainers, currentLayer, tagIndex, classIndex, idIndex, universal, keys, layerRegistry, ref order, ref hasFirstLineRules);
                         break;
                 }
             }
@@ -791,6 +811,24 @@ namespace PeachPDF.Html.Core
                     return false;
             }
         }
+
+        /// <summary>
+        /// A document-level, box-independent superset of <see cref="MatchesAsFirstLineSelector"/>: same
+        /// selector-shape switch, but the <see cref="CompoundSelector"/> case omits the per-box
+        /// <c>compound.Where(...).All(s => DoesSelectorMatch(s, box))</c> conjunct, since no box exists
+        /// yet when this runs (once, in <see cref="EnsureIndex"/>). Can therefore return true for a
+        /// selector that ends up matching no box, but can never return false for one that would have
+        /// matched some box - so a false result from every rule in the document proves
+        /// <see cref="HasFirstLineRules"/> can safely stay false, and <see cref="GetFirstLineStyleRules"/>
+        /// would always return empty.
+        /// </summary>
+        private static bool CouldMatchAsFirstLineSelector(ISelector selector) => selector switch
+        {
+            ListSelector list => list.Any(CouldMatchAsFirstLineSelector),
+            ComplexSelector complex => complex.LastOrDefault().Selector is { } last && HasFirstLineSubject(last),
+            CompoundSelector compound => HasFirstLineSubject(compound),
+            _ => false
+        };
 
         private static bool HasFirstLineSubject(ISelector selector) => selector switch
         {

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -883,6 +883,11 @@ namespace PeachPDF.Html.Core.Parse
         /// </summary>
         private static void ResolveFirstLineStyle(CssValueParser valueParser, CssBox box, CssData cssData, MediaQueryContext media, ContainerQuerySizes? containerSizes = null)
         {
+            // Cheap document-level check first: on the overwhelming majority of documents (no
+            // ::first-line rule anywhere), this skips both candidate-gathering passes below entirely
+            // instead of paying for two full selector walks just to learn the answer is "no rules".
+            if (!cssData.HasFirstLineRules) return;
+
             var firstLineUaRules = cssData.GetFirstLineStyleRules(media, box, userAgentOnly: true, containerSizes).ToList();
             var firstLineAuthorRules = cssData.GetFirstLineStyleRules(media, box, userAgentOnly: false, containerSizes).ToList();
 


### PR DESCRIPTION
## Summary

- `DomParser.ResolveFirstLineStyle` ran once per box and opened with two full `::first-line` candidate gathers (`CssData.GetFirstLineStyleRules`, each materialized with `.ToList()`) before the check that made the whole method a no-op — so every box in a document with zero `::first-line` rules (the overwhelming majority) still paid for two selector-index walks and two list allocations.
- Adds `CssData.HasFirstLineRules`, a document-level flag computed once in `EnsureIndex` (alongside the existing `HasCascadeLayers`) by walking the indexed rules and testing each selector with a new `CouldMatchAsFirstLineSelector` predicate — a deliberate superset of the existing `MatchesAsFirstLineSelector` (same selector-shape switch, minus the per-box `DoesSelectorMatch` conjunct in the `CompoundSelector` case, since no box exists yet at index-build time). It can return `true` for a selector that ends up matching no box, but can never return `false` for one that would have matched some box.
- `ResolveFirstLineStyle` now opens with `if (!cssData.HasFirstLineRules) return;`, before either candidate gather runs.

No behavior change to the per-box matching path itself (`MatchesAsFirstLineSelector`, `GetFirstLineStyleRules`) — this is purely an early-exit gate in front of it.

Fixes #911

## Test plan

- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 9908 passed, 0 failed, 9 skipped (pre-existing platform-gated skips, unrelated), including the full pre-existing `FirstLinePseudoElementIntegrationTests` suite unchanged.
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings, 0 errors.
- [x] Diff coverage (`diff-cover` against `main`) — 100% on the two changed production files.
- [x] New tests in `src/PeachPDF.Tests/CSS/FirstLineRulesFlagTests.cs` exercise `CssData.HasFirstLineRules` directly across selector shapes (plain tag, class compound, ancestor combinator, list-selector alternative, rule nested in `@media`) and confirm it stays false for ordinary non-first-line rules and for a same-pseudo-family distractor (`::before`).
- [x] Recorded the change in `.claude/recent-fixes/2026-09-07-first-line-rule-check-skips-candidate-gathering.md` per this repo's convention.
