### PR TITLE
Fix how the intrinsic-width walk measures a line

### DIFF
--- a/.claude/recent-fixes/2026-09-08-what-the-intrinsic-width-walk-gets-wrong-about-a-line.md
+++ b/.claude/recent-fixes/2026-09-08-what-the-intrinsic-width-walk-gets-wrong-about-a-line.md
@@ -1,0 +1,45 @@
+# Four things the intrinsic-width walk got wrong about what a line is
+
+`CssBox.GetMinMaxWidth`/`GetMinMaxSumWords` is a flat walk carrying ONE running line total across a
+whole subtree. Four separate defects all trace to that shape, and all four show up as a
+shrink-to-fit box or an auto table column sized for something other than what it draws.
+
+- **A `<br>` ends a line, so max-content is the widest line, not the sum.** The walk had no notion
+  of a line ending mid-subtree, so a cell holding `H-095<br>H-095-A1 HOSE` measured as the whole run
+  and took width from its neighbour. `widestLine` now carries the widest line CLOSED by a forced
+  break anywhere in the subtree, and `maxWidth` is the max of that and the still-open total.
+- **A flex ROW's items sit side by side.** One running total cannot express that: a `<br>` inside
+  one item terminated the total the previous item had contributed to, so a row measured as
+  "first item + the second item's first line". A row is now measured as the sum of its items, each
+  measured in isolation, with the gaps counted (css-align-3 §8).
+- **Hanging white space was counted at both ends of a line.** css-text-3 §4.1.2 removes a
+  collapsible space at the start of a line and at the end. Counted, measurement claimed 2.6pt per
+  line more than the box draws.
+- **An inline child's horizontal margins sit ON the line.** Uncounted, a shrink-to-fit box measured
+  80pt narrower than the run it had to hold and wrapped text that fits.
+
+Plus one that cannot wrap: a `white-space: nowrap`/`pre` box has no smaller size to offer, so its
+min-content IS its max-content (CSS 2.1 §17.5.2). Measured as its longest word it is far smaller,
+and an auto table column sized from that stays narrower than the run it holds.
+
+## What running it turned up
+
+- **`trailingSpace` was not reset alongside the rest of the per-line state.** `StartsNewLine` resets
+  `maxSum`, `paddingSum` and `atLineStart`; the hanging space of the previous line survived. It is
+  now reset with them. Worth being precise: I could not build a fixture where it changes the result,
+  and the reason is structural — the stale value only ever reaches
+  `widestLine = Math.Max(widestLine, maxSum - trailingSpace)` against a running maximum that already
+  dominates the freshly-reset `maxSum`. Fixed for consistency, not because a document was wrong.
+- **The css-text-3 citations were off by a subsection.** The comments said §4.1.1 and §4.1.3;
+  both rules (leading and trailing collapsible spaces on a line) are §4.1.2, Phase II: Trimming and
+  Positioning. Checked against the spec text rather than from memory.
+- **A `float` in a full-width container is not shrink-to-fit** and says nothing about this walk — it
+  stretches. The first version of the inline-margin fixture used one and passed against the merge
+  base. `position: absolute` (CSS 2.1 §10.3.7) and an auto table cell are the shapes that actually
+  exercise it.
+
+## Evidence
+
+`IntrinsicWidthWalkTests`, five fixtures asserting laid-out geometry: three fail against the merge
+base (both forced-break cases and the inline-margin one), one is the widest-vs-first contrast case,
+one guards the forced-break-first shape. Full suite green on net8.0, 0 build warnings.

--- a/src/PeachPDF.Tests/Integration/IntrinsicWidthWalkTests.cs
+++ b/src/PeachPDF.Tests/Integration/IntrinsicWidthWalkTests.cs
@@ -1,0 +1,137 @@
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Tests.TestSupport;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// Layout assertions for <c>CssBox.GetMinMaxWidth</c>/<c>GetMinMaxSumWords</c> — the intrinsic
+    /// (min-content/max-content) walk that sizes a shrink-to-fit box, an auto table column, and a
+    /// flex item. It is a flat walk carrying one running line total across a whole subtree, which is
+    /// where each of these cases went wrong.
+    /// <para>
+    /// Asserted on laid-out geometry rather than on the walk's own outputs, because the walk is
+    /// private and because a number it returns only matters through where it puts content.
+    /// </para>
+    /// </summary>
+    public class IntrinsicWidthWalkTests
+    {
+        [Fact]
+        public async Task ForcedBreakInACell_DoesNotWidenTheColumnToTheWholeRun()
+        {
+            // A <br> ends a line, so a cell's max-content is the WIDEST line it holds, not the sum of
+            // every line's words. Measured as the sum, the column is sized for a run that never draws
+            // on one line and the table takes width from its neighbour.
+            var narrow = await ColumnStartAsync("H-095<br>H-095-A1 HOSE");
+            var oneLine = await ColumnStartAsync("H-095-A1 HOSE");
+
+            // The two cells' widest single line is the same text, so the second column must start at
+            // the same x in both. Summed across the break, the first is pushed measurably right.
+            Assert.Equal(oneLine, narrow, 3);
+        }
+
+        [Fact]
+        public async Task ForcedBreak_StillTakesTheWidestLine_NotTheFirst()
+        {
+            // The contrast case: taking the widest line must not degrade into taking the FIRST line,
+            // which is the other way to get this wrong. Here the second line is the wider one.
+            var wideSecond = await ColumnStartAsync("A<br>WWWWWWWWWWWWWWWW");
+            var justTheWideLine = await ColumnStartAsync("WWWWWWWWWWWWWWWW");
+
+            Assert.Equal(justTheWideLine, wideSecond, 3);
+        }
+
+        [Fact]
+        public async Task InlineChildHorizontalMargins_CountTowardTheLineWidth()
+        {
+            // An inline child's horizontal margins sit ON the line and are part of its width. Left
+            // out, a shrink-to-fit box is measured 80pt narrower than the run it has to hold and
+            // wraps text that fits. position:absolute is used because it is genuinely shrink-to-fit
+            // (CSS 2.1 §10.3.7) — a float in a full-width container stretches instead, and would say
+            // nothing about the intrinsic walk.
+            var html = LayoutHarness.Wrap(@"
+                <div id='shrink' style='position:absolute;'>
+                    <span style='margin-left:40pt; margin-right:40pt;'>one two three</span>
+                </div>");
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var shrink = LayoutHarness.FindById(root, "shrink")!;
+
+            // 80pt of margin plus the run itself: one line, and the box holds it.
+            Assert.Equal(1, LayoutHarness.Descendants(shrink).Sum(b => b.LineBoxes.Count));
+
+            var widestWord = LayoutHarness.Descendants(shrink).SelectMany(b => b.Words)
+                .Select(w => w.Right).DefaultIfEmpty(0).Max();
+            Assert.True(shrink.ActualRight >= widestWord,
+                $"the box must contain the run it was measured for: right {shrink.ActualRight} vs content {widestWord}");
+        }
+
+        [Fact]
+        public async Task FlexRow_IsMeasuredAsTheSumOfItsItems_NotOneRunningLine()
+        {
+            // A flex row's items sit side by side, so the row's max-content is the SUM of theirs and
+            // each item is measured in isolation. The flat walk carries one running total across the
+            // whole subtree, so a <br> inside one item used to terminate the total the previous item
+            // had contributed to — the row then measured as "first item + the second's first line".
+            var html = LayoutHarness.Wrap(@"
+                <div id='row' style='float:left; display:flex;'>
+                    <div>LOGO</div>
+                    <div>line one<br>a much longer second line</div>
+                </div>");
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var row = LayoutHarness.FindById(root, "row")!;
+
+            // Every word must sit inside the row it was measured for. Measured short, the second
+            // item is handed less than it needs and its text draws over the first.
+            foreach (var word in LayoutHarness.Descendants(row).SelectMany(b => b.Words))
+            {
+                Assert.True(word.Right <= row.ActualRight + 0.5,
+                    $"a word drew past the row's right edge ({word.Right} > {row.ActualRight})");
+            }
+        }
+
+        [Fact]
+        public async Task ABlockWhoseFirstWordIsAForcedBreak_MeasuresWideEnoughForItsContent()
+        {
+            // The shape that reaches `widestLine = Math.Max(widestLine, maxSum - trailingSpace)`
+            // before any word of this box has been measured — a block whose very first word is a
+            // forced break, following a block that left a hanging space behind. trailingSpace is now
+            // reset with the rest of the per-line state so nothing carries across, though this
+            // fixture passes either way: the value only ever reaches a Math.Max against a running
+            // maximum that already dominates it. Kept as a guard on the shape, not as proof of the
+            // reset.
+            var html = LayoutHarness.Wrap(@"
+                <div id='shrink' style='float:left;'>
+                    <div>alpha bravo charlie</div>
+                    <div style='margin-left:30pt;'><br>delta</div>
+                </div>");
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            var shrink = LayoutHarness.FindById(root, "shrink")!;
+
+            foreach (var word in LayoutHarness.Descendants(shrink).SelectMany(b => b.Words))
+            {
+                Assert.True(word.Right <= shrink.ActualRight + 0.5,
+                    $"a word drew past the box's right edge ({word.Right} > {shrink.ActualRight})");
+            }
+        }
+
+        /// <summary>
+        /// Lays out a two-column auto table whose first cell holds <paramref name="firstCellHtml"/>,
+        /// and returns where the SECOND column starts — the observable the first column's intrinsic
+        /// width decides.
+        /// </summary>
+        private static async Task<double> ColumnStartAsync(string firstCellHtml)
+        {
+            var html = LayoutHarness.Wrap($@"
+                <table style='width:400pt; table-layout:auto;'>
+                    <tr><td>{firstCellHtml}</td><td id='second'>SECOND</td></tr>
+                </table>");
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            return LayoutHarness.FindById(root, "second")!.Location.X;
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -6639,11 +6639,58 @@ namespace PeachPDF.Html.Core.Dom
             double paddingSum = 0f;
             double marginSum = 0f;
 
-            GetMinMaxSumWords(this, ref min, ref maxSum, ref paddingSum, ref marginSum);
+            // WidestLine carries the widest line CLOSED by a <br> anywhere in the
+            // subtree, which maxSum alone cannot -- see GetMinMaxSumWords's own break handling.
+            double widestLine = 0f;
 
-            maxWidth = paddingSum + maxSum;
+            // The trailing space of the last word before a <br> -- see the break handling
+            // in GetMinMaxSumWords.
+            double trailingSpace = 0f;
+
+            // Nothing precedes the first word measured, so its own leading space is at the
+            // start of a line and is removed -- see the word loop in GetMinMaxSumWords.
+            var atLineStart = true;
+
+            GetMinMaxSumWords(this, ref min, ref maxSum, ref paddingSum, ref marginSum, ref widestLine, ref trailingSpace, ref atLineStart);
+
+            maxWidth = paddingSum + Math.Max(maxSum, widestLine);
             minWidth = paddingSum + (min < 90999 ? min : 0);
+
+            // A box that cannot wrap has no smaller size to offer -- its min-content
+            // IS its max-content (CSS 2.1 §17.5.2). Measured as the longest word it is far
+            // smaller, and a table column is sized from this: a column then stays narrower than
+            // the run it holds, and the run prints over the column beside it. The case that found
+            // this declares `.field-label { white-space: nowrap; width: 100px }` and puts a
+            // 23-character label in one -- Chrome widens that column from the declared
+            // 75pt to the 82.4pt the run needs, this left it at 75pt and overprinted the value.
+            // Patch 2 stopped the overflow being clipped away, so it became visible rather
+            // than lost.
+            if (WhiteSpace.Value is Whitespace.NoWrap or Whitespace.Pre)
+            {
+                minWidth = Math.Max(minWidth, maxWidth);
+            }
         }
+
+        /// <summary>
+        /// Whether this box begins a line of its own in the intrinsic walk, and so
+        /// competes for "widest line wins" rather than adding to the line in progress. Named
+        /// because three places need to agree on it.
+        /// </summary>
+        private static bool StartsNewLine(CssBox box) =>
+            box.DerivedStyle.ActualDisplay != Keywords.Inline
+            && box.DerivedStyle.ActualDisplay != Keywords.TableCell
+            && box.WhiteSpace.Value != Whitespace.NoWrap;
+
+        /// <summary>
+        /// Whether this box lays its children out along a horizontal flex line, so their
+        /// intrinsic widths ADD UP instead of competing for "widest line wins".
+        ///
+        /// Row only. A flex column genuinely does stack its items, which is what the block rule this
+        /// walk is built on already describes.
+        /// </summary>
+        private static bool IsFlexRow(CssBox box) =>
+            box.DerivedStyle.ActualDisplay is Keywords.Flex or Keywords.InlineFlex
+            && box.FlexDirection.Value is CSS.FlexDirection.Row or CSS.FlexDirection.RowReverse;
 
         /// <summary>
         /// Get the <paramref name="min"/> and <paramref name="maxSum"/> of the box words content and <paramref name="paddingSum"/>.<br/>
@@ -6653,8 +6700,11 @@ namespace PeachPDF.Html.Core.Dom
         /// <param name="maxSum">the max width a single line of words can take without wrapping</param>
         /// <param name="paddingSum">the total amount of padding the content has </param>
         /// <param name="marginSum"></param>
+        /// <param name="widestLine">the widest line closed by a &lt;br&gt; anywhere in the subtree.</param>
+        /// <param name="trailingSpace">the hanging trailing space of the last word measured.</param>
+        /// <param name="atLineStart">whether nothing has been measured onto the current line yet.</param>
         /// <returns></returns>
-        private static void GetMinMaxSumWords(CssBox box, ref double min, ref double maxSum, ref double paddingSum, ref double marginSum)
+        private static void GetMinMaxSumWords(CssBox box, ref double min, ref double maxSum, ref double paddingSum, ref double marginSum, ref double widestLine, ref double trailingSpace, ref bool atLineStart)
         {
             double? oldSum = null;
             // paddingSum must be scoped per "line" the same way maxSum is (see the oldSum save/restore
@@ -6669,12 +6719,20 @@ namespace PeachPDF.Html.Core.Dom
             double? oldPaddingSum = null;
 
             // not inline (block) boxes start a new line so we need to reset the max sum
-            if (box.DerivedStyle.ActualDisplay != Keywords.Inline && box.DerivedStyle.ActualDisplay != Keywords.TableCell && box.WhiteSpace.Value != Whitespace.NoWrap)
+            if (StartsNewLine(box))
             {
                 oldSum = maxSum;
                 maxSum = marginSum;
                 oldPaddingSum = paddingSum;
                 paddingSum = 0;
+                atLineStart = true;
+                // Reset with the rest of the per-line state. trailingSpace is the hanging space of
+                // the last word measured, and the line it hung off has just ended -- carrying it into
+                // a freshly-reset maxSum would subtract a previous line's space from this one. The
+                // reachable shape is a block whose very first word is a forced break, where
+                // `widestLine = Math.Max(widestLine, maxSum - trailingSpace)` runs before any word of
+                // this box has been measured.
+                trailingSpace = 0;
             }
 
             // add the padding
@@ -6685,13 +6743,85 @@ namespace PeachPDF.Html.Core.Dom
             if (box.DerivedStyle.ActualDisplay == Keywords.Table)
                 paddingSum += CssLayoutEngineTable.GetTableSpacing(box);
 
-            if (box.Words.Count > 0)
+            // A flex ROW's items sit side by side, so the row's intrinsic width is the SUM
+            // of theirs, and each item's own content is measured in isolation. The flat walk below
+            // cannot express either: it carries ONE running line total across the whole subtree, so a
+            // <br> inside one item terminates the total the previous item contributed to. The case that
+            // found this is a logo beside a five-line address, and the row measured as "logo + the address's
+            // FIRST line" (140pt against the 164pt it needs) -- the outer row then handed it 140pt, and
+            // the address wrapped to one word per line with the logo painted over it.
+            if (IsFlexRow(box) && box.Boxes.Count > 0)
+            {
+                double rowMax = 0, rowMin = 0;
+                var wraps = box.FlexWrap.Value is not CSS.FlexWrap.NoWrap;
+                var items = 0;
+                foreach (var item in box.Boxes)
+                {
+                    if (item.DerivedStyle.ActualDisplay == Keywords.None) continue;
+
+                    item.GetMinMaxWidth(out var itemMin, out var itemMax);
+                    var itemMargins = item.ActualMarginLeft + item.ActualMarginRight;
+                    rowMax += itemMax + itemMargins;
+                    // A wrapping row can put every item on its own line, so its min-content is the
+                    // widest single item rather than the sum.
+                    rowMin = wraps
+                        ? Math.Max(rowMin, itemMin + itemMargins)
+                        : rowMin + itemMin + itemMargins;
+                    items++;
+                }
+
+                // The gaps sit between the items on the line and are part of the width the row needs
+                // (css-align-3 §8). Left out, the row measures narrower than it lays out and its own
+                // items are shrunk to fit a size that was never big enough.
+                if (items > 1)
+                {
+                    var gap = box.FlexColumnGap.Value is { IsValue: true, Value: { } gapLength }
+                        ? CssValueParser.ParseLength(gapLength, 0, box)
+                        : 0;
+                    rowMax += gap * (items - 1);
+                    if (!wraps) rowMin += gap * (items - 1);
+                }
+
+                maxSum += rowMax;
+                min = Math.Max(min, rowMin);
+            }
+            else if (box.Words.Count > 0)
             {
                 // calculate the min and max sum for all the words in the box
                 foreach (var word in box.Words)
                 {
-                    maxSum += word.FullWidth + (word.HasSpaceBefore ? word.OwnerBox.ActualWordSpacing : 0);
+                    // A <br> ends the line, so max-content is the WIDEST line either
+                    // side of it, not their sum -- the same "widest line wins" rule the block
+                    // boundary at the top of this function already applies, and the reason a
+                    // block-level sibling resets to marginSum rather than accumulating.
+                    // Without it a table cell reading "H-095<br>H-095-A1 HOSE" measured both
+                    // lines end to end and claimed a column 17pt wider than the browser's,
+                    // which the surplus distribution then took out of every other column.
+                    if (word.IsLineBreak)
+                    {
+                        // The space that ended the line hangs and is not part of the line's width
+                        // (css-text-3 §4.1.2), the same rule the last-word subtraction below applies
+                        // to a box's final line. CssRect.FullWidth adds one unconditionally, so
+                        // without this every <br>-separated line measured one space too wide -- 2.6pt
+                        // on that five-line address block, enough to over-subscribe its flex row and wrap
+                        // the heading beside it.
+                        widestLine = Math.Max(widestLine, maxSum - trailingSpace);
+                        maxSum = marginSum;
+                        trailingSpace = 0;
+                        atLineStart = true;
+                        continue;
+                    }
+
+                    // The leading space of the first word on a line is removed the same way its
+                    // trailing one is (css-text-3 §4.1.2) -- and the same way layout now removes it,
+                    // so the two agree. They did not: measurement claimed 2.6pt per line more than
+                    // that same address block draws, over-subscribed the flex row it shares with the
+                    // document heading, and wrapped the heading to get the space back.
+                    maxSum += word.FullWidth
+                              + (word.HasSpaceBefore && !atLineStart ? word.OwnerBox.ActualWordSpacing : 0);
                     min = Math.Max(min, word.Width);
+                    trailingSpace = word.ActualWordSpacing;
+                    atLineStart = false;
                 }
 
                 // remove the last word padding
@@ -6707,9 +6837,23 @@ namespace PeachPDF.Html.Core.Dom
 
                     marginSum += childBox.ActualMarginLeft + childBox.ActualMarginRight;
 
-                    //maxSum += childBox.ActualMarginLeft + childBox.ActualMarginRight;
+                    // An inline child's horizontal margins sit ON the line and are part
+                    // of its width. A child that starts its own line does not need this -- the
+                    // reset at the top of its own call seeds maxSum from marginSum, which already
+                    // carries them, and adding them here as well would count them twice.
+                    //
+                    // A label/value column labels its detail fields with
+                    // `<span class="label">Printed Date:</span>`, and `.label` has
+                    // `margin-right: 5px`. Uncounted, the `space-between` row holding those fields
+                    // measured 3.8pt narrower than it draws, so the row's right-hand column was
+                    // handed less than its content and wrapped its last word.
+                    if (!StartsNewLine(childBox))
+                    {
+                        maxSum += childBox.ActualMarginLeft + childBox.ActualMarginRight;
+                    }
+
                     var maxSumBeforeChild = maxSum;
-                    GetMinMaxSumWords(childBox, ref min, ref maxSum, ref paddingSum, ref marginSum);
+                    GetMinMaxSumWords(childBox, ref min, ref maxSum, ref paddingSum, ref marginSum, ref widestLine, ref trailingSpace, ref atLineStart);
 
                     // This walk otherwise never consults a box's own explicit CSS `width` at all - only
                     // literal word/text content. That's usually fine (explicit width constrains layout
@@ -6750,8 +6894,7 @@ namespace PeachPDF.Html.Core.Dom
                         && !(childBox.DerivedStyle.ActualDisplay == Keywords.Inline && childBox.Words.Count == 0))
                     {
                         var explicitContentWidth = CssValueParser.ParseLength(childBox.Width, 0, childBox);
-                        var childStartsNewLine = childBox.DerivedStyle.ActualDisplay != Keywords.Inline
-                            && childBox.DerivedStyle.ActualDisplay != Keywords.TableCell && childBox.WhiteSpace.Value != Whitespace.NoWrap;
+                        var childStartsNewLine = StartsNewLine(childBox);
                         maxSum = childStartsNewLine
                             ? Math.Max(maxSum, explicitContentWidth)
                             : Math.Max(maxSum, maxSumBeforeChild + explicitContentWidth);


### PR DESCRIPTION
`CssBox.GetMinMaxWidth` / `GetMinMaxSumWords` answer "how wide is this content if it never wraps". Several things it counts wrongly, all in the same walk — so a table column or a flex item comes out the wrong width, and content wraps where it should not.

They are carried together because they are one walk and share its new widest-line tracking. Two measured directly:

## 1. A `<br>` does not end a line

The walk resets its running total at a block boundary ("widest line wins") but walks straight *through* a line-break word, summing the text either side into one line.

```html
<table><tr><td>H-095<br>H-095-A1 HOSE</td><td>SECOND</td></tr></table>
```

| | `SECOND` starts at |
| --- | --- |
| `main` | x = **152.14** |
| with this change | x = **122.18** |

The column claims 30 pt more than its widest line — exactly the width of `H-095`, the first line being summed in.

## 2. An inline child's horizontal margins are not on the line

```html
<style>.m { margin-left: 40pt; margin-right: 40pt; }</style>
<table><tr><td>AA<span class="m">BB</span>CC</td><td>NEXT</td></tr></table>
```

The cell is measured without the 80 pt, so it is sized too narrow and the three words **wrap onto three lines**:

| | AA | BB | CC |
| --- | --- | --- | --- |
| **`main`** | y = 36.38 | y = **49.58** | y = **62.78** — three lines |
| **with this change** | x = 36.38 | x = 91.05 | x = 145.72 — one line, margins honoured |

91.05 − 36.38 is `AA` plus the declared 40 pt; 145.72 − 91.05 is `BB` plus the other 40 pt.

## The rest

Same class, same walk: a flex row's items measured as though they stacked, and the hanging space at either end of a line. I have not built a standalone repro for those two — happy to split them out if you would rather take this in pieces.

## Tests

`PeachPDF.Tests` on this branch: **10,207 passed, 0 failed, 9 skipped**, over four runs.

One run reported a single failure that did not recur; three subsequent runs on this branch and three on `main` (`cd28a35`) were all clean, so it looks like an existing flake rather than anything here. Flagging it rather than quietly re-running until green.