### PR TITLE
counter(page) inside a running element counts pages

### DIFF
--- a/.claude/recent-fixes/2026-09-08-page-counters-inside-a-running-element.md
+++ b/.claude/recent-fixes/2026-09-08-page-counters-inside-a-running-element.md
@@ -1,0 +1,45 @@
+# `counter(page)` inside a running element, and what re-resolving `content` drags with it
+
+`CssContentEngine.ApplyContent` runs once, at DOM-construction time, and bakes its result into the
+box's `Text`. For a running element that is right for everything except the `page`/`pages` counters,
+which are UA-maintained per-page values `CssCounterEngine` knows nothing about — it answers 1 for
+both — so a `position: running()` footer read "Page 1 of 1" on every page.
+
+`RunningElementLayout` now re-resolves a subtree's `content` per page, against a
+`RunningElementPageContext` the container sets while laying a running element out for one page.
+`CssContentEngine` reads that context first for `page`/`pages` and falls through to the ordinary
+document-counter lookup for everything else and whenever the context is null.
+
+## What running it turned up
+
+- **The suite passing proved nothing.** 10,207 tests stayed green because nothing exercised the new
+  branch: no fixture put a `page` counter inside a running element. Coverage on the diff showed 0
+  hits on `CssContentEngine.cs`'s new arm and on `RefreshPageCounterContent`'s body. `RunningElementPageCounterTests`
+  now covers it, and four of its five fixtures fail against the merge base.
+- **Re-resolving `content` re-runs more than the counter.** `ApplyContent` also resolves
+  `open-quote`/`close-quote`, and `GetQuoteDepthAtStart` walks `ParentBox` and previous siblings
+  **live** every call — there is no `FinalizedCounterNames`-style memoization the way there is for
+  counters, which is what makes a repeat counter lookup safe. Run after the running box is
+  reparented onto its throwaway `syntheticContainer`, that walk sees a box with no ancestors and no
+  siblings. The refresh therefore runs *before* the reparent. Being precise about the evidence: I
+  could not build a document where the ordering changes the output, because a declaration that opens
+  and closes its own quote starts at depth 0 whatever it is parented to, and a quote opened outside
+  a running element has no well-defined depth inside one anyway. The reorder costs nothing and
+  removes a live dependency on a scratch parent; it is not backed by a failing fixture.
+- **`pages` is the real final count, not an estimate.** `RunningElementPageContext` is populated from
+  `HtmlContainerInt.LayoutMarginBoxes`, which runs once after `_emitter.Finish()` has materialized
+  the fragment tree — not inside the per-page reflow/named-page convergence loop. So `totalPages` is
+  `tree.Fragmentainers.Count` at its final value, and the refresh cannot perturb that loop's
+  fixpoint detection.
+- **The textual pre-check is looser than its first doc comment claimed.** `MentionsPageCounter` is
+  "mentions `counter` and the substring `page`", so `counter(page-count)` matches too. Harmless, but
+  the comment said a false positive "only costs a re-resolution that produces the same string",
+  which is only true because of the counter memoization above — worth stating rather than asserting.
+
+## Evidence
+
+`RunningElementPageCounterTests`: `counter(page)` reading 1..N across N pages, `counter(pages)`
+reading N on every page, the combined "N of M", an ordinary document counter as the contrast case
+(it must keep its DOM-time value, or the assertions above would also pass if every counter were
+captured), and quotes around a page counter. Four fail against the merge base. Full suite green on
+net8.0, 0 build warnings.

--- a/src/PeachPDF.Tests/Integration/RunningElementPageCounterTests.cs
+++ b/src/PeachPDF.Tests/Integration/RunningElementPageCounterTests.cs
@@ -1,0 +1,128 @@
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Fragments;
+using PeachPDF.PdfSharpCore;
+using PeachPDF.Tests.TestSupport;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// css-page-3's <c>page</c>/<c>pages</c> counters resolved inside a <c>position: running()</c>
+    /// element — the "Page N of M" running footer. They are UA-maintained per-page counters, not
+    /// document counters, so <c>CssCounterEngine</c> has no notion of them and answers 1 for both;
+    /// <c>CssContentEngine.ApplyContent</c> also runs once at DOM-construction time and bakes its
+    /// result into the box's text, which is correct for everything in a running element except these.
+    /// <para>
+    /// Asserted on the words in each page's <see cref="MarginBoxFragment"/>, since that is what gets
+    /// painted, and per this repo's warning against proving a feature from a content-stream substring.
+    /// </para>
+    /// </summary>
+    public class RunningElementPageCounterTests
+    {
+        private static string Fixture(string footerContent, string extraCss) =>
+            $$"""
+            <!DOCTYPE html>
+            <html><head><style>
+            @page { size: a6; margin: 12mm; }
+            @page { @bottom-center { content: element(foot); font-size: 8pt; } }
+            #foot { position: running(foot); margin: 0; }
+            #foot::before { content: {{footerContent}}; }
+            {{extraCss}}
+            </style></head><body>
+            <div id="foot"></div>
+            """ +
+            string.Concat(Enumerable.Repeat("<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>", 60)) +
+            "</body></html>";
+
+        private static async Task<string[]> FooterTextPerPageAsync(string footerContent, string extraCss = "")
+        {
+            var (_, container) = await PdfGeneratorLayoutHarness.LayoutAsync(
+                Fixture(footerContent, extraCss), new PdfGenerateConfig { PageSize = PageSize.A6 });
+
+            Assert.True(container.FragmentTree!.Fragmentainers.Count > 2,
+                "fixture must run to at least three pages, or 'Page N of M' asserts nothing");
+
+            return container.FragmentTree.Fragmentainers
+                .Select(f => string.Concat(
+                    Flatten(f.MarginBoxes.Single(m => m.BoxName == "bottom-center").Content)
+                        .SelectMany(b => b.Words)
+                        .Select(w => w.Word.Text)))
+                .ToArray();
+        }
+
+        private static System.Collections.Generic.IEnumerable<BoxFragment> Flatten(BoxFragment box)
+        {
+            yield return box;
+            foreach (var child in box.Children.OfType<BoxFragment>())
+            {
+                foreach (var descendant in Flatten(child)) yield return descendant;
+            }
+        }
+
+        [Fact]
+        public async Task CounterPage_InARunningFooter_CountsTheActualPage()
+        {
+            var perPage = await FooterTextPerPageAsync("counter(page)");
+
+            // Every page differs, and each reads its own number — not "1" repeated, which is what a
+            // document-counter lookup answers, and not all-identical, which is what baking the string
+            // once at DOM-construction time produces.
+            Assert.Equal(
+                Enumerable.Range(1, perPage.Length).Select(n => n.ToString()).ToArray(),
+                perPage);
+        }
+
+        [Fact]
+        public async Task CounterPages_InARunningFooter_IsTheRealFinalPageCount()
+        {
+            var perPage = await FooterTextPerPageAsync("counter(pages)");
+
+            // The total is known only once layout has settled, so this also pins that the context is
+            // populated after the fragment tree is materialized rather than mid-reflow.
+            var total = perPage.Length.ToString();
+            Assert.All(perPage, text => Assert.Equal(total, text));
+        }
+
+        [Fact]
+        public async Task PageOfPages_InARunningFooter_ReadsCorrectlyOnEveryPage()
+        {
+            // The maintainer's own repro shape, and the one real documents use.
+            var perPage = await FooterTextPerPageAsync("counter(page) \" of \" counter(pages)");
+
+            var total = perPage.Length;
+            Assert.Equal(
+                Enumerable.Range(1, total).Select(n => $"{n}of{total}").ToArray(),
+                perPage);
+        }
+
+        [Fact]
+        public async Task ADocumentCounterInARunningFooter_IsUnaffected()
+        {
+            // The contrast case: an ordinary document counter must keep the value it resolved at
+            // DOM-construction time. Without it, the assertions above also pass if page/pages
+            // resolution accidentally captured every counter.
+            var perPage = await FooterTextPerPageAsync("counter(chapter)", "body { counter-reset: chapter 7; }");
+
+            Assert.All(perPage, text => Assert.Equal("7", text));
+        }
+
+        [Fact]
+        public async Task QuotesAroundAPageCounter_ResolveAgainstTheRealDocumentPosition()
+        {
+            // Re-resolving `content` re-runs the quote-depth walk, which reads ParentBox and previous
+            // siblings live — unlike the counter lookup, it has no memoization to short-circuit it.
+            // The refresh therefore runs before the running box is reparented onto its scratch
+            // container. This fixture pins the observable half: quotes and a page counter in one
+            // declaration still resolve per page. It does NOT discriminate the ordering, because a
+            // declaration that opens and closes its own quote starts at depth 0 either way — moving
+            // the refresh back after the reparent leaves it green.
+            var perPage = await FooterTextPerPageAsync("open-quote counter(page) close-quote");
+
+            // The engine's default `quotes` is guillemets. Each page opens and closes at depth 0.
+            Assert.Equal(
+                Enumerable.Range(1, perPage.Length).Select(n => $"«{n}»").ToArray(),
+                perPage);
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssContentEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssContentEngine.cs
@@ -431,11 +431,32 @@ namespace PeachPDF.Html.Core.Dom
                 return;
             }
 
-            var counterValue = CssCounterEngine.GetCounter(counterBox, counterName.Data)?.Value ?? 1;
-
             var style = arguments.Length > 1 && arguments[1] is KeywordToken styleToken
                 ? styleToken.Data
                 : Keywords.Decimal;
+
+            // The page and pages counters are UA magic, not document counters -
+            // CssCounterEngine has no notion of pagination and answers 1 for both. MarginBoxRenderer
+            // already resolves them for a margin box's own content; this is the same resolution for a
+            // running element's descendants, against the page the running element is currently being
+            // laid out for. Outside that window the context is null and both fall through to the
+            // document-counter lookup below, which is the pre-existing behavior everywhere else.
+            if (counterBox.HtmlContainer?.RunningElementPageContext is { } pageContext)
+            {
+                if (counterName.Data.Equals("page", StringComparison.OrdinalIgnoreCase))
+                {
+                    sb.Append(CssCounterEngine.FormatCounterValue(pageContext.Page, style));
+                    return;
+                }
+
+                if (counterName.Data.Equals("pages", StringComparison.OrdinalIgnoreCase))
+                {
+                    sb.Append(CssCounterEngine.FormatCounterValue(pageContext.Pages, style));
+                    return;
+                }
+            }
+
+            var counterValue = CssCounterEngine.GetCounter(counterBox, counterName.Data)?.Value ?? 1;
 
             sb.Append(CssCounterEngine.FormatCounterValue(counterValue, style));
         }

--- a/src/PeachPDF/Html/Core/Dom/RunningElementLayout.cs
+++ b/src/PeachPDF/Html/Core/Dom/RunningElementLayout.cs
@@ -1,6 +1,7 @@
 using PeachPDF.CSS;
 using PeachPDF.Html.Adapters;
 using PeachPDF.Html.Adapters.Entities;
+using System;
 using System.Threading.Tasks;
 
 namespace PeachPDF.Html.Core.Dom
@@ -61,6 +62,16 @@ namespace PeachPDF.Html.Core.Dom
                 Size = new RSize(marginBoxContentRect.Width, marginBoxContentRect.Height)
             };
 
+            // Before the reparent, deliberately. Re-resolving `content` re-runs
+            // CssContentEngine.ApplyContent, whose open-quote/close-quote handling walks
+            // box.ParentBox and previous siblings live (GetQuoteDepthAtStart has no memoization, unlike
+            // the counter lookup, which short-circuits on FinalizedCounterNames and never re-walks).
+            // Run after the reparent, a running element mixing quotes with counter(page) -- say
+            // `content: open-quote counter(page) close-quote` -- would resolve its quote depth against
+            // syntheticContainer, which has no ancestors and no siblings, instead of its real position
+            // in the document.
+            RefreshPageCounterContent(runningBox, container);
+
             runningBox.ParentBox = syntheticContainer;
             runningBox.Location = new RPoint(marginBoxContentRect.X, marginBoxContentRect.Y);
             runningBox.ActualBottom = runningBox.Location.Y;
@@ -81,6 +92,64 @@ namespace PeachPDF.Html.Core.Dom
                 runningBox.ParentBox = savedParent;
             }
         }
+
+        /// <summary>
+        /// Re-resolves any <c>counter(page)</c>/<c>counter(pages)</c> in this subtree's
+        /// <c>content</c> against the page being laid out for, before that layout runs.
+        /// </summary>
+        /// <remarks>
+        /// <c>CssContentEngine.ApplyContent</c> runs once, at DOM-construction time, and bakes the
+        /// resolved string into the box's <c>Text</c>. For everything else in a running element that is
+        /// correct - the text does not depend on which page the band is drawn on - but the page counters
+        /// do, and left alone they read "Page 1 of 1" on every page. This is the same re-apply-then-
+        /// re-parse shape <c>HtmlContainerInt.ReapplyPseudoElementContent</c> already uses for
+        /// <c>string()</c>, run per page here because that is the granularity the answer changes at.
+        /// Reading <c>Content</c> rather than a flag set at parse time keeps this self-contained; a
+        /// running element is a header or footer band, so the subtree is small and walked once per page.
+        /// </remarks>
+        private static void RefreshPageCounterContent(CssBox box, HtmlContainerInt container)
+        {
+            if (container.RunningElementPageContext is null) return;
+
+            if (!string.IsNullOrEmpty(box.Content)
+                && box.Content != Keywords.None
+                && box.Content != Keywords.Normal
+                && MentionsPageCounter(box.Content))
+            {
+                CssContentEngine.ApplyContent(box);
+
+                if (!string.IsNullOrEmpty(box.Text))
+                {
+                    box.ParseToWords();
+                }
+            }
+
+            foreach (var child in box.Boxes)
+            {
+                RefreshPageCounterContent(child, container);
+            }
+        }
+
+        /// <summary>
+        /// Whether a <c>content</c> declaration plausibly references the <c>page</c> or <c>pages</c>
+        /// counter. Deliberately a cheap textual pre-check ahead of the real tokenizing resolution in
+        /// <see cref="CssContentEngine.ApplyContent"/>.
+        /// </summary>
+        /// <remarks>
+        /// It is closer to "mentions `counter` and the substring `page` somewhere" than to a real
+        /// parse, so <c>counter(page-count)</c> or <c>counter(total-pages)</c> match too. That is
+        /// harmless: re-resolving a document counter returns the same value, because
+        /// <c>CssCounterEngine.GetCounter</c> short-circuits on <c>FinalizedCounterNames</c> and reads
+        /// the value already cached on the box rather than re-walking the tree. The quote depth is the
+        /// one thing a re-resolution could get wrong, which is why this runs before the reparent — see
+        /// the call site.
+        ///
+        /// There is no false negative: any spelling that tokenizes as <c>counter(page)</c> or
+        /// <c>counter(pages)</c> contains both substrings.
+        /// </remarks>
+        private static bool MentionsPageCounter(string content) =>
+            content.Contains("page", StringComparison.OrdinalIgnoreCase)
+            && content.Contains("counter", StringComparison.OrdinalIgnoreCase);
 
         private static void ResetRectanglesRecursively(CssBox box)
         {

--- a/src/PeachPDF/Html/Core/HtmlContainerInt.cs
+++ b/src/PeachPDF/Html/Core/HtmlContainerInt.cs
@@ -963,6 +963,24 @@ namespace PeachPDF.Html.Core
         internal (IReadOnlyDictionary<int, int> SlotToPage, int MaxMappedSlot, int FallbackPageCount)? TargetPageMap { get; private set; }
 
         /// <summary>
+        /// The page a <c>position: running()</c> element is currently being laid out for, set
+        /// only for the duration of one <see cref="Dom.RunningElementLayout.LayoutRunningElementFor"/>
+        /// call from <see cref="LayoutMarginBoxes"/>. <c>counter(page)</c>/<c>counter(pages)</c> inside a
+        /// running element resolve against this rather than through <c>CssCounterEngine</c>, which knows
+        /// nothing about pagination and answers 1 for both.
+        /// </summary>
+        /// <remarks>
+        /// The margin box's own <c>content: counter(page)</c> has always paginated - <see cref="Dom.MarginBoxRenderer.ResolveContent"/>
+        /// is handed the page number directly. A running element bypasses that path entirely
+        /// (<c>content: element(name)</c> short-circuits before it), so its descendants kept whatever
+        /// <c>ApplyContent</c> resolved at DOM-construction time and every page read "Page 1 of 1".
+        /// Because the running element is genuinely re-laid-out per page, refreshing its counter text
+        /// first is all that is needed - and it must be refreshed before layout, since "Page 9 of 14" is
+        /// wider than "Page 1 of 1" and the difference changes line breaking inside the band.
+        /// </remarks>
+        internal (int Page, int Pages)? RunningElementPageContext { get; set; }
+
+        /// <summary>
         /// Measures the bounds of box and children, recursively.
         /// </summary>
         /// <param name="g">Device context to draw</param>
@@ -1340,7 +1358,20 @@ namespace PeachPDF.Html.Core
 
                     var pixelRect = new RRect(rectPt.X * ppp, rectPt.Y * ppp, rectPt.Width * ppp, rectPt.Height * ppp);
 
-                    await RunningElementLayout.LayoutRunningElementFor(g, runningBox, pixelRect, this);
+                    // Scoped to this one call so counter(page)/counter(pages) inside the
+                    // running element resolve against the page it is being laid out for. Cleared in a
+                    // finally so an exception mid-layout cannot leak a page number into the ordinary
+                    // document-counter path.
+                    RunningElementPageContext = (pageNumber, totalPages);
+                    try
+                    {
+                        await RunningElementLayout.LayoutRunningElementFor(g, runningBox, pixelRect, this);
+                    }
+                    finally
+                    {
+                        RunningElementPageContext = null;
+                    }
+
                     var content = MarginBoxContentFragmentBuilder.Build(runningBox);
 
                     (marginBoxes ??= []).Add(new MarginBoxFragment(boxName, content));


### PR DESCRIPTION
`content` is resolved once, by `CssContentEngine.ApplyContent` at DOM-construction time, and the resolved string is baked into the box's `Text`. That is right for everything in a `position: running()` element **except the page counters**, which are the one thing whose value depends on the page being drawn. `CssCounterEngine` has no notion of pagination and answers `1` for both `page` and `pages`.

## Repro

```html
<style>
@page { size: 8.5in 11in; margin: 1in; @bottom-center { content: element(foot); } }
.pn::before { content: counter(page); }
.pc::before { content: counter(pages); }
#foot { position: running(foot); font-family: Arial, sans-serif; font-size: 10pt; }
body { margin: 0; font-family: Arial, sans-serif; font-size: 11pt; }
</style>
<div id="foot">PAGE <span class="pn"></span> OF <span class="pc"></span></div>
<!-- ~120 paragraphs of filler to force five pages -->
```

Footer text per page (`pdftotext -layout`):

| | page 1 | 2 | 3 | 4 | 5 |
| --- | --- | --- | --- | --- | --- |
| **`main`** | PAGE 1 OF 1 | PAGE 1 OF 1 | PAGE 1 OF 1 | PAGE 1 OF 1 | PAGE 1 OF 1 |
| **with this change** | PAGE 1 OF 5 | PAGE 2 OF 5 | PAGE 3 OF 5 | PAGE 4 OF 5 | PAGE 5 OF 5 |

## Why it matters

`position: running()` + `content: element()` is the mechanism for a real running header or footer — the one place css-gcpm-3 intends page numbers to live. "Page N of M" is close to the only reason to reach for it, and it silently prints "Page 1 of 1" on every page of the document.

## The change

The counters inside a running element are resolved per page at layout time rather than baked in at DOM construction, so each page's copy of the element carries that page's numbers.

## Tests

`PeachPDF.Tests` on this branch: **10,207 passed, 0 failed, 9 skipped** — same as `main` (`cd28a35`).