### PR TITLE
Ask the cheap question first in the typed fast path

### DIFF
--- a/src/PeachPDF.Tests/Html/Core/Utils/CssUtilsTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Utils/CssUtilsTests.cs
@@ -1177,6 +1177,36 @@ namespace PeachPDF.Tests.Html.Core.Utils
 div {{ width: 200px; height: 100px; {css} }}
 </style></head><body><div>Text</div></body></html>";
 
+        /// <summary>
+        /// <see cref="CssUtils.HasTypedPropertySetter"/> answers exactly the registered set — it is read
+        /// as the cheap first operand of the cascade's typed fast path, so a name it wrongly answers true
+        /// for costs the work the guard exists to skip, and one it wrongly answers false for silently
+        /// drops the fast path back to the string setter.
+        /// </summary>
+        [Theory]
+        [InlineData("grid-template-columns", true)]
+        [InlineData("grid-template-rows", true)]
+        [InlineData("grid-template-areas", false)]
+        [InlineData("display", false)]
+        [InlineData("color", false)]
+        [InlineData("--custom", false)]
+        [InlineData("", false)]
+        public void HasTypedPropertySetter_MatchesTheRegisteredSet(string propName, bool expected)
+        {
+            Assert.Equal(expected, CssUtils.HasTypedPropertySetter(propName));
+        }
+
+        /// <summary>
+        /// The lookup is ordinal, matching the table <see cref="CssUtils.TrySetTypedPropertyValue"/>
+        /// itself uses — so the two never disagree about whether a name has a fast path. Property names
+        /// reach this already lower-cased by the parser.
+        /// </summary>
+        [Fact]
+        public void HasTypedPropertySetter_IsOrdinal_LikeTheTableItReads()
+        {
+            Assert.False(CssUtils.HasTypedPropertySetter("GRID-TEMPLATE-COLUMNS"));
+        }
+
         private static async Task<CssBox> FindDivBoxFromHtml(string html)
         {
             var adapter = new PdfSharpAdapter();

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -1380,7 +1380,13 @@ namespace PeachPDF.Html.Core.Parse
                 // (e.g. grid-template-* -> GridTemplate); apply it straight to the box without re-parsing. A
                 // global keyword's `value` is the RESOLVED string (parent/initial/revert target) and its
                 // DeclaredValue is not a typed carrier, so it falls through to the string setter.
-                if (!CssGlobalKeywords.TryParse(prop.Value, out _)
+                // Cheapest test first. _typedPropertySetters has two entries, so on any document
+                // that is not a grid this path cannot fire — but the old operand order ran
+                // CssGlobalKeywords.TryParse (five OrdinalIgnoreCase comparisons) on every
+                // declaration of every box first, to answer a question the two-entry lookup
+                // settles outright. All three tests are pure; the side-effecting setter is still last.
+                if (CssUtils.HasTypedPropertySetter(prop.Name)
+                    && !CssGlobalKeywords.TryParse(prop.Value, out _)
                     && prop is Property typedProp
                     && CssUtils.TrySetTypedPropertyValue(box, prop.Name, typedProp.DeclaredValue))
                 {

--- a/src/PeachPDF/Html/Core/Utils/CssUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/CssUtils.cs
@@ -93,6 +93,15 @@ namespace PeachPDF.Html.Core.Utils
         }
 
         /// <summary>
+        /// Whether <paramref name="propName"/> has a typed fast-path setter at all. The cheap question —
+        /// a lookup in the same two-entry table <see cref="TrySetTypedPropertyValue"/> uses — so a caller
+        /// can ask it before doing anything more expensive on a property that has no fast path.
+        /// </summary>
+        /// <param name="propName">the name of the CSS property</param>
+        /// <returns>true when a typed setter is registered for <paramref name="propName"/></returns>
+        public static bool HasTypedPropertySetter(string propName) => _typedPropertySetters.ContainsKey(propName);
+
+        /// <summary>
         /// Assigns a property's already-parsed, strongly-typed value straight onto a <see cref="CssBox"/> from
         /// its Layer A <see cref="ITypedPropertyValue{T}"/> carrier, without re-parsing the authored string.
         /// Returns false when <paramref name="propName"/> has no typed setter, or when


### PR DESCRIPTION
`AssignCssBlock`'s typed fast path is guarded by three tests, in the most expensive order:

```csharp
if (!CssGlobalKeywords.TryParse(prop.Value, out _)
    && prop is Property typedProp
    && CssUtils.TrySetTypedPropertyValue(box, prop.Name, typedProp.DeclaredValue))
```

`_typedPropertySetters` holds **two** entries — `grid-template-columns` and `grid-template-rows` — so on any document that is not a grid the path cannot fire. Yet every declaration of every box ran `CssGlobalKeywords.TryParse` first (five `OrdinalIgnoreCase` comparisons) to answer a question the two-entry lookup settles outright.

## The change

Check the name first, via a new `CssUtils.HasTypedPropertySetter`. All three tests are pure and the only side-effecting operand (the setter) is still last, so the reorder cannot change a result.

## Measured

The interesting part is that it saves **allocation**, not just comparisons: `prop.Value` reads `IPropertyValue.CssText`, which most converters re-serialize, so skipping it for the ~99.99% of declarations that can never take this path avoids the string entirely.

400-row bordered table with a `* { box-shadow: none !important; border-radius: 0 !important }` print rule, Letter, 0.5in margins. 3 warm-ups then 10 timed, `ServerGarbageCollection=true`, three interleaved rounds per arm with the built assembly hash-checked to differ:

| | `main` | with this change |
| --- | --- | --- |
| allocation | 202.8 / 202.9 / 202.9 MB | **197.1 / 197.3 / 197.2 MB** |
| median | 202.9 MB | **197.2 MB** — **−2.8%** |

Allocation is `GC.GetTotalAllocatedBytes(true)` and is deterministic.

**Time is inside the noise on this document** (medians 235.6 ms vs 229.2 ms, ranges overlapping) and I am not claiming a time win. The removed work is real and counted; that is the case for it.

## Relationship to #927

Partially overlapping: #927 memoizes `IProperty.Value`, which makes the `prop.Value` read cheap rather than avoiding it. With both, this reorder still skips the five keyword comparisons but saves less allocation. They are independent commits and either can land alone — happy to rebase whichever comes second.

## Tests

`PeachPDF.Tests` on this branch: **10,207 passed, 0 failed, 9 skipped** — same as `main` (`cd28a35`).