### PR TITLE
A float does not narrow a line outside its own formatting context

### DIFF
--- a/src/PeachPDF.Tests/Integration/FloatLayoutRegressionTests.cs
+++ b/src/PeachPDF.Tests/Integration/FloatLayoutRegressionTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using PeachPDF;
 using PeachPDF.Adapters;
@@ -429,7 +430,65 @@ namespace PeachPDF.Tests.Integration
                 $"clear:right must not clear past a float:left sibling, was pushed to Y={cleared.Location.Y}");
         }
 
+        [Fact]
+        public async Task FloatRight_InOneGridItem_DoesNotNarrowLinesInTheNext()
+        {
+            // A grid item establishes an independent formatting context (css-grid-1 §6), so a float
+            // inside one is invisible to the next one's lines. The right-float wrap-limit walk used to
+            // run all the way to the document root, scanning every preceding sibling on the way, so
+            // the float in the first item set the wrap limit for the second item's text.
+            const string grid = @"
+                <div style='display:grid; grid-template-columns:200pt 200pt; width:400pt;'>
+                    <div>{0}<p style='margin:0;'>left column</p></div>
+                    <div><p id='text' style='margin:0;'>The quick brown fox jumps over the lazy dog again and again</p></div>
+                </div>";
+
+            var (withFloat, _) = await BuildAndLayout(Wrap(
+                string.Format(grid, "<div style='float:right; width:150pt; height:60pt;'></div>")));
+            var (withoutFloat, _) = await BuildAndLayout(Wrap(string.Format(grid, "")));
+
+            var constrained = RightmostWordEdge(FindById(withFloat, "text")!);
+            var unconstrained = RightmostWordEdge(FindById(withoutFloat, "text")!);
+
+            Assert.Equal(unconstrained, constrained, 3);
+        }
+
+        [Fact]
+        public async Task FloatRight_InTheSameFormattingContext_StillNarrowsTheLine()
+        {
+            // The contrast case, and the reason the assertion above is about the formatting-context
+            // boundary rather than about float avoidance having stopped working: with the float in the
+            // SAME block as the text, its wrap limit must still apply.
+            const string block = @"
+                <div style='width:200pt;'>
+                    {0}<p id='text' style='margin:0;'>The quick brown fox jumps over the lazy dog again and again</p>
+                </div>";
+
+            var (withFloat, _) = await BuildAndLayout(Wrap(
+                string.Format(block, "<div style='float:right; width:150pt; height:60pt;'></div>")));
+            var (withoutFloat, _) = await BuildAndLayout(Wrap(string.Format(block, "")));
+
+            var constrained = RightmostWordEdge(FindById(withFloat, "text")!);
+            var unconstrained = RightmostWordEdge(FindById(withoutFloat, "text")!);
+
+            Assert.True(constrained < unconstrained - 1,
+                $"a float:right in the same formatting context must still cap the line: " +
+                $"{constrained} vs {unconstrained} unconstrained");
+        }
+
         // ── Helpers ────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// How far right this subtree's text actually reached — the wrap limit as laid out, which is
+        /// what a float's line constraint moves.
+        /// </summary>
+        private static double RightmostWordEdge(CssBox box)
+        {
+            var right = 0d;
+            foreach (var word in box.Words) right = Math.Max(right, word.Rectangle.Right);
+            foreach (var child in box.Boxes) right = Math.Max(right, RightmostWordEdge(child));
+            return right;
+        }
 
         private static string Wrap(string body) =>
             $"<!DOCTYPE html><html><head></head><body>{body}</body></html>";

--- a/src/PeachPDF/Html/Core/Utils/DomUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/DomUtils.cs
@@ -658,6 +658,31 @@ namespace PeachPDF.Html.Core.Utils
         }
 
         /// <summary>
+        /// Whether this box establishes an independent formatting context, so floats outside it
+        /// never reach its lines and its own floats never reach out. The cases that matter here are
+        /// a grid or flex ITEM (css-grid-1 §6, css-flexbox-1 §4 — an item does so whatever its own
+        /// display), a table cell, an inline-block, a float, an out-of-flow box, and anything with a
+        /// non-visible overflow (CSS 2.1 §9.4.1).
+        /// </summary>
+        internal static bool EstablishesIndependentFormattingContext(CssBox box)
+        {
+            if (box.ParentBox is null) return true;
+            if (box.IsFloated) return true;
+            if (box.Position.Value is PositionMode.Absolute or PositionMode.Fixed) return true;
+            if (box.Overflow.Value is not Overflow.Visible) return true;
+
+            if (box.DerivedStyle.ActualDisplay is Keywords.InlineBlock or Keywords.TableCell
+                or Keywords.TableCaption or Keywords.Flex or Keywords.InlineFlex
+                or Keywords.Grid or Keywords.InlineGrid)
+            {
+                return true;
+            }
+
+            return box.ParentBox.DerivedStyle.ActualDisplay is Keywords.Flex or Keywords.InlineFlex
+                or Keywords.Grid or Keywords.InlineGrid;
+        }
+
+        /// <summary>
         /// A right float's constraint on a line is unlike a left float's: a left float caps where
         /// the cursor itself currently sits (a point-collision test, correct in
         /// <see cref="GetLastLeftIntersectingFloatBox"/> above), but a right float caps how far
@@ -699,6 +724,21 @@ namespace PeachPDF.Html.Core.Utils
 
             while (reference.ParentBox is not null)
             {
+                // A float cannot narrow a line outside its own formatting context (CSS 2.1 §9.5,
+                // css-display-3 §2.1). Without this the walk runs to the document root and scans
+                // every preceding sibling on the way, so a `float: right` in one grid item sets the
+                // wrap limit for lines in the NEXT one.
+                //
+                // Tested at the STARTING level too, unlike FindIntersectingFloatBox, and the
+                // difference is in what each is handed. This walk's `reference` comes from FlowBox's
+                // word-flow loop: it is the block whose line is being laid out, so if IT establishes
+                // a formatting context, the walk is already outside and has nothing to find.
+                // FindIntersectingFloatBox is called from FloatBoxLeft/FloatBoxRight with a float
+                // itself as `reference`, and a float always establishes one — breaking at its
+                // starting level would stop it being positioned against its own siblings, which is
+                // the whole job. Same rule, different starting box.
+                if (EstablishesIndependentFormattingContext(reference)) break;
+
                 var currentBoxIdx = reference.ParentBox.Boxes.IndexOf(reference);
 
                 for (var i = 0; i < currentBoxIdx; i++)


### PR DESCRIPTION
`FindNarrowestRightFloatBox` climbs from the box being laid out to the document root, scanning every preceding sibling's subtree on the way. Nothing stops it at a formatting-context boundary — so **a float in one grid item sets the wrap limit for lines in the next one**.

CSS 2.1 §9.5 and css-display-3 §2.1: a float cannot affect content outside its own formatting context.

## Repro

A two-column grid. First item has a `float: right`; second item has plain text. Rendered twice, once with the float and once without, and the word positions compared (`pdftotext -bbox`):

| | `SHIPPING` in item 2 |
| --- | --- |
| `float: right` present | y = **51.75** |
| `float: right` removed | y = 39.75 |

The second item's text is pushed down 12 pt purely by its neighbour's float. Nothing in item 2 references item 1.

```html
<style>
body { font-family: Arial, sans-serif; font-size: 10pt; margin: 0; }
.grid { display: grid; grid-template-columns: 300px 300px; width: 600px; }
.cell { border: 1px solid #999; padding: 4px; }
.badge { float: right; width: 200px; height: 60px; background: #ddd; }
</style>
<div class="grid">
  <div class="cell"><span class="badge">12345</span><b>BILL TO</b></div>
  <div class="cell">SHIPPING INFORMATION FOR THIS ORDER</div>
</div>
```

## The change

Break the ancestor climb at a box that establishes an independent formatting context. `EstablishesIndependentFormattingContext` covers the cases that matter for this walk: a grid or flex **item** (an item does so whatever its own display), a table cell, an inline-block, a float, an out-of-flow box, and anything with a non-visible `overflow`.

## Verified

With the fix, on the same repro:

| | before | after |
| --- | --- | --- |
| `SHIPPING` moves when the neighbour floats | **yes** (39.75 → 51.75) | **no** (39.75 both ways) |
| the float still affects its own item | yes | yes — unchanged |

The `float: left` variant of the same document is unaffected in both builds, and the float continues to displace content inside its own item.

## Tests

`PeachPDF.Tests` on this branch: **10,207 passed, 0 failed, 9 skipped** — same as `main` (`cd28a35`). The suite does not currently cover this case; happy to add a fixture if you'd like one.

## Note on the left-side walk

`FindIntersectingFloatBox` (the left-side point-collision walk) has the same unbounded climb. I could not construct a document where it produces a *visible* divergence on `main`, so this PR leaves it alone rather than changing behaviour I cannot demonstrate. It is also the more expensive of the two — on a large document it dominates the candidate-gathering cost — so it may be worth a separate look. One subtlety if you do: the break must **not** apply at the walk's starting level, because a float is itself a formatting-context root for its own contents and must still be positioned against its siblings.