### PR TITLE
Re-resolve bidi when a running element's page counter changes length

### DIFF
--- a/.claude/recent-fixes/2026-09-08-a-page-counter-that-gains-a-digit-restales-its-bidi-levels.md
+++ b/.claude/recent-fixes/2026-09-08-a-page-counter-that-gains-a-digit-restales-its-bidi-levels.md
@@ -1,0 +1,34 @@
+# A page counter that gains a digit re-stales its bidi levels
+
+`RunningElementLayout.RefreshPageCounterContent` re-resolves a running element's `content` per page
+so `counter(page)`/`counter(pages)` read the page they are drawn on. It called `ApplyContent` then
+`ParseToWords` — and skipped the step between them that the other two content-re-resolution paths
+already take.
+
+`BidiLevels`, `CharScripts` and `JoiningForms` are indexed against the text the LAST resolution saw.
+A page counter changes its own length the moment it gains a digit — `"9"` becomes `"10"` — so
+`AppendWordsFromText` walked past the end of a stale array and threw `IndexOutOfRangeException`.
+Any document with a running footer showing a page counter and **ten or more pages** crashed.
+
+The fix is the one line `HtmlContainerInt.ReapplyPseudoElementContent` and `ResolveTargetPageContent`
+both already carry, with the comment on the first one saying exactly why:
+`CssBidiParagraphResolver.ResolveOwnTextAsParagraph(box)`.
+
+## What running it turned up
+
+- **The bug shipped because every fixture stopped at seven pages.** All five of the original
+  fixtures run a document to about seven pages, where the counter is one digit from first to last
+  and the stale array is coincidentally the right length. The defect needs page ten. A "Page N of M"
+  feature tested only on single-digit documents is not tested.
+- **It was found by rendering the real corpus, not by reading.** One production document died with
+  `IndexOutOfRangeException` where pristine upstream had rendered it; bisecting the two files the
+  page-counter change touched isolated it in one step.
+- **The public repro is twelve lines.** A running footer with `counter(page)` over enough paragraphs
+  to reach page ten — no customer content needed, which is what made it reportable.
+
+## Evidence
+
+`RunningElementPageCounterTests.CounterPage_PastTheFirstTwoDigitPage_DoesNotThrow` runs to 23 pages
+and asserts the full 1..N sequence; removing the one added line reproduces the
+`IndexOutOfRangeException`. Full suite green on net8.0 (10,253), 0 new build warnings. The corpus
+document that crashed now renders.

--- a/src/PeachPDF.Tests/Integration/RunningElementPageCounterTests.cs
+++ b/src/PeachPDF.Tests/Integration/RunningElementPageCounterTests.cs
@@ -20,7 +20,7 @@ namespace PeachPDF.Tests.Integration
     /// </summary>
     public class RunningElementPageCounterTests
     {
-        private static string Fixture(string footerContent, string extraCss) =>
+        private static string Fixture(string footerContent, string extraCss, int paragraphs = 60) =>
             $$"""
             <!DOCTYPE html>
             <html><head><style>
@@ -32,13 +32,13 @@ namespace PeachPDF.Tests.Integration
             </style></head><body>
             <div id="foot"></div>
             """ +
-            string.Concat(Enumerable.Repeat("<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>", 60)) +
+            string.Concat(Enumerable.Repeat("<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>", paragraphs)) +
             "</body></html>";
 
-        private static async Task<string[]> FooterTextPerPageAsync(string footerContent, string extraCss = "")
+        private static async Task<string[]> FooterTextPerPageAsync(string footerContent, string extraCss = "", int paragraphs = 60)
         {
             var (_, container) = await PdfGeneratorLayoutHarness.LayoutAsync(
-                Fixture(footerContent, extraCss), new PdfGenerateConfig { PageSize = PageSize.A6 });
+                Fixture(footerContent, extraCss, paragraphs), new PdfGenerateConfig { PageSize = PageSize.A6 });
 
             Assert.True(container.FragmentTree!.Fragmentainers.Count > 2,
                 "fixture must run to at least three pages, or 'Page N of M' asserts nothing");
@@ -93,6 +93,25 @@ namespace PeachPDF.Tests.Integration
             var total = perPage.Length;
             Assert.Equal(
                 Enumerable.Range(1, total).Select(n => $"{n}of{total}").ToArray(),
+                perPage);
+        }
+
+        [Fact]
+        public async Task CounterPage_PastTheFirstTwoDigitPage_DoesNotThrow()
+        {
+            // Re-resolving `content` changes the text's LENGTH the moment the counter gains a digit
+            // — "9" becomes "10". BidiLevels/CharScripts/JoiningForms are indexed against the text
+            // the last resolution saw, so without re-resolving bidi first, ParseToWords indexes past
+            // the end of a stale array and throws IndexOutOfRangeException.
+            //
+            // Every other fixture here runs to seven pages, where the counter is one digit
+            // throughout and the arrays happen to stay the right length. This one has to pass ten.
+            var perPage = await FooterTextPerPageAsync("counter(page)", paragraphs: 200);
+
+            Assert.True(perPage.Length >= 10,
+                $"fixture must reach a two-digit page number, only got {perPage.Length}");
+            Assert.Equal(
+                Enumerable.Range(1, perPage.Length).Select(n => n.ToString()).ToArray(),
                 perPage);
         }
 

--- a/src/PeachPDF/Html/Core/Dom/RunningElementLayout.cs
+++ b/src/PeachPDF/Html/Core/Dom/RunningElementLayout.cs
@@ -118,6 +118,14 @@ namespace PeachPDF.Html.Core.Dom
             {
                 CssContentEngine.ApplyContent(box);
 
+                // Re-resolve bidi for the new text before re-parsing words. BidiLevels/CharScripts/
+                // JoiningForms are indexed against the text the LAST resolution saw, and a page
+                // counter changes its own length -- "9" becomes "10" -- so ParseToWords would index
+                // past the end of a stale array and throw IndexOutOfRangeException. Same contract
+                // HtmlContainerInt.ReapplyPseudoElementContent and ResolveTargetPageContent already
+                // follow for the other two re-resolution paths.
+                CssBidiParagraphResolver.ResolveOwnTextAsParagraph(box);
+
                 if (!string.IsNullOrEmpty(box.Text))
                 {
                     box.ParseToWords();


### PR DESCRIPTION
**Regression from #936, which I authored — apologies. A running footer with a page counter crashes any document of ten or more pages.**

```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at PeachPDF.Html.Core.Dom.CssBox.AppendWordsFromText(String sourceText)
   at PeachPDF.Html.Core.Dom.CssBox.ParseToWords()
   at PeachPDF.Html.Core.Dom.RunningElementLayout.RefreshPageCounterContent(...)
   at PeachPDF.Html.Core.Dom.RunningElementLayout.LayoutRunningElementFor(...)
   at PeachPDF.Html.Core.HtmlContainerInt.LayoutMarginBoxes(...)
```

## Repro

Twelve lines, no fixture files:

```html
<!DOCTYPE html><html><head><style>
@page { size: a6; margin: 12mm; }
@page { @bottom-center { content: element(foot); font-size: 8pt; } }
#foot { position: running(foot); margin: 0; }
#foot::before { content: counter(page); }
</style></head><body>
<div id="foot"></div>
<!-- enough paragraphs to reach page 10 -->
</body></html>
```

Under ten pages it renders. At ten it throws.

## Cause

`RefreshPageCounterContent` calls `ApplyContent` and then `ParseToWords`, and skips the step between them that the other two content-re-resolution paths take.

`BidiLevels`, `CharScripts` and `JoiningForms` are indexed against the text the **last** resolution saw. A page counter changes its own length the moment it gains a digit — `"9"` becomes `"10"` — so `AppendWordsFromText` indexes past the end of a stale array.

`HtmlContainerInt.ReapplyPseudoElementContent` already carries the fix, and its comment says exactly why:

> Re-parse words after content changes — re-resolve bidi levels for the new text first […] since `childBox.BidiLevels` would otherwise still reflect whatever (possibly now-stale) content the last resolution saw.

`ResolveTargetPageContent` does the same. This adds the same `CssBidiParagraphResolver.ResolveOwnTextAsParagraph(box)` call to the third path.

## Why the tests I added with #936 missed it

All five run a document to about seven pages, where the counter is one digit from first to last and the stale array is coincidentally the right length. The defect needs page ten. A "Page N of M" feature tested only on single-digit documents is not tested, and I should have seen that when I wrote them.

`RunningElementPageCounterTests.CounterPage_PastTheFirstTwoDigitPage_DoesNotThrow` now runs to 23 pages and asserts the full `1..N` sequence. Removing the one added line reproduces the exception.

## How it was found

Rendering a real 26-document corpus through this engine, where one document died that pristine `main` had rendered. Bisecting the two files #936 touched isolated it in one step. The public repro above came afterwards — nothing customer-specific is needed to trigger it.

`dotnet build PeachPDF.Tests -t:Rebuild`: no new warnings. `dotnet test --framework net8.0`: 10,253 passed, 0 failed, 9 skipped.
