### PR TITLE
Let the stacking-hoist candidate scan see into a repeated header's proxy

### DIFF
--- a/.claude/invariants/proxy-a-document-wide-tree-walk-must-unwrap-cssproxybox-or-miss-its-subtree.md
+++ b/.claude/invariants/proxy-a-document-wide-tree-walk-must-unwrap-cssproxybox-or-miss-its-subtree.md
@@ -1,0 +1,23 @@
+# A document-wide tree walk must unwrap `CssProxyBox` or miss its subtree entirely
+
+`CssProxyBox` deliberately does not expose its `SourceBox` subtree through `CssBox.Boxes` — that is the
+whole point of it: one detached source subtree (a repeating `<thead>`/`<tfoot>`'s row group, removed from
+the live tree by `CssLayoutEngineTable.RemoveHeaderFooterFromTree`) is shown at a different position on
+every page it repeats onto, via one proxy per page.
+
+Any code that walks `CssBox.Boxes` recursively over the **whole document** (not scoped to one already-known
+subtree) to answer a yes/no question about "does a box like *this* exist anywhere" is blind to a box that
+exists **only** inside a repeated header/footer's source subtree, unless it explicitly unwraps
+`CssProxyBox.SourceBox` the way `Fragmentation.FragmentEmitter.ChildrenOf` and
+`HtmlContainerInt.ComputeFlowFlags` both do. The failure mode is not a narrowly wrong answer — when the
+predicate being scanned for exists *only* inside such a subtree, the flag comes back `false`/`empty`
+exactly as if nothing of the kind existed in the document at all, which for
+`HasStackingHoistCandidates` meant a stacking-context box was never painted on any page, not merely
+misplaced (issue #345's own investigation surfaced this as a prerequisite bug, tracked and fixed
+separately).
+
+Before adding a new document-wide `CssBox.Boxes` walk (a feature-detection flag, a "does anything need X"
+short-circuit, a global count), check whether the answer could depend on content inside a repeated
+header/footer, and if so unwrap `CssProxyBox` the same way. A walk that is already scoped to a specific,
+already-materialized subtree (never crossing into a `CssProxyBox`) does not need this — the risk is
+specific to a walk that starts at `Root` and means to see everything.

--- a/.claude/recent-fixes/2026-09-07-stacking-hoist-scan-sees-into-a-repeated-headers-proxy.md
+++ b/.claude/recent-fixes/2026-09-07-stacking-hoist-scan-sees-into-a-repeated-headers-proxy.md
@@ -1,0 +1,40 @@
+# `HasStackingHoistCandidates` (and the float/out-of-flow flags beside it) now see into a repeated header/footer's proxy
+
+`HtmlContainerInt.ComputeFlowFlags` computes three document-wide flags — `HasFloatedBoxes`,
+`HasOutOfFlowBoxes`, `HasStackingHoistCandidates` — by walking `CssBox.Boxes` from `Root` once, after
+layout. `StackingOrder.Flatten` gates its entire hoisting search on `HasStackingHoistCandidates` alone
+(`if (!(box.HtmlContainer?.HasStackingHoistCandidates ?? true)) yield break;`): a plain-wrapper ancestor's
+ordinary paint loop deliberately skips a descendant that needs hoisting, trusting some enclosing search to
+find and paint it instead. When the flag is wrongly `false`, no such search ever runs, so the box is not
+merely mis-clipped or mis-ordered — it is **never painted on any page**.
+
+**The gap.** A repeating `<thead>`/`<tfoot>` is detached from the live tree
+(`CssLayoutEngineTable.RemoveHeaderFooterFromTree`) and stood back in per page by a `CssProxyBox`, whose
+real content lives in `SourceBox` — deliberately not part of `.Boxes`, exactly so one source subtree can
+be shown at many positions (see `CssProxyBox`'s own remarks, and `FragmentEmitter.ChildrenOf`'s identical
+unwrap for fragment-building). `ComputeFlowFlags`'s walk had no equivalent unwrap, so a stacking-context
+box (`position:relative;z-index:0`, `opacity:0.99`, etc.) reachable *only* through a repeated header's
+source subtree was invisible to the scan. With no other stacking-hoist candidate anywhere else in the
+document, `HasStackingHoistCandidates` came out `false` and the box's content silently never painted at
+all, on any page — reproducible on a single page, no pagination needed.
+
+**Fix.** `ComputeFlowFlags`'s recursive step now also descends into `((CssProxyBox)box).SourceBox` when
+the box being visited is a proxy, mirroring `FragmentEmitter.ChildrenOf`'s own proxy unwrap. Applied to
+all three flags uniformly, not just the stacking one — a float or an out-of-flow box that exists only
+inside a repeated header/footer would have hit the identical blind spot in `DomUtils.GetFirstIntersectingFloatBox`'s
+own `HasFloatedBoxes` short-circuit, just with a less visible symptom (a float not avoided, rather than
+content dropped outright).
+
+**Found, not invented, while working on a *different* issue** (#345, `RenderUtils.PushAncestorOverflowClips`
+reading live `CssBox` geometry instead of the fragment tree) — the natural end-to-end repro for #345 needed
+a stacking-context box inside a repeated header, which turned out to not paint at all, independent of
+whatever #345 itself fixes about clip geometry. The two are unrelated: this is about whether a stacking
+participant is *found*, #345 is about the clip rect once one *is* found.
+
+**Evidence.** New tests in
+`src/PeachPDF.Tests/Integration/RepeatedTableHeaderClipIntegrationTests.cs` —
+`StackingContextOnlyReachableThroughARepeatedHeader_IsPaintedOnEveryPage` (fails on every page pre-fix:
+`HEADERMARKER` never appears in the paint recording) and a plain, non-table control
+(`StackingContextInsideAPlainOverflowClip_IsPainted`, passes unchanged before and after — confirming the
+gap is specifically about the proxy, not stacking hoist in general). Full suite (net8.0, 9920 tests) and a
+solution-wide `dotnet build -t:Rebuild` both clean; diff coverage 100% on the changed lines.

--- a/src/PeachPDF.Tests/Integration/RepeatedTableHeaderClipIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/RepeatedTableHeaderClipIntegrationTests.cs
@@ -108,5 +108,68 @@ namespace PeachPDF.Tests.Integration
             string.Join("|", LayoutHarness.Descendants(root).Select(b =>
                 $"{b.Location.X:F3},{b.Location.Y:F3},{b.ActualRight:F3},{b.ActualBottom:F3}," +
                 string.Join(";", b.Words.Select(w => $"{w.Left:F3},{w.Top:F3}"))));
+
+        /// <summary>
+        /// A stacking-context box (<c>position:relative;z-index:0</c>) reached only through a repeated
+        /// <c>&lt;thead&gt;</c>'s detached source subtree, with no other stacking-context box anywhere
+        /// else in the document. <c>HtmlContainerInt.HasStackingHoistCandidates</c> is a single
+        /// document-wide flag computed once by walking <c>CssBox.Boxes</c> from the root - a walk that
+        /// cannot see into a <c>CssProxyBox</c>'s <c>SourceBox</c>, since the repeating row group is
+        /// detached from the live tree (<c>CssLayoutEngineTable.RemoveHeaderFooterFromTree</c>) and is
+        /// reachable only through the proxy standing in for it on each page. When this box is the
+        /// <i>only</i> stacking-hoist candidate in the whole document, the flag comes out false, and
+        /// <c>StackingOrder.Flatten</c>'s hoisting search - gated on that same flag - never runs at all:
+        /// the box's own plain-wrapper ancestor already skips it on the assumption some enclosing
+        /// search will paint it instead, so it is not merely mis-clipped or mis-ordered, it is never
+        /// painted anywhere.
+        /// </summary>
+        private static string StackingContextInRepeatedHeaderTable() => LayoutHarness.Wrap(
+            "<table style='width:300pt;border-collapse:collapse;font:10pt Arial'>" +
+            "<thead><tr><th style='padding:0;text-align:left'>" +
+            "<div style='overflow:hidden;height:14pt'>" +
+            "<div style='position:relative;z-index:0'><span>HEADERMARKER</span></div>" +
+            "</div></th></tr></thead><tbody>" +
+            string.Join("", Enumerable.Range(1, 30).Select(i =>
+                $"<tr><td style='height:14pt;padding:0'>Row {i}</td></tr>")) +
+            "</tbody></table>");
+
+        [Fact]
+        public async Task StackingContextOnlyReachableThroughARepeatedHeader_IsPaintedOnEveryPage()
+        {
+            var (_, container) = await LayoutHarness.LayoutAsync(StackingContextInRepeatedHeaderTable(),
+                pageHeight: PageHeight, margin: Margin);
+
+            var pages = container.FragmentTree!.Fragmentainers.Count;
+            Assert.True(pages >= 3, $"fixture must span several pages, got {pages}");
+
+            for (var page = 0; page < pages; page++)
+            {
+                var recording = new TestRecordingGraphics();
+                FragmentPaintHarness.PaintPage(container, recording, page);
+
+                Assert.Contains(recording.DrawStringCalls, w => w.Text.Contains("HEADERMARKER"));
+            }
+        }
+
+        /// <summary>
+        /// The same shape without a table at all - the minimal case <c>HasStackingHoistCandidates</c>
+        /// has to get right regardless of where the stacking-context box sits, kept alongside the
+        /// table-repeated case above so the two can be compared directly.
+        /// </summary>
+        [Fact]
+        public async Task StackingContextInsideAPlainOverflowClip_IsPainted()
+        {
+            var html = LayoutHarness.Wrap(
+                "<div style='overflow:hidden;height:14pt'>" +
+                "<div style='position:relative;z-index:0'><span>PLAINMARKER</span></div>" +
+                "</div>");
+
+            var (_, container) = await LayoutHarness.LayoutAsync(html, pageHeight: PageHeight, margin: Margin);
+
+            var recording = new TestRecordingGraphics();
+            FragmentPaintHarness.PaintPage(container, recording, page: 0);
+
+            Assert.Contains(recording.DrawStringCalls, w => w.Text.Contains("PLAINMARKER"));
+        }
     }
 }

--- a/src/PeachPDF/Html/Core/HtmlContainerInt.cs
+++ b/src/PeachPDF/Html/Core/HtmlContainerInt.cs
@@ -2173,6 +2173,17 @@ namespace PeachPDF.Html.Core
             if (includeStackingHoistCandidates && !isRoot && DomUtils.NeedsStackingHoist(box))
                 hasStackingHoistCandidates = true;
 
+            // A repeating <thead>/<tfoot>'s proxy stands in for its source row group, detached from the
+            // live tree by CssLayoutEngineTable.RemoveHeaderFooterFromTree - so a float, an out-of-flow
+            // box, or a stacking-context box that exists only inside a repeated header/footer is invisible
+            // to the ordinary Boxes walk below. FragmentEmitter.ChildrenOf unwraps the same proxy the same
+            // way for fragment-building; this is that pattern's paint/layout-flags counterpart.
+            if (box is CssProxyBox proxy)
+            {
+                ComputeFlowFlags(proxy.SourceBox, false, includeStackingHoistCandidates,
+                    ref hasFloated, ref hasOutOfFlow, ref hasStackingHoistCandidates);
+            }
+
             foreach (var childBox in box.Boxes)
             {
                 if (hasFloated && hasOutOfFlow && (!includeStackingHoistCandidates || hasStackingHoistCandidates))


### PR DESCRIPTION
## Summary
- `HtmlContainerInt.ComputeFlowFlags` computes a document-wide `HasStackingHoistCandidates` flag by walking `CssBox.Boxes` from the root once, after layout. `StackingOrder.Flatten` gates its entire stacking-hoist search on this one flag: a plain-wrapper ancestor's ordinary paint loop deliberately skips a descendant that needs hoisting, trusting some enclosing search to find and paint it instead.
- A repeating `<thead>`/`<tfoot>` is detached from the live tree (`CssLayoutEngineTable.RemoveHeaderFooterFromTree`) and stood back in per page by a `CssProxyBox`, whose real content lives in `SourceBox` — deliberately not part of `.Boxes`. `ComputeFlowFlags` had no equivalent unwrap, so a stacking-context box reachable *only* through a repeated header's source subtree was invisible to the scan. With no other stacking-hoist candidate anywhere else in the document, the flag came out `false` and the box's content was **never painted on any page at all** — not merely mis-clipped or mis-ordered.
- Fix: `ComputeFlowFlags` now descends into a `CssProxyBox`'s `SourceBox` the same way `FragmentEmitter.ChildrenOf` already does for fragment-building, applied uniformly to all three flags it computes (a float or out-of-flow box only reachable through a repeated header/footer had the identical blind spot, just with a less visible symptom).

Found while working on #345 (`RenderUtils.PushAncestorOverflowClips` reading live `CssBox` geometry instead of the fragment tree) — the natural end-to-end repro for #345 needed a stacking-context box inside a repeated header, which turned out not to paint at all, independent of anything #345 itself fixes about clip geometry.

## Test plan
- [x] New regression test verified to fail against the pre-fix code and pass against the fix (manual hunk revert): `RepeatedTableHeaderClipIntegrationTests.StackingContextOnlyReachableThroughARepeatedHeader_IsPaintedOnEveryPage`, plus a plain non-table control (`StackingContextInsideAPlainOverflowClip_IsPainted`) confirming the gap is specific to the proxy, not stacking hoist in general
- [x] Full suite green: `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` (9919 passed)
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] Diff coverage 100% on changed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)