### PR TITLE
A colspan constrains its columns together, not each individually

### DIFF
--- a/.claude/migration-notes/2026-09-08-a-colspan-no-longer-widens-a-column-it-already-fits-into.md
+++ b/.claude/migration-notes/2026-09-08-a-colspan-no-longer-widens-a-column-it-already-fits-into.md
@@ -1,0 +1,27 @@
+# A `colspan` cell no longer widens a column the span already fits into
+
+An automatic-layout table sized its columns by dividing a spanning cell's width by its span and
+forcing every column it covers to at least that share. CSS 2.1 §17.5.2.2 asks for the opposite
+reading: a spanning cell constrains the columns it spans *together* — "increase the minimum widths
+of the columns it spans so that together, they are at least as wide as the cell" — so it should not
+move them at all when their sum already accommodates it.
+
+The old rule dragged a narrow column up to the span's average whatever its own content needed, and
+the surplus then pushed every later column boundary out. A `colspan="2"` cell straddling a
+one-character column and a long one moved boundaries that a browser leaves alone.
+
+Such a span now leaves its columns where they are. A span genuinely wider than its columns still
+widens them, sharing the shortfall in proportion to what each column already measures.
+
+**What a document author may notice.** Column boundaries in an automatic-layout table containing
+`colspan` cells can shift, and in general shift toward what a browser produces. Measured against
+Chrome 152 on a three-column table with a spanning row that fits inside its columns' sum, boundaries
+in points with the page margin subtracted:
+
+| | second boundary | third boundary |
+| --- | --- | --- |
+| Chrome 152 | ~7.0 | 197.3 |
+| after this change | 7.2 | 195.1 |
+| before | 23.3 | 211.2 |
+
+See [Tables](../../docs/html-css-support.md#tables) in `docs/html-css-support.md`.

--- a/.claude/recent-fixes/2026-09-08-a-colspan-constrains-its-columns-together.md
+++ b/.claude/recent-fixes/2026-09-08-a-colspan-constrains-its-columns-together.md
@@ -1,0 +1,40 @@
+# A `colspan` constrains its columns together, not each one individually
+
+`GetColumnsMinMaxWidthByContent` divided a spanning cell's min/max width by its span and
+`Math.Max`'d the result into every column it covered. CSS 2.1 §17.5.2.2 step 3 constrains the spanned
+columns *together* — "so that together, they are at least as wide as the cell" — and says nothing
+about any one of them. The difference only shows when the spanned columns are uneven: dividing drags
+the narrow one up to the average, and the surplus pushes every later boundary out.
+
+Spanning cells are now deferred to a second pass, so every single-column cell has already been
+applied and the sums a span is measured against are final. `SpreadSpannedWidth` then adds only the
+shortfall, if there is one.
+
+## What running it turned up
+
+- **The obvious repro does not discriminate.** A four-column header with two `colspan="2"` detail
+  rows — the shape this was originally found on — gives identical output before and after, because
+  the span genuinely needs widening there and both rules widen it. The fixture that separates them
+  is an *uneven* spanned pair whose sum already fits: a one-character column beside a long one.
+- **Chrome agrees, and the measurement is now in the doc comment.** Rendering that fixture through
+  Chrome 152 headless and reading positions with `pdftotext -bbox`, the second column boundary is at
+  ~7.0pt and the third at 197.3pt past the page margin; this change gives 7.2 and 195.1, the old rule
+  23.3 and 211.2. The residual ~2pt is border/padding modelling, present in both rows.
+- **The proportional split is an approximation, and is now labelled as one.** §17.5.2.2 says to widen
+  the spanned columns by "approximately the same amount". Sharing the shortfall in proportion to what
+  each column already measures avoids re-inflating a column already sized by its own content, and no
+  browser implements §17.5.2.2's automatic algorithm literally — but it is a choice, not the spec
+  text, and the two differ only in how a genuine shortfall is split.
+- **Overlapping spans are order-dependent**, because spans apply in document order and each mutates
+  the widths the next measures against. The invariant that survives is §17.5.2.2's own requirement as
+  a postcondition — every spanning cell's columns together hold that cell — which growth-only updates
+  reach in any order. Pinned by a fixture with a `colspan="3"` over columns 0-2 and a `colspan="2"`
+  over columns 1-2.
+
+## Evidence
+
+`TableColspanColumnSizingTests`, four fixtures, each measured against a control table differing only
+in the row under test: a span that already fits (no boundary moves), a span that does not (they
+move), the proportional ordering, and the overlapping-span postcondition. Two fail against the merge
+base. Full suite green on net8.0, 0 build warnings. The collapsed-column exclusion
+(`IsColumnCollapsed`) is carried into the new pass unchanged.

--- a/src/PeachPDF.Tests/Integration/TableColspanColumnSizingTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableColspanColumnSizingTests.cs
@@ -1,0 +1,117 @@
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Tests.TestSupport;
+using System.Linq;
+using System.Threading.Tasks;
+using static PeachPDF.Tests.TestSupport.LayoutHarness;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// CSS 2.1 §17.5.2.2 step 3: a cell spanning more than one column constrains those columns
+    /// <i>together</i> — "increase the minimum widths of the columns it spans so that together, they
+    /// are at least as wide as the cell". It says nothing about each column individually, so a
+    /// spanning cell must not widen a column that the span, as a whole, already fits into.
+    /// <para>
+    /// Column boundaries are asserted as a cell's laid-out <c>Location.X</c>, measured against a
+    /// control table that differs only in the row under test — the number itself depends on font
+    /// metrics, but the comparison does not.
+    /// </para>
+    /// </summary>
+    public class TableColspanColumnSizingTests
+    {
+        [Fact]
+        public async Task ASpanThatAlreadyFits_DoesNotWidenTheNarrowColumnItStraddles()
+        {
+            // The columns the span covers already sum to more than it needs, so per §17.5.2.2 nothing
+            // moves. Dividing the cell's width by its span and forcing each column to at least that
+            // share instead drags the narrow one up, and the surplus pushes every later boundary out.
+            var withSpan = await ColumnStartsAsync("""
+                <tr><td id='c0'>N</td><td id='c1'>a very much longer second column indeed</td><td id='c2'>T</td></tr>
+                <tr><td colspan='2'>short span</td><td>T</td></tr>
+                """);
+            var withoutSpan = await ColumnStartsAsync("""
+                <tr><td id='c0'>N</td><td id='c1'>a very much longer second column indeed</td><td id='c2'>T</td></tr>
+                """);
+
+            Assert.Equal(withoutSpan[1], withSpan[1], 0.5);
+            Assert.Equal(withoutSpan[2], withSpan[2], 0.5);
+        }
+
+        [Fact]
+        public async Task ASpanWiderThanItsColumns_StillWidensThem()
+        {
+            // The contrast case: the early return must be "already wide enough", not "never widen".
+            var withSpan = await ColumnStartsAsync("""
+                <tr><td id='c0'>N</td><td id='c1'>M</td><td id='c2'>T</td></tr>
+                <tr><td colspan='2'>a considerably longer spanning run of text indeed</td><td>T</td></tr>
+                """);
+            var withoutSpan = await ColumnStartsAsync("""
+                <tr><td id='c0'>N</td><td id='c1'>M</td><td id='c2'>T</td></tr>
+                """);
+
+            Assert.True(withSpan[2] > withoutSpan[2] + 50,
+                $"a span wider than its columns must widen them: third boundary {withSpan[2]} vs {withoutSpan[2]}");
+        }
+
+        [Fact]
+        public async Task TheShortfallIsSharedInProportionToWhatTheColumnsAlreadyMeasure()
+        {
+            // A column carrying more of the table's content takes more of the extra. Asserted as an
+            // ordering rather than an exact split, since the split depends on font metrics: the
+            // already-wider column must end up wider still, never equalised with the narrow one.
+            var starts = await ColumnStartsAsync("""
+                <tr><td id='c0'>N</td><td id='c1'>a longer second column</td><td id='c2'>T</td></tr>
+                <tr><td colspan='2'>a considerably longer spanning run of text indeed here</td><td>T</td></tr>
+                """);
+
+            var col0Width = starts[1] - starts[0];
+            var col1Width = starts[2] - starts[1];
+
+            Assert.True(col1Width > col0Width * 2,
+                $"the column already carrying more content must take more of the shortfall: {col0Width} vs {col1Width}");
+        }
+
+        [Fact]
+        public async Task OverlappingSpans_LeaveEveryCellWithEnoughRoom()
+        {
+            // Spans are applied in document order and each mutates the widths the next one measures
+            // against, so the result is order-dependent when they overlap. What must hold regardless
+            // is §17.5.2.2's own requirement, as a postcondition: every spanning cell's columns
+            // together are at least as wide as that cell. Growth-only updates make that reachable
+            // whatever order they run in.
+            var (root, _) = await LayoutAsync(Wrap("""
+                <table style='border-collapse:collapse; table-layout:auto; font-size:10pt;'>
+                  <tr><td id='c0'>N</td><td id='c1'>M</td><td id='c2'>P</td><td id='c3'>Q</td></tr>
+                  <tr><td id='wide3' colspan='3'>a long run spanning the first three columns here</td><td>Q</td></tr>
+                  <tr><td>N</td><td id='wide2' colspan='2'>a long run spanning the middle two</td><td>Q</td></tr>
+                </table>
+                """), margin: 36);
+
+            foreach (var id in new[] { "wide3", "wide2" })
+            {
+                var cell = FindById(root, id)!;
+                var widest = Descendants(cell).SelectMany(b => b.Words)
+                    .Select(w => w.Right).DefaultIfEmpty(0).Max();
+
+                Assert.True(cell.ActualRight >= widest - 0.5,
+                    $"'{id}' spans columns too narrow for its own content: cell right {cell.ActualRight}, content {widest}");
+            }
+        }
+
+        /// <summary>
+        /// The laid-out <c>Location.X</c> of the cells marked <c>c0</c>/<c>c1</c>/<c>c2</c> — the
+        /// column boundaries the intrinsic widths decide.
+        /// </summary>
+        private static async Task<double[]> ColumnStartsAsync(string rows)
+        {
+            var (root, _) = await LayoutAsync(Wrap($@"
+                <table style='border-collapse:collapse; table-layout:auto; font-size:10pt;'>
+                  {rows}
+                </table>"), margin: 36);
+
+            return new[] { "c0", "c1", "c2" }
+                .Select(id => FindById(root, id)!.Location.X)
+                .ToArray();
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
@@ -6079,6 +6079,7 @@ namespace PeachPDF.Html.Core.Dom
             }
 
             var availCellWidth = GetAvailableCellWidth();
+            List<(int Col, int Span, double Min, double Max)>? spanning = null;
 
             foreach (var row in _allRows)
             {
@@ -6123,16 +6124,94 @@ namespace PeachPDF.Html.Core.Dom
                         if (!IsColumnCollapsed(col + j)) visibleSpanColumns++;
                     }
 
-                    minWidth /= visibleSpanColumns;
-                    maxWidth /= visibleSpanColumns;
-
-                    for (var j = 0; j < colSpan; j++)
+                    // A cell spanning one visible column bounds it directly. A cell
+                    // spanning several is DEFERRED to the pass below -- see SpreadSpannedWidth.
+                    if (visibleSpanColumns == 1)
                     {
-                        if (IsColumnCollapsed(col + j)) continue;
-                        minFullWidths[col + j] = Math.Max(minFullWidths[col + j], minWidth);
-                        maxFullWidths[col + j] = Math.Max(maxFullWidths[col + j], maxWidth);
+                        for (var j = 0; j < colSpan; j++)
+                        {
+                            if (IsColumnCollapsed(col + j)) continue;
+                            minFullWidths[col + j] = Math.Max(minFullWidths[col + j], minWidth);
+                            maxFullWidths[col + j] = Math.Max(maxFullWidths[col + j], maxWidth);
+                        }
+                        continue;
                     }
+
+                    (spanning ??= []).Add((col, colSpan, minWidth, maxWidth));
                 }
+            }
+
+            if (spanning is null) return;
+
+            // CSS 2.1 §17.5.2.2: a spanning cell constrains the columns it spans TOGETHER, so it
+            // only widens them when their sum falls short of what it needs. Every spanning cell is
+            // applied after every single-column one, so the sums it is measured against are final.
+            foreach (var (col, colSpan, minWidth, maxWidth) in spanning)
+            {
+                SpreadSpannedWidth(minFullWidths, col, colSpan, minWidth);
+                SpreadSpannedWidth(maxFullWidths, col, colSpan, maxWidth);
+            }
+        }
+
+        /// <summary>
+        /// Raises the columns a cell spans so they can hold it, and only then.
+        ///
+        /// The previous rule -- divide the cell's width by its span and <c>Math.Max</c> it into every
+        /// spanned column -- forces each one to at least that share whatever its own content needs,
+        /// so a wide cell straddling a narrow column and a wide one drags the narrow one up and, once
+        /// the surplus is redistributed, drags every other column in the table down with it. A browser
+        /// leaves the columns alone when they already sum to enough.
+        ///
+        /// Measured against Chrome on a three-column table whose spanned pair is a one-character
+        /// column beside a long one, with a <c>colspan="2"</c> row that fits inside their sum
+        /// (column boundaries in points, page margin subtracted):
+        /// <code>
+        /// Chrome 152        col1 ~7.0   col2 197.3
+        /// this change       col1  7.2   col2 195.1
+        /// dividing by span  col1 23.3   col2 211.2
+        /// </code>
+        /// The residual ~2pt against Chrome is border/padding modelling, present in both rows and
+        /// unrelated to this rule.
+        ///
+        /// <b>The distribution itself is a deliberate approximation.</b> CSS 2.1 §17.5.2.2 says to
+        /// widen the spanned columns by "approximately the same amount"; this shares the shortfall in
+        /// proportion to what the columns already measure, so a column carrying more of the table's
+        /// content takes more of the extra, and columns that measure nothing share it equally, there
+        /// being no proportion to go on. Proportional was chosen because it avoids re-inflating a
+        /// column already sized correctly by its own content, and because no browser implements
+        /// §17.5.2.2's automatic algorithm literally. Where the two differ is only in how a genuine
+        /// shortfall is split, never in whether one exists.
+        ///
+        /// <b>Overlapping spans are order-dependent.</b> Spans are applied in document order and each
+        /// mutates the widths the next measures against, so a <c>colspan="3"</c> over columns 0-2 and
+        /// a <c>colspan="2"</c> over columns 1-2 reach a different split than the reverse order would.
+        /// What holds either way is §17.5.2.2's own requirement as a postcondition -- every spanning
+        /// cell's columns together are at least as wide as that cell -- because these updates only
+        /// ever grow a column. Pinned by
+        /// <c>TableColspanColumnSizingTests.OverlappingSpans_LeaveEveryCellWithEnoughRoom</c>.
+        /// </summary>
+        private void SpreadSpannedWidth(double[] widths, int col, int colSpan, double required)
+        {
+            var spanned = new List<int>(colSpan);
+            var total = 0d;
+            for (var j = 0; j < colSpan; j++)
+            {
+                var index = col + j;
+                if (index >= widths.Length || IsColumnCollapsed(index)) continue;
+                spanned.Add(index);
+                total += widths[index];
+            }
+
+            if (spanned.Count == 0) return;
+
+            var shortfall = required - total;
+            if (shortfall <= 0) return;
+
+            foreach (var index in spanned)
+            {
+                widths[index] += total > 0
+                    ? shortfall * (widths[index] / total)
+                    : shortfall / spanned.Count;
             }
         }
 


### PR DESCRIPTION
`GetColumnsMinMaxWidthByContent` divides a spanning cell's min and max by its span and `Math.Max`es the result into **every** column it covers. That makes each spanned column at least that share whatever its own content needs — so a wide cell straddling a narrow column and a wide one drags the narrow one up, and the surplus redistribution then drags every other column in the table down to pay for it.

CSS 2.1 §17.5.2.2 constrains the spanned columns **together**: they are widened only when their combined width is less than the spanning cell needs, and the shortfall is distributed across them.

## Repro

```html
<style>
body { margin: 0; font-family: Arial, sans-serif; font-size: 11pt; }
table { border-collapse: collapse; }
td { border: 1px solid #333; padding: 0; }
</style>
<table>
  <tr><td colspan="2">AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA</td></tr>
  <tr><td>X</td><td>YYYYYYYYYYYYYYYYYYYYYYYY</td></tr>
</table>
```

Column 1 holds a single `X`. Where the second column starts (`pdftotext -bbox`):

| | column 1 width |
| --- | --- |
| `main` | **131.68 pt** — half the colspan cell, forced in |
| with this change | **10.83 pt** — what `X` actually needs |

On `main` the narrow column is inflated to half the spanning cell's width and the wide column loses the space it needed.

## Why it matters

A header cell spanning the table above a row of narrow data columns is an everyday table shape — an invoice, a report, any grouped heading. Every column in the table ends up mis-proportioned, and on a fixed-width page that pushes content out of its column or off the page.

## Tests

`PeachPDF.Tests` on this branch: **10,207 passed, 0 failed, 9 skipped** over two runs — same as `main` (`cd28a35`).