### PR TITLE
A float does not land below the line it belongs to

### DIFF
--- a/src/PeachPDF.Tests/Integration/FloatLayoutRegressionTests.cs
+++ b/src/PeachPDF.Tests/Integration/FloatLayoutRegressionTests.cs
@@ -429,6 +429,61 @@ namespace PeachPDF.Tests.Integration
                 $"clear:right must not clear past a float:left sibling, was pushed to Y={cleared.Location.Y}");
         }
 
+        [Fact]
+        public async Task FloatAfterAnInlineRun_LandsOnThatRunsLine()
+        {
+            // CSS 2.1 §9.5.1 rule 6: a float's outer top may not be lower than the top of the line box
+            // it appears in. The inline run before the float closes a line, and the float is laid out as
+            // an ordinary block child, so without the rule it starts on the line BELOW its own.
+            var html = Wrap(@"
+                <div style='width:300pt;'>
+                    <b>BILL TO</b><div id='badge' style='float:left; width:40pt; height:12pt;'></div>
+                </div>");
+
+            var (root, _) = await BuildAndLayout(html);
+            var badge = FindById(root, "badge")!;
+            var word = FindFirstWord(root)!;
+
+            Assert.True(badge.Location.Y <= word.Rectangle.Top + 0.001,
+                $"the float belongs on the line it follows (top {word.Rectangle.Top}), was at Y={badge.Location.Y}");
+        }
+
+        [Fact]
+        public async Task FloatAfterAnInlineRun_WithClear_StillGoesBelowTheLine()
+        {
+            // `clear` is ClearBox's job and rule 6 must not pre-empt it: the same shape with clear:left
+            // keeps the float below the line.
+            var html = Wrap(@"
+                <div style='width:300pt;'>
+                    <div style='float:left; width:20pt; height:30pt;'></div>
+                    <b>BILL TO</b><div id='badge' style='clear:left; float:left; width:40pt; height:12pt;'></div>
+                </div>");
+
+            var (root, _) = await BuildAndLayout(html);
+            var badge = FindById(root, "badge")!;
+
+            Assert.True(badge.Location.Y >= 30,
+                $"clear:left must still clear the 30pt float, was at Y={badge.Location.Y}");
+        }
+
+        [Fact]
+        public async Task FloatAfterARealBlockSibling_StartsBelowIt()
+        {
+            // The rule is scoped to a float whose preceding sibling is the ANONYMOUS block the parser
+            // wrapped an inline run in. After a real block-level element a float starts below it, which
+            // is what a browser does — so the preceding-sibling test has to distinguish the two.
+            var html = Wrap(@"
+                <div style='width:300pt;'>
+                    <p style='margin:0; height:30pt;'>BILL TO</p><div id='badge' style='float:left; width:40pt; height:12pt;'></div>
+                </div>");
+
+            var (root, _) = await BuildAndLayout(html);
+            var badge = FindById(root, "badge")!;
+
+            Assert.True(badge.Location.Y >= 30,
+                $"a float after a real block sibling starts below it, was at Y={badge.Location.Y}");
+        }
+
         // ── Helpers ────────────────────────────────────────────────────────────
 
         private static string Wrap(string body) =>

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -5403,6 +5403,33 @@ namespace PeachPDF.Html.Core.Dom
             offset.Value.Value is { } value ? CssValueParser.ParseLength(value, basis, box) : 0;
 
         /// <summary>
+        /// CSS 2.1 §9.5.1 rule 6 -- a float's outer top may not be lower than the top of the
+        /// line box it appears in. A float is laid out here as an ordinary block child, so inline
+        /// content before it has already closed a line and the float landed on the NEXT one. The case
+        /// that found this: a bordered badge that belongs beside a heading in the same table cell was
+        /// drawn a line below it.
+        ///
+        /// Scoped to the one shape that means the float shares a line with what precedes it: the
+        /// immediately preceding sibling is the ANONYMOUS block the parser wrapped that inline run in
+        /// (no HtmlTag of its own) and it ended with a line box. A float after a real block-level
+        /// sibling starts below it, which is what a browser does too, and a float with `clear` is left
+        /// to <c>ClearBox</c>. Returns null when the rule does not apply.
+        /// </summary>
+        private double? FloatLineTop(CssBox child, double top)
+        {
+            if (!child.IsFloated || child.Clear.Value is not ClearMode.None) return null;
+
+            var index = Boxes.IndexOf(child);
+            if (index <= 0) return null;
+
+            var prev = Boxes[index - 1];
+            if (prev.HtmlTag is not null || prev.IsExcludedFromFlow || prev.LineBoxes.Count == 0) return null;
+
+            var lineTop = prev.LineBoxes[^1].LineTop;
+            return lineTop < top ? lineTop : null;
+        }
+
+        /// <summary>
         /// Writes the offset <see cref="ResolveBlockChildOffset"/> decided on, positions
         /// <paramref name="child"/> under whichever positioning scheme it uses, and registers the used page
         /// name it lands on.
@@ -5419,7 +5446,7 @@ namespace PeachPDF.Html.Core.Dom
             {
                 if (offset.PositionedInBlockFlow)
                 {
-                    var top = offset.Top;
+                    var top = FloatLineTop(child, offset.Top) ?? offset.Top;
 
                     child.Location = new RPoint(offset.Left + child.ActualMarginLeft, top);
                     child.ActualBottom = top;


### PR DESCRIPTION
CSS 2.1 §9.5.1 rule 6: a float's outer top may not be higher than the top of the line box it appears in — and it must not be pushed below it either. `CssBox.CommitBlockChildOffset` lays a float out as an ordinary block child, so inline content before it has already closed a line and the float lands on the *next* one.

## Repro

```html
<!DOCTYPE html><html><head><style>
body { margin: 0; font-family: Arial, sans-serif; font-size: 12pt; }
.cell { width: 300px; border: 1px solid #999; }
.badge { float: left; border: 1px solid #000; padding: 2px; }
</style></head><body>
<div class="cell"><b>BILLTO</b><span class="badge">1038348</span></div>
</body></html>
```

Word positions via `pdftotext -bbox`:

| | `main` | with this change |
| --- | --- | --- |
| `BILLTO` yTop | 36.75 | 36.75 |
| **`1038348` (the float) yTop** | **53.40** | **39.00** |

On `main` the float sits a full line (16.65 pt) below the text it belongs beside. With the change it sits on that line, offset only by its own border and padding.

The same document with `float: right` behaves identically in both builds — the defect is vertical placement, not side.

## Why it matters

This is the common "badge beside a heading in a table cell / grid item" idiom. The float dropping a line pushes everything after it down, and on a paginated document that difference accumulates into a changed page count.

## Tests

`PeachPDF.Tests` on this branch: **10,207 passed, 0 failed, 9 skipped** — same as `main` (`cd28a35`).