### PR TITLE
rem resolves against the root element, not the engine default

### DIFF
--- a/src/PeachPDF.Tests/Integration/RemResolvesAgainstRootElementIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/RemResolvesAgainstRootElementIntegrationTests.cs
@@ -1,0 +1,121 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.PdfSharpCore.Drawing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// css-values-3 §5.1.2: <c>rem</c> resolves against the font size of the ROOT ELEMENT.
+    /// <see cref="DerivedStyle.GetRemHeight"/> used to walk to the topmost <see cref="CssBox"/>, which is
+    /// the container's synthetic root sitting ABOVE <c>&lt;html&gt;</c> and carrying no element, so its
+    /// font size is always the resolver's default — every <c>rem</c> in a document that declares
+    /// <c>html { font-size }</c> silently resolved against that default instead.
+    /// <para>
+    /// Every fixture here declares a non-default root font size, which is what makes the bug visible: with
+    /// the root left at the UA default the wrong answer and the right one are the same number, which is why
+    /// a 10,000-test suite stayed green through it. The expected values are written as literals rather than
+    /// read back off the tree, so an assertion cannot agree with the bug.
+    /// </para>
+    /// </summary>
+    public class RemResolvesAgainstRootElementIntegrationTests
+    {
+        // html { font-size: 32px } -> 32 x 0.75pt/px = 24pt (CSS Values & Units §6.2).
+        private const double RootFontPt = 24.0;
+
+        [Fact]
+        public async Task RemFontSize_ResolvesAgainstTheRootElement_NotTheEngineDefault()
+        {
+            var root = await BuildAndLayout("""
+                html { font-size: 32px; }
+                body { font-size: 10pt; margin: 0; }
+                """,
+                "<div id='rem' style='font-size:1rem'>x</div>");
+
+            Assert.Equal(RootFontPt, FindById(root, "rem")!.ActualFont.Size, 3);
+        }
+
+        [Fact]
+        public async Task EmFontSize_StillResolvesAgainstTheParent()
+        {
+            // The contrast case: em is the PARENT's font size, so the two units must disagree here.
+            // Without it, a `rem` that wrongly followed the parent would pass the test above whenever
+            // the parent happened to be the root.
+            var root = await BuildAndLayout("""
+                html { font-size: 32px; }
+                body { font-size: 10pt; margin: 0; }
+                """,
+                "<div id='em' style='font-size:1em'>x</div>");
+
+            Assert.Equal(10.0, FindById(root, "em")!.ActualFont.Size, 3);
+        }
+
+        [Fact]
+        public async Task RemLength_ResolvesAgainstTheRootElement()
+        {
+            // Not only font-size: every length that takes a rem reads the same basis.
+            var root = await BuildAndLayout("""
+                html { font-size: 32px; }
+                body { font-size: 10pt; margin: 0; }
+                """,
+                "<div id='target' style='padding-top:2rem'>x</div>");
+
+            Assert.Equal(2 * RootFontPt, FindById(root, "target")!.ActualPaddingTop, 3);
+        }
+
+        [Fact]
+        public async Task RemOnTheRootElementItself_ResolvesAgainstTheInitialValue()
+        {
+            // css-values-3 §5.1.2's anti-recursion rule: a rem in the root element's OWN font-size
+            // refers to the initial value, not to the size being computed.
+            var root = await BuildAndLayout("html { font-size: 2rem; }", "<div id='x'>x</div>");
+
+            var html = FindByTag(root, "html")!;
+            Assert.Equal(2 * DefaultFontSizePt(root), html.ActualFont.Size, 3);
+        }
+
+        private static double DefaultFontSizePt(CssBox root) => root.ActualFont.Size;
+
+        private static async Task<CssBox> BuildAndLayout(string css, string bodyHtml)
+        {
+            var html = $"<!DOCTYPE html><html><head><style>{css}</style></head><body>{bodyHtml}</body></html>";
+
+            var adapter = new PdfSharpAdapter { PixelsPerPoint = 1.0 };
+            var container = new HtmlContainerInt(adapter);
+            await container.SetHtml(html, null);
+
+            var size = new XSize(595, 842);
+            container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+            container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+            var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+            using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+            await container.PerformLayout(graphics);
+
+            Assert.NotNull(container.Root);
+            return container.Root!;
+        }
+
+        private static CssBox? FindById(CssBox box, string id)
+        {
+            if (box.HtmlTag?.TryGetAttribute("id", "") == id) return box;
+            foreach (var child in box.Boxes)
+            {
+                if (FindById(child, id) is { } found) return found;
+            }
+            return null;
+        }
+
+        private static CssBox? FindByTag(CssBox box, string tag)
+        {
+            if (box.HtmlTag?.Name == tag) return box;
+            foreach (var child in box.Boxes)
+            {
+                if (FindByTag(child, tag) is { } found) return found;
+            }
+            return null;
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
+++ b/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
@@ -1184,19 +1184,36 @@ namespace PeachPDF.Html.Core.Dom
         /// <summary>Gets the size of 1em, per spec: an element's own computed font-size.</summary>
         public double GetEmHeight() => ActualFont.Size;
 
-        /// <summary>Gets the height of the root font.</summary>
+        /// <summary>
+        /// The font size of the ROOT ELEMENT (css-values-3 §5.1.2), which is the outermost box that
+        /// corresponds to an element.
+        ///
+        /// Walking all the way to the topmost <see cref="CssBox"/> instead lands on the container's
+        /// own root box, which sits above &lt;html&gt; and carries no element, so its font size is
+        /// always <see cref="DefaultFontResolver.FontSize"/>. Every <c>rem</c> in the document then
+        /// resolves against that default no matter what the root declares: with
+        /// <c>html { font-size: 32px }</c>, <c>1em</c> and <c>1rem</c> disagree in the same document.
+        /// </summary>
         public double GetRemHeight()
         {
             var box = Owner;
-            var parentBox = box.ParentBox;
+            CssBox? rootElement = null;
 
-            while (parentBox is not null)
+            for (var parentBox = box.ParentBox; parentBox is not null; parentBox = parentBox.ParentBox)
             {
                 box = parentBox;
-                parentBox = box.ParentBox;
+                if (box.HtmlTag is not null)
+                {
+                    rootElement = box;
+                }
             }
 
-            return box.GetEmHeight();
+            // `box` is now the topmost box, above <html> and carrying no element, so its font size is
+            // the default. That is the right answer when there is no root ELEMENT above the caller: a
+            // fragment with no element boxes, and — importantly — the root element resolving its OWN
+            // font size, where a rem resolves against the initial value (css-values-3 §5.1.2) and
+            // consulting the root again would recurse forever through ActualFont.
+            return (rootElement ?? box).GetEmHeight();
         }
 
         #endregion


### PR DESCRIPTION
css-values-3 §5.1.2 defines `rem` as the font size of the **root element**. `DerivedStyle.GetRemHeight` walks to the topmost `CssBox` instead — which is the container's own root box. It sits above `<html>`, carries no element, and so always reports `DefaultFontResolver.FontSize`. Every `rem` in the document therefore resolves against that default, whatever the root declares.

## Repro

```html
<!DOCTYPE html><html><head><style>
html { font-size: 32px; }
body { margin: 0; font-family: Arial, sans-serif; }
.px  { font-size: 32px; }
.rem { font-size: 1rem; }
.em  { font-size: 1em; }
</style></head><body>
<div class="px">PX</div>
<div class="rem">REM</div>
<div class="em">EM</div>
</body></html>
```

All three must render at the same size. Glyph heights via `pdftotext -bbox`:

| | `main` | with this change |
| --- | --- | --- |
| `font-size: 32px` | 26.81 | 26.81 |
| `font-size: 1em` | 26.81 | 26.81 |
| **`font-size: 1rem`** | **12.29** | **26.81** |

`1em` and `1rem` disagree in the same document, and `1rem` lands on the 11 pt default rather than the declared 32 px.

## Why it is worth fixing

It presents as a **scale error**, not a unit error. A stylesheet that sizes everything in `rem` — which is most of them, and every Tailwind-style one — gets a single wrong multiplier applied uniformly, so the whole document renders at the wrong size and paginates accordingly. Nothing looks broken; it is just silently the wrong size.

## The change

The walk now remembers the outermost box that **has** an element. Falling back to the topmost box keeps two cases right:

- a fragment with no element boxes at all;
- the root element resolving its **own** font size, where a `rem` resolves against the initial value (css-values-3 §5.1.2) and consulting the root again would recurse through `ActualFont`.

## Out of scope: the same bug in `@page` context

`DomParser.ApplyPageStylesOnce` resolves `@page`'s `em`/`rem` bases off the **synthetic wrapper** box rather than `<html>`, so an `@page { margin-top: 1rem }` still lands on the default however the document declares `html { font-size }`. Fixing `GetRemHeight()`'s walk cannot reach it — the wrapper has nothing above it to walk to — and the obvious lookup (`DomUtils.GetBoxByTagName(root, "html")`) is actively harmful there, because `ApplyPageStylesOnce` runs before `CascadeApplyStyles` and `ActualFont` memoizes on first read, so it caches the default font on `<html>` permanently and breaks `rem` for the whole document.

Filed separately as #942 with the measurements and the options, per `CLAUDE.md`'s convention for a deliberately out-of-scope gap. This PR stays scoped to `DerivedStyle.GetRemHeight()`.

## Tests

Added `RemResolvesAgainstRootElementIntegrationTests` — four fixtures, every one declaring a non-default root font size, which is what makes the bug visible at all. Expected values are written as literals rather than read back off the tree, so an assertion cannot agree with the bug. Two of the four fail on `main` and pass here.

`PeachPDF.Tests` on this branch: **10,202 passed, 0 failed, 9 skipped** — `main`'s 10,198 plus the four new fixtures. (Run against a single `net9.0` target, which is the SDK I have here; upstream multi-targets `net8.0;net10.0`, so the absolute totals differ from CI's.)
