### PR TITLE
A flex item with block children is measured by its content, not its container

### DIFF
--- a/.claude/migration-notes/2026-09-08-a-flex-item-with-block-children-is-sized-by-its-content.md
+++ b/.claude/migration-notes/2026-09-08-a-flex-item-with-block-children-is-sized-by-its-content.md
@@ -1,0 +1,25 @@
+# A flex item whose children are blocks is now sized by its content, not by its container
+
+Previously, a flex item whose children were block-level boxes measured as wide as the flex
+container itself. An auto-width block child fills its containing block during layout, so reading
+the item's laid-out width reported the container's width rather than the item's own content — every
+item on the line measured the full container, `justify-content` was left with no free space to
+distribute, and the line rendered as an even split however narrow the items' content actually was.
+A `space-between` row of two short items landed each one on half the page instead of hugging its
+own edge.
+
+Such an item is now measured by its own intrinsic content, per css-flexbox-1 §9.2 — so
+`justify-content` (`space-between`, `space-around`, `flex-end`, `center`) has real free space to
+distribute and positions the items where the property asks for.
+
+Two narrower changes ride along in the same measurement:
+
+- White space at the end of a wrapped line no longer counts toward an item's measure
+  (css-text-3 §4.1.2 — it hangs). A wrapped item previously measured one word space wider than it
+  drew, which could over-subscribe the line and make `flex-shrink` narrow a sibling that had room.
+- An item whose own min-content is wider than the line now keeps its min-content width and
+  overflows, rather than being sized below what it can draw. This is CSS 2.1 §10.3.5's
+  shrink-to-fit, `min(max(min-content, available), max-content)`, where min-content is the lower
+  bound.
+
+See [Flexbox](../../docs/html-css-support.md#flexbox) in `docs/html-css-support.md`.

--- a/.claude/recent-fixes/2026-09-08-flex-item-hypothetical-size-from-content-not-container.md
+++ b/.claude/recent-fixes/2026-09-08-flex-item-hypothetical-size-from-content-not-container.md
@@ -1,0 +1,48 @@
+# A flex item's hypothetical main size comes from its content, not from its laid-out width
+
+`MeasureItem`'s main-axis-physical-X branch derived an item's max-content width from its
+*laid-out* width (`naturalMain`) whenever the item was not inlines-only. That is correct for a
+replaced leaf, and wrong for a box with block children: an auto-width block child fills its
+containing block during layout, so `naturalMain` is the flex CONTAINER's width, not the item's
+content. Every item then measured the container, the free space `justify-content` distributes came
+out as zero, and the result read as an even split.
+
+The load-bearing idea is that the item has a real intrinsic measurement available already —
+`CssLayoutEngine.GetMinContentWidth`/`GetMaxContentWidth`, the same pair the float sizing a few
+lines above relies on, both returning outer widths, which is what `hypothetical` is.
+
+## What running it turned up
+
+- **The clamp order is not interchangeable.** The first version wrote
+  `min(max(max-content, min-content), available)`, which — given the invariant max-content ≥
+  min-content — collapses to `min(max-content, available)` and has no min-content floor at all.
+  CSS 2.1 §10.3.5 is `min(max(min-content, available), max-content)`: min-content is the LOWER
+  bound. The two agree everywhere except the case that matters, an item whose own min-content
+  exceeds the line, where the correct answer is to keep min-content and overflow. Pinned by
+  `FlexboxIntegrationTests.Item_WhoseMinContentExceedsTheRow_KeepsItsMinContent`, which needs
+  `flex-shrink: 0` — with shrink left on, the shrink pass clamps the item back to the line either
+  way and the fixture says nothing about the clamp.
+- **`GetFitContentWidth` is not the helper to reach for here**, despite the name. It is
+  `min(GetLargestChildWidth(max-content), available)` — no min-content floor either — so it has the
+  same gap. An earlier comment in this method cited it while the code called something else; both
+  now say the same thing.
+- **A hanging space is worth 3.07pt at the default font**, and it was being counted. `LineContentWidth`
+  trims it per css-text-3 §4.1.2. The observable symptom is an item box wider than anything drawn
+  inside it: 0.01pt of slack (the deliberate anti-rounding epsilon) with the trim, 3.07pt without.
+  That difference is what `WrappedItem_DoesNotCountTrailingWhiteSpaceInItsMeasure` asserts — an
+  earlier version of that test put the text in a block child, which takes the other measurement
+  branch entirely, and passed with the trim reverted.
+
+## Evidence
+
+Three fixtures in `FlexboxIntegrationTests.cs`, each mutation-checked: reverting
+`CssLayoutEngineFlex.cs` to `main` fails two of them; reverting only the clamp order fails the
+min-content one; reverting only `LineContentWidth`'s trim fails the trailing-space one. Full suite
+10,201 passed / 0 failed / 9 skipped on net8.0; diff coverage 100% on the changed lines.
+
+## Deliberately not done
+
+The grid-container fallback (`box.DerivedStyle.ActualDisplay is Keywords.Grid or InlineGrid` →
+`naturalMain`) is left as it was. A nested grid places its children on tracks the intrinsic walk
+knows nothing about, so measuring it this way would report a number with no relationship to how it
+lays out; that needs the grid engine's own intrinsic sizing, which is a separate piece of work.

--- a/src/PeachPDF.Tests/Integration/FlexboxIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FlexboxIntegrationTests.cs
@@ -2080,6 +2080,96 @@ namespace PeachPDF.Tests.Integration
             return FindByTag(root, tag)!;
         }
 
+        // ─── Item sizing from block children (css-flexbox-1 §9.2) ───────────────
+
+        [Fact]
+        public async Task SpaceBetween_ItemWithBlockChildren_IsSizedByItsContent_NotAnEvenSplit()
+        {
+            // A flex item's hypothetical main size is its max-content size. An auto-width BLOCK
+            // child fills its container on layout, so measuring the item by its laid-out width
+            // reports the CONTAINER's width instead of the item's content -- every item then
+            // measures the full container, justify-content has no free space left to distribute,
+            // and the result reads as an even split.
+            var html = Wrap(@"
+                <div style='display:flex; justify-content:space-between; width:400pt;'>
+                    <div id='a'><div>SHORT</div></div>
+                    <div id='b'><div>a considerably longer run of text than the first item</div></div>
+                </div>");
+
+            var (root, _) = await BuildAndLayout(html);
+            var a = FindById(root, "a")!;
+            var b = FindById(root, "b")!;
+
+            // Sized by content: the two items differ, and neither is the 200pt even split.
+            Assert.True(a.ActualRight - a.Location.X < b.ActualRight - b.Location.X,
+                $"the short item must measure narrower than the long one, was {a.ActualRight - a.Location.X} vs {b.ActualRight - b.Location.X}");
+            Assert.True(a.ActualRight - a.Location.X < 150,
+                $"the short item must hug its content, not take half the 400pt row, was {a.ActualRight - a.Location.X}");
+
+            // space-between then has real free space to distribute: the second item is pushed to
+            // the row's far edge rather than starting at its midpoint.
+            Assert.True(b.ActualRight >= root.Location.X + 390,
+                $"space-between must push the last item to the row's right edge, ended at {b.ActualRight}");
+        }
+
+        [Fact]
+        public async Task Item_WhoseMinContentExceedsTheRow_KeepsItsMinContent()
+        {
+            // CSS 2.1 §10.3.5 shrink-to-fit is min(max(min-content, available), max-content):
+            // min-content is the LOWER bound. An unbreakable token wider than the row must keep its
+            // min-content width and overflow, not be clamped down to the available width -- clamping
+            // the other way round (max-content vs min-content first, then against available)
+            // collapses to min(max-content, available) and silently under-sizes exactly this case.
+            // flex-shrink:0 so the item keeps its hypothetical main size -- the stage this clamp
+            // decides. With shrink left on, the shrink pass would clamp it back to the row either
+            // way and the fixture would say nothing about the clamp order.
+            var html = Wrap(@"
+                <div style='display:flex; width:60pt;'>
+                    <div id='item' style='flex-shrink:0;'><div>Supercalifragilisticexpialidocious</div></div>
+                </div>");
+
+            var (root, _) = await BuildAndLayout(html);
+            var item = FindById(root, "item")!;
+            var width = item.ActualRight - item.Location.X;
+
+            Assert.True(width > 60,
+                $"an item whose min-content exceeds the row keeps its min-content and overflows, was {width} in a 60pt row");
+        }
+
+        [Fact]
+        public async Task WrappedItem_DoesNotCountTrailingWhiteSpaceInItsMeasure()
+        {
+            // css-text-3 §4.1.2: white space at the end of a line hangs and is not part of the
+            // line's measure. Counted, a wrapped item measures one word space wider than it draws,
+            // the row's items over-subscribe their container, and flex-shrink takes the difference
+            // out of the item that can least afford it.
+            //
+            // max-width forces the wrap, so the intrinsic per-line measurement is what sizes the
+            // item; flex-shrink:0 keeps the shrink pass from resizing it afterwards.
+            var html = Wrap(@"
+                <div style='display:flex; width:200pt;'>
+                    <div id='item' style='flex-shrink:0; max-width:80pt;'>alpha bravo charlie delta echo foxtrot</div>
+                </div>");
+
+            var (root, _) = await BuildAndLayout(html);
+            var item = FindById(root, "item")!;
+
+            var widestDrawn = LayoutHarness.Descendants(item)
+                .SelectMany(b => b.Words)
+                .Select(w => w.Right)
+                .DefaultIfEmpty(0)
+                .Max();
+
+            Assert.True(LayoutHarness.Descendants(item).Sum(b => b.LineBoxes.Count) > 1,
+                "fixture must actually wrap, or it says nothing about a line's trailing space");
+
+            // The item's box tracks what it draws, to within the deliberate 0.01 anti-rounding
+            // epsilon added at the measurement site. Counting the hanging space instead leaves a
+            // whole word space of slack — 3.07pt against 0.01pt here.
+            Assert.True(item.ActualRight - widestDrawn < 1.0,
+                $"the item is {item.ActualRight - widestDrawn}pt wider than anything it draws — a hanging space was counted into its measure");
+        }
+
         private static async Task<(CssBox root, HtmlContainerInt container)> BuildAndLayout(string html)
         {
             var adapter = new PdfSharpAdapter();

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineFlex.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineFlex.cs
@@ -430,7 +430,13 @@ namespace PeachPDF.Html.Core.Dom
                     double maxContent;
                     if (DomUtils.ContainsInlinesOnly(box) && box.LineBoxes.Count > 0)
                     {
-                        double lineWidth = box.LineBoxes.Max(lb => lb.Words.Sum(w => w.FullWidth));
+                        // Trailing white space at the end of a line does not contribute to
+                        // max-content (css-text-3 §4.1.2 -- it hangs). Counted, an item measures wider
+                        // than it draws, the line's items over-subscribe their container and flex-shrink
+                        // takes the difference out of the item that can least afford it. A header with a
+                        // logo beside an address block, a newline between the two in the source,
+                        // wrapped the address on that one space.
+                        double lineWidth = box.LineBoxes.Max(lb => LineContentWidth(lb));
                         // Add a sub-pixel epsilon so that when this width is used as the explicit
                         // content size in ResizeItem, the same words don't spuriously wrap due to
                         // IEEE 754 rounding differences between (a+b)+c and (a+c)+b.
@@ -438,10 +444,47 @@ namespace PeachPDF.Html.Core.Dom
                             + box.ActualPaddingLeft + box.ActualPaddingRight
                             + box.ActualBorderLeftWidth + box.ActualBorderRightWidth;
                     }
+                    else if (box.Boxes.Count == 0
+                             || box.DerivedStyle.ActualDisplay is Keywords.Grid or Keywords.InlineGrid)
+                    {
+                        // Two cases the intrinsic measurement below cannot answer, both falling back
+                        // to the laid-out width as this always did.
+                        //
+                        // A leaf with no line boxes has no content to measure -- a replaced element,
+                        // where the laid-out width IS the intrinsic width.
+                        //
+                        // A nested GRID container places its children on tracks the intrinsic walk
+                        // knows nothing about. A nested flex row is handled: CssBox.IsFlexRowItem
+                        // stops its items each starting a new line, so their widths add up the way
+                        // the row lays them out.
+                        maxContent = naturalMain;
+                    }
                     else
                     {
-                        // Block children: no word measurement; use container fill width as fallback.
-                        maxContent = naturalMain;
+                        // Block children get the same intrinsic measurement everything else
+                        // does, rather than the container-fill width. An auto-width block child fills
+                        // its container on layout, so naturalMain is the CONTAINER's width, not the
+                        // item's content -- every item measured the full container and
+                        // justify-content then had no free space to distribute, which reads as an
+                        // equal split. A document with two address blocks in a
+                        // space-between row had each one land on half the page instead of hugging
+                        // its own edge.
+                        //
+                        // CSS 2.1 §10.3.5's shrink-to-fit: min(max(min-content, available),
+                        // max-content) -- min-content is the LOWER bound, so an item whose own
+                        // min-content is wider than the row keeps its min-content and overflows,
+                        // rather than being sized below what it can draw. Clamping the other way
+                        // round (max first, then min against the available width) collapses to
+                        // min(max-content, available) and silently under-sizes exactly that case.
+                        //
+                        // Not CssLayoutEngine.GetFitContentWidth: that is
+                        // min(GetLargestChildWidth(max-content), available), which has no
+                        // min-content floor either. Both of these return outer widths, which is
+                        // what `hypothetical` is.
+                        var minContent = await CssLayoutEngine.GetMinContentWidth(g, box);
+                        maxContent = Math.Max(
+                            minContent,
+                            Math.Min(await CssLayoutEngine.GetMaxContentWidth(g, box), naturalMain));
                     }
                     // min-width constrains content width; outer minimum = min-width + padding + border
                     if (box.MinWidth != "0" && CssValueParser.IsValidLength(box.MinWidth))
@@ -1690,6 +1733,34 @@ namespace PeachPDF.Html.Core.Dom
                 outerSize = Math.Max(outerSize, CssValueParser.ParseLength(minRaw, mainSize, box) + MainPaddingBorder(box));
 
             return outerSize;
+        }
+
+        /// <summary>
+        /// A line box's width with its trailing white space removed, per css-text-3 §4.1.2 —
+        /// white space at the end of a line hangs and does not contribute to the line's measure.
+        ///
+        /// Counted, an item measures wider than it draws: the line's items over-subscribe their
+        /// container and flex-shrink takes the difference out of the item that can least afford it.
+        /// <see cref="CssBox.GetMinMaxSumWords"/> already backs the same space out of ITS total,
+        /// which is why the two measurements disagreed by exactly one word space.
+        /// </summary>
+        private static double LineContentWidth(CssLineBox line)
+        {
+            var width = 0d;
+            var pending = 0d;
+            var trailingSpacing = 0d;
+            foreach (var word in line.Words)
+            {
+                // Held back rather than dropped: a space only hangs when nothing follows it on the
+                // line, and spaces BETWEEN words are part of the content.
+                if (word.IsSpaces && !word.IsLineBreak) { pending += word.FullWidth; continue; }
+                width += pending + word.FullWidth;
+                pending = 0;
+                // CssRect.FullWidth adds a word space unconditionally, so the last word on the line
+                // carries one that nothing follows.
+                trailingSpacing = word.ActualWordSpacing;
+            }
+            return Math.Max(0, width - trailingSpacing);
         }
 
         // ─── Gap helpers ──────────────────────────────────────────────────────────


### PR DESCRIPTION
`CssLayoutEngineFlex.MeasureItem` derives an auto-basis item's hypothetical main size from its own line boxes, and falls back to the laid-out width when there are none:

```csharp
// Block children: no word measurement; use container fill width as fallback.
maxContent = naturalMain;
```

An auto-width block child **fills its container** on layout, so `naturalMain` is the *container's* width, not the item's content. Every item in the line therefore measures the same, and the line divides evenly however different the items actually are.

## Repro

```html
<style>
body { margin: 0; font-family: Arial, sans-serif; font-size: 11pt; }
.row  { display: flex; width: 500px; border: 1px solid #333; }
.item { border: 1px solid #a00; }
</style>
<div class="row">
  <div class="item"><div>SHORT</div></div>
  <div class="item"><div>A MUCH LONGER PIECE OF CONTENT HERE</div></div>
</div>
```

Word positions (`pdftotext -bbox`):

| | `main` | with this change |
| --- | --- | --- |
| item 1 (`SHORT`) width | **~187 pt** — half the container | **~40 pt** — its content |
| item 2 starts at | x = 225.00 | x = 77.30 |
| item 2's text | **wraps onto two lines** (`CONTENT`/`HERE` at y = 50.70) | **one line**, everything at y = 37.50 |

Both items measure identically on `main` despite one holding five words more than the other, so the 500 pt splits evenly and the longer item wraps inside its half while the shorter one keeps 150 pt of empty space.

## Why it matters

Wrapping a flex item's contents in a `<div>` is the ordinary way to write one. As soon as an item's children are block-level rather than bare text, the whole line stops sizing to content and divides evenly instead.

## Tests

`PeachPDF.Tests` on this branch: **10,207 passed, 0 failed, 9 skipped** over two runs — same as `main` (`cd28a35`).