### PR TITLE
Memoize IProperty.Value

### DIFF
--- a/src/PeachPDF.Tests/CSS/Property.cs
+++ b/src/PeachPDF.Tests/CSS/Property.cs
@@ -1508,6 +1508,41 @@ namespace PeachPDF.Tests.CSS
             Assert.Equal("my-Property", property.Name);
             Assert.IsType<UnknownProperty>(property);
         }
+
+        /// <summary>
+        /// <see cref="Property.Value"/> memoizes the declaration's serialization, so reassigning the
+        /// declaration must invalidate it. Reading <c>Value</c> before each reassignment is the point
+        /// of the test — an unmemoized implementation passes it either way.
+        /// </summary>
+        [Fact]
+        public void CssPropertyValueFollowsAReassignedDeclaration()
+        {
+            var property = ParseDeclaration("break-after: avoid");
+            Assert.Equal("avoid", property.Value);
+
+            Assert.True(property.TrySetValue(ParseValue("page")));
+            Assert.Equal("page", property.Value);
+            Assert.Equal("break-after: page", property.CssText);
+
+            Assert.True(property.TrySetValue(ParseValue("column")));
+            Assert.Equal("column", property.Value);
+        }
+
+        /// <summary>
+        /// The no-declaration arm of <see cref="Property.Value"/> is memoized too, and the derived
+        /// <see cref="Property.IsInitial"/>/<see cref="Property.IsInherited"/> read through it.
+        /// </summary>
+        [Fact]
+        public void CssPropertyValueFollowsADeclarationClearedToInitial()
+        {
+            var property = ParseDeclaration("break-after: avoid");
+            Assert.Equal("avoid", property.Value);
+            Assert.False(property.IsInitial);
+
+            Assert.True(property.TrySetValue(null));
+            Assert.Equal(Keywords.Initial, property.Value);
+            Assert.True(property.IsInitial);
+        }
     }
 }
 

--- a/src/PeachPDF/CSS/StyleProperties/Property.cs
+++ b/src/PeachPDF/CSS/StyleProperties/Property.cs
@@ -33,16 +33,37 @@ namespace PeachPDF.CSS
             return true;
         }
 
-        public string Value => DeclaredValue != null ? DeclaredValue.CssText : Keywords.Initial;
+        /// <summary>
+        /// Memoized. <see cref="IPropertyValue.CssText"/> is not a stored string — nearly every
+        /// converter re-serializes it on each read, several with LINQ and string.Join over their
+        /// components (BorderRadiusConverter, EndListValueConverter, BackgroundPositionValueConverter,
+        /// …).
+        ///
+        /// A parsed declaration is shared by every box its rule matches, and the cascade reads this
+        /// up to three times per declaration per box (the global-keyword switch, its fall-through arm,
+        /// and CssGlobalKeywords.TryParse), so one document-wide rule re-serializes its values
+        /// thousands of times in a single render.
+        ///
+        /// Invalidated by <see cref="DeclaredValue"/>'s setter, which is the only way the underlying
+        /// value changes; the value objects a converter builds are themselves immutable.
+        ///
+        /// <c>null</c> is the "not computed yet" marker, the same way <see cref="DeclaredValue"/>'s
+        /// own <c>null</c> means "no declaration" — this file is <c>#nullable disable</c>, so the
+        /// field carries no annotation. A converter that returned a null <c>CssText</c> would only
+        /// re-serialize on the next read; it could never report a stale value.
+        /// </summary>
+        public string Value => _valueText ??= DeclaredValue != null ? DeclaredValue.CssText : Keywords.Initial;
+
+        private string _valueText;
 
         public string Original => DeclaredValue != null ? DeclaredValue.Original.Text : Keywords.Initial;
 
         public bool IsInherited => (_flags & PropertyFlags.Inherited) == PropertyFlags.Inherited && IsInitial ||
-                                   DeclaredValue != null && DeclaredValue.CssText.Is(Keywords.Inherit);
+                                   DeclaredValue != null && Value.Is(Keywords.Inherit);
 
         public bool IsAnimatable => (_flags & PropertyFlags.Animatable) == PropertyFlags.Animatable;
 
-        public bool IsInitial => DeclaredValue == null || DeclaredValue.CssText.Is(Keywords.Initial);
+        public bool IsInitial => DeclaredValue == null || Value.Is(Keywords.Initial);
 
         internal bool HasValue => DeclaredValue != null;
 
@@ -62,6 +83,16 @@ namespace PeachPDF.CSS
 
         internal abstract IValueConverter Converter { get; }
 
-        internal IPropertyValue DeclaredValue { get; set; }
+        internal IPropertyValue DeclaredValue
+        {
+            get => _declaredValue;
+            set
+            {
+                _declaredValue = value;
+                _valueText = null;
+            }
+        }
+
+        private IPropertyValue _declaredValue = null!;
     }
 }


### PR DESCRIPTION
`IPropertyValue.CssText` is not a stored string — nearly every converter **re-serializes** it on each read, several with LINQ and `string.Join` over their components (`BorderRadiusConverter`, `EndListValueConverter`, `BackgroundPositionValueConverter`, …).

A parsed declaration is shared by every box its rule matches, and `DomParser.AssignCssBlock` reads `Value` up to **three times per declaration per box** — the global-keyword `switch`, its fall-through arm, and `CssGlobalKeywords.TryParse`. So a single document-wide rule re-serializes its values thousands of times in one render.

The shape that makes it visible is an ordinary print stylesheet:

```css
* { box-shadow: none !important; border-radius: 0 !important; }
```

It matches every box, and `border-radius` re-serializes through four corner components each time.

## The change

`Value` caches its text, invalidated by `DeclaredValue`'s setter — the only way the underlying value changes; the value objects a converter builds are themselves immutable. `IsInitial` and `IsInherited` read through the same cache.

## Measured

Self-contained repro: a 400-row, 4-column bordered table (~1,600 boxes) with the universal print rule above, Letter, 0.5in margins. 3 warm-up renders, then 10 timed, `ServerGarbageCollection=true`. Three interleaved rounds of each build, rebuilt and hash-checked between arms:

| | `main` | with this change |
| --- | --- | --- |
| time | 222.8 / 234.5 / 230.8 ms | **211.4 / 203.6 / 203.5 ms** |
| allocation | 203.0 / 203.0 / 202.9 MB | **179.9 / 179.7 / 179.8 MB** |
| median | 230.8 ms, 203.0 MB | **203.6 ms, 179.8 MB** |
| | | **−11.8% time, −11.4% allocation** |

Allocation is counted with `GC.GetTotalAllocatedBytes(true)` and is deterministic — the 23.2 MB/render is exact, not a sample.

<details>
<summary>Repro generator</summary>

```python
rows = 400
cells = "".join(
    f"<tr><td class='c'>Item {i}</td><td class='c'>SKU-{i:05d}</td>"
    f"<td class='c num'>{i*7%997}</td><td class='c num'>{i*13%89}.{i%100:02d}</td></tr>"
    for i in range(rows))
html = f"""<!DOCTYPE html><html><head><meta charset='utf-8'><style>
* {{ box-shadow: none !important; border-radius: 0 !important; }}
html {{ font-size: 16px; }}
body {{ font-family: Arial, sans-serif; font-size: 9pt; margin: 0; }}
table {{ width: 100%; border-collapse: collapse; }}
.c {{ border: 1px solid #999; padding: 2px 4px; }}
.num {{ text-align: right; }}
</style></head><body><table>{cells}</table></body></html>"""
open("bench.html","w").write(html)
```
</details>

## Tests

`PeachPDF.Tests` on this branch: **10,207 passed, 0 failed, 9 skipped** — same as `main` (`cd28a35`).

Found while profiling PeachPDF as the rendering engine behind a document-generation service; happy to adjust anything about the approach.