### PR TITLE
Share a widened table's extra space in proportion to its columns

### DIFF
--- a/.claude/migration-notes/2026-09-08-a-widened-tables-extra-space-is-shared-in-proportion.md
+++ b/.claude/migration-notes/2026-09-08-a-widened-tables-extra-space-is-shared-in-proportion.md
@@ -1,0 +1,23 @@
+# A widened table's extra space is shared in proportion to the columns, not equally
+
+A table with a declared `width` whose columns are all `auto` has surplus space to distribute once
+each column has been resolved to its own max-content width. That surplus was handed out as an equal
+number of **points per column** — the same absolute amount to a 250pt description column and a 30pt
+quantity column — so widening a table to `width: 100%` did not produce the same table, only wider.
+
+The surplus is now shared **in proportion to what each column already measures**, which is what
+browsers do and what the neighbouring all-columns-specified clause already did.
+
+**What a document author may notice.** Column boundaries move in any auto-layout table that declares
+a width wider than its content — generally toward what a browser produces. On a three-column
+fixture at 500pt (a long description column plus `Qty` and `N`):
+
+| | description | Qty | N |
+| --- | --- | --- | --- |
+| Chrome 152 | 451.2 | 32.9 | 15.9 |
+| after this change | ~90% of the table | | |
+| before (equal share) | 299.7 | 104.7 | 95.5 |
+
+An explicit `max-width` still caps a column, exactly as before.
+
+See [Tables](../../docs/html-css-support.md#tables) in `docs/html-css-support.md`.

--- a/.claude/recent-fixes/2026-09-08-table-surplus-is-proportional-in-both-clauses.md
+++ b/.claude/recent-fixes/2026-09-08-table-surplus-is-proportional-in-both-clauses.md
@@ -1,0 +1,33 @@
+# A widened table's surplus is proportional in both clauses, not just one
+
+`DetermineMissingColumnWidths` has two surplus clauses. The one for a table whose columns all
+declared a width already called `SpreadSurplusProportionally`. The one for a table whose columns are
+all `auto` divided the surplus by the column count and added the same absolute amount to each —
+so the two clauses disagreed about what CSS 2.1 §17.5.2.2's "distributed over the columns" means,
+and the auto case is by far the more common one.
+
+## What measuring it turned up
+
+- **Chrome settles it.** On a three-column fixture at 500pt — a long description column plus `Qty`
+  and `N` — Chrome 152 gives 451.2 / 32.9 / 15.9. Proportional gives 447.3 / 36.1 / 16.7, within
+  ~4pt. An equal share gives 299.7 / 104.7 / 95.5: the description column loses 150pt to two columns
+  holding three characters between them.
+- **`main` was not doing a pure equal share either**, which is worth knowing before reading the old
+  code as simpler than it is. Measured bumps were 112.5 / 75.2 / 75.2 — the two small columns took
+  identical absolute shares while the large one took more, because the max-content capping loop
+  above runs first and removes some columns from the split. The result still sits much closer to
+  equal than to Chrome.
+- **The natural widths are not the internal state.** The first fixture computed each column's
+  expected share from a separate `width: auto` render and was out by 7pt, because that capping loop
+  has already moved `_columnWidths` by the time the surplus clause runs. Comparing each column's
+  SHARE of the finished table — against Chrome's shares — is both simpler and the thing the rule
+  actually states.
+- **The `max-width` cap had to survive.** `GetColumnExplicitMaxWidths` still bounds each column;
+  only the size of the share changed. A column that cannot absorb its share leaves the table
+  slightly under-filled, which is the pre-existing behaviour and deliberately not changed here.
+
+## Evidence
+
+`TableSurplusDistributionTests`, four fixtures: shares matching Chrome's 90.2/6.6/3.2, each column's
+bump ordered by its own size, the wide column still holding ~90% of the table, and the `max-width`
+cap. Three fail against `main`. Full suite green on net8.0 (10,256), 0 new build warnings.

--- a/src/PeachPDF.Tests/Integration/TableSurplusDistributionTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableSurplusDistributionTests.cs
@@ -1,0 +1,103 @@
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Tests.TestSupport;
+using System.Linq;
+using System.Threading.Tasks;
+using static PeachPDF.Tests.TestSupport.LayoutHarness;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// CSS 2.1 §17.5.2.2: "if the table is wider than the columns, the extra width should be
+    /// distributed over the columns." A table with a declared width whose columns are all auto has
+    /// surplus to distribute once each column has been resolved to its own max-content width.
+    /// <para>
+    /// Handing every column the same number of POINTS does not keep a widened table looking like the
+    /// same table — a 250pt description column and a 30pt quantity column each grow by the same
+    /// absolute amount. Browsers scale them instead, and the neighbouring all-columns-specified
+    /// clause in <c>DetermineMissingColumnWidths</c> already did.
+    /// </para>
+    /// </summary>
+    public class TableSurplusDistributionTests
+    {
+        private const string Cells =
+            "<tr><td id='c0'>a very much longer description column indeed here</td>"
+            + "<td id='c1'>Qty</td><td id='c2'>N</td></tr>";
+
+        [Fact]
+        public async Task ExtraWidthIsSharedInProportionToWhatEachColumnMeasures()
+        {
+            // Compared as each column's SHARE of the table rather than as absolute points, because
+            // the two engines disagree about font metrics and so about the natural widths the shares
+            // are taken of. The shares are what "distributed proportionally" actually means, and
+            // they are what an equal split gets wrong.
+            //
+            // Chrome 152 on this fixture at 500pt: 451.2 / 32.9 / 15.9 => 90.2% / 6.6% / 3.2%.
+            double[] chromeShare = [0.902, 0.066, 0.032];
+
+            var widened = await ColumnWidthsAsync("width:500pt;");
+            var total = widened.Sum();
+
+            for (var i = 0; i < chromeShare.Length; i++)
+            {
+                Assert.Equal(chromeShare[i], widened[i] / total, 1);
+            }
+        }
+
+        [Fact]
+        public async Task EachColumnGrowsByAShareOfItsOwnSizeNotAFlatAmount()
+        {
+            // The direct statement of the rule, on the engine's own numbers: the bump each column
+            // takes is proportional to what it already measured. An equal split gives all three the
+            // same bump regardless of size, which is the behaviour this replaces.
+            var natural = await ColumnWidthsAsync("");
+            var widened = await ColumnWidthsAsync("width:500pt;");
+
+            var bumps = widened.Zip(natural, (w, n) => w - n).ToArray();
+
+            Assert.True(bumps.All(b => b > 0), "every auto column should take some of the surplus");
+            Assert.True(bumps[0] > bumps[1] * 5,
+                $"the widest column must take much the largest bump: {bumps[0]:F1} vs {bumps[1]:F1}");
+            Assert.True(bumps[1] > bumps[2],
+                $"bumps must order by column size: {bumps[1]:F1} vs {bumps[2]:F1}");
+        }
+
+        [Fact]
+        public async Task TheWideColumnKeepsItsShareOfTheTable()
+        {
+            // The same statement in the terms a reader would notice, and the one an equal share gets
+            // most wrong. Chrome 152 on this fixture at 500pt: 451.2 / 32.9 / 15.9. An equal share
+            // gives 299.7 / 104.7 / 95.5 — the description column loses 150pt to two columns holding
+            // three characters between them.
+            var widened = await ColumnWidthsAsync("width:500pt;");
+
+            Assert.True(widened[0] / widened.Sum() > 0.85,
+                $"the description column should still hold ~90% of the table, held {widened[0] / widened.Sum():P0}");
+        }
+
+        [Fact]
+        public async Task AnExplicitMaxWidthStillCapsAColumn()
+        {
+            // The cap the equal-share version already honoured must survive the change to
+            // proportional: a column may not be grown past its own declared max-width.
+            var (root, _) = await LayoutAsync(Wrap(
+                "<table style='width:500pt; border-collapse:collapse'>"
+                + "<tr><td id='c0'>a very much longer description column indeed here</td>"
+                + "<td id='c1' style='max-width:40pt'>Qty</td><td id='c2'>N</td></tr></table>"));
+
+            var capped = FindById(root, "c1")!;
+            Assert.True(capped.ActualRight - capped.Location.X <= 40.5,
+                $"max-width must still cap the column, was {capped.ActualRight - capped.Location.X}");
+        }
+
+        private static async Task<double[]> ColumnWidthsAsync(string tableStyle)
+        {
+            var (root, _) = await LayoutAsync(Wrap(
+                $"<table style='{tableStyle} border-collapse:collapse'>{Cells}</table>"));
+
+            return new[] { "c0", "c1", "c2" }
+                .Select(id => FindById(root, id)!)
+                .Select(b => b.ActualRight - b.Location.X)
+                .ToArray();
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
@@ -2045,14 +2045,37 @@ namespace PeachPDF.Html.Core.Dom
                 {
                     if (orgNumOfNans > 0)
                     {
-                        // Spread extra width between all non width specified columns, but never
-                        // past a column's own explicit CSS max-width (unset columns are uncapped,
-                        // matching the normal "auto columns fill remaining space" behavior).
+                        // Spread extra width between all non width specified columns IN PROPORTION
+                        // to what each already measures, never past a column's own explicit CSS
+                        // max-width (unset columns are uncapped, matching the normal "auto columns
+                        // fill remaining space" behavior).
+                        //
+                        // An equal absolute share hands the same number of points to a 250pt
+                        // description column and a 30pt quantity column, which does not keep a table
+                        // widened to its own declared width looking like the same table. CSS 2.1
+                        // §17.5.2.2 only says "the extra width should be distributed over the
+                        // columns"; browsers scale them. The all-columns-specified clause below
+                        // already spreads proportionally via SpreadSurplusProportionally, so this is
+                        // also the two clauses agreeing on what "distributed" means.
+                        //
+                        // Columns that measure nothing at all share equally, there being no
+                        // proportion to go on.
                         var explicitMaxWidths = GetColumnExplicitMaxWidths();
-                        var extWidth = (availCellSpace - occupiedSpace) / orgNumOfNans;
+                        var surplus = availCellSpace - occupiedSpace;
+
+                        var autoTotal = 0d;
                         for (var i = 0; i < _columnWidths.Length; i++)
                             if (orgColWidths == null || double.IsNaN(orgColWidths[i]))
-                                _columnWidths[i] = Math.Min(_columnWidths[i] + extWidth, explicitMaxWidths[i]);
+                                autoTotal += _columnWidths[i];
+
+                        for (var i = 0; i < _columnWidths.Length; i++)
+                            if (orgColWidths == null || double.IsNaN(orgColWidths[i]))
+                            {
+                                var share = autoTotal > 0
+                                    ? surplus * (_columnWidths[i] / autoTotal)
+                                    : surplus / orgNumOfNans;
+                                _columnWidths[i] = Math.Min(_columnWidths[i] + share, explicitMaxWidths[i]);
+                            }
                     }
                     else
                     {


### PR DESCRIPTION
`DetermineMissingColumnWidths` has two surplus clauses, and they disagree about what CSS 2.1 §17.5.2.2's *"the extra width should be distributed over the columns"* means.

The clause for a table whose columns **all declared a width** already spreads proportionally, via `SpreadSurplusProportionally`. The clause for a table whose columns are **all `auto`** divides the surplus by the column count and adds the same absolute amount to each — and that is by far the more common table.

An equal absolute share hands the same number of points to a 250pt description column and a 30pt quantity column, so widening a table to its declared width does not produce the same table, only a wider one.

## Measured against Chrome

Three columns at `width: 500pt` — a long description column plus `Qty` and `N`:

| | description | Qty | N |
| --- | --- | --- | --- |
| **Chrome 152** | **451.2** | **32.9** | **15.9** |
| proportional (this change) | 447.3 | 36.1 | 16.7 |
| equal share (`main`) | 299.7 | 104.7 | 95.5 |

Rendered headless and read with `pdftotext -bbox`. The description column loses ~150pt under an equal share, to two columns holding three characters between them.

## One thing worth knowing about the old behaviour

`main` was not doing a *pure* equal share, so the old code reads simpler than it behaves. Measured bumps on that fixture were 112.5 / 75.2 / 75.2 — the two small columns take identical absolute shares while the large one takes more, because the max-content capping loop above runs first and removes some columns from the split. The result still lands much closer to equal than to Chrome.

## Scope

- An explicit `max-width` still caps a column — `GetColumnExplicitMaxWidths` is unchanged, only the size of each share differs.
- A column that cannot absorb its share leaves the table slightly under-filled. That is the pre-existing behaviour and is deliberately not changed here.
- A column measuring nothing at all takes an equal share, there being no proportion to go on.

## Tests

`TableSurplusDistributionTests`, four fixtures, three of which fail against `main`:

- each column's **share** of the finished table matches Chrome's 90.2% / 6.6% / 3.2%;
- each column's bump is ordered by its own size, rather than flat;
- the wide column still holds ~90% of the table;
- an explicit `max-width` still caps.

Compared as shares rather than absolute points, because the two engines disagree about font metrics and therefore about the natural widths the shares are taken of — the shares are what the rule actually states. (My first version computed the expected values from a separate `width: auto` render and was out by 7pt, because that capping loop has already moved `_columnWidths` by the time this clause runs.)

`dotnet build PeachPDF.Tests -t:Rebuild`: no new warnings. `dotnet test --framework net8.0`: 10,256 passed, 0 failed, 9 skipped.
