### PR TITLE
An inline-block reserves its declared width on the line

### DIFF
--- a/.claude/migration-notes/2026-09-08-width-on-an-inline-block-now-occupies-that-width-on-the-line.md
+++ b/.claude/migration-notes/2026-09-08-width-on-an-inline-block-now-occupies-that-width-on-the-line.md
@@ -1,0 +1,22 @@
+# `width` on a `display: inline-block` now occupies that width on the line
+
+An atomic inline-level box occupies its own used width on the line (CSS 2.1 §10.3.9). The inline
+flow accumulated its content's word widths instead, so a `width` on a `display: inline-block` had no
+effect at all and whatever followed sat flush against the box's text.
+
+Two shapes it broke, both common:
+
+- **A fixed-width label.** `<span style="display:inline-block;width:160px">Hi</span>` reserved only
+  the width of "Hi", so a column of such labels stopped lining its values up.
+- **An empty bordered box used as a glyph** — a checkbox drawn as
+  `<span style="display:inline-block;width:120px;border:1px solid"></span>` — has no content at all,
+  so it took no room whatsoever.
+
+Such a box now reserves its declared width. Measured against Chrome 152 on the same shapes: the
+first puts the following text exactly 120pt past the container's edge (160px at 96 CSS dpi), the
+second at 91.5pt (90pt plus its 1px borders). PeachPDF now agrees with both to within 0.1pt.
+
+Content **wider** than the declared width still overflows rather than being pulled back, which is
+what `overflow: visible` means, and a **percentage** width is unaffected.
+
+See [Display](../../docs/html-css-support.md#display) in `docs/html-css-support.md`.

--- a/.claude/recent-fixes/2026-09-08-an-inline-block-reserves-its-declared-width-on-the-line.md
+++ b/.claude/recent-fixes/2026-09-08-an-inline-block-reserves-its-declared-width-on-the-line.md
@@ -1,0 +1,38 @@
+# An inline-block reserves its declared width on the line
+
+CSS 2.1 §10.3.9 makes an atomic inline-level box occupy its own used width on the line. `FlowBox`
+just accumulated word widths, so `width` on a `display: inline-block` was inert.
+
+The flex/grid path a few hundred lines up already does exactly this, via
+`coordinates.CurrentX = b.ClientRight`.
+
+## What running it turned up
+
+- **`ClientRight` cannot be reused here, which is why the fix looks different from its precedent.**
+  On the plain inline path the child box's geometry is never assigned at all — measured on a
+  `width: 160px` inline-block, `Location.X`, `Size.Width`, `ClientRight` and `ActualRight` are all
+  `0`. So the declared width has to be resolved from the CSS at the advance point, against a
+  `childContentStartX` captured after every branch that can establish the child's line position
+  (including the left-float branch, which re-establishes it from scratch).
+- **Chrome agrees to 0.1pt** on both shapes that matter: 120pt for `width: 160px` with short
+  content, 91.5pt for an empty `width: 120px` box with a 1px border. That second one is the case an
+  accumulate-the-words flow gets most wrong — no content means no room at all.
+- **`box-sizing: border-box` has to be taken off, and the obvious helper does the opposite.**
+  `childContentStartX` is the content-box start and `rightSpacing` is added after, so what belongs
+  between them is the CONTENT width. Under `border-box` the declared width already covers the
+  padding and border those two spacings re-add, so they are counted twice unless subtracted here.
+  `ActualBoxSizeIncludedWidth` cannot do it: it answers what a declared size does NOT include, so
+  it is padding+border for content-box and ZERO for border-box — a no-op in exactly the case that
+  needs adjusting, and wrong in the case that does not. Chrome puts a `border-box; width: 120px`
+  box with a 1px border at exactly 90pt; without the subtraction it came out 91.5pt.
+- **Percentages are deliberately excluded.** A percentage resolves against a containing block this
+  line does not know. There is a fixture asserting the exclusion so it reads as a decision rather
+  than an oversight.
+
+## Evidence
+
+`InlineBlockDeclaredWidthTests`, four fixtures: the declared width reserved (Chrome's 120pt), the
+empty bordered box (Chrome's 91.5pt), the same box under `border-box` (Chrome's 90pt), a
+`border-box` box with padding (Chrome's 120pt), content wider than the declared width still
+overflowing, and a percentage width left alone. The first two fail against `main`. Full suite green on net8.0
+(10,256), 0 new build warnings.

--- a/src/PeachPDF.Tests/Integration/InlineBlockDeclaredWidthTests.cs
+++ b/src/PeachPDF.Tests/Integration/InlineBlockDeclaredWidthTests.cs
@@ -1,0 +1,113 @@
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Tests.TestSupport;
+using System.Linq;
+using System.Threading.Tasks;
+using static PeachPDF.Tests.TestSupport.LayoutHarness;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// CSS 2.1 §10.3.9: an atomic inline-level box occupies its own used width on the line, not the
+    /// width its content happened to measure. The inline flow accumulates word widths, so a
+    /// <c>width</c> on a <c>display: inline-block</c> had no effect and whatever followed sat flush
+    /// against its text.
+    /// <para>
+    /// Reference measurements are Chrome 152 on the same shapes, rendered headless and read with
+    /// <c>pdftotext -bbox</c>: a <c>width: 160px</c> box puts the following text exactly 120pt past
+    /// the container's edge, and an empty <c>width: 120px</c> box with a 1px border puts it at 91.5pt.
+    /// </para>
+    /// </summary>
+    public class InlineBlockDeclaredWidthTests
+    {
+        [Fact]
+        public async Task ADeclaredWidthWiderThanTheContentReservesThatWidthOnTheLine()
+        {
+            // 160px is 120pt at 96 CSS dpi, and "Hi" is nowhere near that wide.
+            var advance = await AdvanceAsync("<span style='display:inline-block;width:160px'>Hi</span>");
+
+            Assert.Equal(120.0, advance, 1);
+        }
+
+        [Fact]
+        public async Task AnEmptyBorderedInlineBlockStillTakesItsWidth()
+        {
+            // The checkbox-glyph shape: no content at all, so an accumulate-the-words flow gives it
+            // no room whatsoever. 120px is 90pt, plus the 1px border on each side.
+            var advance = await AdvanceAsync(
+                "<span style='display:inline-block;width:120px;border:1px solid black'></span>");
+
+            Assert.Equal(91.5, advance, 1);
+        }
+
+        [Fact]
+        public async Task BorderBoxDoesNotCountThePaddingAndBorderTwice()
+        {
+            // Under box-sizing: border-box the declared width ALREADY covers padding and border, and
+            // the line re-adds them either side of the content (leftSpacing/rightSpacing). Treating
+            // the declared width as a content width therefore counts them twice.
+            // Chrome 152: a border-box width:120px box with a 1px border advances exactly 90pt.
+            var advance = await AdvanceAsync(
+                "<span style='display:inline-block;width:120px;border:1px solid black;box-sizing:border-box'></span>");
+
+            Assert.Equal(90.0, advance, 1);
+        }
+
+        [Fact]
+        public async Task BorderBoxWithPaddingAlsoAdvancesItsDeclaredWidth()
+        {
+            // The same with padding rather than border, so the fix is not passing by only covering
+            // one of the two. Chrome 152: exactly 120pt (160px).
+            var advance = await AdvanceAsync(
+                "<span style='display:inline-block;width:160px;padding:0 10px;box-sizing:border-box'>Hi</span>");
+
+            Assert.Equal(120.0, advance, 1);
+        }
+
+        [Fact]
+        public async Task ContentWiderThanTheDeclaredWidthOverflowsRatherThanBeingPulledBack()
+        {
+            // Only ever forward — which is what `overflow: visible` means. The advance must be the
+            // content's, not the declared 15pt.
+            var declared = await AdvanceAsync(
+                "<span style='display:inline-block;width:20px'>Wider than the box</span>");
+            var auto = await AdvanceAsync(
+                "<span style='display:inline-block'>Wider than the box</span>");
+
+            Assert.Equal(auto, declared, 1);
+            Assert.True(declared > 15, $"content wider than the declared 15pt must not be pulled back, was {declared}");
+        }
+
+        [Fact]
+        public async Task APercentageWidthIsLeftAlone()
+        {
+            // A percentage resolves against a containing block this line does not know, so it is
+            // deliberately not handled here — asserted so the exclusion is deliberate rather than
+            // discovered later.
+            var percent = await AdvanceAsync("<span style='display:inline-block;width:50%'>Hi</span>");
+            var auto = await AdvanceAsync("<span style='display:inline-block'>Hi</span>");
+
+            Assert.Equal(auto, percent, 1);
+        }
+
+        /// <summary>
+        /// How far the text after <paramref name="inlineBlock"/> is pushed along the line, measured
+        /// from where it sits with nothing before it at all.
+        /// </summary>
+        private static async Task<double> AdvanceAsync(string inlineBlock)
+        {
+            var withBox = await AfterWordXAsync($"<div style='width:400pt'>{inlineBlock}<span id='a'>AFTER</span></div>");
+            var without = await AfterWordXAsync("<div style='width:400pt'><span id='a'>AFTER</span></div>");
+            return withBox - without;
+        }
+
+        private static async Task<double> AfterWordXAsync(string body)
+        {
+            var (root, _) = await LayoutAsync(Wrap(body));
+            return Descendants(FindById(root, "a")!)
+                .SelectMany(b => b.Words)
+                .Select(w => w.Left)
+                .DefaultIfEmpty(0)
+                .Min();
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -2537,6 +2537,12 @@ namespace PeachPDF.Html.Core.Dom
                     coordinates.CurrentX = lastLeftIntersectingFloatBox.ActualRight + lastLeftIntersectingFloatBox.ActualMarginRight + appliedLeftSpacing;
                 }
 
+                // Where b's own content box starts on this line, after every branch above that can
+                // establish it. An atomic inline-level box has to occupy its declared width from
+                // here, not just the width its words happened to measure - see the advance at the
+                // end of this child's placement.
+                var childContentStartX = coordinates.CurrentX;
+
                 if (b.Words.Count > 0)
                 {
                     var wrapNoWrapBox = false;
@@ -2952,6 +2958,43 @@ namespace PeachPDF.Html.Core.Dom
                 if (preShiftedForAtomicInset && ReferenceEquals(lineBeforeChild, coordinates.Line))
                 {
                     coordinates.CurrentY -= atomicTopInset;
+                }
+
+                // CSS 2.1 §10.3.9: an atomic inline-level box occupies its own used width on the
+                // line, not the width its content happened to measure. The flow otherwise just
+                // accumulates word widths, so `width` on a display: inline-block was inert and
+                // whatever followed sat flush against its text - a fixed-width label span stopped
+                // lining its values up, and an empty bordered inline-block used as a checkbox glyph
+                // took no room at all. The flex/grid path a few hundred lines up already does exactly
+                // this via `CurrentX = b.ClientRight`; this box's own geometry is never assigned on
+                // the plain inline path, so the declared width has to be resolved here instead.
+                //
+                // Only ever forward: content wider than the declared width overflows rather than
+                // being pulled back, which is what `overflow: visible` means. A percentage width is
+                // left alone - it resolves against a containing block this line does not know.
+                if (b.DerivedStyle.ActualDisplay is Keywords.InlineBlock
+                    && !ReferenceEquals(b, box)
+                    && CssValueParser.IsValidLength(b.Width)
+                    && !b.Width.EndsWith('%'))
+                {
+                    // childContentStartX is the CONTENT-box start (leftSpacing has been applied) and
+                    // rightSpacing is added below, so what belongs between them is the CONTENT width.
+                    // A declared width is that already under box-sizing: content-box, but under
+                    // border-box it also covers the padding and border those two spacings re-add, so
+                    // they come off here or they are counted twice.
+                    //
+                    // Not ActualBoxSizeIncludedWidth: that answers the opposite question - what a
+                    // declared size does NOT include - so it is padding+border for content-box and
+                    // ZERO for border-box, which is a no-op in exactly the case that needs adjusting.
+                    var declared = CssValueParser.ParseLength(b.Width, 0, b);
+
+                    if (b.BoxSizing.Value is BoxSizingMode.BorderBox)
+                    {
+                        declared -= b.ActualPaddingLeft + b.ActualPaddingRight
+                                    + b.ActualBorderLeftWidth + b.ActualBorderRightWidth;
+                    }
+
+                    coordinates.CurrentX = Math.Max(coordinates.CurrentX, childContentStartX + declared);
                 }
 
                 // A box whose content was all placed in an earlier fragmentainer is not re-closed here


### PR DESCRIPTION
CSS 2.1 §10.3.9: an atomic inline-level box occupies its own **used width** on the line, not the width its content happened to measure. The inline flow accumulates word widths, so `width` on a `display: inline-block` is inert today and whatever follows sits flush against the box's text.

Two shapes it breaks, both common:

```html
<!-- a fixed-width label: reserves only the width of "Hi", so a column of these stops lining up -->
<span style="display:inline-block;width:160px">Hi</span><span>AFTER</span>

<!-- a checkbox glyph: no content at all, so it takes no room whatsoever -->
<span style="display:inline-block;width:120px;border:1px solid"></span><span>AFTER</span>
```

## Measured against Chrome

How far `AFTER` is pushed along the line, in points past the container's edge:

| | Chrome 152 | `main` | this change |
| --- | --- | --- | --- |
| `width: 160px` (=120pt), content `Hi` | **120.0** | the width of "Hi" | 120.0 |
| `width: 120px` (=90pt), empty, 1px border | **91.5** | 0 | 91.5 |

Rendered headless and read with `pdftotext -bbox`. Both now agree with Chrome to within 0.1pt.

## Why it does not just reuse `b.ClientRight`

The flex/grid path a few hundred lines up already does exactly this, with `coordinates.CurrentX = b.ClientRight`, and reusing that was my first instinct. It cannot work here: on the plain inline path the child box's geometry is never assigned at all. Measured on a `width: 160px` inline-block at that point, `Location.X`, `Size.Width`, `ClientRight` and `ActualRight` are **all zero**.

So the declared width is resolved from the CSS at the advance point, against a `childContentStartX` captured after every branch that can establish the child's position on the line — including the left-float branch, which re-establishes it from scratch rather than adjusting it.

## Scope

- **Only ever forward.** `Math.Max`, so content wider than the declared width overflows rather than being pulled back — which is what `overflow: visible` means.
- **Percentages are left alone**, because a percentage resolves against a containing block this line does not know. There is a fixture asserting that, so it reads as a decision rather than an oversight.

## Tests

`InlineBlockDeclaredWidthTests`, four fixtures, the first two failing against `main`:

- the declared width reserved (Chrome's 120pt);
- the empty bordered box (Chrome's 91.5pt) — the case an accumulate-the-words flow gets most wrong;
- content wider than the declared width still overflowing, measured against the same markup with `width: auto`;
- a percentage width unaffected.

Each measures the *advance* — the difference between where the following text sits with the box and without it — rather than an absolute coordinate, so the assertions do not depend on the harness's own margins.

`dotnet build PeachPDF.Tests -t:Rebuild`: no new warnings. `dotnet test --framework net8.0`: 10,256 passed, 0 failed, 9 skipped.
