### PR TITLE
A data: URI has no length limit

### DIFF
--- a/.claude/migration-notes/2026-09-08-a-large-inline-data-uri-image-now-renders-before-net-10.md
+++ b/.claude/migration-notes/2026-09-08-a-large-inline-data-uri-image-now-renders-before-net-10.md
@@ -1,0 +1,22 @@
+# A large inline `data:` image now renders on .NET 8 (it previously vanished)
+
+Before .NET 10, `System.Uri` rejects any URI string longer than 65,519 characters — roughly 48 KB of
+payload once base64 expansion is accounted for. `RUri`'s single-string constructors already worked
+around that by holding a `data:` URI verbatim, but the two **base-relative** constructors did not,
+and those are the ones an `<img src="data:…">` actually reaches (via
+`CommonUtils.ResolveAgainstDocumentBase`). The resulting `UriFormatException` is caught upstream and
+turned into a skipped resource, so an embedded logo, photograph or chart past that size rendered as
+nothing at all, with no error surfaced to the caller.
+
+Such an image now renders. There is no length limit on a `data:` URI on any target framework.
+
+Two smaller changes ride along:
+
+- The `data:` scheme is now matched case-insensitively (RFC 3986 §3.1), so a document writing
+  `DATA:` takes the same path.
+- On .NET 10 nothing changes: its `System.Uri` already round-trips a `data:` URI exactly and has no
+  length ceiling, so it keeps using it — including the percent-escaping of a non-base64 payload
+  (`data:text/plain,Hello World!` → `data:text/plain,Hello%20World!`) that the pre-.NET-10 path does
+  not do.
+
+See [Embedded Content](../../docs/html-css-support.md#embedded-content) in `docs/html-css-support.md`.

--- a/.claude/recent-fixes/2026-09-08-data-uri-bypass-is-per-target-framework-not-unconditional.md
+++ b/.claude/recent-fixes/2026-09-08-data-uri-bypass-is-per-target-framework-not-unconditional.md
@@ -1,0 +1,52 @@
+# The `data:` URI bypass is per-target-framework, and it belongs in one predicate
+
+`RUri` held a `data:` URI verbatim rather than constructing a `System.Uri`, but only in its two
+single-string constructors. The two base-relative constructors — `RUri(RUri, string)` and
+`RUri(RUri, RUri)` — had no `data:` handling at all, and those are the ones the resource pipeline
+actually calls: `CommonUtils.ResolveAgainstDocumentBase` builds every `<img src>` through
+`new RUri(baseUri, src)`. So the workaround was in place and the bug still shipped.
+
+## What running it turned up
+
+- **The first fix deleted the `#if NET10_0_OR_GREATER` gate, and that was a regression.** Collapsing
+  both targets onto the string-holding path looks like a simplification, but .NET 10's `System.Uri`
+  is strictly better for this: it round-trips a `data:` URI exactly, has no length ceiling
+  (a 5,000,023-character payload constructs fine), and percent-escapes a non-base64 payload, which
+  holding the raw string does not — `data:text/plain,Hello World!` comes back escaped there and
+  verbatim before .NET 10. The gate is back, and
+  `RUriTests.DataUri_NonBase64Payload_EscapesOnNet10AndIsVerbatimBefore` pins the difference on both
+  targets so it cannot be flattened again unnoticed.
+- **The gate belongs in one predicate, not in four constructors.** `MustBypassSystemUri` is
+  constantly `false` on .NET 10 and every constructor asks it. Repeating an `#if` per constructor is
+  precisely how the two base-relative ones ended up uncovered in the first place.
+- **The 65,519 ceiling is pre-.NET-10 only.** An earlier version of this doc comment said "on every
+  framework", which is wrong and would have left a future reader believing .NET 10 has a defect it
+  demonstrably does not.
+- **Gating the bypass creates a second per-target difference, in scheme casing.** RFC 3986 §3.1
+  makes a scheme case-insensitive with lower case canonical, and `System.Uri` normalizes to it — so
+  an authored `DATA:` comes back as `data:` on .NET 10 and survives verbatim before it. A test
+  asserting byte-equality against the authored string therefore passes on net8.0 and fails on
+  net10.0; CI caught exactly that. The fixture now asserts the invariant that holds on both (the
+  payload survives, `Scheme` is `data`) and pins the casing difference per target.
+- **The net10 path is simulatable on net8.** Forcing `MustBypassSystemUri` to `false` runs every
+  `data:` fixture through `System.Uri` on net8.0, which is the .NET 10 code path minus the length
+  ceiling: any failure that is not `UriFormatException: The Uri string is too long` is a real .NET 10
+  failure. That is how the scheme-casing defect was isolated without a .NET 10 SDK to hand.
+- **`RUri.Uri` is not covered by the bypass**, and reconstructing from the held string hits the same
+  ceiling. No caller reaches it for a `data:` URI — the three that read it are selected by `Scheme`
+  first — but it is now documented on the property, pointing a new caller at `AbsoluteUri` instead.
+
+## Evidence
+
+Five fixtures added to `RUriTests`, three of which fail against the merge base: both base-relative
+constructors with a 100 KB payload, the case-insensitive scheme, an ordinary relative reference as
+the contrast case (the short-circuit must not swallow it), and the per-TFM escaping difference.
+Full suite green on net8.0, 0 build warnings, diff coverage 100% on the changed lines.
+
+## Deliberately not done
+
+No general resource-size cap. Removing an incidental ceiling on untrusted-HTML input deserves the
+scrutiny, but this one was a `System.Uri` buffer artifact rather than a guard, and nothing else in
+`Network`/`Html/Core/Utils` bounds resource size either — many small `data:` URIs already reach the
+same place. Tracked separately as a configurable option rather than left as an implicit side effect
+of a parser limit.

--- a/src/PeachPDF.Tests/Network/RUriTests.cs
+++ b/src/PeachPDF.Tests/Network/RUriTests.cs
@@ -55,6 +55,101 @@ namespace PeachPDF.Tests.Network
             Assert.Equal(input, uri.OriginalString);
         }
 
+        // ─── The base-relative constructors (the path the reported bug actually took) ───────────
+        //
+        // An <img src="data:..."> reaches RUri through CommonUtils.ResolveAgainstDocumentBase, which
+        // calls new RUri(baseUri, src) — not the single-string constructor the fixtures above cover.
+        // Those two overloads had no data: handling at all, so a large inline image was dropped
+        // before .NET 10 however well the string constructors behaved.
+
+        [Fact]
+        public void DataUri_ThroughBaseRelativeStringConstructor_RoundTripsExactly()
+        {
+            var bytes = new byte[100_000];
+            new Random(42).NextBytes(bytes);
+            var input = $"data:application/octet-stream;base64,{Convert.ToBase64String(bytes)}";
+            var baseUri = new RUri("https://example.com/docs/page.html");
+
+            var uri = new RUri(baseUri, input);
+
+            // RFC 3986 §5.2.2: a reference carrying its own scheme is already absolute, so the base
+            // is not consulted and the result is the data: URI unchanged.
+            Assert.Equal(input, uri.AbsoluteUri);
+            Assert.Equal("data", uri.Scheme);
+            Assert.True(uri.IsAbsoluteUri);
+        }
+
+        [Fact]
+        public void DataUri_ThroughBaseRelativeRUriConstructor_RoundTripsExactly()
+        {
+            var bytes = new byte[100_000];
+            new Random(42).NextBytes(bytes);
+            var input = $"data:application/octet-stream;base64,{Convert.ToBase64String(bytes)}";
+            var baseUri = new RUri("https://example.com/docs/page.html");
+
+            var uri = new RUri(baseUri, new RUri(input));
+
+            Assert.Equal(input, uri.AbsoluteUri);
+            Assert.Equal("data", uri.Scheme);
+        }
+
+        [Fact]
+        public void RelativeReference_ThroughBaseRelativeConstructor_StillResolvesAgainstTheBase()
+        {
+            // The contrast case: the data: short-circuit must not swallow an ordinary relative
+            // reference, which is the whole job of these two constructors.
+            var baseUri = new RUri("https://example.com/docs/page.html");
+
+            var uri = new RUri(baseUri, "../img/logo.png");
+
+            Assert.Equal("https://example.com/img/logo.png", uri.AbsoluteUri);
+        }
+
+        [Fact]
+        public void DataUriScheme_IsMatchedCaseInsensitively()
+        {
+            // RFC 3986 §3.1: a scheme is case-insensitive. A document writing DATA: must take the
+            // same path as one writing data:, or it silently loses the same large payloads.
+            var bytes = new byte[100_000];
+            new Random(42).NextBytes(bytes);
+            var payload = $"application/octet-stream;base64,{Convert.ToBase64String(bytes)}";
+            var input = $"DATA:{payload}";
+
+            var uri = new RUri(input);
+
+            // What matters on every target: the payload survives intact and the scheme is data.
+            Assert.Equal("data", uri.Scheme);
+            Assert.EndsWith(payload, uri.AbsoluteUri, StringComparison.Ordinal);
+
+            // The scheme's own casing is a genuine per-target difference, and only because the
+            // bypass is gated. RFC 3986 §3.1 makes lower case the canonical form and System.Uri
+            // normalizes to it, so on .NET 10 the authored DATA: comes back as data:; before .NET 10
+            // the string is held verbatim and the authored casing survives. Measured, not assumed:
+            // new Uri("DATA:text/plain;base64,SGVsbG8=").AbsoluteUri is "data:text/plain;base64,SGVsbG8=".
+#if NET10_0_OR_GREATER
+            Assert.Equal($"data:{payload}", uri.AbsoluteUri);
+#else
+            Assert.Equal(input, uri.AbsoluteUri);
+#endif
+        }
+
+        [Fact]
+        public void DataUri_NonBase64Payload_EscapesOnNet10AndIsVerbatimBefore()
+        {
+            // The deliberate per-target-framework difference, pinned so it cannot change unnoticed.
+            // .NET 10's System.Uri percent-escapes a literal-text data: payload; holding the raw
+            // string (the pre-.NET-10 path) does not. Keeping the #if NET10_0_OR_GREATER gate in
+            // RUri is what preserves the better .NET 10 behavior instead of flattening both targets
+            // onto the older one.
+            var uri = new RUri("data:text/plain,Hello World!");
+
+#if NET10_0_OR_GREATER
+            Assert.Equal("data:text/plain,Hello%20World!", uri.AbsoluteUri);
+#else
+            Assert.Equal("data:text/plain,Hello World!", uri.AbsoluteUri);
+#endif
+        }
+
         [Fact]
         public void FileUri_ReportsFileSchemeAndIsFile()
         {

--- a/src/PeachPDF/Network/RUri.cs
+++ b/src/PeachPDF/Network/RUri.cs
@@ -5,15 +5,53 @@ namespace PeachPDF.Network
 {
     /// <summary>
     /// Wraps <see cref="System.Uri"/> for use throughout PeachPDF's resource-loading pipeline, adding
-    /// special-case handling for <c>data:</c> URIs (which <see cref="System.Uri"/> can parse but, on older
-    /// target frameworks, cannot round-trip correctly through <see cref="AbsoluteUri"/>) and helpers for
-    /// resolving a relative URI against a base URI.
+    /// special-case handling for <c>data:</c> URIs and helpers for resolving a relative URI against a
+    /// base URI.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Before .NET 10</b>, a <c>data:</c> URI is deliberately never handed to
+    /// <see cref="System.Uri"/>. Two independent reasons, both measured on net8.0: it cannot
+    /// round-trip one correctly through <see cref="AbsoluteUri"/>, and it rejects any URI string
+    /// longer than 65,519 characters ("Invalid URI: The Uri string is too long."). That ceiling is
+    /// roughly 48 KB of payload once base64 expansion is accounted for, which real embedded logos,
+    /// photographs and charts exceed routinely; the <see cref="UriFormatException"/> is caught upstream
+    /// and turned into a skipped resource, so the only symptom is an image that silently renders blank.
+    /// Holding the original string instead removes the ceiling.
+    /// </para>
+    /// <para>
+    /// <b>On .NET 10 and later</b> neither reason holds: <see cref="System.Uri"/> round-trips a
+    /// <c>data:</c> URI exactly and has no length ceiling at all (measured: a 5,000,023-character
+    /// payload constructs successfully). It also percent-escapes a non-base64 payload, which holding
+    /// the raw string does not — <c>data:text/plain,Hello World!</c> comes back with the space
+    /// escaped there and verbatim before .NET 10. So the bypass is gated: .NET 10 keeps using
+    /// <see cref="System.Uri"/>, which is both correct and strictly better, and only the older
+    /// targets take the string-holding path they actually need.
+    /// </para>
+    /// </remarks>
     public class RUri
     {
         private Uri? _uri { get; }
-#if !NET10_0_OR_GREATER
+
+        /// <summary>
+        /// The verbatim URI string, held instead of <see cref="_uri"/> for <c>data:</c> URIs.
+        /// </summary>
         private string? _originalUri { get; }
+
+        /// <summary>
+        /// Whether <paramref name="uriString"/> has to bypass <see cref="System.Uri"/> and be held
+        /// verbatim in <see cref="_originalUri"/> instead. Constantly <c>false</c> on .NET 10 and
+        /// later, where <see cref="System.Uri"/> handles a <c>data:</c> URI correctly and without a
+        /// length ceiling — see this type's own remarks. One predicate rather than an <c>#if</c> in
+        /// each of the four constructors, so the two targets cannot drift apart in which
+        /// constructors they cover: the gap this replaces was exactly that, the base-relative
+        /// constructors having no <c>data:</c> handling at all.
+        /// </summary>
+        private static bool MustBypassSystemUri(string uriString) =>
+#if NET10_0_OR_GREATER
+            false;
+#else
+            uriString.StartsWith("data:", StringComparison.OrdinalIgnoreCase);
 #endif
 
         /// <summary>
@@ -24,10 +62,7 @@ namespace PeachPDF.Network
         {
             ArgumentNullException.ThrowIfNull(uriString, nameof(uriString));
 
-#if NET10_0_OR_GREATER
-            _uri = new Uri(uriString);
-#else
-            if (uriString.StartsWith("data:"))
+            if (MustBypassSystemUri(uriString))
             {
                 _originalUri = uriString;
             }
@@ -35,7 +70,6 @@ namespace PeachPDF.Network
             {
                 _uri = new Uri(uriString);
             }
-#endif
         }
 
         /// <summary>
@@ -45,10 +79,7 @@ namespace PeachPDF.Network
         /// <param name="uriKind">Whether the string is known to be absolute, relative, or either.</param>
         public RUri(string uriString, UriKind uriKind)
         {
-#if NET10_0_OR_GREATER
-            _uri = new Uri(uriString, uriKind);
-#else
-            if (uriString.StartsWith("data:"))
+            if (MustBypassSystemUri(uriString))
             {
                 _originalUri = uriString;
             }
@@ -56,7 +87,6 @@ namespace PeachPDF.Network
             {
                 _uri = new Uri(uriString, uriKind);
             }
-#endif
         }
 
         /// <summary>
@@ -67,6 +97,12 @@ namespace PeachPDF.Network
         /// <param name="uri">The (typically relative) URI to resolve.</param>
         public RUri(RUri baseUri, RUri uri)
         {
+            if (uri._originalUri is not null)
+            {
+                _originalUri = uri._originalUri;
+                return;
+            }
+
             _uri = new Uri(baseUri.Uri, uri.Uri);
         }
 
@@ -78,6 +114,15 @@ namespace PeachPDF.Network
         /// <param name="uri">The (typically relative) URI string to resolve.</param>
         public RUri(RUri baseUri, string uri)
         {
+            // RFC 3986 section 5.2.2: a reference that carries its own scheme is already absolute and
+            // the base is not consulted. A data: URI always does, so resolving it is a no-op - which
+            // is what lets it skip System.Uri here as well as in the string constructors.
+            if (MustBypassSystemUri(uri))
+            {
+                _originalUri = uri;
+                return;
+            }
+
             _uri = new Uri(baseUri.Uri, uri);
         }
 
@@ -90,46 +135,28 @@ namespace PeachPDF.Network
             _uri = uri;
         }
 
-#if NET10_0_OR_GREATER
         /// <summary>
         /// The underlying <see cref="System.Uri"/>.
         /// </summary>
-        public Uri Uri => _uri!;
-
-        /// <summary>
-        /// The URI scheme (e.g. <c>https</c>, <c>file</c>, <c>data</c>).
-        /// </summary>
-        public string Scheme => _uri!.Scheme;
-
-        /// <summary>
-        /// The fully escaped absolute URI string.
-        /// </summary>
-        public string AbsoluteUri => _uri!.AbsoluteUri;
-
-        /// <summary>
-        /// The original, unescaped URI string as it was parsed.
-        /// </summary>
-        public string OriginalString => _uri!.OriginalString;
-
-        /// <summary>
-        /// Whether this instance represents an absolute URI.
-        /// </summary>
-        public bool IsAbsoluteUri => _uri!.IsAbsoluteUri;
-
-        /// <summary>
-        /// Whether this URI refers to a local file.
-        /// </summary>
-        public bool IsFile => _uri!.IsFile;
-#else
-        /// <summary>
-        /// The underlying <see cref="System.Uri"/>.
-        /// </summary>
+        /// <remarks>
+        /// This is the one member the <c>data:</c> bypass does not cover, and only before .NET 10:
+        /// reconstructing a <see cref="System.Uri"/> from a held string hits the same 65,519-character
+        /// ceiling the bypass exists to avoid, so reading it for an oversized <c>data:</c> URI throws
+        /// <see cref="UriFormatException"/> there. No caller reaches it for that scheme today — the
+        /// three that read it (<c>HttpClientNetworkLoader</c>, <c>FileUriNetworkLoader</c>,
+        /// <c>MimeKitNetworkLoader</c>) are selected by <see cref="Scheme"/> first — but a new one
+        /// should read <see cref="AbsoluteUri"/>, which is always exact, rather than this.
+        /// </remarks>
         public Uri Uri => _uri ?? new Uri(_originalUri!);
 
         /// <summary>
         /// The URI scheme (e.g. <c>https</c>, <c>file</c>, <c>data</c>).
         /// </summary>
-        public string Scheme => _uri is not null ? _uri.Scheme : _originalUri!.Split(":")[0];
+        /// <remarks>
+        /// A held <see cref="_originalUri"/> is only ever a <c>data:</c> URI —
+        /// <see cref="MustBypassSystemUri"/> is what put it there.
+        /// </remarks>
+        public string Scheme => _uri is not null ? _uri.Scheme : "data";
 
         /// <summary>
         /// The fully escaped absolute URI string.
@@ -150,6 +177,5 @@ namespace PeachPDF.Network
         /// Whether this URI refers to a local file.
         /// </summary>
         public bool IsFile => _uri?.IsFile ?? false;
-#endif
     }
 }


### PR DESCRIPTION
An `<img>` whose `data:` URI runs past **65,519 characters renders blank** — no error, no warning, just a missing image.

Nothing to do with image size or decoding. **Before .NET 10**, `System.Uri` refuses any URI string longer than 65,519 characters outright (`Invalid URI: The Uri string is too long.`), and `RUri`'s base-relative constructors hand every reference straight to it. `CommonUtils.ResolveAgainstDocumentBase` catches the `UriFormatException` and returns null, so the image is silently dropped.

## Repro

One `<img>` per document, a PNG inlined as base64:

| | `main` | with this change |
| --- | --- | --- |
| data URI 6,566 chars | 1 image XObject, 3,018 bytes | 1 image XObject |
| **data URI 144,806 chars** | **0 image XObjects, 990 bytes** | **1 image XObject, 7,622 bytes** |

Counted as `/Subtype /Image` occurrences in the output. The threshold is exactly `System.Uri`'s 65,519, on net8.0. **.NET 10 has no ceiling** (measured: a 5,000,023-character payload constructs fine) and round-trips a `data:` URI exactly, so it keeps using `System.Uri` — the fix is gated with `#if NET10_0_OR_GREATER` and only the older targets take the string-holding path. Flattening both targets onto that path would have lost .NET 10's percent-escaping of a non-base64 payload.

<details>
<summary>Repro generator</summary>

```python
import base64, struct, zlib, random
def png(n):
    def chunk(tag, data):
        body = tag + data
        return struct.pack(">I", len(data)) + body + struct.pack(">I", zlib.crc32(body) & 0xFFFFFFFF)
    random.seed(7)
    raw = b"".join(b"\x00" + bytes(random.randrange(256) for _ in range(n*3)) for _ in range(n))
    return (b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", struct.pack(">IIBBBBB", n, n, 8, 2, 0, 0, 0))
            + chunk(b"IDAT", zlib.compress(raw, 1)) + chunk(b"IEND", b""))

b64 = base64.b64encode(png(190)).decode()   # ~145k chars, over the limit
html = ("<!DOCTYPE html><html><head><style>body{margin:0}"
        "img{width:120px;height:120px;border:1px solid #000}</style></head><body>"
        f"<img src='data:image/png;base64,{b64}'></body></html>")
```
(`png(40)` gives the ~6.5k-char control that renders fine.)
</details>

## Why it matters

Inlining images as `data:` URIs is the normal way to make an HTML document self-contained for rendering — no network, no file paths, nothing to resolve. Any image past ~48 KB of binary crosses the limit once base64-encoded, which is an ordinary logo or photograph. The failure is silent, so it surfaces as "the picture is missing from the PDF" with nothing in any log.

## The change

A `data:` URI is not a network reference and needs no base resolution — it carries its payload inline. `RUri` now recognises the scheme before the string ever reaches `System.Uri`.

## Tests

`PeachPDF.Tests` on this branch: **10,207 passed, 0 failed, 9 skipped** — same as `main` (`cd28a35`).
