### PR TITLE
Fix CSS scientific-notation number tokenization

### DIFF
--- a/.claude/migration-notes/2026-09-07-css-scientific-notation-numbers.md
+++ b/.claude/migration-notes/2026-09-07-css-scientific-notation-numbers.md
@@ -1,0 +1,12 @@
+# CSS scientific-notation numbers now parse correctly
+
+Any CSS numeric value written in scientific notation - `1e2`, `1.5e-3`, `1E2`, a length like `1e2px`,
+or a percentage like `1e2%` - used to be silently mis-tokenized: the value's leading digits and the
+`e`/`E` were split off as a bogus one-letter dimension (e.g. `1e2` read as "the number 1 with unit
+`e`" followed by a stray `2`), so the value was effectively discarded or misread by whatever CSS
+property consumed it, with no warning.
+
+It's now parsed correctly as CSS Syntax Level 3 §4.3.13 describes: `1e2` is the number `100`, `1e2px`
+is the length `100px`, and `1e2%` is the percentage `100%`. A document that happens to use scientific
+notation in its CSS (uncommon by hand, but a possible output shape from CSS produced or transformed by
+other tooling) will now be measured/rendered using the intended value instead of a silently-wrong one.

--- a/.claude/recent-fixes/2026-09-07-css-scientific-notation-tokenization.md
+++ b/.claude/recent-fixes/2026-09-07-css-scientific-notation-tokenization.md
@@ -1,0 +1,58 @@
+# CSS scientific-notation number tokenization (issue #921)
+
+## The load-bearing idea
+
+`Lexer.NumberRest`/`NumberFraction` (`src/PeachPDF/CSS/Parser/Lexer.cs`) never reached their own
+exponent-handling code: the scanning loop's `current.IsNameStart()` branch claimed `'e'`/`'E'` as a
+unit-start letter before the trailing `switch`'s `case 'e': case 'E': return
+NumberExponential(current);` could ever run, so `NumberExponential`/`SciNotation` were dead code and
+`"1e2"` tokenized as two tokens (`Dimension("1","e")` + `Number("2")`) instead of the single
+scientific-notation `Number(100)` CSS Syntax Level 3 §4.3.13 describes. Filed as #921 while writing
+the allocation-free length fast path for #910 - see
+[`2026-09-07-allocation-free-length-tokenization-stage-1.md`](2026-09-07-allocation-free-length-tokenization-stage-1.md)
+(that entry now describes this as a still-open gap; it's fixed as of this entry, and will read as
+stale prose once it ages out at its own 30-day mark rather than being edited here, per this folder's
+own "add a file, don't edit a sibling" rule).
+
+The fix: the loop now breaks unconditionally on `'e'`/`'E'` instead of claiming it as a unit start,
+deferring entirely to the pre-existing `NumberExponential`, which already re-derives "digit, or sign
+then digit, follows" and already falls back to `Dimension` correctly when it isn't a valid exponent.
+No new lookahead helper was needed - an earlier draft added one (`IsExponentStart`), but it turned out
+to fully duplicate `NumberExponential`'s own decision and was removed in favor of just breaking and
+letting the existing switch dispatch do the one decision it was already built for.
+
+## What was found by running it, not by reading it
+
+**`SciNotation()` was untested dead code, and reaching it for the first time exposed a second, real
+bug**: it unconditionally returned a plain `NewNumber`, never checking whether what follows the
+exponent digits starts a unit, an escape, or `%` - so `"1e2px"` would have mis-tokenized into
+`Number("1e2")` + a stray `px` ident, and `"1e2-foo"` into `Number("1e2")` + a stray `-foo` ident,
+even after the loop-ordering fix made the exponent path reachable. A post-change multi-angle review
+(8 parallel finder passes) independently converged on this from three directions - reuse,
+simplification, and altitude all flagged that `SciNotation` was re-deriving logic `NumberRest`/
+`NumberFraction` already had, and one finder empirically traced `"1e2-foo"` through the pre-fix code
+and confirmed it produced two tokens instead of the spec-correct single `Dimension(100, "-foo")` that
+the non-exponent `"1-foo"` already produces via `NumberDash`.
+
+Fixed by extracting two helpers shared by `NumberRest`, `NumberFraction`, and `SciNotation` instead of
+a third hand-copied dispatch: `TryStartDimension(char)` (the loop-level "does this start a unit or
+escape" check) and `FinishNumberOrPercentage(char)` (the terminal `%`/`-`-led-dimension/plain-number
+dispatch, including the `NumberDash` case `SciNotation` had been missing).
+
+## Deliberately not done
+
+`NumberSyntax.cs`'s `TryConsumeNumber` (the allocation-free fast-path number grammar from #910) still
+doesn't consume an exponent - that's unrelated to this bug and doesn't need to be: its own caller
+(`CssValueParser.TryClassifyLengthFast`) already rejects any exponent-bearing shape as `Inconclusive`
+via its unrelated "is the remainder all letters" check, before or after this fix, so the fast path and
+the real tokenizer never disagreed on classification for these inputs - only the real tokenizer's own
+internal token shape changed. Its doc comments were reworded to stop describing the old Lexer bug as
+current fact, not to add exponent support.
+
+## Evidence
+
+Full net8.0 suite: 10198 passed / 0 failed / 9 skipped (pre-existing platform-specific skips), run
+twice (before and after the post-review refactor). Diff coverage 100% (gate is 90%) against `main`.
+Zero-warning `dotnet build PeachPDF.slnx -t:Rebuild`. An 8-angle post-change review pass caught the
+`SciNotation`/`NumberDash` gap and the redundant lookahead helper before merge; both fixed and
+re-verified against the full suite and coverage gate.

--- a/src/PeachPDF.Tests/CSS/NumberSyntaxTests.cs
+++ b/src/PeachPDF.Tests/CSS/NumberSyntaxTests.cs
@@ -39,11 +39,11 @@ namespace PeachPDF.Tests.CSS
             Assert.Equal(expectedValue, value, 6);
         }
 
-        // The real Lexer's NumberRest/NumberFraction never reach their own exponent-handling code
-        // (NumberExponential/SciNotation): any 'e'/'E' right after the digits is claimed by the
-        // unit-starting branch first (CharExtensions.IsNameStart treats 'e'/'E' like any other
-        // identifier-start letter), so this deliberately does NOT consume an exponent - matching that
-        // real (if not CSS-Syntax-3-conformant) behavior exactly rather than the spec's own grammar.
+        // The real Lexer's NumberRest/NumberFraction now correctly consume a trailing exponent
+        // (issue #921), but this fast path deliberately still doesn't: TryClassifyLengthFast's
+        // "is the remainder all letters" check already rejects any exponent shape (a digit follows
+        // the 'e'/'E') and falls through to Inconclusive - the real tokenizer - so duplicating
+        // exponent-consumption here would add complexity with no classification ever reaching it.
         [Theory]
         [InlineData("1e2", 1, 1d)]
         [InlineData("1E2", 1, 1d)]

--- a/src/PeachPDF.Tests/CSS/Tokenization.cs
+++ b/src/PeachPDF.Tests/CSS/Tokenization.cs
@@ -214,6 +214,123 @@ namespace PeachPDF.Tests.CSS
             var token = tokenizer.Get();
             Assert.Equal("\n", token.Data);
         }
+
+        // Issue #921: CSS Syntax Level 3 §4.3.13 treats an exponent ('e'/'E', optional sign, digits)
+        // as part of a <number>, so "1e2" is the single number 100 - not a Dimension("1", "e")
+        // followed by a separate Number("2"). NumberRest/NumberFraction's scanning loop used to claim
+        // any 'e'/'E' for the general unit-start branch before the exponent-handling switch case
+        // could ever run.
+        [Theory]
+        [InlineData("1e2", 100d)]
+        [InlineData("1E2", 100d)]
+        [InlineData("1e+2", 100d)]
+        [InlineData("1e-2", 0.01d)]
+        [InlineData("1.5e2", 150d)]
+        public void LexerScientificNotation_TokenizesAsSingleNumber(string teststring, double expected)
+        {
+            var tokenizer = new Lexer(new TextSource(teststring));
+            var token = tokenizer.Get();
+
+            Assert.Equal(TokenType.Number, token.Type);
+            Assert.Equal(expected, ((NumberToken)token).Value, 5);
+            Assert.Equal(TokenType.EndOfFile, tokenizer.Get().Type);
+        }
+
+        // "1em" is an ordinary dimension - unaffected by the exponent fix since 'm' never starts an
+        // exponent. "1e" has no digit after the 'e', so per spec it stays a dimension with unit "e"
+        // rather than becoming (invalid) scientific notation.
+        [Theory]
+        [InlineData("1em", "em")]
+        [InlineData("1e", "e")]
+        public void LexerScientificNotation_NoExponentDigit_StaysADimension(string teststring, string expectedUnit)
+        {
+            var tokenizer = new Lexer(new TextSource(teststring));
+            var token = tokenizer.Get();
+
+            Assert.Equal(TokenType.Dimension, token.Type);
+            var unitToken = (UnitToken)token;
+            Assert.Equal(1d, unitToken.Value, 5);
+            Assert.Equal(expectedUnit, unitToken.Unit);
+            Assert.Equal(TokenType.EndOfFile, tokenizer.Get().Type);
+        }
+
+        [Fact]
+        public void LexerScientificNotation_SignWithNoDigit_StaysADimensionPlusLeftoverSign()
+        {
+            var tokenizer = new Lexer(new TextSource("1e+"));
+
+            var first = tokenizer.Get();
+            Assert.Equal(TokenType.Dimension, first.Type);
+            var unitToken = (UnitToken)first;
+            Assert.Equal(1d, unitToken.Value, 5);
+            Assert.Equal("e", unitToken.Unit);
+
+            var second = tokenizer.Get();
+            Assert.Equal(TokenType.Delim, second.Type);
+            Assert.Equal("+", second.Data);
+        }
+
+        // Exercises the SciNotation() fix: once the exponent digits are consumed, whatever follows
+        // still needs the same dimension/percentage/number disambiguation the non-exponent paths
+        // apply - SciNotation used to unconditionally return a plain number, which would have
+        // silently split "1e2px" into Number("1e2") + a stray "px" ident token.
+        [Fact]
+        public void LexerScientificNotation_FollowedByUnit_TokenizesAsSingleDimension()
+        {
+            var tokenizer = new Lexer(new TextSource("1e2px"));
+            var token = tokenizer.Get();
+
+            Assert.Equal(TokenType.Dimension, token.Type);
+            var unitToken = (UnitToken)token;
+            Assert.Equal(100d, unitToken.Value, 5);
+            Assert.Equal("px", unitToken.Unit);
+            Assert.Equal(TokenType.EndOfFile, tokenizer.Get().Type);
+        }
+
+        // Exercises SciNotation()'s dash-led-unit branch (NumberDash): a unit may start with '-' after
+        // digits, exactly like the non-exponent case "1-foo" already does - this must behave the same
+        // regardless of whether the digits that precede it came from a plain integer or an exponent.
+        [Fact]
+        public void LexerScientificNotation_FollowedByDashLedUnit_TokenizesAsSingleDimension()
+        {
+            var tokenizer = new Lexer(new TextSource("1e2-foo"));
+            var token = tokenizer.Get();
+
+            Assert.Equal(TokenType.Dimension, token.Type);
+            var unitToken = (UnitToken)token;
+            Assert.Equal(100d, unitToken.Value, 5);
+            Assert.Equal("-foo", unitToken.Unit);
+            Assert.Equal(TokenType.EndOfFile, tokenizer.Get().Type);
+        }
+
+        // Exercises SciNotation()'s escape-sequence branch: a unit starting right after the exponent
+        // digits with an escape ("\70 " = hex 0x70 = 'p') rather than a plain letter, mirroring the
+        // escape handling NumberRest/NumberFraction already have for the non-exponent case.
+        [Fact]
+        public void LexerScientificNotation_FollowedByEscapedUnitStart_TokenizesAsSingleDimension()
+        {
+            var tokenizer = new Lexer(new TextSource("1e2\\70 x"));
+            var token = tokenizer.Get();
+
+            Assert.Equal(TokenType.Dimension, token.Type);
+            var unitToken = (UnitToken)token;
+            Assert.Equal(100d, unitToken.Value, 5);
+            Assert.Equal("px", unitToken.Unit);
+            Assert.Equal(TokenType.EndOfFile, tokenizer.Get().Type);
+        }
+
+        [Fact]
+        public void LexerScientificNotation_FollowedByPercent_TokenizesAsSinglePercentage()
+        {
+            var tokenizer = new Lexer(new TextSource("1e2%"));
+            var token = tokenizer.Get();
+
+            Assert.Equal(TokenType.Percentage, token.Type);
+            var unitToken = (UnitToken)token;
+            Assert.Equal(100d, unitToken.Value, 5);
+            Assert.Equal("%", unitToken.Unit);
+            Assert.Equal(TokenType.EndOfFile, tokenizer.Get().Type);
+        }
     }
 }
 

--- a/src/PeachPDF.Tests/Html/Core/Parse/CssValueParserGetUnitFastPathTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Parse/CssValueParserGetUnitFastPathTests.cs
@@ -71,10 +71,11 @@ namespace PeachPDF.Tests.Html.Core.Parse
                                         // this is actually two tokens (Dimension "10px" + Number "2")
         [InlineData("1e2")]            // "e" (a letter) looks unit-like, but "2" right after it isn't a
                                         // letter, so the all-letters unit check rejects the whole "e2" -
-                                        // the real tokenizer's own answer here is also two tokens (see
-                                        // NumberSyntax's remarks: 'e' claims the unit branch, not exponent
-                                        // syntax, then Dimension() stops at the first non-letter, '2')
-        [InlineData("1e+")]            // 'e' claims the unit branch, then a bare trailing '+' left over
+                                        // the real tokenizer now correctly reads this as a single
+                                        // scientific-notation Number(100) token (issue #921), which still
+                                        // isn't a UnitToken, so this stays Inconclusive either way
+        [InlineData("1e+")]            // no digit follows the sign, so this isn't an exponent - 'e'
+                                        // claims the unit branch, then a bare trailing '+' left over
         [InlineData("10-foo")]         // NumberDash: a unit may start with '-' after digits
         public void TryClassifyLengthFast_AmbiguousShapes_ClassifiesAsInconclusive(string input)
         {

--- a/src/PeachPDF/CSS/Parser/Lexer.cs
+++ b/src/PeachPDF/CSS/Parser/Lexer.cs
@@ -615,21 +615,18 @@ namespace PeachPDF.CSS
                 {
                     StringBuffer.Append(current);
                 }
-                else if (current.IsNameStart())
+                else if (current == 'e' || current == 'E')
                 {
-                    var number = FlushBuffer();
-                    StringBuffer.Append(current);
-                    return Dimension(number);
-                }
-                else if (IsValidEscape(current))
-                {
-                    current = GetNext();
-                    var number = FlushBuffer();
-                    StringBuffer.Append(ConsumeEscape(current));
-                    return Dimension(number);
+                    // Defer to the switch below: NumberExponential already re-derives (and correctly
+                    // falls back to Dimension for) the same "digit, or sign then digit" decision, so
+                    // there is nothing to disambiguate here - just stop claiming 'e'/'E' as a unit
+                    // start before that dedicated exponent handling ever gets a chance to run.
+                    break;
                 }
                 else
                 {
+                    var dimension = TryStartDimension(current);
+                    if (dimension is not null) return dimension;
                     break;
                 }
 
@@ -648,16 +645,13 @@ namespace PeachPDF.CSS
 
                     Back();
                     return NewNumber(FlushBuffer());
-                case '%':
-                    return NewPercentage(FlushBuffer());
                 case 'e':
                 case 'E':
                     return NumberExponential(current);
+                case '%':
                 case Symbols.Minus:
-                    return NumberDash();
                 default:
-                    Back();
-                    return NewNumber(FlushBuffer());
+                    return FinishNumberOrPercentage(current);
             }
         }
 
@@ -670,21 +664,14 @@ namespace PeachPDF.CSS
                 {
                     StringBuffer.Append(current);
                 }
-                else if (current.IsNameStart())
+                else if (current == 'e' || current == 'E')
                 {
-                    var number = FlushBuffer();
-                    StringBuffer.Append(current);
-                    return Dimension(number);
-                }
-                else if (IsValidEscape(current))
-                {
-                    current = GetNext();
-                    var number = FlushBuffer();
-                    StringBuffer.Append(ConsumeEscape(current));
-                    return Dimension(number);
+                    break;
                 }
                 else
                 {
+                    var dimension = TryStartDimension(current);
+                    if (dimension is not null) return dimension;
                     break;
                 }
 
@@ -697,13 +684,61 @@ namespace PeachPDF.CSS
                 case 'E':
                     return NumberExponential(current);
                 case '%':
-                    return NewPercentage(FlushBuffer());
                 case Symbols.Minus:
-                    return NumberDash();
                 default:
-                    Back();
-                    return NewNumber(FlushBuffer());
+                    return FinishNumberOrPercentage(current);
             }
+        }
+
+        /// <summary>
+        /// Shared by <see cref="NumberRest"/>/<see cref="NumberFraction"/>/<see cref="SciNotation"/>'s
+        /// digit-scanning loops: once a number's digits stop, checks whether <paramref name="current"/>
+        /// starts a unit (a name-start character, or a valid escape) and if so flushes the accumulated
+        /// digits as the number and hands off to <see cref="Dimension"/> to consume it. Returns
+        /// <see langword="null"/> when <paramref name="current"/> doesn't start a unit, leaving the
+        /// caller's loop position and <see cref="LexerBase.StringBuffer"/> untouched so the caller can
+        /// break out and dispatch on <paramref name="current"/> itself.
+        /// </summary>
+        private Token TryStartDimension(char current)
+        {
+            if (current.IsNameStart())
+            {
+                var number = FlushBuffer();
+                StringBuffer.Append(current);
+                return Dimension(number);
+            }
+
+            if (IsValidEscape(current))
+            {
+                current = GetNext();
+                var number = FlushBuffer();
+                StringBuffer.Append(ConsumeEscape(current));
+                return Dimension(number);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Shared terminal dispatch for <see cref="NumberRest"/>/<see cref="NumberFraction"/>/
+        /// <see cref="SciNotation"/>: once a number is known to be neither a fraction continuation nor
+        /// an exponent nor a unit-starting dimension, decides between a percentage, a dash-led dimension
+        /// (<see cref="NumberDash"/>), or a plain number.
+        /// </summary>
+        private Token FinishNumberOrPercentage(char current)
+        {
+            if (current == '%')
+            {
+                return NewPercentage(FlushBuffer());
+            }
+
+            if (current == Symbols.Minus)
+            {
+                return NumberDash();
+            }
+
+            Back();
+            return NewNumber(FlushBuffer());
         }
 
         private Token Dimension(string number)
@@ -730,19 +765,24 @@ namespace PeachPDF.CSS
 
         private Token SciNotation()
         {
+            var current = GetNext();
             while (true)
             {
-                var current = GetNext();
                 if (current.IsDigit())
                 {
                     StringBuffer.Append(current);
                 }
                 else
                 {
-                    Back();
-                    return NewNumber(FlushBuffer());
+                    var dimension = TryStartDimension(current);
+                    if (dimension is not null) return dimension;
+                    break;
                 }
+
+                current = GetNext();
             }
+
+            return FinishNumberOrPercentage(current);
         }
 
         private Token UrlStart(string functionName)

--- a/src/PeachPDF/CSS/Parser/NumberSyntax.cs
+++ b/src/PeachPDF/CSS/Parser/NumberSyntax.cs
@@ -8,20 +8,19 @@ namespace PeachPDF.CSS
     /// <summary>
     /// A pure, allocation-free model of the &lt;number&gt; grammar this codebase's real <see cref="Lexer"/>
     /// actually implements via <c>NumberStart</c>/<c>NumberRest</c>/<c>NumberFraction</c> - deliberately
-    /// <em>not</em> the CSS Syntax Level 3 §4.3.13 grammar those methods are named after.
+    /// <em>not</em> the full CSS Syntax Level 3 §4.3.13 grammar those methods are named after, since it
+    /// leaves out the optional exponent (see remarks).
     /// </summary>
     /// <remarks>
-    /// <see cref="Lexer"/>'s numeric-token state machine never actually reaches its own exponent-handling
-    /// code (<c>NumberExponential</c>/<c>SciNotation</c>): <c>NumberRest</c>/<c>NumberFraction</c>'s main
-    /// loop treats <em>any</em> <see cref="CharExtensions.IsNameStart"/> character - which includes 'e'/'E',
-    /// indistinguishable from any other unit-starting letter - as the start of a unit-ident token
-    /// <em>before</em> the switch statement housing the 'e'/'E' exponent cases is ever reached. So e.g.
-    /// <c>"1e2"</c> tokenizes today as two tokens (a Dimension token "1e" followed by a separate Number
-    /// token "2"), never as the single scientific-notation Number(100) CSS Syntax 3 describes. This is a
-    /// pre-existing, real spec-compliance gap, unrelated to this method's purpose - it is modeled here
-    /// exactly as-is (no exponent consumption) so this faster path always agrees with what callers
-    /// already get from <c>CssValueParser.GetUnit</c>'s full-tokenizer path today, rather than "fixing"
-    /// the number grammar as an incidental side effect.
+    /// <see cref="Lexer"/>'s numeric-token state machine does correctly consume a trailing exponent
+    /// ('e'/'E', optional sign, digits) via <c>NumberExponential</c>/<c>SciNotation</c> (issue #921).
+    /// This fast path deliberately still doesn't: <c>CssValueParser.TryClassifyLengthFast</c>'s own
+    /// post-number "is the remainder all letters" check already rejects any exponent shape (a digit
+    /// follows the 'e'/'E', which isn't a letter) and falls through to its <c>Inconclusive</c> result -
+    /// the real, full tokenizer - so duplicating exponent-consumption here would add complexity with no
+    /// classification ever reaching it. Every exponent-bearing input was, and remains, classified
+    /// <c>Inconclusive</c> before and after the Lexer fix; only the real tokenizer's own answer for
+    /// those inputs changed.
     /// </remarks>
     internal static class NumberSyntax
     {


### PR DESCRIPTION
## Summary

- `Lexer.NumberRest`/`NumberFraction`'s scanning loop claimed `e`/`E` as a unit-start letter before the trailing switch's `case 'e': case 'E': return NumberExponential(current);` could ever run, so `1e2` tokenized as two tokens (`Dimension("1","e")` + `Number("2")`) instead of the single scientific-notation `Number(100)` CSS Syntax Level 3 §4.3.13 describes.
- The loop now breaks unconditionally on `e`/`E` and defers to the existing (previously unreachable) `NumberExponential`/`SciNotation` code, which already correctly disambiguates an exponent from a `em`/`ex`-style unit and falls back to a dimension when no digit follows.
- `SciNotation` was untested dead code before this fix, and making it reachable exposed a second bug: it never checked what followed the exponent digits, so `1e2px` and `1e2-foo` would have mis-tokenized into a stray extra token. Fixed by extracting the unit/escape/percent/dash-led-dimension dispatch that `NumberRest`/`NumberFraction` already had into two shared helpers (`TryStartDimension`, `FinishNumberOrPercentage`) all three methods now call, instead of a third hand-copied version.

## Test plan

- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 10198 passed, 0 failed, 9 pre-existing skips
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings, 0 errors
- [x] Diff coverage against `main` via `diff-cover` — 100% (gate is 90%)
- [x] New regression tests in `Tokenization.cs` cover `1e2`, `1E2`, `1e+2`, `1e-2`, `1.5e2`, `1em`, `1e`, `1e+`, `1e2px`, `1e2%`, `1e2-foo`, and an escaped-unit-after-exponent case
- [x] 8-angle post-change review pass, findings fixed and re-verified

Fixes #921