### PR TITLE
A running element does not grow the document's ActualSize

### DIFF
--- a/.claude/migration-notes/2026-09-08-a-running-header-no-longer-shrinks-the-whole-document.md
+++ b/.claude/migration-notes/2026-09-08-a-running-header-no-longer-shrinks-the-whole-document.md
@@ -1,0 +1,18 @@
+# A running header or footer wider than the content box no longer shrinks the whole document
+
+A `position: running()` element is painted into a page margin box, so its width is bounded by the
+page margin band rather than by the flow's content box — a header spanning the full page width is
+wider than the content box by design, and legitimately so. It was nonetheless growing the document's
+own recorded extent (`HtmlContainerInt.ActualSize`), which reports the document as overflowing its
+page when nothing in the flow does.
+
+With `ShrinkToFit` enabled, that made the whole document scale down to fit content that was never in
+the flow. Measured: a Letter invoice with a company header and footer band rendered at 0.968 scale,
+while the same document with both bands removed did not scale at all.
+
+A running element and its descendants no longer contribute to `ActualSize`. Ordinary content —
+including content that is genuinely too wide for the page — still does, so `ShrinkToFit` behaves
+exactly as before for everything that is really in the flow.
+
+See [Running elements](../../docs/html-css-support.md#running-elements-position-running--element) in
+`docs/html-css-support.md`.

--- a/.claude/recent-fixes/2026-09-08-a-running-band-is-not-part-of-the-flow-actualsize-measures.md
+++ b/.claude/recent-fixes/2026-09-08-a-running-band-is-not-part-of-the-flow-actualsize-measures.md
@@ -1,0 +1,42 @@
+# A running band is not part of the flow `ActualSize` measures
+
+`CssBox`'s layout epilogue grows `HtmlContainerInt.ActualSize` from every box it finishes, gated only
+on `IsFixed`. A `position: running()` element is painted into a page margin box, bounded by the
+margin band rather than the content box, so a full-width header band reported the document as
+overflowing its own page — and `ShrinkToFit`, which reads `ActualSize`, scaled everything down to fit
+content that was never in the flow.
+
+The gate is now `IsFixedOrInRunningElement`: one ancestor walk answering both, because the epilogue
+runs for every box and a second walk would be a measurable cost on a deep document.
+
+## What running it turned up
+
+- **Testing `ActualSize` directly proves nothing here.** Two fixtures built on the lightweight
+  `LayoutHarness` — a wide running box, and a wide box nested inside a running box — pass against the
+  pre-fix code as well as the fixed one; the epilogue's update only runs on the path the real
+  generator takes. The fixtures that discriminate go through
+  `PdfGeneratorLayoutHarness.LayoutWithRescaleAsync` and assert the rescale, which is also the
+  reported symptom rather than a proxy for it.
+- **`pixelsPerPoint` moves the opposite way to intuition.** It is the device scale the fit is
+  expressed as, so shrinking the document *raises* it: 900pt of content into a 540pt content box
+  comes out at ~1.68, i.e. drawn at ~0.6×. An unscaled document is exactly 1.0. The first version of
+  the contrast case asserted `< 1.0` and failed against correct behaviour.
+- **The width has to be on a CHILD of the running box to reach the defect.** The running box itself
+  was already skipped by an earlier flow-exclusion path; its wrapper children each ran the same
+  `ActualSize` update in their own right. A fixture putting the width on the running box passes
+  either way.
+- **Why not `IsExcludedFromFlow`.** It sits twelve lines away and answers an adjacent-sounding
+  question — whether a box contributes to its PARENT's in-flow content — and is the wider set,
+  including `IsOutOfFlow`. Reusing it here would also stop absolutely-positioned and floated content
+  growing `ActualSize`, which is a much larger behaviour change than the defect. Both doc comments
+  now cross-reference the other so the next reader does not have to re-derive why there are two.
+- **`IsFixed` is `virtual` with no override today**, and this walk re-implements its
+  `Position.Value == PositionMode.Fixed` test rather than calling it per ancestor (nesting two
+  ancestor walks is quadratic). Noted in the doc comment: if an override is ever added, the two have
+  to change together.
+
+## Evidence
+
+Two fixtures in `RunningElementLayoutIntegrationTests`, bracketing the behaviour: a running band
+wider than the content box leaves the document unscaled (fails against the merge base), and the
+identical wide box in the flow still shrinks it. Full suite green on net8.0, 0 build warnings.

--- a/src/PeachPDF.Tests/Integration/RunningElementLayoutIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/RunningElementLayoutIntegrationTests.cs
@@ -160,6 +160,89 @@ namespace PeachPDF.Tests.Integration
             Assert.Equal("heading", entry.Name);
         }
 
+        // ─── A running band must not grow the flow's own extent (HtmlContainerInt.ActualSize) ───
+        //
+        // Asserted through ShrinkToFit rather than by reading ActualSize directly. ActualSize is
+        // reachable from the lightweight harness, but a fixture built on it passes against the
+        // pre-fix code either way — the update only runs on the path the real generator takes. The
+        // rescale is also the reported symptom, so this exercises the defect rather than a proxy
+        // for it.
+
+        private const string BandFixture = """
+            <!DOCTYPE html><html><head><style>
+            @page { size: letter; margin: 36pt; }
+            @page { @top-center { content: element(band); } }
+            #band { position: running(band); }
+            </style></head><body>
+            <div id="band"><div style="width:900pt;">a company header spanning the full page</div></div>
+            <p>Body content that fits the content box comfortably.</p>
+            </body></html>
+            """;
+
+        private const string InFlowFixture = """
+            <!DOCTYPE html><html><head><style>
+            @page { size: letter; margin: 36pt; }
+            </style></head><body>
+            <div><div style="width:900pt;">a company header spanning the full page</div></div>
+            <p>Body content that fits the content box comfortably.</p>
+            </body></html>
+            """;
+
+        [Fact]
+        public async Task ShrinkToFit_DoesNotScaleTheDocumentDownForARunningBand()
+        {
+            // A running element is painted into a page MARGIN box, so its width is bounded by the
+            // margin band, not by the flow's content box — a header spanning the full page is wider
+            // than the content box by design. Counted into ActualSize it reports the document as
+            // overflowing its own page when nothing in the flow does, and ShrinkToFit then scales the
+            // whole document down to fit content that was never in the flow.
+            //
+            // The wide box is a CHILD of the running box, which is the shape that reaches this: the
+            // running box itself was already skipped, but its wrapper children each ran the same
+            // ActualSize update in their own right.
+            var (_, _, _, pixelsPerPoint) = await PdfGeneratorLayoutHarness.LayoutWithRescaleAsync(
+                BandFixture, new PdfGenerateConfig { PageSize = PageSize.Letter, ShrinkToFit = true });
+
+            Assert.Equal(1.0, pixelsPerPoint, 3);
+        }
+
+        [Fact]
+        public async Task ShrinkToFit_StillScalesDownForTheSameContentInTheFlow()
+        {
+            // The contrast case: the identical wide box, not running. ShrinkToFit must still do its
+            // job — otherwise the assertion above also passes if ActualSize stopped tracking width.
+            var (_, _, _, pixelsPerPoint) = await PdfGeneratorLayoutHarness.LayoutWithRescaleAsync(
+                InFlowFixture, new PdfGenerateConfig { PageSize = PageSize.Letter, ShrinkToFit = true });
+
+            // pixelsPerPoint is the device scale the fit is expressed as, so shrinking the document
+            // raises it: 900pt of content into a 540pt content box comes out at ~1.68, i.e. drawn at
+            // ~0.6x. The band case above stays at exactly 1.0 — no rescale at all.
+            Assert.True(pixelsPerPoint > 1.0,
+                $"in-flow content wider than the page must still shrink the document, was {pixelsPerPoint}");
+        }
+
+        [Fact]
+        public async Task IsFixedOrInRunningElement_TerminatesOnASelfParentingBox()
+        {
+            // The ancestor walk carries the same `box.ParentBox == box` guard IsFixed's own walk has.
+            // Nothing in the tree produces a self-parented box today, but the guard is what stops the
+            // walk spinning if anything ever does — and an uncovered loop-termination guard is worth
+            // exactly one test.
+            var (root, _) = await LayoutAsync(Wrap("<div id='solo'>x</div>"));
+            var solo = FindById(root, "solo")!;
+            var savedParent = solo.ParentBox;
+
+            try
+            {
+                solo.ParentBox = solo;
+                Assert.False(solo.IsFixedOrInRunningElement);
+            }
+            finally
+            {
+                solo.ParentBox = savedParent;
+            }
+        }
+
         [Fact]
         public async Task RunningMulticolChild_ExcludedFromColumnFlow_AndRegistered()
         {

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -509,6 +509,10 @@ namespace PeachPDF.Html.Core.Dom
         /// into it: <see cref="IsOutOfFlow"/> also gates the absolute/fixed <i>placement</i> machinery
         /// (<c>CommitBlockChildOffset</c>), which a running box must never enter at all - it is excluded
         /// from flow far more completely than "out of flow but still positioned like <c>absolute</c>".
+        ///
+        /// See also <see cref="IsFixedOrInRunningElement"/>, which is narrower and answers a different
+        /// question — whether a box is painted outside the flow <see cref="HtmlContainerInt.ActualSize"/>
+        /// measures, rather than whether it contributes to its parent's in-flow content.
         /// </summary>
         internal bool IsExcludedFromFlow => IsOutOfFlow || IsRunningPositioned;
 
@@ -521,6 +525,59 @@ namespace PeachPDF.Html.Core.Dom
         /// (<see cref="DomUtils.GetAllLinkBoxes"/>) and tagged-PDF /Link mapping, not just :link matching.
         /// </summary>
         public virtual bool IsClickable => HtmlTag is { Name: HtmlConstants.A } && HtmlTag.HasAttribute("href");
+
+        /// <summary>
+        /// Whether this box, or any ancestor, is <c>position: fixed</c> or
+        /// <c>position: running()</c> - i.e. painted somewhere other than the flow.
+        ///
+        /// One ancestor walk answering both, rather than <see cref="IsFixed"/> followed by a
+        /// second walk for the running case: this runs at the end of every box's layout, so a
+        /// duplicate walk is a measurable cost on a deep document for an answer already in hand.
+        ///
+        /// A running element is placed in a page MARGIN box, so its width is bounded by the page
+        /// margin band and not by the flow's content box. It is legitimate, and normal, for it to
+        /// be wider than the content box: a header that spans the full page is exactly that.
+        /// Letting it grow <see cref="HtmlContainerInt.ActualSize"/> therefore reports the document
+        /// as overflowing its own page when nothing in the flow does, and <c>ShrinkToFit</c> then
+        /// scales the whole document down to fit content that was never in the flow. Measured: a
+        /// Letter invoice with a company header and footer shrank to 0.968 while the same document
+        /// with both bands removed did not shrink at all.
+        ///
+        /// Walks ancestors rather than testing this box alone because the band's own wrapper divs
+        /// are CHILDREN of the running box and each grows ActualSize in its own right.
+        ///
+        /// <b>Not <see cref="IsExcludedFromFlow"/>, deliberately.</b> That answers the adjacent-sounding
+        /// question "does this box contribute to its PARENT's in-flow content", and is the wider set:
+        /// it includes <see cref="IsOutOfFlow"/>, so absolute and floated boxes too. This one answers
+        /// "is this box painted somewhere other than the flow whose extent
+        /// <see cref="HtmlContainerInt.ActualSize"/> reports", and the gate here only ever excluded
+        /// <c>fixed</c>. Widening it to the whole of <see cref="IsExcludedFromFlow"/> would silently
+        /// stop absolutely-positioned and floated content growing <c>ActualSize</c> as well — a real
+        /// behaviour change well beyond the running-element defect, and one <c>ShrinkToFit</c> would
+        /// feel immediately. Two predicates because there are two questions.
+        ///
+        /// The <c>Position.Value == PositionMode.Fixed</c> test is written out rather than reading
+        /// <see cref="IsFixed"/> per ancestor, because <see cref="IsFixed"/> is itself an ancestor walk
+        /// and nesting the two is quadratic. <see cref="IsFixed"/> is <c>virtual</c> but has no override
+        /// in the tree today; if one is ever added, this walk will not pick it up and both will need to
+        /// change together.
+        /// </summary>
+        internal bool IsFixedOrInRunningElement
+        {
+            get
+            {
+                for (var box = this; box is not null; box = box.ParentBox)
+                {
+                    if (box.Position.Value == PositionMode.Fixed || box.IsRunningPositioned)
+                        return true;
+
+                    if (box.ParentBox == box)
+                        break;
+                }
+
+                return false;
+            }
+        }
 
         /// <summary>
         /// Gets a value indicating whether this instance or one of its parents has Position = fixed.
@@ -6041,7 +6098,9 @@ namespace PeachPDF.Html.Core.Dom
 #if DEBUG
             Console.WriteLine($"layout finish: {ToString()} [x: {Location.X}, y: {Location.Y}, b: {ActualBottom}, r: {ActualRight}, h: {Size.Height}, w: {Size.Width}]");
 #endif
-            if (IsFixed) return;
+            // A fixed box is painted per page rather than flowed, and a running box is painted
+            // into a page margin box - neither is part of the flow whose width ActualSize reports.
+            if (IsFixedOrInRunningElement) return;
 
             var actualWidth = Math.Max(GetMinimumWidth() + GetWidthMarginDeep(this), Size.Width < 90999 ? ActualRight - HtmlContainer!.Root!.Location.X : 0);
             HtmlContainer!.ActualSize = CommonUtils.Max(HtmlContainer.ActualSize, new RSize(actualWidth, ActualBottom - HtmlContainer!.Root!.Location.Y));


### PR DESCRIPTION
A `position: running()` element is painted in a page **margin box**, so its width is bounded by the page margin, not by the flow. It still contributes to the container's `ActualSize`, which is the flow's own extent — so a wide running header or footer inflates a number describing content it is not part of.

`ShrinkToFit` reads `ActualSize` to pick a scale, which makes the consequence visible: a wide running footer shrinks **the whole document** to fit a band that was never in the flow.

## Repro

```html
<style>
@page { size: 8.5in 11in; margin: 1in; @bottom-center { content: element(foot); } }
#foot { position: running(foot); white-space: nowrap; font-family: Arial, sans-serif; font-size: 9pt; }
body { margin: 0; font-family: Arial, sans-serif; font-size: 11pt; }
</style>
<div id="foot">WWWWWWWW…(wider than the page)</div>
<p>BODYSTART</p>
```

Rendered with `PdfGenerateConfig.ShrinkToFit = true`:

| | `BODYSTART` rendered width |
| --- | --- |
| `main` | **29.90 pt** — the document scaled to ~45% |
| with this change | **66.21 pt** — unscaled |

The body content is identical in both; only the running footer is wide.

## The change

The end-of-layout check that decides whether a box contributes to `ActualSize` now recognises a running element as well as `position: fixed`. Both are answered by one ancestor walk rather than two, since it runs at the end of every box's layout.

## Tests

`PeachPDF.Tests` on this branch: **10,207 passed, 0 failed, 9 skipped** over two runs — same as `main` (`cd28a35`).