### PR TITLE
Split nested multi-column fragments per inner column; retake flex/grid forced breaks

### DIFF
--- a/.claude/accepted-gaps/marker-on-a-block-content-list-item-inside-a-multi-column-container.md
+++ b/.claude/accepted-gaps/marker-on-a-block-content-list-item-inside-a-multi-column-container.md
@@ -39,3 +39,40 @@ sweep on the build before it reports every one of these markers missing outright
 producing no fragment at all — so this is a residual of a strictly improved state, not a regression.
 Closing it means settling how the columns engine fragments a block-level list item, which is a larger
 change than the marker rule.
+
+**A second attempt (2026-09-07) found the actual mechanism, and it is not the column-rejection arms.**
+The plan for this attempt was "take the marker back wherever `CssBox.LayoutBlockChildren`'s own
+column-rejection arms (§3.1 forced/avoid-column-break, column-overflow, column-span:all, the orphans
+retry) push an already-placed child to the next column wholesale" — mirroring
+`TakeBackTheMarkerOfAnItemThisPassKeptNothingOf`'s shape but unconditional, since the whole subtree
+moves. Implemented at all four arms and measured against the same 162-combination sweep: **the late/bad
+counts (21 late, 14 bad on the current build's own parameter grid) were bit-for-bit identical with and
+without the fix.** The four arms are real, but every one of them hands the rejected child a fresh
+`BlockBreakToken` with `ChildToken: null` — and `MarkerBelongsToTheFragmentainerBeingFilled` already
+treats a `null` resume as "reposition it" unconditionally, regardless of whether `AwaitPlacement` was
+ever called. The take-back is not wrong, but it is inert: nothing in the sweep ever needed it.
+
+**The real mechanism, traced from one sweep failure (`li5`, `column-count:2;column-fill:auto`, 8 items,
+2 `<p>` children, page height 120):** the item's *marker word* and the item's own final `Location` came
+back pointing at two different columns entirely — `Location.X` at the column the item's content actually
+settled in, the marker's own word rect still at the column an *earlier, abandoned* attempt had placed it
+in. The seam is `CssBox.ResumeInTheNextFragmentainer` (`CssBox.cs`, called from `DriveBlockChildPass`
+whenever a box resumes with a non-null token): its own doc comment states the design plainly — "**only
+this box moves, not its subtree**... its already-placed descendants belong to the fragmentainer being
+left and keep the geometry that one's own fragment was built from." That is correct for ordinary content
+(a `<p>`'s first half genuinely does stay in the fragmentainer it was placed in), but the *marker* is not
+"content behind in the fragmentainer being left" the way a placed line is — it names a position derived
+from the item's own border box, and `ResumeInTheNextFragmentainer` moves that border box (`Location`)
+without moving the one child (the marker) whose position is supposed to describe it. Compounding this:
+the failing items' own fragments (both, in `li5`'s case) ended up on a pagination slot neither of the two
+logged `LayoutPassContents` visits ever named, meaning at least one further whole-container relayout
+attempt is involved that a simple per-visit trace does not capture — consistent with the file's own
+"settling how the columns engine fragments a block-level list item" framing above, not a narrow gap in
+one method.
+
+**Status: still open, scope confirmed larger than a marker-only fix.** A real fix needs
+`ResumeInTheNextFragmentainer` (or whatever relays the item across that further whole-container retry)
+to either move the marker's word along with the box, or explicitly take it back so a later pass
+repositions it — and the second, currently-untraced relayout path needs identifying before either change
+can be verified against the sweep. Left as this file's own open gap rather than shipped as a fix that
+measurably does nothing.

--- a/.claude/migration-notes/2026-09-07-forced-break-below-a-flex-grid-items-own-child-now-takes-effect.md
+++ b/.claude/migration-notes/2026-09-07-forced-break-below-a-flex-grid-items-own-child-now-takes-effect.md
@@ -1,0 +1,12 @@
+# A forced break below a flex or grid item's own child now takes effect
+
+Previously, `break-before`/`break-after: page` (or `column`) declared on a descendant of a flex or grid
+item — not the item itself, but something inside it — could be silently lost. Every earlier layout of
+that item is a *measurement* (sizing the item before its final position is known), and a measurement pass
+lays the item's content out for real, which could mark the forced break as already taken before the
+item's own, final commit layout ever ran; the commit pass never got a second chance to see it.
+
+A flex or grid item's own commit layout now clears that "already taken" state on its whole subtree before
+laying it out for real, the same way the multi-column engine's own equivalent transition already did for
+its own refill — so a forced break below a flex or grid item's own child now takes effect on the page
+where it was declared, the same way it already did for a break declared directly on the item.

--- a/.claude/migration-notes/2026-09-07-nested-multicolumn-containers-now-split-per-inner-column.md
+++ b/.claude/migration-notes/2026-09-07-nested-multicolumn-containers-now-split-per-inner-column.md
@@ -1,0 +1,14 @@
+# A multi-column container nested inside another one now splits per inner column, not just per outer one
+
+Previously, a multi-column container nested inside another multi-column container split its own children
+at the outer container's column boundaries only: whichever inner column a descendant's content actually
+landed in, its fragment carried the enclosing outer column's geometry rather than its own — so a decorated
+box (a background, a border) inside the inner container's second column could paint at the inner
+container's *first* column position instead, since the fragment tree had no way to tell the inner
+container's own columns apart once it was already inside an outer one.
+
+A multi-column container nested inside another one now splits its own children per inner column,
+independently in each outer column it is filled in — the same per-column fragment behavior a top-level
+(non-nested) multi-column container already had.
+
+See [Multi-column Layout](../../docs/html-css-support.md#multi-column-layout) in `docs/html-css-support.md`.

--- a/.claude/recent-fixes/2026-09-07-nested-multicol-fragment-splitting-and-flex-grid-forced-break-retake.md
+++ b/.claude/recent-fixes/2026-09-07-nested-multicol-fragment-splitting-and-flex-grid-forced-break-retake.md
@@ -1,0 +1,79 @@
+# A multi-column container nested inside another one splits per inner column; a flex/grid item's own forced break survives its measurement pass
+
+Two independent fixes landed together (issues #369 and #395), both residuals of earlier fragment-model
+work, plus one bug the post-change review pass found in the #369 fix itself before it shipped.
+
+## #369 — nested multi-column splitting
+
+`FragmentEmitter._nested` keys a box's captured per-column geometry by `(CssBox, Slot)` alone.
+`FragmentEmitter.ChildrenOf`'s old gate (`nested is null && ...`) consulted a box's own captures only when
+that box was not itself already inside a nested fragmentainer — so an inner multi-column container's own
+columns were never split once reached through an outer one; its children were read flat off `CssBox.Boxes`
+instead, describing only whichever outer column the inner container was filled in *last*.
+
+Fix: `NestedFragmentainer` (the per-capture record) now carries `Self` (the `FragmentainerContext` this
+capture was filled under) and `ParentContext` (what was active immediately before that). `ChildrenOf`
+always attempts the lookup now, filtering candidates by `ParentContext == nested.Value.Self` when already
+nested, so it can tell which outer column's fill a given inner capture belongs to instead of only
+consulting one level. Threaded through `CssLayoutEngineColumns.FillColumns`'s single call site into
+`RecordNestedFragmentainer`.
+
+**A second bug, found only by the post-change review pass, not by the tests above.** `FragmentKey`
+(`(CssBox, CssProxyBox?, Instance)`) disambiguates simultaneous fragments of one box within one slot —
+Instance names which column. But `Instance` is assigned by `ChildrenOf`'s own per-call loop (`i + 1`),
+which restarts at 1 on *every* call — so once the fix above let a box's own captures be consulted while
+nested, two *different* outer columns' own visits to the same inner box's `ChildrenOf` each restart at
+Instance 1, and their children collide on identical `FragmentKey`s. `_rectangles[key]`/`_spans[key]`
+accumulate across calls sharing a key, so two unrelated same-page fragments' decoration rectangles would
+merge under one entry — invisible for a box whose own lines are all it owns (the overwhelmingly common
+case: `SliceGeometriesOf` treats those independently regardless of dictionary size), but wrong for an
+inline run split across a differently-owned decoration box, where the merged rectangle set genuinely
+changes the computed slice geometry.
+
+Fixed at the root rather than patched at each call site: `FragmentKey` gained a fourth field,
+`EnclosingContext` (`nested?.Self` at the point a box's own draft is built), defaulting to `null` so every
+existing 3-argument construction (the document root, the page-grid resumption-chain keys that never carry
+an owner or a real instance either) is unaffected. `FragmentainerContext` has no custom `Equals`, so the
+new field's default record-struct equality is exactly the reference identity the fix needs.
+
+## #395 — flex/grid item's own forced break spent by its measurement pass
+
+The direct-child multicol shape of this defect class was already fixed (#434:
+`CssBox.AllowDescendantForcedBreaksToBeRetaken` recursively clears `PlacedByForcedBreak` through a
+subtree on refill). Flex and grid never called it at all: `CssLayoutEngineFlex.MeasureItem` runs a *real*
+layout pass to measure an item, which can set `PlacedByForcedBreak = true` on a forced break somewhere in
+the item's own subtree during measurement — and `ItemContentCommit.CommitLayout` (the item's real, final
+layout) never reset it before re-entering, so the break was read as already taken and silently never
+retaken.
+
+Fix: `ItemContentCommit.CommitLayout`'s fresh-commit branch (`resume is null`) now calls
+`box.AllowDescendantForcedBreaksToBeRetaken()` before laying the item out for real — the same reset the
+multi-column engine's own refill transition already needed for the identical reason. The method's
+visibility changed from `private` to `internal` for this new caller.
+
+## Evidence
+
+Both new tests verified fail-before/pass-after against the pre-fix code (`git stash`/manual hunk revert,
+per this repo's testing-rigor convention), not just written and left green:
+`FragmentEmitterTests.InnerMulticolSpanningSeveralOuterColumns_SplitsPerInnerColumnNotJustPerOuterOne` and
+`FlexGridFragmentationIntegrationTests`' new `Flex_ForcedBreakBelowTheItemsOwnChild_TakesEffect`/
+`Grid_ForcedBreakBelowTheItemsOwnChild_TakesEffect`. Full suite (net8.0, 9922 tests) green, solution-wide
+`dotnet build -t:Rebuild` clean, diff coverage 100% on changed lines. An 8-angle review pass ran against
+the full diff after implementation; the `FragmentKey` collision above is the one finding it surfaced that
+changed the shipped code — the rest (a documented, deliberately-unwidened `ClearNestedFragmentainers`,
+`AllowDescendantForcedBreaksToBeRetaken`'s lack of its own idempotency guard, `ReferenceEquals` depending
+on `FragmentainerContext` staying a reference type) were judged acceptable as-is or too narrow to justify
+further scope in this change; see `.claude/invariants/` if a future change needs to revisit them.
+
+**Deliberately not widened:** `ClearNestedFragmentainers`/`ClearNestedFragmentainersFrom` still wipe (or
+truncate) a whole `(CssBox, Slot)` entry regardless of which enclosing capture recorded it. A first attempt
+threaded the same `ParentContext`-scoped filtering into the clear path too, reasoning that an unconditional
+wipe could delete a sibling outer column's still-valid captures — but this broke real, existing tests
+(`AColumnContainer_InsideAnotherEngine_EmitsEveryWordExactlyOnce`,
+`TwoColumnContainers_InSeparateFlexItemsOnOneLine_BothEmitEveryWordExactlyOnce`): a flex item's own
+measurement-then-commit cycle can lay a *top-level* multi-column container out more than once under
+different `CurrentFragmentainer` states, and the narrower filter left the measurement pass's own stale
+captures behind for the commit pass to double-count. Reverted; the unconditional wipe is correct for every
+case this fix's own tests reach. A nested-in-nested container needing a `column-fill: balance` retry may
+still be exposed to the narrower version of this problem — not proven, not reproduced, left as a gap for a
+future change to find with evidence rather than fixed speculatively here.

--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -598,7 +598,7 @@ A multi-column container whose content is only text, with no block-level child o
 
 - A decoration defined over the *whole* box — a `border-radius`, a gradient or image background layer, a `box-shadow` — is measured against the whole box under `slice`, so a rounded, gradient-filled box divided between two columns rounds only at its true ends and its gradient runs on from one column into the next. See [Decorations at a break](#decorations-at-a-break).
 
-One limitation at a column boundary specifically: a multi-column container nested inside another one splits its children at the outer level only.
+A multi-column container nested inside another one splits its own children per inner column, independently in each outer column it is filled in.
 
 | Property | MDN Reference | Notes |
 |----------|--------------|-------|

--- a/src/PeachPDF.Tests/Html/Core/Fragments/FragmentEmitterTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Fragments/FragmentEmitterTests.cs
@@ -1086,6 +1086,70 @@ namespace PeachPDF.Tests.Html.Core.Fragments
                 $"decoration {line.Rect.Bottom} must cover its content {words.Max(w => w.Rect.Bottom)}");
         }
 
+        // ─── A box's own nested captures are told apart by which outer column filled them (#369) ──
+
+        /// <summary>
+        /// A multi-column container nested inside another one is filled once per <i>outer</i> column, and
+        /// each of those fills records its own nested captures for its own children under the very same
+        /// <c>(CssBox, Slot)</c> key in <c>FragmentEmitter._nested</c> as every other outer column's fill of
+        /// it. Before the fix, <c>ChildrenOf</c>'s one-level-only consult (<c>nested is null</c>) never
+        /// looked at the inner container's own captures once already inside an outer one, so the inner
+        /// paragraph's per-line rectangles were read from <c>BoxGeometrySnapshot</c>'s ordinary recursive
+        /// capture instead - which is deep enough to keep every line's content and position correct (no word
+        /// is lost or claimed twice either before or after this fix), but flattens the paragraph's own two
+        /// inner columns into a single fragment whose bounds run from the inner container's left edge only,
+        /// discarding the inline offset its own second column placed lines at. The paragraph's fragments
+        /// must therefore show as many distinct inline positions as it has (outer column × inner column)
+        /// combinations, not merely as many as the outer container alone has columns for.
+        /// </summary>
+        [Fact]
+        public async Task InnerMulticolSpanningSeveralOuterColumns_SplitsPerInnerColumnNotJustPerOuterOne()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(
+                NestedMulticol(wordCount: 800), pageWidth: 400, pageHeight: 150, margin: 0);
+
+            var inner = LayoutHarness.FindById(root, "inner")!;
+            var fragments = FragmentsOf(container.FragmentTree!, "p");
+
+            Assert.True(fragments.Count > 1, $"expected the paragraph to split across fragments, got {fragments.Count}");
+
+            // No word is lost or claimed twice - true with or without the fix, since BoxGeometrySnapshot's
+            // capture is recursive and this is not what #369 breaks. Pinned anyway as the safety net a
+            // fragment-count/position fix like this one could plausibly regress.
+            var words = fragments.SelectMany(Flatten).SelectMany(f => f.Words).Select(w => w.Word).ToList();
+            Assert.Equal(800, words.Count);
+            Assert.Equal(words.Count, words.Distinct().Count());
+
+            // The inner container itself must actually have spanned more than one outer column for this
+            // test to exercise the bug at all - otherwise there is only one capture to begin with and the
+            // fix has nothing to do.
+            var innerFragments = FragmentsOf(container.FragmentTree!, "inner");
+            var distinctOuterX = innerFragments.Select(f => System.Math.Round(f.Rect.X, 1)).Distinct().Count();
+            Assert.True(distinctOuterX > 1,
+                $"expected the inner container to occupy more than one outer column's worth of X positions, got {distinctOuterX}");
+            Assert.True(inner.Boxes.Count > 0);
+
+            // The fix's own signature: the paragraph (inner's child) must show MORE distinct inline
+            // positions than the inner container's own outer-level split alone accounts for - the extra
+            // ones are its own two inner columns, told apart per outer column only once ChildrenOf consults
+            // the inner container's own captures instead of falling back to the flat, merged read.
+            var distinctParagraphX = fragments.Select(f => System.Math.Round(f.Rect.X, 1)).Distinct().Count();
+            Assert.True(distinctParagraphX > distinctOuterX,
+                $"expected the paragraph to split per inner column too, got {distinctParagraphX} distinct " +
+                $"positions against the container's own {distinctOuterX}");
+        }
+
+        /// <summary>
+        /// An outer 2-column container narrow enough that its own nested 2-column child cannot finish
+        /// inside one outer column, forcing that child to be filled again - under a different outer column -
+        /// for the same page.
+        /// </summary>
+        private static string NestedMulticol(int wordCount) => LayoutHarness.Wrap(
+            "<div id='outer' style='columns:2; column-gap:20pt; column-fill:auto;'>" +
+            "<div id='inner' style='columns:2; column-gap:10pt; column-fill:auto; font:10pt Arial; line-height:12pt; margin:0'>" +
+            $"<p id='p' style='margin:0'>{Words(wordCount)}</p>" +
+            "</div></div>");
+
         // ─── §6.2's block-axis edges ───────────────────────────────────────────────
 
         /// <summary>

--- a/src/PeachPDF.Tests/Integration/FlexGridFragmentationIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FlexGridFragmentationIntegrationTests.cs
@@ -343,6 +343,53 @@ namespace PeachPDF.Tests.Integration
             Assert.Equal(authored.OrderBy(w => w), claimed.OrderBy(w => w));
         }
 
+        // ─── A forced break below an item's own child, not the item itself (#395) ──
+
+        // The item's own measurement pass (CssLayoutEngineFlex.MeasureItem) runs a real layout of the
+        // item's content to size it, which can set CssBox.PlacedByForcedBreak on the break's target
+        // before the item's real, final commit layout (ItemContentCommit.CommitLayout) ever runs - a
+        // one-shot latch with no notion of "that was only a measurement", so without resetting it the
+        // break is silently spent and never seen again.
+        [Fact]
+        public async Task Flex_ForcedBreakBelowTheItemsOwnChild_TakesEffect()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(
+                LayoutHarness.Wrap(
+                    "<div style='display:flex'>" +
+                    "<div id='item' style='flex:1;margin:0;line-height:22pt;font-size:10pt'>" +
+                    "<p id='para1' style='margin:0'>Para1</p>" +
+                    "<p id='para2' style='margin:0;break-before:page'>Para2</p>" +
+                    "</div></div>"),
+                pageHeight: PageHeight, margin: 20);
+
+            var para1 = LayoutHarness.FindById(root, "para1")!;
+            var para2 = LayoutHarness.FindById(root, "para2")!;
+
+            Assert.Equal(0, container.PageIndexOf(para1.Location.Y));
+            Assert.Equal(1, container.PageIndexOf(para2.Location.Y));
+            Assert.Equal(container.PageTopOf(1), para2.Location.Y, 2);
+        }
+
+        [Fact]
+        public async Task Grid_ForcedBreakBelowTheItemsOwnChild_TakesEffect()
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(
+                LayoutHarness.Wrap(
+                    "<div style='display:grid'>" +
+                    "<div id='item' style='margin:0;line-height:22pt;font-size:10pt'>" +
+                    "<p id='para1' style='margin:0'>Para1</p>" +
+                    "<p id='para2' style='margin:0;break-before:page'>Para2</p>" +
+                    "</div></div>"),
+                pageHeight: PageHeight, margin: 20);
+
+            var para1 = LayoutHarness.FindById(root, "para1")!;
+            var para2 = LayoutHarness.FindById(root, "para2")!;
+
+            Assert.Equal(0, container.PageIndexOf(para1.Location.Y));
+            Assert.Equal(1, container.PageIndexOf(para2.Location.Y));
+            Assert.Equal(container.PageTopOf(1), para2.Location.Y, 2);
+        }
+
         // ─── Grid ─────────────────────────────────────────────────────────────────
 
         [Theory]

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -1982,9 +1982,15 @@ namespace PeachPDF.Html.Core.Dom
         /// </summary>
         /// <remarks>
         /// The recursive half of <see cref="ResetForRefill"/> - see its remarks for why this is narrower
-        /// than a full prologue reset and why that is safe.
+        /// than a full prologue reset and why that is safe. <c>internal</c> rather than <c>private</c> so
+        /// <see cref="Fragmentation.ItemContentCommit.CommitLayout"/> can call it directly on a flex/grid
+        /// item transitioning from measurement to its real, final layout (#395): unlike the columns
+        /// engine's own refill (which calls this once per direct child, from the container), an item's
+        /// measurement pass can spend the flag on the item box itself, which is the one case
+        /// <see cref="ResetForRefill"/> - called on a container, only ever recursing into its own
+        /// children - cannot reach.
         /// </remarks>
-        private void AllowDescendantForcedBreaksToBeRetaken()
+        internal void AllowDescendantForcedBreaksToBeRetaken()
         {
             PlacedByForcedBreak = false;
 

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineColumns.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineColumns.cs
@@ -623,7 +623,9 @@ namespace PeachPDF.Html.Core.Dom
                         (boxTop, Math.Max(boxTop + target, columnBottom)),
                         (columnInlineLeft, columnInlineLeft + columnWidth),
                         BoxGeometrySnapshot.Capture(ChildrenIn(children, columnStart, placedBelow), beyond),
-                        ContinuingPast(columnsBox.PendingBreakToken));
+                        ContinuingPast(columnsBox.PendingBreakToken),
+                        column,
+                        previousContext);
                 }
                 finally
                 {

--- a/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
@@ -83,8 +83,19 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// <see cref="Instance"/> names which of a slot's nested fragmentainers the fragment belongs to, 0
         /// for the page itself. Two columns of one page are two fragmentainers of the same slot, so a box
         /// appearing in both produces two fragments that a (box, slot) pair alone could not tell apart.
+        /// <see cref="EnclosingContext"/> extends this one level of disambiguation to arbitrary nesting
+        /// depth: <see cref="Instance"/> alone restarts at 1 on every call to <see cref="ChildrenOf"/>, so
+        /// a box nested one level deep - re-filled once per <i>outer</i> column - hands out the same
+        /// <c>Instance</c> numbers under every outer column it is filled in, and without this field two
+        /// simultaneous, unrelated fragments (one per outer column, both instance 1) would collide on the
+        /// same key and have their decoration rectangles merged in <see cref="_rectangles"/>. It is the
+        /// enclosing capture's own <see cref="NestedFragmentainer.Self"/> that was active when this
+        /// fragment's own <c>Instance</c> was assigned - null wherever <see cref="Instance"/> alone is
+        /// already unique (the page level, and the degenerate page-grid-resumption keys that never carry
+        /// an owner or a real instance either).
         /// </remarks>
-        private readonly record struct FragmentKey(CssBox Box, CssProxyBox? Owner, int Instance);
+        private readonly record struct FragmentKey(
+            CssBox Box, CssProxyBox? Owner, int Instance, FragmentainerContext? EnclosingContext = null);
 
         /// <summary>
         /// One emitted pagination slot: its index and the document-space band layout paginated against.
@@ -168,11 +179,23 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// column and one that ends there have the same block extent, so nothing downstream can tell them
         /// apart.
         /// </remarks>
+        /// <remarks>
+        /// <see cref="Self"/> is the fragmentainer context this capture was itself filled under — the
+        /// specific column instance <see cref="CssLayoutEngineColumns.FillColumns"/> entered to produce it.
+        /// <see cref="ParentContext"/> is whatever was active immediately before <see cref="Self"/> was
+        /// entered — null for a capture recorded at the page level. Two different fills of the same
+        /// <i>inner</i> multi-column container, one per <i>outer</i> column, are otherwise indistinguishable:
+        /// both land under the same <c>(CssBox, Slot)</c> key in <see cref="_nested"/>, and a deeper
+        /// capture's own <see cref="ParentContext"/> is what lets <see cref="ChildrenOf"/> tell which outer
+        /// column's fill it belongs to, by comparing it against the outer capture's own <see cref="Self"/>.
+        /// </remarks>
         private readonly record struct NestedFragmentainer(
             FragmentRegion Region,
             BoxGeometrySnapshot Geometry,
             IReadOnlySet<CssBox> Continuing,
-            IReadOnlySet<CssBox> ContinuedFrom);
+            IReadOnlySet<CssBox> ContinuedFrom,
+            FragmentainerContext Self,
+            FragmentainerContext? ParentContext);
 
         /// <summary>
         /// A fragment before its first/last flags are known — which cannot be until every slot has been
@@ -592,13 +615,23 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// which it can be recorded — content continuing into the next one is laid out again there.
         /// </param>
         /// <param name="continuing">the boxes that carry on into the next fragmentainer</param>
+        /// <param name="self">
+        /// the fragmentainer context this fill was entered under — see
+        /// <see cref="NestedFragmentainer"/>'s own remarks.
+        /// </param>
+        /// <param name="parentContext">
+        /// the fragmentainer that was active immediately before <paramref name="self"/> was entered, or null
+        /// at the page level — see <see cref="NestedFragmentainer"/>'s own remarks.
+        /// </param>
         internal void RecordNestedFragmentainer(
             CssBox contextRoot,
             int slot,
             (double Top, double Bottom) band,
             (double Left, double Right) inline,
             BoxGeometrySnapshot geometry,
-            IReadOnlySet<CssBox> continuing)
+            IReadOnlySet<CssBox> continuing,
+            FragmentainerContext self,
+            FragmentainerContext? parentContext)
         {
             if (!_nested.TryGetValue((contextRoot, slot), out var fragmentainers))
             {
@@ -609,7 +642,9 @@ namespace PeachPDF.Html.Core.Fragmentation
                 new FragmentRegion(band.Top, band.Bottom, inline.Left, inline.Right),
                 geometry,
                 continuing,
-                fragmentainers.Count > 0 ? fragmentainers[^1].Continuing : NoBoxes));
+                fragmentainers.Count > 0 ? fragmentainers[^1].Continuing : NoBoxes,
+                self,
+                parentContext));
 
             // Which children this container yields, how many times, and against which geometry, are all
             // decided by the set of fragmentainers recorded for it - so an earlier "emitted nothing
@@ -1891,7 +1926,8 @@ namespace PeachPDF.Html.Core.Fragmentation
 
             subtreePrunable &= contiguous;
 
-            var draft = new Draft(new FragmentKey(box, owner, instance), box, slot, region, snapshot, originY);
+            var draft = new Draft(
+                new FragmentKey(box, owner, instance, nested?.Self), box, slot, region, snapshot, originY);
 
             draft.Lines.AddRange(lines);
             draft.Words.AddRange(words);
@@ -2046,11 +2082,14 @@ namespace PeachPDF.Html.Core.Fragmentation
         /// which the box's own single <c>Location</c> cannot express and the captures can.
         /// </para>
         /// <para>
-        /// Nested contexts are consulted at one level only — a container already inside a nested
-        /// fragmentainer reads through the enclosing capture instead, so a multi-column container inside
-        /// another one splits at the outer level alone. The reason is that a box's captures are keyed by
-        /// pagination slot, and the inner container's columns are re-filled once per <i>outer</i> column, so
-        /// two outer columns' worth of inner captures would be indistinguishable from each other.
+        /// A box already inside a nested fragmentainer can still own its own nested captures — a
+        /// multi-column container nested inside another one — and <see cref="NestedFragmentainer.ParentContext"/>
+        /// is what tells them apart: a box's inner columns are re-filled once per <i>outer</i> column, so all
+        /// of them land under the same <c>(CssBox, Slot)</c> key in <see cref="_nested"/>, and only the
+        /// enclosing capture's own <see cref="NestedFragmentainer.Self"/> — compared against each candidate's
+        /// <see cref="NestedFragmentainer.ParentContext"/> — says which outer column's fill a given inner
+        /// capture belongs to. At the page level (<paramref name="nested"/> null) there is only one outer
+        /// instance to begin with, so every capture recorded for the box is its own, unfiltered.
         /// </para>
         /// </remarks>
         private IEnumerable<(CssBox Box, CssProxyBox? Owner, BoxGeometrySnapshot? Snapshot,
@@ -2072,32 +2111,40 @@ namespace PeachPDF.Html.Core.Fragmentation
             if (box is CssSpacingBox spacing)
                 yield return (spacing.ExtendedBox, owner, snapshot, nested, instance);
 
-            if (nested is null
-                && _nested.TryGetValue((box, slot.Index), out var fragmentainers)
-                && fragmentainers.Count > 0)
+            if (_nested.TryGetValue((box, slot.Index), out var allCaptures) && allCaptures.Count > 0)
             {
-                for (var i = 0; i < fragmentainers.Count; i++)
-                {
-                    var fragmentainer = fragmentainers[i];
+                // At the page level every capture recorded for this box is its own. Nested one level
+                // deeper, only the captures recorded while the enclosing capture's own column was the one
+                // being filled belong to it - see this method's own remarks.
+                var fragmentainers = nested is null
+                    ? allCaptures
+                    : allCaptures.FindAll(f => ReferenceEquals(f.ParentContext, nested.Value.Self));
 
+                if (fragmentainers.Count > 0)
+                {
+                    for (var i = 0; i < fragmentainers.Count; i++)
+                    {
+                        var fragmentainer = fragmentainers[i];
+
+                        foreach (var childBox in box.Boxes)
+                        {
+                            if (fragmentainer.Geometry.Holds(childBox))
+                                yield return (childBox, owner, fragmentainer.Geometry, fragmentainer, i + 1);
+                        }
+                    }
+
+                    // A child no fragmentainer holds was not placed into one — an out-of-flow child, which
+                    // css-multicol resolves against the container rather than a column, and which the columns
+                    // engine lays out once at the end. It is read live and belongs to the page, exactly as it
+                    // did before nested fragmentainers existed.
                     foreach (var childBox in box.Boxes)
                     {
-                        if (fragmentainer.Geometry.Holds(childBox))
-                            yield return (childBox, owner, fragmentainer.Geometry, fragmentainer, i + 1);
+                        if (!HeldByAny(fragmentainers, childBox))
+                            yield return (childBox, owner, snapshot, null, instance);
                     }
-                }
 
-                // A child no fragmentainer holds was not placed into one — an out-of-flow child, which
-                // css-multicol resolves against the container rather than a column, and which the columns
-                // engine lays out once at the end. It is read live and belongs to the page, exactly as it
-                // did before nested fragmentainers existed.
-                foreach (var childBox in box.Boxes)
-                {
-                    if (!HeldByAny(fragmentainers, childBox))
-                        yield return (childBox, owner, snapshot, null, instance);
+                    yield break;
                 }
-
-                yield break;
             }
 
             foreach (var childBox in box.Boxes)

--- a/src/PeachPDF/Html/Core/Fragmentation/ItemContentCommit.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/ItemContentCommit.cs
@@ -81,6 +81,15 @@ namespace PeachPDF.Html.Core.Fragmentation
                 box.Height = FormatLayoutUnits(Math.Max(0, box.ActualBoxSizingHeight - box.ActualBoxSizeIncludedHeight), box);
 
                 box.RectanglesReset();
+
+                // A forced break (break-before/break-after) on this item, or anywhere in its own
+                // subtree, may already have been "taken" by the measurement pass that sized this item
+                // before this, its real and final layout, ever ran - CssBox.PlacedByForcedBreak is a
+                // one-shot latch with no notion of "that was only a measurement" (#395). Without this,
+                // the break is silently never seen again: the multi-column engine's own equivalent
+                // transition (CssBox.ResetForRefill) already has to clear the same latch for exactly
+                // this reason.
+                box.AllowDescendantForcedBreaksToBeRetaken();
             }
             else
             {

--- a/src/PeachPDF/Html/Core/HtmlContainerInt.cs
+++ b/src/PeachPDF/Html/Core/HtmlContainerInt.cs
@@ -2045,8 +2045,10 @@ namespace PeachPDF.Html.Core
             (double Top, double Bottom) band,
             (double Left, double Right) inline,
             BoxGeometrySnapshot geometry,
-            IReadOnlySet<CssBox> continuing) =>
-            _emitter?.RecordNestedFragmentainer(contextRoot, slot, band, inline, geometry, continuing);
+            IReadOnlySet<CssBox> continuing,
+            FragmentainerContext self,
+            FragmentainerContext? parentContext) =>
+            _emitter?.RecordNestedFragmentainer(contextRoot, slot, band, inline, geometry, continuing, self, parentContext);
 
         /// <summary>
         /// Discards what <paramref name="contextRoot"/> recorded in <paramref name="slot"/> — or, with no


### PR DESCRIPTION
## Summary
- A multi-column container nested inside another one used to split its children at the outer container's column boundaries only, since `FragmentEmitter`'s nested-capture lookup only ever consulted a box's own captures one level deep. `NestedFragmentainer` now carries the enclosing capture's own identity (`Self`/`ParentContext`) so `ChildrenOf` can tell which outer column's fill a given inner capture belongs to at any nesting depth.
- Found by the post-change review pass, not by the tests above: the fix above exposed a latent `FragmentKey` collision (two outer columns' own inner-column-1 fragments both getting `Instance = 1`, merging their decoration rectangles). `FragmentKey` gained a fourth discriminator field (`EnclosingContext`) to fix it at the root.
- A flex or grid item's own forced break below one of its descendants could be silently spent by the item's *measurement* pass (a real layout at a provisional position) before the item's real, final commit layout ever ran. `ItemContentCommit.CommitLayout` now resets that one-shot latch before a fresh commit, mirroring the multi-column engine's own equivalent transition.

Fixes #369
Fixes #395

## Test plan
- [x] New regression tests verified to fail against the pre-fix code and pass against the fix (manual hunk revert, per this repo's testing convention): `FragmentEmitterTests.InnerMulticolSpanningSeveralOuterColumns_SplitsPerInnerColumnNotJustPerOuterOne`, `FlexGridFragmentationIntegrationTests.Flex_ForcedBreakBelowTheItemsOwnChild_TakesEffect` / `Grid_ForcedBreakBelowTheItemsOwnChild_TakesEffect`
- [x] Full suite green: `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` (9922 passed)
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] Diff coverage 100% on changed lines
- [x] 8-angle post-change review pass run against the full diff; findings addressed or recorded as deliberate/out-of-scope in the accompanying `.claude/recent-fixes/` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)