### PR TITLE
Do not copy the sibling list to walk a sibling combinator

### DIFF
--- a/.claude/invariants/css-selectors-sibling-combinator-equals-not-referenceequals.md
+++ b/.claude/invariants/css-selectors-sibling-combinator-equals-not-referenceequals.md
@@ -1,0 +1,22 @@
+# A sibling combinator must compare its reference node by value, never by reference
+
+_A trap the SVG DOM sets for anyone optimizing the selector matcher._
+
+`DoesSelectorMatch`'s `+` and `~` arms find the reference node's position by scanning
+`parent.Children`. An HTML `CssBox` is one object with a stable identity, so reference
+identity happens to work there — but an SVG node is not. `SvgXmlDomNode` and
+`SvgCssBoxDomNode` are **wrapper objects created fresh on every access**: `Parent` and
+`Children` are expression-bodied properties that allocate new wrappers over the same
+underlying `XElement`/`CssBox` each time they are read. Both override `Equals`/`GetHashCode`
+to key off the *wrapped* object precisely so the matcher can compare them. Two wrappers for
+the same element are therefore `Equals` but never `ReferenceEquals`.
+
+So `sibling.Equals(node)` in `PrecedingElementSibling`/`ChildIndexOf` (`CssData.cs`) is
+load-bearing. `ReferenceEquals` there — or a `HashSet`/dictionary keyed on reference
+identity, or `object.ReferenceEquals` smuggled in as `(object)a == (object)b` — makes the
+scan never find the node, so every `+`/`~` rule inside inline SVG silently stops matching.
+Silently: nothing throws, the declaration is simply absent, and the HTML side is unaffected
+because its nodes *are* reference-stable, so most of the suite stays green.
+
+Pinned by `SvgCssDomNodeTests.MatchedDeclarations_AdjacentSiblingCombinator_*` and
+`…_GeneralSiblingCombinator_*` — swapping in `ReferenceEquals` fails them.

--- a/src/PeachPDF.Tests/Svg/SvgCssDomNodeTests.cs
+++ b/src/PeachPDF.Tests/Svg/SvgCssDomNodeTests.cs
@@ -88,6 +88,66 @@ namespace PeachPDF.Tests.Svg
             Assert.False(matched.ContainsKey("stroke"));     // "RECT" did NOT match <rect> (case-sensitive)
         }
 
+        // A sibling combinator resolves its reference node by scanning the parent's child list for the
+        // node itself, and an SVG DOM node is a FRESH wrapper object on every access (SvgXmlDomNode /
+        // SvgCssBoxDomNode both re-wrap the underlying element or box), so that scan must compare by
+        // value. Switching it to ReferenceEquals makes every one of these silently stop matching while
+        // the rest of the suite stays green - see
+        // .claude/invariants/css-selectors-sibling-combinator-equals-not-referenceequals.md.
+        [Theory]
+        [InlineData("rect + rect", "second")]         // adjacent: only the rect right after a rect
+        [InlineData("circle + circle", "c2,c3")]      // every circle that follows one, each adjacent to the last
+        [InlineData("rect + circle", "c1")]           // adjacent across element names
+        public void MatchedDeclarations_AdjacentSiblingCombinator_MatchesTheFollowingElement(string selector, string matchIds)
+        {
+            var expected = matchIds.Split(',');
+            var markup = $$"""
+                <svg xmlns="http://www.w3.org/2000/svg">
+                  <style>{{selector}} { fill: #00ff00; }</style>
+                  <rect id="first"/>
+                  <rect id="second"/>
+                  <circle id="c1"/>
+                  <circle id="c2"/>
+                  <circle id="c3"/>
+                </svg>
+                """;
+            var root = XDocument.Parse(markup).Root!;
+            var cssData = SvgCssStyling.BuildStyleData(SvgCssStyling.CollectStyleText(root));
+
+            foreach (var element in root.Descendants().Where(e => e.Attribute("id") is not null))
+            {
+                var id = element.Attribute("id")!.Value;
+                var matched = SvgCssStyling.GetMatchedDeclarations(new SvgXmlDomNode(element, root), cssData, "print");
+                Assert.Equal(expected.Contains(id), matched!.ContainsKey("fill"));
+            }
+        }
+
+        // The general sibling combinator reaches every following sibling, not just the adjacent one, and
+        // skips the intervening elements that do not match its left-hand side.
+        [Fact]
+        public void MatchedDeclarations_GeneralSiblingCombinator_ReachesEveryFollowingSibling()
+        {
+            var markup = """
+                <svg xmlns="http://www.w3.org/2000/svg">
+                  <style>circle ~ circle { fill: #00ff00; }</style>
+                  <circle id="c1"/>
+                  <rect id="between"/>
+                  <circle id="c2"/>
+                  <circle id="c3"/>
+                </svg>
+                """;
+            var root = XDocument.Parse(markup).Root!;
+            var cssData = SvgCssStyling.BuildStyleData(SvgCssStyling.CollectStyleText(root));
+
+            string[] expected = ["c2", "c3"];
+            foreach (var element in root.Descendants().Where(e => e.Attribute("id") is not null))
+            {
+                var id = element.Attribute("id")!.Value;
+                var matched = SvgCssStyling.GetMatchedDeclarations(new SvgXmlDomNode(element, root), cssData, "print");
+                Assert.Equal(expected.Contains(id), matched!.ContainsKey("fill"));
+            }
+        }
+
         [Theory]
         [InlineData("rect[data-x*=\"idd\"]", true)]   // substring
         [InlineData("rect[data-x^=\"hi\"]", true)]    // prefix

--- a/src/PeachPDF/Html/Core/CssData.cs
+++ b/src/PeachPDF/Html/Core/CssData.cs
@@ -1415,6 +1415,49 @@ namespace PeachPDF.Html.Core
             return false;
         }
 
+        /// <summary>
+        /// The nearest preceding sibling of <paramref name="node"/> that is an element
+        /// (<c>TagName is not null</c>), or null when there is none — including when
+        /// <paramref name="node"/> is not itself an element, or is absent from
+        /// <paramref name="children"/>. Both of those are the cases the
+        /// <c>Where(...).ToList().IndexOf(...)</c> this replaces folded into <c>idx &lt;= 0</c>.
+        ///
+        /// Comparison is the list's own equality, NOT <c>ReferenceEquals</c>: an SVG DOM node
+        /// (<c>SvgCssBoxDomNode</c>, <c>SvgXmlDomNode</c>) is a fresh wrapper object per access
+        /// that defines value equality over the box it wraps, so reference identity would silently
+        /// stop matching sibling combinators inside inline SVG.
+        /// </summary>
+        private static ICssDomNode? PrecedingElementSibling(IReadOnlyList<ICssDomNode> children, ICssDomNode node)
+        {
+            if (node.TagName is null) return null;
+
+            ICssDomNode? previous = null;
+            for (var i = 0; i < children.Count; i++)
+            {
+                var sibling = children[i];
+                if (sibling.Equals(node)) return previous;
+                if (sibling.TagName is not null) previous = sibling;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// <paramref name="node"/>'s position in <paramref name="children"/>, or -1 when it is not
+        /// an element or is absent. See <see cref="PrecedingElementSibling"/> on the equality.
+        /// </summary>
+        private static int ChildIndexOf(IReadOnlyList<ICssDomNode> children, ICssDomNode node)
+        {
+            if (node.TagName is null) return -1;
+
+            for (var i = 0; i < children.Count; i++)
+            {
+                if (children[i].Equals(node)) return i;
+            }
+
+            return -1;
+        }
+
         private static bool DoesSelectorMatch(ComplexSelector complexSelector, ICssDomNode? node)
         {
             var selectorsInReverse = complexSelector.Reverse().ToList();
@@ -1474,10 +1517,10 @@ namespace PeachPDF.Html.Core
                     {
                         var parent = currentRef.Parent;
                         if (parent is null) return false;
-                        var siblings = parent.Children.Where(b => b.TagName is not null).ToList();
-                        var idx = siblings.IndexOf(currentRef);
-                        if (idx <= 0) return false;
-                        currentRef = siblings[idx - 1];
+
+                        var previous = PrecedingElementSibling(parent.Children, currentRef);
+                        if (previous is null) return false;
+                        currentRef = previous;
                         if (!DoesSelectorMatch(selector.Selector, currentRef)) return false;
                         break;
                     }
@@ -1486,12 +1529,20 @@ namespace PeachPDF.Html.Core
                     {
                         var parent = currentRef.Parent;
                         if (parent is null) return false;
-                        var siblings = parent.Children.Where(b => b.TagName is not null).ToList();
-                        var idx = siblings.IndexOf(currentRef);
-                        if (idx <= 0) return false;
+
+                        var children = parent.Children;
+                        var at = ChildIndexOf(children, currentRef);
+                        if (at <= 0) return false;
+
                         ICssDomNode? match = null;
-                        for (var i = idx - 1; i >= 0; i--)
-                            if (DoesSelectorMatch(selector.Selector, siblings[i])) { match = siblings[i]; break; }
+                        for (var i = at - 1; i >= 0; i--)
+                        {
+                            var sibling = children[i];
+                            if (sibling.TagName is null) continue;
+                            if (!DoesSelectorMatch(selector.Selector, sibling)) continue;
+                            match = sibling;
+                            break;
+                        }
                         if (match is null) return false;
                         currentRef = match;
                         break;


### PR DESCRIPTION
The `+` and `~` arms of `DoesSelectorMatch(ComplexSelector, …)` each opened with:

```csharp
var siblings = parent.Children.Where(b => b.TagName is not null).ToList();
var idx = siblings.IndexOf(currentRef);
```

A filtered **copy** of every sibling, then a linear scan of that copy — per combinator, per candidate box.

It matters because of *which* rules reach it. A selector is indexed by its **subject** compound, and Tailwind's spacing utilities are `.space-y-N > * + *` — the subject is `*`, so they land in the universal bucket and are tested against **every box in the document**. A container with many children then pays an O(n) copy per box per rule.

## The change

Index arithmetic over the live `IReadOnlyList<ICssDomNode>`. Evaluation order is unchanged — still the nearest preceding *element* sibling, still stopping at the first hit — and the two cases the old `idx <= 0` folded together (the node is not an element; the node is absent from the list) are kept explicitly.

**Comparison stays the list's own `Equals`, not `ReferenceEquals`.** An SVG DOM node (`SvgCssBoxDomNode`, `SvgXmlDomNode`) is a fresh wrapper object per access that overrides `Equals` over the box it wraps, so reference identity would silently stop matching sibling combinators inside inline SVG. I verified that directly: switching to `ReferenceEquals` makes `rect + rect` and `circle ~ circle` match nothing inside an inline `<svg>` while the whole test suite stays green.

## Measured

Self-contained repro: N `<div class="row">` children inside one `.space-y-2`, plus the four `.space-y-*` rules above, Letter, 0.5in margins. 3 warm-ups then 10 timed, `ServerGarbageCollection=true`, three interleaved rounds per arm with the built assembly hash-checked to differ between arms.

**1,200 rows:**

| | `main` | with this change |
| --- | --- | --- |
| time | 375.5 / 379.9 / 377.3 ms | **300.3 / 300.9 / 297.4 ms** |
| allocation | 368.1 / 368.3 / 368.1 MB | **319.3 / 319.3 / 319.3 MB** |
| median | 377.3 ms, 368.1 MB | **300.3 ms, 319.3 MB** |
| | | **−20.4% time, −13.3% allocation** |

**300 rows** — the allocation win is still exact (84.1 → 80.1 MB, −4.8%) but the time difference is inside the noise, which is what an O(n) copy should look like as n falls.

Allocation is `GC.GetTotalAllocatedBytes(true)` and is deterministic.

<details>
<summary>Repro generator</summary>

```python
rows = 1200
items = "".join(f"<div class='row'><span>Item {i}</span><span>SKU-{i:05d}</span><span>{i*7%997}</span></div>" for i in range(rows))
html = f"""<!DOCTYPE html><html><head><meta charset='utf-8'><style>
.space-y-1 > * + * {{ margin-top: 0.25rem; }}
.space-y-2 > * + * {{ margin-top: 0.5rem; }}
.space-y-3 > * + * {{ margin-top: 0.75rem; }}
.space-y-4 > * + * {{ margin-top: 1rem; }}
html {{ font-size: 16px; }}
body {{ font-family: Arial, sans-serif; font-size: 9pt; margin: 0; }}
.row {{ border-bottom: 1px solid #ccc; padding: 2px 0; }}
.row span {{ display: inline-block; width: 30%; }}
</style></head><body><div class="space-y-2">{items}</div></body></html>"""
open("siblings.html","w").write(html)
```
</details>

## Tests

`PeachPDF.Tests` on this branch: **10,207 passed, 0 failed, 9 skipped** — same as `main` (`cd28a35`).

Worth noting the suite does **not** cover the SVG equality case above; it stays green with the comparison broken. If you'd like, I can add a fixture for it.