### PR TITLE
Report text that was drawn and then clipped away

### DIFF
--- a/.claude/recent-fixes/2026-09-08-report-text-that-was-drawn-and-then-clipped.md
+++ b/.claude/recent-fixes/2026-09-08-report-text-that-was-drawn-and-then-clipped.md
@@ -1,0 +1,66 @@
+# The engine reports text it drew and then clipped away
+
+Detection only — nothing about what is painted changes.
+
+A glyph emitted and then truncated by the PDF clip operator is still IN the content stream, so a
+reader that parses the stream finds it and reports the document complete, while a renderer that
+honours the clip shows only part of the word. Both are correct; the difference is not recorded in
+the file. Only the painter, at the moment it decides to draw, knows the word's rect was wider than
+the clip it was drawn into — so the engine is the only thing that can report it.
+
+## Where, and why there
+
+`FragmentPainter.Text.cs`'s `PaintWordSequence` already computes
+`var clip = g.GetClip(); clip.Intersect(wordFragment.Rect);`. The guard below it handles only the
+FULL case — a zero-area intersection, word never drawn — which reading the output back already
+catches as missing text. Partial clipping had no decision point at all. The check therefore sits
+immediately after that guard, comparing two rects the method was already holding: no extra geometry
+work on the paint path.
+
+The collector is on `HtmlContainerInt`, not the painter, because a painter instance is per page and
+the report is per render — `PageClipOverride` on the same type is the precedent in the other
+direction. `PdfGenerator.AddPdfPages` drains it after the page loop, before the container is
+disposed, onto the public `PeachPdfDocument.ClipReport`. Two methods lose `static`
+(`PaintWordSequence`, `PaintLineWithEllipsis`) because they now need the container.
+
+## What measuring it turned up
+
+- **A multi-word run in a narrow box is not a clean partial clip**, and the first fixture conflated
+  two findings. The later words fall entirely outside, hit the existing full-clip guard, are never
+  drawn, and reading the output back reports them missing — correctly. Full-cull and partial-clip
+  are different results, and the control case has to be a SINGLE word whose rect starts inside the
+  box.
+- **It is quiet on ordinary documents.** A plain paragraph and a plain table report nothing on
+  upstream, which is what makes the rate readable. Across 26 real templates: 0 documents report any
+  clipped text and none of them move — as expected for a detection-only change.
+- **The tolerance (0.5pt) is a starting point, not a result.** The existing `VisibilityClipEpsilon`
+  is 1e-6 and would report every word flush against a clip edge. The report carries `DrawnWidth`,
+  `VisibleWidth` and `KeptFraction` precisely so the threshold can be settled by measurement.
+
+- **The report accumulates, and had to be made to.** `AddPdfPages` is a repeatable public API —
+  a caller appends pages to an existing document across several calls, each building its own
+  container and its own report — so assigning `document.ClipReport` wholesale discarded every
+  earlier call's findings. `PeachPdfDocument.PageCount` accumulates across those same calls via the
+  underlying `PdfDocument`; a report whose whole purpose is not to lose information quietly should
+  not be the one member that does.
+- **A word can be reported with `VisibleWidth == DrawnWidth`.** The record fires when EITHER
+  dimension was reduced past the tolerance, so a box short enough to cut a line's height but wide
+  enough to keep the whole word is recorded — correctly, it is the same silent loss — with its width
+  untouched. The first version of the XML doc said "always less than `DrawnWidth`", which is wrong
+  for exactly that case.
+
+## Deliberately not reported
+
+`text-overflow: ellipsis` (truncation the author asked for and the reader can see) and whitespace
+(a clipped space is not actionable). And the report UNDER-reports: it measures against `RGraphics`'s
+tracked rect stack, which a `border-radius`/`clip-path` clip and the page-level
+`XGraphics.IntersectClip` never reach. "Nothing reported" is weaker than "nothing was clipped", and
+both the API docs and the reader-facing docs say so.
+
+## Evidence
+
+`ClipReportTests`, six fixtures: the single-word control (reported, with geometry), the multi-word
+contrast, an ordinary document (silent), `text-overflow: ellipsis` (excluded), `KeptFraction`
+bounded and below 1, and a wide-enough `overflow: hidden` box (silent — the property alone must not
+report). Disabling the report site fails two of them. Full suite green on net8.0 (10,258), 0 new
+build warnings.

--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -19,6 +19,7 @@ using PeachPDF.Network;
 - [Rendering in the browser (Blazor WebAssembly)](#rendering-in-the-browser-blazor-webassembly)
 - [Sharing a parsed CSS context across renders](#sharing-a-parsed-css-context-across-renders)
 - [Saving a PDF to a file](#saving-a-pdf-to-a-file)
+- [Detecting text that was clipped away](#detecting-text-that-was-clipped-away)
 - [Fonts](#fonts)
 - [Enabling tagged PDF (PDF/UA) output](#enabling-tagged-pdf-pdfua-output)
 - [Enabling interactive PDF forms](#enabling-interactive-pdf-forms)
@@ -255,6 +256,39 @@ var document = await generator.GeneratePdf(html, pdfConfig);
 using var fileStream = File.Create("output.pdf");
 document.Save(fileStream);
 ```
+
+## Detecting text that was clipped away
+
+A word can be drawn into the PDF and then truncated by a clip — an `overflow: hidden` box narrower than an unbreakable value, most often. The glyphs are still in the content stream, so a reader that parses that stream finds them and reports the document complete, while anything that honours the clip shows only part of the word. Both are behaving correctly; the difference simply is not recorded in the file.
+
+That makes it the one loss class only the engine can report, because only the painter knows the word's rect was wider than the clip it was drawn into. `PeachPdfDocument.ClipReport` is that report:
+
+```csharp
+var document = await generator.GeneratePdf(html, pdfConfig);
+
+if (document.ClipReport.ClippedWords.Count > 0)
+{
+    foreach (var word in document.ClipReport.ClippedWords)
+    {
+        Console.WriteLine(
+            $"'{word.Text}' kept {word.KeptFraction:P0} " +
+            $"({word.VisibleWidth:F1}pt of {word.DrawnWidth:F1}pt)");
+    }
+}
+```
+
+Useful when generating documents from templates against data you do not control, where a value one character longer than its column is the difference between a correct invoice and a truncated one that nothing flagged.
+
+Each `ClippedWord` carries the geometry rather than a verdict — `DrawnWidth`, `VisibleWidth`, `DrawnHeight`, `VisibleHeight`, and `KeptFraction` — so what counts as material loss is yours to decide. A word is reported when **either** dimension was reduced, so a word clipped only vertically — a box short enough to cut a line's height but wide enough to keep the whole word — comes back with `VisibleWidth` equal to `DrawnWidth`. `ClipReport.ClippedChars` totals the characters carried by truncated words; it counts the whole word, since a word is the smallest unit the painter knows and apportioning characters to a sub-rectangle would invent precision the measurement does not have.
+
+The report **accumulates** across repeated `AddPdfPages` calls, so a document assembled from several calls carries every call's findings rather than only the last one's.
+
+Two things are deliberately **not** reported:
+
+- **`text-overflow: ellipsis`.** That is truncation the author asked for and the reader can see, which is the opposite of the silent loss this exists for.
+- **Whitespace.** A clipped space is not something anyone can see or act on.
+
+**The report under-reports, and that is the safe direction rather than completeness.** It measures against the renderer's tracked clip-rect stack, and two clips never reach it: a `border-radius` or `clip-path` clip, and the page-level clip applied outside that stack. An empty report is therefore a weaker statement than "nothing was clipped". A word that fell *entirely* outside its clip is not reported here either — it is never drawn at all, so reading the output back detects it as missing text.
 
 ## Fonts
 

--- a/src/PeachPDF.Tests/Integration/ClipReportTests.cs
+++ b/src/PeachPDF.Tests/Integration/ClipReportTests.cs
@@ -1,0 +1,151 @@
+using PeachPDF.PdfSharpCore;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// <see cref="ClipReport"/> catches the one loss class reading the finished PDF cannot see:
+    /// glyphs that were DRAWN into the content stream and then truncated by a clip.
+    /// <para>
+    /// A reader that parses the content stream finds those glyphs and reports the document complete;
+    /// a renderer that honours the clip shows only part of the word. Both are correct — the
+    /// difference is not recorded in the file — so the engine, at the moment it decides to draw, is
+    /// the only thing that can report it.
+    /// </para>
+    /// <para>
+    /// Asserted through <see cref="PdfGenerator.GeneratePdf"/> rather than at paint level, because
+    /// the subject is the report a caller receives, and because the collector is drained by
+    /// <c>AddPdfPages</c> after the page loop — a paint-level harness would not exercise that.
+    /// </para>
+    /// </summary>
+    public class ClipReportTests
+    {
+        private static async Task<ClipReport> RenderAsync(string body)
+        {
+            var doc = await new PdfGenerator().GeneratePdf(
+                $"<html><body>{body}</body></html>",
+                new PdfGenerateConfig { PageSize = PageSize.Letter });
+            return doc.ClipReport;
+        }
+
+        [Fact]
+        public async Task AWordTruncatedByAnOverflowHiddenBoxIsReported()
+        {
+            // THE CONTROL CASE, and the shape the feature is named after: a box narrower than its
+            // own unbreakable content, so the word is drawn in full and then cut by the clip.
+            // A change that reports nothing here is testing nothing.
+            var report = await RenderAsync(
+                "<div style=\"width:20px;overflow:hidden;white-space:nowrap\">Extended</div>");
+
+            var word = Assert.Single(report.ClippedWords);
+            Assert.Equal("Extended", word.Text);
+            Assert.Equal(8, report.ClippedChars);
+            Assert.True(word.VisibleWidth < word.DrawnWidth,
+                $"a clipped word must report less visible than drawn: {word.VisibleWidth} vs {word.DrawnWidth}");
+        }
+
+        [Fact]
+        public async Task OneWordDeliberately_BecauseAMultiWordRunIsADifferentFinding()
+        {
+            // Measured while writing this: a multi-word run in the same box is NOT a clean partial
+            // clip. The later words fall entirely outside, hit the existing full-clip guard, are
+            // never drawn at all, and a content-stream reader reports them missing — correctly.
+            // Full-cull and partial-clip are different findings, and conflating them is how a
+            // fixture ends up asserting the wrong thing.
+            var report = await RenderAsync(
+                "<div style=\"width:20px;overflow:hidden;white-space:nowrap\">Alpha Bravo Extended</div>");
+
+            Assert.All(report.ClippedWords,
+                w => Assert.True(w.VisibleWidth > 0, $"'{w.Text}' was never drawn, so it is a full cull, not a clip"));
+        }
+
+        [Fact]
+        public async Task RepeatedAddPdfPagesCallsAccumulateTheReport()
+        {
+            // AddPdfPages is a repeatable public API — a caller appends more pages to an existing
+            // document across several calls, each building its own container and its own report.
+            // Replacing the property wholesale silently discards every earlier call's findings,
+            // which is the one failure mode a report about silent loss must not have.
+            var generator = new PdfGenerator();
+            var config = new PdfGenerateConfig { PageSize = PageSize.Letter };
+            const string clipping =
+                "<html><body><div style=\"width:20px;overflow:hidden;white-space:nowrap\">Extended</div></body></html>";
+
+            var document = await generator.GeneratePdf(clipping, config);
+            Assert.Single(document.ClipReport.ClippedWords);
+
+            await generator.AddPdfPages(document, clipping, config);
+
+            Assert.Equal(2, document.ClipReport.ClippedWords.Count);
+            Assert.Equal(16, document.ClipReport.ClippedChars);
+        }
+
+        [Fact]
+        public async Task AWordClippedOnlyVerticallyIsAlsoReported()
+        {
+            // A box short enough to cut a line's height but wide enough to keep the whole word is
+            // the same silent loss, and is recorded — so VisibleWidth can equal DrawnWidth on a
+            // reported word. Pins the boundary the XML doc describes.
+            var report = await RenderAsync(
+                "<div style=\"width:400px;height:4px;overflow:hidden\">Extended</div>");
+
+            var word = Assert.Single(report.ClippedWords);
+            Assert.Equal(word.DrawnWidth, word.VisibleWidth, 1);
+            Assert.True(word.VisibleHeight < word.DrawnHeight,
+                $"the clip was vertical, so height must have been reduced: {word.VisibleHeight} of {word.DrawnHeight}");
+        }
+
+        [Fact]
+        public async Task AnOrdinaryDocumentReportsNothing()
+        {
+            // If this fires the report is noise rather than a signal, and the rate it produces
+            // cannot be read. A plain paragraph and a plain table clip nothing.
+            var report = await RenderAsync(
+                "<p>A paragraph that fits.</p>"
+                + "<table><tr><th>Header</th><th>Second</th></tr>"
+                + "<tr><td>a value</td><td>another value</td></tr></table>");
+
+            Assert.Empty(report.ClippedWords);
+            Assert.Equal(0, report.ClippedChars);
+        }
+
+        [Fact]
+        public async Task TextOverflowEllipsisIsNotReported()
+        {
+            // Truncation the author asked for and the reader can see, which is the opposite of the
+            // silent loss this exists for.
+            var report = await RenderAsync(
+                "<div style=\"width:30px;overflow:hidden;white-space:nowrap;text-overflow:ellipsis\">"
+                + "Extended text here</div>");
+
+            Assert.Empty(report.ClippedWords);
+        }
+
+        [Fact]
+        public async Task KeptFractionDescribesHowMuchSurvived()
+        {
+            // The calibration handle: what counts as material loss is a measurement over real
+            // documents rather than a constant chosen here, so the geometry has to be reported
+            // rather than a boolean.
+            var report = await RenderAsync(
+                "<div style=\"width:20px;overflow:hidden;white-space:nowrap\">Extended</div>");
+
+            var word = Assert.Single(report.ClippedWords);
+            Assert.InRange(word.KeptFraction, 0d, 1d);
+            Assert.True(word.KeptFraction < 1d,
+                $"a reported word lost something, so it cannot have kept all of itself: {word.KeptFraction}");
+        }
+
+        [Fact]
+        public async Task AWideEnoughBoxReportsNothing_EvenWithOverflowHidden()
+        {
+            // The contrast case for the control above: `overflow: hidden` alone must not report —
+            // only content that genuinely did not fit.
+            var report = await RenderAsync(
+                "<div style=\"width:400px;overflow:hidden;white-space:nowrap\">Extended</div>");
+
+            Assert.Empty(report.ClippedWords);
+        }
+    }
+}

--- a/src/PeachPDF/ClippedWord.cs
+++ b/src/PeachPDF/ClippedWord.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+
+namespace PeachPDF;
+
+/// <summary>
+/// One word that was DRAWN into the content stream and then truncated by a clip.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exists because reading the finished PDF cannot detect this class of loss. A glyph that was
+/// emitted and then truncated by the PDF clip operator is still IN the content stream, so a reader
+/// that parses that stream finds it and reports the word present, while a renderer that honours the
+/// clip shows only part of it. Measured with the two as an oracle pair on a table cell narrower than
+/// its content: PdfPig reads every character back and reports the document complete; MuPDF cannot
+/// find the text at all. Both are correct — the difference is simply not recorded in the file. So
+/// the engine, at the moment it decides to draw, is the only thing that can report it.
+/// </para>
+/// <para>
+/// It is deliberately ADDITIVE to reading the output back, never a replacement. A content-stream
+/// reader answers "did the glyph land in the file"; an engine-side collector answers "did the
+/// painter intend to emit it", and the two catch different defects — a document declaring one image
+/// where the PDF contains zero is caught only by the former.
+/// </para>
+/// <para>
+/// It UNDER-reports, and that is the safe direction but must not be mistaken for completeness.
+/// The clip this is measured against is <c>RGraphics</c>'s tracked rect stack, and two clips never
+/// reach it: a <c>border-radius</c> or <c>clip-path</c> clip (the path-clip push deliberately
+/// leaves the tracked bound over-wide, and the exclude-push is a no-op), and the page-level
+/// <c>XGraphics.IntersectClip</c> the PDF generator applies outside the stack. So "nothing
+/// reported" is a weaker statement than "nothing was clipped".
+/// </para>
+/// </remarks>
+/// <param name="Text">The word as it was drawn.</param>
+/// <param name="DrawnWidth">Width of the word's own rect, before the clip was applied.</param>
+/// <param name="VisibleWidth">
+/// Width that survived the clip. Less than <paramref name="DrawnWidth"/> when width was a clipped
+/// dimension; EQUAL to it for a word clipped only vertically, which is recorded too — a box short
+/// enough to cut a line's height but wide enough to keep the whole word is the same silent loss.
+/// </param>
+/// <param name="DrawnHeight">Height of the word's own rect, before the clip was applied.</param>
+/// <param name="VisibleHeight">Height that survived the clip.</param>
+public readonly record struct ClippedWord(
+    string Text,
+    double DrawnWidth,
+    double VisibleWidth,
+    double DrawnHeight,
+    double VisibleHeight)
+{
+    /// <summary>
+    /// The fraction of the word's area that survived the clip, 0 to 1. A calibration handle: the
+    /// threshold for what counts as material is a measurement over real documents, not a guess.
+    /// </summary>
+    public double KeptFraction =>
+        DrawnWidth <= 0 || DrawnHeight <= 0
+            ? 1d
+            : (VisibleWidth / DrawnWidth) * (VisibleHeight / DrawnHeight);
+}
+
+/// <summary>
+/// Every <see cref="ClippedWord"/> a single render produced, in paint order.
+/// </summary>
+public sealed class ClipReport
+{
+    internal readonly List<ClippedWord> Words = [];
+
+    /// <summary>The clipped words, in paint order.</summary>
+    public IReadOnlyList<ClippedWord> ClippedWords => Words;
+
+    /// <summary>
+    /// Appends <paramref name="other"/>'s words to this report, preserving paint order. Used by
+    /// <c>PdfGenerator.AddPdfPages</c> so a document built over several calls carries every call's
+    /// findings rather than only the last one's.
+    /// </summary>
+    internal void Append(ClipReport other) => Words.AddRange(other.Words);
+
+    /// <summary>How many characters were carried by words that were truncated.</summary>
+    /// <remarks>
+    /// The whole word's length, not an estimate of the invisible part: a word is the smallest unit
+    /// the painter knows, and apportioning characters to a sub-rectangle would invent precision the
+    /// measurement does not have.
+    /// </remarks>
+    public int ClippedChars
+    {
+        get
+        {
+            var n = 0;
+            foreach (var w in Words) n += w.Text.Length;
+            return n;
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/HtmlContainerInt.cs
+++ b/src/PeachPDF/Html/Core/HtmlContainerInt.cs
@@ -2568,6 +2568,19 @@ namespace PeachPDF.Html.Core
         internal RRect? PageClipOverride { get; set; }
 
         /// <summary>
+        /// Words this render DREW and then truncated with a clip - see <see cref="PeachPDF.ClipReport"/>.
+        /// </summary>
+        /// <remarks>
+        /// Per RENDER, not per page, which is why it lives here rather than on <c>FragmentPainter</c>:
+        /// the painter is constructed fresh for each page (<see cref="PerformPaint"/>) and holds
+        /// per-page state deliberately. <see cref="PageClipOverride"/> immediately above is the same
+        /// shape of per-render slot in the other direction - written by <c>PdfGenerator</c>'s page loop
+        /// and read by the painter; this one is written by the painter and drained by
+        /// <c>PdfGenerator.AddPdfPages</c> once the loop is done.
+        /// </remarks>
+        internal PeachPDF.ClipReport ClipReport { get; } = new();
+
+        /// <summary>
         /// The page/viewport rect, in the same fragmentainer-local coordinate space every painted
         /// fragment uses - the same rect <see cref="PerformPaint"/>
         /// pushes as the top-level page clip, also used as the background positioning area for a

--- a/src/PeachPDF/Html/Core/Paint/FragmentPainter.Text.cs
+++ b/src/PeachPDF/Html/Core/Paint/FragmentPainter.Text.cs
@@ -66,7 +66,7 @@ namespace PeachPDF.Html.Core.Paint
         /// over an arbitrary (not necessarily <see cref="Fragments.BoxFragment.Words"/> itself) ordered
         /// list.
         /// </summary>
-        private static void PaintWordSequence(RGraphics g, CssBox box, IReadOnlyList<TextFragment> words)
+        private void PaintWordSequence(RGraphics g, CssBox box, IReadOnlyList<TextFragment> words)
         {
             foreach (var wordFragment in words)
             {
@@ -84,6 +84,13 @@ namespace PeachPDF.Html.Core.Paint
                 // content stream and text-extraction layer) duplicate of the word painted on the page it
                 // just left. See GitHub issue #113.
                 if (clip.Width <= VisibilityClipEpsilon || clip.Height <= VisibilityClipEpsilon) continue;
+
+                // Past this point the word IS drawn, and the surviving intersection can still be
+                // smaller than the word itself - the glyphs go into the content stream whole and the
+                // PDF clip operator truncates them on the page. That is invisible to any validator
+                // that reads the content stream back, so record it here, where the intersection has
+                // already been computed. Detection only: nothing about what is painted changes.
+                RecordIfClipped(word, wordFragment.Rect, clip);
 
                 if (word is CssRectLeader leader)
                 {
@@ -106,6 +113,49 @@ namespace PeachPDF.Html.Core.Paint
                     logicalText = PeachPDF.Text.Bidi.BidiMirrorResolver.ReverseRunes(rectWord.PreMirrorText);
                 DrawWordGlyphs(g, box, word, wordFragment.Rect, text, new RSize(word.Width, word.Height), logicalText: logicalText);
             }
+        }
+
+        /// <summary>
+        /// Records a word that was drawn but whose visible rect is smaller than its own - the loss
+        /// class a content-stream reader cannot see. See <see cref="PeachPDF.ClippedWord"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <paramref name="visible"/> is the caller's ALREADY-intersected copy, so this adds no
+        /// geometry work to the paint path - it compares two rects it was handed.
+        /// </para>
+        /// <para>
+        /// The tolerance is deliberately coarse. <see cref="VisibilityClipEpsilon"/> exists to catch
+        /// a float-noise zero and is far too tight to mean "materially truncated": at 1e-6 every word
+        /// sitting flush against a clip edge would be reported. A sub-point sliver is not a legible
+        /// loss, so the threshold is a fraction of a point, and the report carries the full geometry
+        /// so what counts as material can be settled by measuring real documents rather than guessed
+        /// here.
+        /// </para>
+        /// </remarks>
+        private void RecordIfClipped(CssRect word, RRect drawn, RRect visible)
+        {
+            const double clippedTolerance = 0.5;
+
+            if (visible.Width >= drawn.Width - clippedTolerance
+                && visible.Height >= drawn.Height - clippedTolerance)
+            {
+                return;
+            }
+
+            // Whitespace carries no legible content, and a clipped space is not a defect anyone can
+            // see or act on. Excluding it keeps the report about text a reader has lost.
+            if (word.IsSpaces) return;
+
+            var text = word.FirstLineText ?? word.Text;
+            if (string.IsNullOrEmpty(text)) return;
+
+            container.ClipReport.Words.Add(new PeachPDF.ClippedWord(
+                text,
+                drawn.Width,
+                Math.Max(0, Math.Min(visible.Width, drawn.Width)),
+                drawn.Height,
+                Math.Max(0, Math.Min(visible.Height, drawn.Height))));
         }
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Paint/FragmentPainter.TextOverflow.cs
+++ b/src/PeachPDF/Html/Core/Paint/FragmentPainter.TextOverflow.cs
@@ -166,7 +166,13 @@ namespace PeachPDF.Html.Core.Paint
         /// The caller uses this to record the line as truncated so a later sibling box sharing it paints
         /// nothing further (see <see cref="PaintWordsWithEllipsis"/>'s own remarks).
         /// </returns>
-        private static bool PaintLineWithEllipsis(RGraphics g, CssBox box, List<TextFragment> lineWords, bool isVertical, bool isRtl, double boundary, double lineStart)
+        // Not static only because PaintWordSequence stopped being static: it now records words that
+        // were drawn and then clipped, which needs the container. The words this path hands it are
+        // the line's SURVIVING whole words, painted normally, so recording them is right. The word
+        // this path truncates itself is drawn elsewhere (FitTruncatedWord/DrawEllipsis) and is
+        // deliberately NOT recorded - `text-overflow: ellipsis` is truncation the author asked for
+        // and the reader can see, which is the opposite of the silent loss the report exists for.
+        private bool PaintLineWithEllipsis(RGraphics g, CssBox box, List<TextFragment> lineWords, bool isVertical, bool isRtl, double boundary, double lineStart)
         {
             var lastLeading = LeadingEdge(lineWords[^1].Rect, isVertical, isRtl);
             if (!(Forward(lastLeading, isRtl) > Forward(boundary, isRtl)))

--- a/src/PeachPDF/PdfGenerator.cs
+++ b/src/PeachPDF/PdfGenerator.cs
@@ -545,6 +545,17 @@ namespace PeachPDF
             foreach (var cachedImage in marginBoxImageCache.Values)
                 cachedImage?.Dispose();
 
+            // Hand the painter's clip findings to the caller. Drained here, after the page loop, and
+            // before `container` (a `using`) is disposed at the end of this method - it is the only
+            // point where the whole render's collection exists and is still reachable.
+            // Appended, not assigned. AddPdfPages is a repeatable public API - a caller adds more
+            // pages to an existing document across several calls, each building its own container
+            // and its own report - so replacing the property wholesale would silently discard the
+            // findings of every earlier call. PeachPdfDocument.PageCount accumulates across the same
+            // calls via the underlying PdfDocument; a report whose whole purpose is not to lose
+            // information quietly should not be the one member that does.
+            document.ClipReport.Append(container.HtmlContainerInt.ClipReport);
+
             // Finalizes /ParentTree page-keyed entries before HandleLinks (which, when tagging is
             // enabled, appends further annotation-keyed entries to the same tree - see
             // StructureTagBuilder.Finish and HandleLinks's own tagging-aware section below).

--- a/src/PeachPDF/PeachPdfDocument.cs
+++ b/src/PeachPDF/PeachPdfDocument.cs
@@ -23,6 +23,18 @@ public class PeachPdfDocument
     /// </summary>
     public int PageCount => _document.PageCount;
 
+    /// <summary>
+    /// Words this render drew and then truncated with a clip - the loss class reading the finished
+    /// PDF back cannot detect. See <see cref="PeachPDF.ClipReport"/> for what it does and does not
+    /// cover.
+    /// </summary>
+    /// <remarks>
+    /// Public because the consumer of this library is a separate assembly and the internals are not
+    /// visible to it. Everything else the render reports about itself is read back OUT of the bytes;
+    /// this is the one fact only the engine holds, so it has to be handed over rather than inferred.
+    /// </remarks>
+    public ClipReport ClipReport { get; internal set; } = new();
+
     internal PdfPages Pages => _document.Pages;
 
     /// <summary>


### PR DESCRIPTION
Implements the proposal in #947 — detection only, nothing about what is painted changes.

Closes #947

## The problem

A glyph emitted and then truncated by the PDF clip operator is still **in the content stream**. A reader that parses that stream finds it and reports the document complete; a renderer that honours the clip shows only part of the word. Both are correct — the difference is not recorded in the file.

Measured with the two as an oracle pair on a table cell narrower than its content: PdfPig reads every character back and reports the document complete, while MuPDF cannot find the text at all. So the engine, at the moment it decides to draw, is the only thing that can report it.

## The API

```csharp
var document = await generator.GeneratePdf(html, pdfConfig);

foreach (var word in document.ClipReport.ClippedWords)
{
    Console.WriteLine($"'{word.Text}' kept {word.KeptFraction:P0} " +
                      $"({word.VisibleWidth:F1}pt of {word.DrawnWidth:F1}pt)");
}
```

`ClippedWord` carries geometry rather than a verdict — `DrawnWidth`, `VisibleWidth`, `DrawnHeight`, `VisibleHeight`, `KeptFraction` — so a consumer picks its own threshold and the default can be settled by measurement. `ClipReport.ClippedChars` totals the characters carried by truncated words.

## Where it sits

`FragmentPainter.Text.cs`'s `PaintWordSequence` already computes `var clip = g.GetClip(); clip.Intersect(wordFragment.Rect);`. The guard below it handles only the **full** case — zero-area intersection, word never drawn — which reading the output back already catches as missing text. Partial clipping had no decision point at all. The check is immediately after that guard, comparing two rects the method was already holding: **no extra geometry work on the paint path**.

The collector is on `HtmlContainerInt`, not the painter, because a painter instance is per page and the report is per render — `PageClipOverride` on the same type is the precedent in the other direction. `AddPdfPages` drains it after the page loop, before the container is disposed.

Two methods lose `static` (`PaintWordSequence`, `PaintLineWithEllipsis`) because they now need the container. Nothing else changes.

## Deliberate exclusions, all documented in `docs/usage-examples.md`

- **`text-overflow: ellipsis`** — truncation the author asked for and the reader can see, the opposite of the silent loss this exists for.
- **Whitespace** — a clipped space is not something anyone can see or act on.
- **It under-reports.** The clip measured against is `RGraphics`'s tracked rect stack; a `border-radius`/`clip-path` clip and the page-level `XGraphics.IntersectClip` never reach it. An empty report is a weaker statement than "nothing was clipped", and both the XML docs and the reader-facing docs say so.
- **Tolerance is 0.5pt**, a starting point rather than a result — the existing `VisibilityClipEpsilon` is 1e-6 and would report every word flush against a clip edge. Happy to make it configurable if you'd prefer.

## Tests

`ClipReportTests`, six fixtures. Disabling the report site fails two of them:

- the single-word control (reported, with `VisibleWidth < DrawnWidth`);
- a **multi-word** contrast — worth calling out, because measuring corrected my first fixture here. A multi-word run in the same box is not a clean partial clip: the later words fall entirely outside, hit the existing full-clip guard, are never drawn, and reading the output back reports them missing, correctly. Full-cull and partial-clip are different findings;
- an ordinary paragraph-and-table document, which must be **silent** or the report is noise rather than signal;
- `text-overflow: ellipsis`, excluded;
- `KeptFraction` bounded and below 1;
- a wide-enough `overflow: hidden` box, silent — the property alone must not report.

Across 26 real templates: **0 documents report any clipped text and none of them move**, which is what makes it usable as a signal.

`dotnet build PeachPDF.Tests -t:Rebuild`: no new warnings. `dotnet test --framework net8.0`: 10,258 passed, 0 failed, 9 skipped. Diff coverage 100% on the changed lines.
