### PR TITLE
A declared cell width is its content width, so add its padding and border

### DIFF
--- a/.claude/migration-notes/2026-09-08-a-declared-cell-width-now-adds-its-own-padding-and-border.md
+++ b/.claude/migration-notes/2026-09-08-a-declared-cell-width-now-adds-its-own-padding-and-border.md
@@ -1,0 +1,25 @@
+# A declared cell width now adds its own padding and border to the column
+
+`box-sizing` defaults to `content-box`, so a table cell's declared `width` is its **content** width
+and its padding and border sit outside it. The engine stored that bare content width as the column's
+width — but a column width is an OUTER width everywhere else, since the same array is filled from
+`cell.GetMinimumWidth()`, which already includes padding and border.
+
+Every explicitly sized column therefore came out narrower than a browser's by exactly its padding
+plus border, and the difference was handed to whichever column was `auto`. On a table of seven
+px-width columns with `padding: 3px 5px`, each was about 8pt narrow and the auto column absorbed
+roughly 58pt it should not have had.
+
+Such a column is now as wide as the browser draws it. Measured against Chrome 152 on a cell
+declaring `width: 100px; padding: 3px 5px; border: 1px solid`:
+
+| | first column |
+| --- | --- |
+| Chrome 152 | 84.75pt |
+| before | the same as an unpadded cell — 75pt |
+| after | 75pt of content plus its own padding and border |
+
+A cell declaring `box-sizing: border-box` is **unaffected** — its declared width already covers
+padding and border, and Chrome puts that shape at the unpadded width too.
+
+See [Tables](../../docs/html-css-support.md#tables) in `docs/html-css-support.md`.

--- a/.claude/recent-fixes/2026-09-08-a-column-width-is-an-outer-width-everywhere-but-one-place.md
+++ b/.claude/recent-fixes/2026-09-08-a-column-width-is-an-outer-width-everywhere-but-one-place.md
@@ -1,0 +1,27 @@
+# A column width is an outer width everywhere but the one place that set it from CSS
+
+`_columnWidths` holds OUTER widths: `GetColumnMinWidths` fills it from `cell.GetMinimumWidth()`,
+which includes padding and border. The clause that reads a cell's declared `width` stored the bare
+parsed length instead — a CONTENT width under `box-sizing: content-box`. So the array mixed two
+meanings, and every explicitly sized column came out narrow by exactly its padding plus border,
+with the shortfall handed to whichever column was `auto`.
+
+## What running it turned up
+
+- **`box-sizing` had to be read, not assumed.** The obvious fix — always add padding and border —
+  is wrong for `box-sizing: border-box`, where the declared width already covers them. Chrome puts
+  that shape at the *unpadded* width, so always-adding would have traded one wrong number for
+  another. `CssBox.ActualBoxSizeIncludedWidth` already makes exactly this distinction (padding +
+  border for content-box, zero for border-box), so the new helper is only its writing-mode switch,
+  mirroring `CellInlineSize`'s.
+- **Chrome measurements, on the three shapes that separate the cases** — `width: 100px` with
+  `padding: 3px 5px; border: 1px`, the same without padding, and the same under `border-box`:
+  84.75pt / 77.25pt / 76.5pt. Padded is ~7.5pt wider than bare; border-box is not wider at all.
+  Asserted as relationships rather than absolute points, since the two engines disagree about font
+  metrics and border-collapse rounding.
+
+## Evidence
+
+`TableDeclaredCellWidthTests`, three fixtures: padded wider than bare (fails against `main`),
+border-box equal to bare, and an unpadded 100px cell still exactly 75pt so the change is a no-op
+where nothing is owed. Full suite green on net8.0 (10,255), 0 new build warnings.

--- a/src/PeachPDF.Tests/Integration/TableDeclaredCellWidthTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableDeclaredCellWidthTests.cs
@@ -1,0 +1,71 @@
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Tests.TestSupport;
+using System.Threading.Tasks;
+using static PeachPDF.Tests.TestSupport.LayoutHarness;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// A cell's declared <c>width</c> is its CONTENT width under <c>box-sizing: content-box</c> (the
+    /// default), so its padding and border sit outside it. <c>_columnWidths</c> holds OUTER widths —
+    /// <c>GetColumnMinWidths</c> fills the same array from <c>cell.GetMinimumWidth()</c>, which
+    /// already includes them — so a bare declared width made every explicitly sized column narrower
+    /// than a browser's by exactly its padding plus border.
+    /// <para>
+    /// Reference measurements are Chrome 152, rendered headless and read with <c>pdftotext -bbox</c>
+    /// on the same three shapes. Asserted as relationships between them rather than as absolute
+    /// points, since the two engines disagree about font metrics and border-collapse rounding.
+    /// </para>
+    /// </summary>
+    public class TableDeclaredCellWidthTests
+    {
+        // Chrome 152, first column's width in points: 84.75 padded, 77.25 bare, 76.5 border-box.
+        private const string Padded =
+            "<td id='c' style='width:100px; padding:3px 5px; border:1px solid black'>x</td>";
+        private const string Bare =
+            "<td id='c' style='width:100px'>x</td>";
+        private const string BorderBox =
+            "<td id='c' style='width:100px; padding:3px 5px; border:1px solid black; box-sizing:border-box'>x</td>";
+
+        [Fact]
+        public async Task ADeclaredWidthIsTheContentWidth_SoPaddingAndBorderWidenTheColumn()
+        {
+            var padded = await ColumnWidthAsync(Padded);
+            var bare = await ColumnWidthAsync(Bare);
+
+            // 10px of horizontal padding is 7.5pt; Chrome puts the same two shapes 7.5pt apart.
+            Assert.True(padded > bare + 6,
+                $"a padded cell's column must be wider than an unpadded one declaring the same width: {padded:F2} vs {bare:F2}");
+        }
+
+        [Fact]
+        public async Task BorderBoxDoesNotWidenTheColumn()
+        {
+            // The contrast case, and the reason this reads box-sizing rather than always adding:
+            // under border-box the declared width already covers padding and border.
+            var borderBox = await ColumnWidthAsync(BorderBox);
+            var bare = await ColumnWidthAsync(Bare);
+
+            Assert.Equal(bare, borderBox, 1);
+        }
+
+        [Fact]
+        public async Task AnUnpaddedCellIsUnaffected()
+        {
+            // 100px is 75pt at 96 CSS dpi. Without padding or border there is nothing to add, so the
+            // column is the declared width and this change is a no-op for it.
+            var bare = await ColumnWidthAsync(Bare);
+
+            Assert.Equal(75.0, bare, 1);
+        }
+
+        private static async Task<double> ColumnWidthAsync(string firstCell)
+        {
+            var (root, _) = await LayoutAsync(Wrap(
+                $"<table style='border-collapse:collapse'><tr>{firstCell}<td>auto</td></tr></table>"));
+
+            var cell = FindById(root, "c")!;
+            return cell.ActualRight - cell.Location.X;
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
@@ -102,6 +102,15 @@ namespace PeachPDF.Html.Core.Dom
 
         private string CellInlineMaxSize(CssBox cell) => _isVertical ? cell.MaxHeight : cell.MaxWidth;
 
+        /// <summary>
+        /// The padding and border a cell's declared inline size does NOT include, along the column
+        /// axis. Zero under <c>box-sizing: border-box</c>, where the declared size already covers
+        /// them — <see cref="CssBox.ActualBoxSizeIncludedWidth"/> makes that distinction, so this is
+        /// only its writing-mode switch, mirroring <see cref="CellInlineSize"/>'s.
+        /// </summary>
+        private double CellInlineSizeExcludes(CssBox cell) =>
+            _isVertical ? cell.ActualBoxSizeIncludedHeight : cell.ActualBoxSizeIncludedWidth;
+
         private string CellInlineMinSize(CssBox cell) => _isVertical ? cell.MinHeight : cell.MinWidth;
 
         /// <summary>The table's own border width consumed at the column axis's start/end edge.</summary>
@@ -1828,11 +1837,22 @@ namespace PeachPDF.Html.Core.Dom
 
                         if (i >= row.Boxes.Count || row.Boxes[i].DerivedStyle.ActualDisplay != Keywords.TableCell) continue;
 
-                        var len = CssValueParser.ParseLength(CellInlineSize(row.Boxes[i]), availCellSpace, row.Boxes[i]);
+                        var cell = row.Boxes[i];
+                        var len = CssValueParser.ParseLength(CellInlineSize(cell), availCellSpace, cell);
 
                         if (!(len > 0)) continue; //If some width specified
 
-                        var colspan = GetColSpan(row.Boxes[i]);
+                        // A declared size is the CONTENT size under box-sizing: content-box (the
+                        // default), so the cell's padding and border sit outside it. _columnWidths
+                        // holds OUTER widths -- GetColumnMinWidths fills the same array from
+                        // cell.GetMinimumWidth(), which already includes them -- so storing the bare
+                        // content width here made every explicitly sized column narrower than a
+                        // browser's by exactly its padding plus border, and handed the difference to
+                        // whichever column was auto. Zero under border-box, where the declared size
+                        // already covers them.
+                        len += CellInlineSizeExcludes(cell);
+
+                        var colspan = GetColSpan(cell);
                         len /= Convert.ToSingle(colspan);
 
                         for (var j = i; j < i + colspan; j++)


### PR DESCRIPTION
`_columnWidths` holds **outer** widths — `GetColumnMinWidths` fills the same array from `cell.GetMinimumWidth()`, which includes padding and border. The clause that reads a cell's declared `width` stored the bare parsed length instead, which under `box-sizing: content-box` (the default) is a **content** width.

So the array mixed two meanings, and every explicitly sized column came out narrower than a browser's by exactly its padding plus border — with the shortfall handed to whichever column was `auto`. On a table of seven px-width columns with `padding: 3px 5px`, each is about 8pt narrow and the auto column absorbs roughly 58pt it should not have.

## Measured against Chrome

Three shapes, rendered headless and read with `pdftotext -bbox`, first column's width in points:

| cell | Chrome 152 | `main` | this change |
| --- | --- | --- | --- |
| `width:100px; padding:3px 5px; border:1px` | **84.75** | 75.0 | 75.0 + its own padding and border |
| `width:100px` | 77.25 | 75.0 | 75.0 (unchanged) |
| the first, plus `box-sizing:border-box` | 76.5 | 75.0 | 75.0 (unchanged) |

## It reads `box-sizing` rather than always adding

Worth calling out, because the obvious fix is wrong for the third row. Under `border-box` the declared width already covers padding and border, and Chrome puts that shape at the *unpadded* width — always-adding would trade one wrong number for another.

`CssBox.ActualBoxSizeIncludedWidth` already makes exactly this distinction (padding + border for content-box, zero for border-box), so the new helper is only its writing-mode switch, mirroring `CellInlineSize`'s:

```csharp
private double CellInlineSizeExcludes(CssBox cell) =>
    _isVertical ? cell.ActualBoxSizeIncludedHeight : cell.ActualBoxSizeIncludedWidth;
```

## Tests

`TableDeclaredCellWidthTests`, three fixtures:

- a padded cell's column is wider than an unpadded one declaring the same width — **fails against `main`**;
- `box-sizing: border-box` does not widen it, which is the contrast case that justifies reading the property;
- an unpadded `width: 100px` cell is still exactly 75pt, so the change is a no-op where nothing is owed.

Asserted as relationships between the three rather than as absolute points, since the two engines disagree about font metrics and border-collapse rounding.

`dotnet build PeachPDF.Tests -t:Rebuild`: no new warnings. `dotnet test --framework net8.0`: 10,255 passed, 0 failed, 9 skipped.

---

This is the second of three fixes that were carried together in our tree as one "table column widths" patch. The first — `calc()` on a table — you already fixed via #901 after our issue #898. The third is #949 (proportional surplus). They touch the same file but are independent, so they are separate PRs; #949 does not conflict with this one.
