### PR TITLE
A float's auto width is shrink-to-fit

### DIFF
--- a/.claude/migration-notes/2026-09-08-a-floats-auto-width-is-now-shrink-to-fit.md
+++ b/.claude/migration-notes/2026-09-08-a-floats-auto-width-is-now-shrink-to-fit.md
@@ -1,0 +1,23 @@
+# A float's `auto` width is now shrink-to-fit
+
+CSS 2.1 §10.3.5 makes a floating box's `auto` width shrink-to-fit —
+`min(max-content, max(min-content, available))`. It was given the ordinary stretch-to-containing-block
+width instead, so an auto-width float filled its containing block.
+
+That leaves `float: right` nowhere to go: it landed at the left as a full-width bar, and the content
+that belongs beside it was pushed onto its own line. A bordered badge tucked into the top right of a
+cell rendered as a full-width band above the cell's text.
+
+Such a float now shrinks to its content and lands where a browser puts it. Measured against Chrome
+152, on a 300pt container:
+
+| | Chrome 152 | before | after |
+| --- | --- | --- | --- |
+| auto-width `float: right`, offset into the container | 257.9pt | 0 (full width) | at the right edge |
+| text after an auto-width `float: left` | beside it | on its own line | beside it |
+
+A float with a **declared** width is unaffected — placement was never the problem, and a declared
+width already landed on a browser's x to the point. An auto-width float is still never wider than
+its containing block.
+
+See [Display & Layout](../../docs/html-css-support.md#display--layout) in `docs/html-css-support.md`.

--- a/.claude/recent-fixes/2026-09-08-a-floats-auto-width-is-shrink-to-fit.md
+++ b/.claude/recent-fixes/2026-09-08-a-floats-auto-width-is-shrink-to-fit.md
@@ -1,0 +1,31 @@
+# A float's auto width is shrink-to-fit
+
+`GetBoxWidth` gave a floating box with `width: auto` the stretch-to-containing-block width. CSS 2.1
+§10.3.5 makes it shrink-to-fit. A float that fills its containing block leaves `float: right`
+nowhere to go, so it lands at the left as a full-width bar and the content that belongs beside it is
+pushed onto its own line.
+
+## What running it turned up
+
+- **Float PLACEMENT was never wrong, which is what made this hard to see.** A float with a DECLARED
+  width lands on Chrome's x to the point, so the placement machinery looks correct under any test
+  that declares a width. Only the auto measurement was wrong, and it is the auto case that a badge
+  or a pull-quote actually uses. There is a fixture pinning the declared-width case precisely so the
+  change is visibly scoped to `auto`.
+- **The formula is already in the tree.** `min(max-content, max(min-content, available))` is what
+  `GetFitContentWidth`/`GetMinContentWidth` compute between them, and the orthogonal-flow shrink in
+  `CssBox.cs` already uses that pair — so this is the existing §10.3.5 implementation reused rather
+  than a second one.
+- **Both measurements are OUTER widths**, so they compare against the stretch width as it stands and
+  the box's own decoration comes back off at the end — the same subtraction the plain auto branch
+  makes, and a no-op under `box-sizing: border-box`.
+- **A 1px border insets the float's own text by 0.75pt**, so "the text sits beside the float" cannot
+  be asserted as an equal baseline. The first version of that fixture compared tops to ±0.05pt and
+  failed against correct behaviour.
+
+## Evidence
+
+`FloatAutoWidthTests`, four fixtures: an auto `float: right` reaching the right of a 300pt container
+(Chrome: 257.9pt in), text sitting beside an auto `float: left` on the same line, a declared width
+unchanged at exactly 45pt, and an auto float never exceeding its containing block. The first two
+fail against `main`. Full suite green on net8.0 (10,256), 0 new build warnings.

--- a/src/PeachPDF.Tests/Integration/FloatAutoWidthTests.cs
+++ b/src/PeachPDF.Tests/Integration/FloatAutoWidthTests.cs
@@ -1,0 +1,88 @@
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Tests.TestSupport;
+using System.Linq;
+using System.Threading.Tasks;
+using static PeachPDF.Tests.TestSupport.LayoutHarness;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// CSS 2.1 §10.3.5: a floating box's <c>auto</c> width is shrink-to-fit,
+    /// <c>min(max-content, max(min-content, available))</c> — not stretch-to-containing-block.
+    /// <para>
+    /// Given the stretch width a float fills its containing block, which leaves <c>float: right</c>
+    /// nowhere to go: it lands at the left as a full-width bar and the content that belongs beside it
+    /// is pushed onto its own line. Float PLACEMENT was never wrong — a float with a DECLARED width
+    /// lands on a browser's x to the point — which is what makes this hard to see.
+    /// </para>
+    /// <para>
+    /// Chrome 152 on a 300pt container: an auto-width <c>float: right</c> badge sits 257.9pt in, and
+    /// text after an auto-width <c>float: left</c> badge sits beside it on the same line.
+    /// </para>
+    /// </summary>
+    public class FloatAutoWidthTests
+    {
+        [Fact]
+        public async Task AnAutoWidthFloatRightSitsAtTheRightEdge()
+        {
+            var (root, _) = await LayoutAsync(Wrap(
+                "<div style='width:300pt'><div id='f' style='float:right; border:1px solid black'>BADGE</div></div>"));
+
+            var badge = FindById(root, "f")!;
+            var width = badge.ActualRight - badge.Location.X;
+            var offsetInContainer = badge.Location.X - FindById(root, "f")!.ContainingBlock.Location.X;
+
+            Assert.True(width < 100, $"a shrink-to-fit badge must not fill its 300pt container, was {width:F1}pt wide");
+            Assert.True(offsetInContainer > 180,
+                $"float:right must reach the right of a 300pt container (Chrome: 257.9pt in), was {offsetInContainer:F1}pt");
+        }
+
+        [Fact]
+        public async Task ContentSitsBesideAnAutoWidthFloatLeft()
+        {
+            // The consequence a reader actually notices: a full-width float leaves no room beside it,
+            // so the text that belongs next to the badge drops onto its own line.
+            var (root, _) = await LayoutAsync(Wrap(
+                "<div style='width:300pt'><div style='float:left; border:1px solid black'>BADGE</div>"
+                + "<span id='t'>beside</span></div>"));
+
+            var badgeWords = Descendants(root).SelectMany(b => b.Words).Where(w => w.Text == "BADGE").ToList();
+            var beside = Descendants(FindById(root, "t")!).SelectMany(b => b.Words).First();
+
+            Assert.NotEmpty(badgeWords);
+
+            // Same line, not the same baseline — the badge's 1px border insets its own text by
+            // 0.75pt, so an exact comparison would be asserting the border away.
+            Assert.True(System.Math.Abs(badgeWords[0].Top - beside.Top) < 3,
+                $"the text must sit on the float's line: badge at y={badgeWords[0].Top}, text at y={beside.Top}");
+            Assert.True(beside.Left > badgeWords[0].Left,
+                "the text must sit to the RIGHT of the float, not under it");
+        }
+
+        [Fact]
+        public async Task ADeclaredFloatWidthIsUnchanged()
+        {
+            // The contrast case: only the auto measurement was wrong, so a declared width must land
+            // exactly where it always did.
+            var (root, _) = await LayoutAsync(Wrap(
+                "<div style='width:300pt'><div id='f' style='float:right; width:60px'>BADGE</div></div>"));
+
+            var badge = FindById(root, "f")!;
+            Assert.Equal(45.0, badge.ActualRight - badge.Location.X, 1);   // 60px at 96 CSS dpi
+        }
+
+        [Fact]
+        public async Task AnAutoWidthFloatIsNeverWiderThanItsContainingBlock()
+        {
+            // max(min-content, available) is bounded above by max-content, so a float whose content
+            // exceeds the container is clamped to the container rather than overflowing.
+            var (root, _) = await LayoutAsync(Wrap(
+                "<div style='width:120pt'><div id='f' style='float:left'>"
+                + "a considerably longer run of text than the container can hold</div></div>"));
+
+            var f = FindById(root, "f")!;
+            Assert.True(f.ActualRight - f.Location.X <= 120.5,
+                $"a float must not exceed its containing block, was {f.ActualRight - f.Location.X:F1}pt");
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -1667,7 +1667,27 @@ namespace PeachPDF.Html.Core.Dom
                 width = CssValueParser.ParseLength(box.Width, widthBasis, box);
             }
 
-            if (box is { Width: Keywords.Auto, Position.Value: not PositionMode.Absolute })
+            // CSS 2.1 §10.3.5: a FLOATING box's auto width is shrink-to-fit, not
+            // stretch-to-containing-block. Given the stretch width, a float fills its containing
+            // block, which leaves `float: right` nowhere to go — it lands at the left as a
+            // full-width bar and the content that belongs beside it is pushed onto its own line.
+            //
+            // Float PLACEMENT was never the problem, which is what makes this hard to see: a float
+            // with a DECLARED width lands on a browser's x to the point. Only the auto measurement
+            // was wrong.
+            //
+            // min(max-content, max(min-content, available)) is §10.3.5's own formula, and the same
+            // fit-content/min-content pair the orthogonal-flow shrink already uses. Both are outer
+            // widths, so they compare against the stretch width as it stands and the box's own
+            // decoration comes back off at the end — the same subtraction the plain auto branch
+            // makes, and a no-op under box-sizing: border-box.
+            if (box is { Width: Keywords.Auto, Position.Value: not (PositionMode.Absolute or PositionMode.Fixed) }
+                && box.IsFloated)
+            {
+                var fit = Math.Max(await GetFitContentWidth(g, box, width), await GetMinContentWidth(g, box));
+                width = fit - box.ActualBoxSizeIncludedWidth;
+            }
+            else if (box is { Width: Keywords.Auto, Position.Value: not PositionMode.Absolute })
             {
                 width -= box.ActualBoxSizeIncludedWidth;
             }


### PR DESCRIPTION
CSS 2.1 §10.3.5 makes a floating box's `auto` width shrink-to-fit — `min(max-content, max(min-content, available))`. `GetBoxWidth` gives it the ordinary stretch-to-containing-block width instead, so an auto-width float fills its containing block.

That leaves `float: right` nowhere to go: it lands at the left as a full-width bar, and the content that belongs beside it is pushed onto its own line.

```html
<div style="width:300pt">
  <div style="float:right; border:1px solid">BADGE</div>
</div>
```

## Measured against Chrome

| | Chrome 152 | `main` | this change |
| --- | --- | --- | --- |
| auto `float: right`, offset into a 300pt container | **257.9pt** | 0 — full width at the left | at the right edge |
| text after an auto `float: left` | beside it | on its own line | beside it |
| `float: right; width: 60px` | 45pt | 45pt | 45pt (unchanged) |

Rendered headless and read with `pdftotext -bbox`.

## Placement was never the problem

Worth stating, because it is what makes this hard to see: a float with a **declared** width lands on a browser's x to the point, so the placement machinery looks correct under any test that declares one. Only the `auto` measurement was wrong — and `auto` is what a badge or a pull-quote actually uses. There is a fixture pinning the declared-width case at exactly 45pt so the change is visibly scoped.

## The formula is already in the tree

`min(max-content, max(min-content, available))` is what `GetFitContentWidth` and `GetMinContentWidth` compute between them, and the orthogonal-flow shrink in `CssBox.cs` already uses that pair for §10.3.5. This reuses it rather than adding a second implementation.

Both are outer widths, so they compare against the stretch width as it stands and the box's own decoration comes back off at the end — the same subtraction the plain `auto` branch makes, and a no-op under `box-sizing: border-box`.

## Tests

`FloatAutoWidthTests`, four fixtures, the first two failing against `main`:

- an auto `float: right` reaching the right of a 300pt container;
- text sitting beside an auto `float: left` on the same line — the consequence a reader actually notices;
- a declared width unchanged at exactly 45pt;
- an auto float never exceeding its containing block, since `max(min-content, available)` is bounded above by max-content.

One note from writing them: a 1px border insets the float's own text by 0.75pt, so "the text sits beside the float" cannot be asserted as an equal baseline. My first version compared tops to ±0.05pt and failed against correct behaviour.

`dotnet build PeachPDF.Tests -t:Rebuild`: no new warnings. `dotnet test --framework net8.0`: 10,256 passed, 0 failed, 9 skipped.
