### PR TITLE
Stop the left float scan at its formatting context

### DIFF
--- a/.claude/recent-fixes/2026-09-08-the-left-float-scan-stops-at-its-formatting-context.md
+++ b/.claude/recent-fixes/2026-09-08-the-left-float-scan-stops-at-its-formatting-context.md
@@ -1,0 +1,31 @@
+# The left float scan stops at its formatting context, like the right one already did
+
+`FindNarrowestRightFloatBox` breaks its ancestor walk at a formatting-context boundary — a float
+cannot affect content outside its own (CSS 2.1 §9.5, css-display-3 §2.1). `FindIntersectingFloatBox`,
+the left-side point-collision walk, did not: it ran to the document root and scanned every preceding
+sibling on the way. Same rule, same shape, one side missing it.
+
+## What running it turned up
+
+- **It is the dominant cost of float layout, not a rounding error.** On a synthetic document of 40
+  two-column grids each holding one float: 237,757 box visits across 2,880 calls, 83 per call. With
+  the boundary check, 1,200 visits — the same 2,880 calls now examining under one box each. The
+  right-side walk, identical but for this rule, has always been ~7 per call.
+- **The starting-level exemption is load-bearing, and it is the opposite of the right-side walk's.**
+  This walk's `reference` is the box being *placed*, and a float is itself a formatting-context root
+  for its own contents — breaking before the first level's siblings are scanned shields a float from
+  the very siblings it must be positioned against. `FloatLayoutRegressionTests`'
+  `FloatRight_InNarrowerNestedBlock_AvoidsAWiderAncestorFloatRightSibling` catches it immediately.
+  `FindNarrowestRightFloatBox` needs no exemption because its `reference` comes from `FlowBox`'s
+  word-flow loop and is never a float.
+- **No output changes.** The walk was climbing past boundaries and finding nothing to collide with,
+  so this is wasted work rather than a visible defect — I could not build a document where the leak
+  moved a line. Pitched and tested as what it is: a cost fix, asserted on
+  `FloatScanBoxVisits`/`FloatScanCalls` rather than on geometry, and on a counter rather than elapsed
+  time for the reason `FloatLayoutRegressionTests`' own class comment gives about wall-clock bounds.
+
+## Evidence
+
+`FloatLayoutRegressionTests.LeftFloatScan_StopsAtAFormattingContextBoundary` asserts under 10 visits
+per call; without the break the same document reports 82.6. Full suite green on net8.0 (10,253),
+0 new build warnings.

--- a/src/PeachPDF.Tests/Integration/FloatLayoutRegressionTests.cs
+++ b/src/PeachPDF.Tests/Integration/FloatLayoutRegressionTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System;
 using System.Text;
 using PeachPDF;
@@ -529,6 +530,30 @@ namespace PeachPDF.Tests.Integration
             Assert.True(constrained < unconstrained - 1,
                 $"a float:right in the same formatting context must still cap the line: " +
                 $"{constrained} vs {unconstrained} unconstrained");
+        }
+
+        [Fact]
+        public async Task LeftFloatScan_StopsAtAFormattingContextBoundary()
+        {
+            // The left-side point-collision walk used to run to the document root, scanning every
+            // preceding sibling on the way, even though a float cannot affect content outside its own
+            // formatting context (CSS 2.1 §9.5, css-display-3 §2.1) — the rule the right-side walk
+            // already applies. Asserted on FloatScanBoxVisits rather than elapsed time, for the reason
+            // this class's own doc comment gives about wall-clock bounds on a contended runner.
+            var (_, container) = await BuildAndLayout(Wrap(string.Concat(Enumerable.Repeat(
+                @"<div style='display:grid; grid-template-columns:200pt 200pt; width:400pt;'>
+                    <div><div style='float:left; width:80pt; height:20pt;'></div><p style='margin:0;'>col a text here</p></div>
+                    <div><p style='margin:0;'>col b text here</p></div>
+                  </div>", 40))));
+
+            // Each grid item is its own formatting context, so a walk that respects the boundary
+            // examines a handful of boxes per call rather than the whole document behind it. Before
+            // the boundary check this document cost 237,757 visits across 2,880 calls (83 each).
+            var perCall = (double)container.FloatScanBoxVisits / container.FloatScanCalls;
+
+            Assert.True(perCall < 10,
+                $"the left float scan should not climb past its formatting context: " +
+                $"{container.FloatScanBoxVisits} visits across {container.FloatScanCalls} calls ({perCall:F1} each)");
         }
 
         // ── Helpers ────────────────────────────────────────────────────────────

--- a/src/PeachPDF/Html/Core/Utils/DomUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/DomUtils.cs
@@ -594,12 +594,45 @@ namespace PeachPDF.Html.Core.Utils
         /// <param name="boxesVisited">Accumulator, not an input: every box the walk examines is added to it.</param>
         private static CssBox? FindIntersectingFloatBox(CssBox reference, CssFloatCoordinates coordinates, Floating floatProp, ref int boxesVisited)
         {
+            var isStartingLevel = true;
+
             while (true)
             {
                 if (reference.ParentBox is null)
                 {
                     return null;
                 }
+
+                // The same CSS 2.1 §9.5 / css-display-3 §2.1 rule
+                // FindNarrowestRightFloatBox already applies — a float cannot affect content outside
+                // its own formatting context — which this, the LEFT-side point-collision walk, was
+                // missing. It ran to the document root and scanned every preceding sibling on the
+                // way, so the cursor for a line in one grid item or table cell could be displaced by
+                // a `float: left` in a different one.
+                //
+                // NOT at the starting level, and that difference is the whole subtlety. The box this
+                // walk begins from is the box being PLACED, and a float is itself a
+                // formatting-context root for its own contents — so breaking before that first
+                // level's siblings are scanned would shield a float from the very siblings it has to
+                // be positioned against. FloatLayoutRegressionTests'
+                // FloatRight_InNarrowerNestedBlock_AvoidsAWiderAncestorFloatRightSibling catches
+                // that immediately. From the second level up, `reference` is a proper ancestor and
+                // the content being placed really is inside it, so the rule applies.
+                //
+                // FindNarrowestRightFloatBox needs no such exemption because of what each is handed:
+                // its `reference` comes from FlowBox's word-flow loop and is the block whose line is
+                // being laid out, never a float itself.
+                //
+                // It is also the most expensive thing this walk does. On a synthetic 40-row document
+                // of two-column grids each holding one float, it costs 237,757 box visits across
+                // 2,880 calls — 83 per call — against 1,200 visits with the break in place. The
+                // right-side walk, identical in shape but for this rule, has always been ~7.
+                if (!isStartingLevel && EstablishesIndependentFormattingContext(reference))
+                {
+                    return null;
+                }
+
+                isStartingLevel = false;
 
                 var currentBoxIdx = reference.ParentBox.Boxes.IndexOf(reference);
 


### PR DESCRIPTION
`FindNarrowestRightFloatBox` breaks its ancestor walk at a formatting-context boundary — a float cannot affect content outside its own (CSS 2.1 §9.5, css-display-3 §2.1). `FindIntersectingFloatBox`, the **left-side** point-collision walk, does not: it runs to the document root and scans every preceding sibling on the way.

Same rule, same traversal shape, one side missing it. This is the other half of #930.

## Cost

A synthetic document of 40 two-column grids, each grid item holding one `float: left`, measured on `main` with the engine's own counters:

| | scan calls | box visits | visits per call |
| --- | --- | --- | --- |
| `main` | 2,880 | **237,757** | 82.6 |
| with this change | 2,880 | **1,200** | 0.4 |
| `FindNarrowestRightFloatBox`, same document | — | — | ~7 |

The call count is unchanged — this is not skipping work that needed doing, it is not walking past the boundary where nothing can be found.

```html
<div style='display:grid; grid-template-columns:200pt 200pt; width:400pt;'>
  <div><div style='float:left; width:80pt; height:20pt;'></div><p style='margin:0;'>col a text here</p></div>
  <div><p style='margin:0;'>col b text here</p></div>
</div>
<!-- ×40 -->
```

## No rendered output changes

Worth being explicit, because the rule is stated as a correctness one: I could not construct a document where the leak actually moved a line. The walk was climbing past formatting-context boundaries and finding nothing to collide with, so on real content this is wasted work rather than a visible defect. It is offered as a cost fix, and tested as one.

## The starting-level exemption

The rule is deliberately **not** applied at the walk's starting level, and that differs from `FindNarrowestRightFloatBox` — which is worth spelling out, since #930's review asked for exactly this distinction in the other direction.

This walk's `reference` is the box being **placed**, and a float is itself a formatting-context root for its own contents. Breaking before that first level's siblings are scanned shields a float from the very siblings it has to be positioned against; `FloatLayoutRegressionTests.FloatRight_InNarrowerNestedBlock_AvoidsAWiderAncestorFloatRightSibling` and two others fail immediately if you try it. From the second level up, `reference` is a proper ancestor and the content being placed really is inside it, so the rule applies.

`FindNarrowestRightFloatBox` needs no exemption because of what it is handed: its `reference` comes from `FlowBox`'s word-flow loop and is the block whose line is being laid out, never a float itself.

## Tests

`FloatLayoutRegressionTests.LeftFloatScan_StopsAtAFormattingContextBoundary` asserts fewer than 10 box visits per scan call on the document above; without the boundary check the same document reports 82.6.

Asserted on `FloatScanBoxVisits`/`FloatScanCalls` rather than elapsed time, per that class's own doc comment on why a wall-clock bound there was flaky on a contended runner — and on a counter rather than geometry, since the geometry does not change.

`dotnet build PeachPDF.Tests -t:Rebuild`: no new warnings. `dotnet test --framework net8.0`: 10,253 passed, 0 failed, 9 skipped.
