### PR TITLE
Resolve the document base once per tree, not once per reference

### DIFF
--- a/.claude/recent-fixes/2026-09-08-the-document-base-is-resolved-once-per-tree-not-once-per-reference.md
+++ b/.claude/recent-fixes/2026-09-08-the-document-base-is-resolved-once-per-tree-not-once-per-reference.md
@@ -1,0 +1,78 @@
+# The document base is resolved once per tree, not once per reference
+
+`<base href>` was looked up with a fresh `DomUtils.GetBoxByTagName(Root, "base")` at each of the three
+places that need it — `CommonUtils.ResolveAgainstDocumentBase` (images, stylesheets),
+`HtmlContainer.ResolveHref` (links, bookmark targets) and `PdfGenerator.HandleRunningElementLinks`
+(a link inside a `content: element()` running element). All three ask **per reference**, not per
+document, and that walk cannot short-circuit when the document declares no `<base>` at all: it visits
+every box in the tree before returning null. A running element's own `<a href>` is re-resolved on
+every page its element was selected onto, so the cost is `pages × links × boxes`.
+
+`HtmlContainerInt.DocumentBaseUri` is now the single place the rule lives, memoized against the
+tree's topmost box identity exactly like `_idIndex`.
+
+## What running it showed, that reading it did not
+
+A 188-page report (a real paginated document with one external link in its running footer) visits, in
+`GetBoxByTagName` alone:
+
+| | box visits |
+|---|---|
+| 188-page report, before | 5 525 506 |
+| 188-page report, after | 79 849 |
+| 7-page report, before | 19 127 |
+| 7-page report, after | 4 815 |
+
+**The sampled profile badly over-stated the time.** `dotnet-trace`'s sample profiler put
+`GetBoxByTagName` at 18.0 % inclusive of the render's CPU (2.38 s of 13.20 s across three renders),
+every bit of it under `HandleRunningElementLinks`. Removing it does not buy 18 %: it buys 5–7 %
+(188-page report, three interleaved rounds of 8 renders per side — median wall 4.07 s → 3.86 s,
+best-of-run CPU 3.77 s → 3.50 s). On a 1–7 page document the difference is below this machine's
+run-to-run noise. The reason is worth remembering before trusting a sampled percentage again — this
+function recurses to the depth of the box tree, so its stacks are the deepest in the whole render and
+each sample taken inside it costs proportionally more to walk. A frame's sampled share is inflated by
+its own stack depth. The box-visit count above is the honest measure of the work removed; the
+timing is what the work was actually worth.
+
+## Deliberately not done
+
+- **`<base>` is still ignored for a `<link>`/`@import` stylesheet.** Those load from inside
+  `DomParser.GenerateCssTree`, and `Root` is only assigned once `SetHtml` returns, so they reach
+  `ResolveAgainstDocumentBase` with a null root and fall back to the adapter's base URI. That is
+  long-standing behaviour and this change preserves it byte-for-byte. Whether the parse-time path
+  *should* honour `<base>` is a separate question. Note this does **not** apply to `<img>`: images are
+  resolved during layout (`CssBoxImage.MeasureWordsSize` → `ImageLoadHandler.SetImageFromPath`), by
+  which point `Root` is assigned and `<base>` is honoured — `FileUriLoaderIntegrationTests`
+  `.BaseHrefFileUri_UnderDefaultLoader_RoutesFileResourcesThroughAdapter` is the proof, since it
+  reaches its `pic.png` only through `<base href>`. Do not read the null-root early return as
+  "`<base>` for images is unimplemented".
+- **The null-root early return is a fast path, not a correctness guard.** Removing it would store a
+  null key, and the next read against a real tree would fail `ReferenceEquals` and re-walk. The key
+  already handles it; `DomUtils.GetBoxByTagName` is null-safe too.
+- **`RAdapter.BaseUri` is not frozen into the memo.** It is a cheap property on the adapter, not a
+  tree walk, and re-reading it keeps the fallback live rather than fixed at first access. The
+  *declared* base is memoized as an already-parsed `RUri`, so a document that has one does not
+  re-parse it per reference either.
+- No change to `new RUri(href)`'s exception behaviour for a malformed `<base href>`: it is still
+  constructed at the same point relative to every caller's own work, and because the memo key is only
+  committed afterwards, a malformed base throws on every read rather than just the first.
+
+## Evidence
+
+- `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings.
+- Full net8.0 suite: 10 258 passed. One pre-existing failure unrelated to this change,
+  `FontSynthesisIntegrationTests.ObliqueWithExplicitAngle_RegularOnlyFamily_UsesDeclaredAngleNotFixedDefault`:
+  it builds its expected substring with `Math.Sin(...).ToString("0.####")`, i.e. **current**-culture
+  formatting, and looks for it in a PDF that writes numbers invariant, so it only passes on a
+  period-decimal culture. It fails identically on unmodified `main` here and passes there under
+  `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1`.
+- Diff coverage: every executable changed line is hit — `DocumentBaseUriTests` covers the no-document,
+  no-`<base>`, declared-`<base>`, blank-`<base>`, memoized-read and second-document paths, and
+  `RunningElementLinksAndTaggingIntegrationTests.RunningElementLink_RelativeHref_ResolvesAgainstTheDocumentBase`
+  asserts the written `/URI` action is base-resolved rather than raw, once per page.
+- Each new test was checked for discrimination, not just coverage:
+  `WithinOneTree_TheBaseIsResolvedOnlyOnce` fails when the memo is forced to always re-walk (verified
+  by patching the key to `if (true)`), `ASecondDocumentReplacesTheFirstOnesBase` fails if it never
+  invalidates, and `WithABlankBaseHref_FallsBackToTheAdapterBaseUri` fails if the whitespace check is
+  dropped (`new RUri("   ")` throws). `WithNoDocumentAtAll_FallsBackToTheAdapterBaseUri` is coverage
+  of the early return rather than proof of it, for the reason given above.

--- a/src/PeachPDF.Tests/Html/Core/DocumentBaseUriTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/DocumentBaseUriTests.cs
@@ -1,0 +1,104 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Utils;
+using PeachPDF.Network;
+using PeachPDF.Tests.TestSupport;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Html.Core
+{
+    /// <summary>
+    /// Coverage for <see cref="HtmlContainerInt.DocumentBaseUri"/> — the one place the
+    /// "<c>&lt;base href&gt;</c>, else the adapter's base URI" rule lives, read by image/stylesheet
+    /// resolution (<c>CommonUtils.ResolveAgainstDocumentBase</c>), link resolution
+    /// (<c>HtmlContainer.ResolveHref</c>) and running-element links
+    /// (<c>PdfGenerator.HandleRunningElementLinks</c>). The <c>&lt;base&gt;</c> lookup behind it is
+    /// memoized per box tree, so both the fresh-tree and the already-resolved read are exercised here,
+    /// as is a second document replacing the first one's answer.
+    /// </summary>
+    public class DocumentBaseUriTests
+    {
+        private static readonly RUri LoaderBase = new("https://loader.test/docs/page.html");
+
+        private static HtmlContainerInt NewContainer() =>
+            new(new PdfSharpAdapter
+                {
+                    PixelsPerPoint = 1.0,
+                    NetworkLoader = new InMemoryNetworkLoader(LoaderBase, string.Empty)
+                });
+
+        private static string Document(string head) =>
+            $"<!DOCTYPE html><html><head>{head}</head><body>Body</body></html>";
+
+        [Fact]
+        public void WithNoDocumentAtAll_FallsBackToTheAdapterBaseUri()
+        {
+            // Root is still null before SetHtml — the state a <link>/@import stylesheet also sees, since
+            // those load from inside GenerateCssTree. (An <img> does not: images resolve during layout.)
+            var container = NewContainer();
+
+            Assert.Equal(LoaderBase.AbsoluteUri, container.DocumentBaseUri?.AbsoluteUri);
+        }
+
+        [Fact]
+        public async Task WithNoBaseElement_FallsBackToTheAdapterBaseUri()
+        {
+            var container = NewContainer();
+            await container.SetHtml(Document(""), null);
+
+            Assert.Equal(LoaderBase.AbsoluteUri, container.DocumentBaseUri?.AbsoluteUri);
+        }
+
+        [Fact]
+        public async Task WithABaseElement_UsesTheDeclaredBase()
+        {
+            var container = NewContainer();
+            await container.SetHtml(Document("<base href='https://example.test/other/'>"), null);
+
+            Assert.Equal("https://example.test/other/", container.DocumentBaseUri?.AbsoluteUri);
+        }
+
+        [Fact]
+        public async Task WithABlankBaseHref_FallsBackToTheAdapterBaseUri()
+        {
+            var container = NewContainer();
+            await container.SetHtml(Document("<base href='   '>"), null);
+
+            Assert.Equal(LoaderBase.AbsoluteUri, container.DocumentBaseUri?.AbsoluteUri);
+        }
+
+        [Fact]
+        public async Task WithinOneTree_TheBaseIsResolvedOnlyOnce()
+        {
+            var container = NewContainer();
+            await container.SetHtml(Document("<base href='https://example.test/other/'>"), null);
+
+            Assert.Equal("https://example.test/other/", container.DocumentBaseUri?.AbsoluteUri);
+
+            // Nothing edits a <base href> after the parse (HtmlTag.SetAttribute's only caller is the
+            // dir="auto" pre-pass), so doing it here is not a supported scenario - it is the only way to
+            // observe from the outside that the resolution really is memoized per tree rather than
+            // re-walked per reference. A read that picked this up would mean the walk is still happening.
+            DomUtils.GetBoxByTagName(container.Root!, "base")!.HtmlTag!.SetAttribute("href", "https://changed.test/");
+
+            Assert.Equal("https://example.test/other/", container.DocumentBaseUri?.AbsoluteUri);
+        }
+
+        [Fact]
+        public async Task ASecondDocumentReplacesTheFirstOnesBase()
+        {
+            var container = NewContainer();
+            await container.SetHtml(Document("<base href='https://first.test/a/'>"), null);
+            Assert.Equal("https://first.test/a/", container.DocumentBaseUri?.AbsoluteUri);
+
+            // A re-parse produces a new tree, which is what invalidates the memo — a second document
+            // must not keep answering with the first one's base.
+            await container.SetHtml(Document("<base href='https://second.test/b/'>"), null);
+            Assert.Equal("https://second.test/b/", container.DocumentBaseUri?.AbsoluteUri);
+
+            await container.SetHtml(Document(""), null);
+            Assert.Equal(LoaderBase.AbsoluteUri, container.DocumentBaseUri?.AbsoluteUri);
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/RunningElementLinksAndTaggingIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/RunningElementLinksAndTaggingIntegrationTests.cs
@@ -2,7 +2,10 @@ using PeachPDF.PdfSharpCore;
 using PeachPDF.PdfSharpCore.Pdf;
 using PeachPDF.PdfSharpCore.Pdf.Structure;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace PeachPDF.Tests.Integration
@@ -84,6 +87,48 @@ namespace PeachPDF.Tests.Integration
                 Assert.True(doc.Pages[i].Annotations.Count > 0,
                     $"page {i + 1} is missing the running header's anchor-link annotation");
             }
+        }
+
+        [Fact]
+        public async Task RunningElementLink_RelativeHref_ResolvesAgainstTheDocumentBase()
+        {
+            // The external-URL branch of HandleRunningElementLinks resolves a relative href against the
+            // document base (its own <base href>, else the adapter's) - and does so once per page the
+            // running element was selected onto, which is why that base is memoized on the container
+            // rather than re-walked. A relative href that reached the annotation unresolved would be
+            // unusable to a reader, so assert the written /URI action, not just that an annotation exists.
+            var html = """
+                <!DOCTYPE html><html><head>
+                <base href="https://example.test/docs/">
+                <style>
+                @page { size: a6; margin: 12mm; }
+                @page { @top-center { content: element(heading); } }
+                h1.running { position: running(heading); margin: 0; font-size: 9pt; }
+                p { line-height: 1.6; }
+                </style></head><body>
+                <h1 class="running">Chapter <a href="chapter-one.html">One</a></h1>
+                """ +
+                string.Concat(Enumerable.Repeat("<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>", 80)) +
+                """
+                </body></html>
+                """;
+
+            var doc = await new PdfGenerator().GeneratePdf(html, PageSize.A6);
+
+            Assert.True(doc.PageCount > 1, "fixture does not paginate, so it asserts nothing");
+
+            var ms = new MemoryStream();
+            doc.Save(ms);
+            var pdfText = Encoding.Latin1.GetString(ms.ToArray());
+
+            Assert.DoesNotContain("/URI(chapter-one.html)", pdfText);
+
+            // One resolved annotation per page, which is also what makes the base worth memoizing: this
+            // is the href re-resolved for every page the running element was selected onto. Counting the
+            // occurrences (rather than asserting one exists) additionally rules out a single match that
+            // came from the main-tree loop, should the running element ever leak into normal flow.
+            var resolved = Regex.Matches(pdfText, Regex.Escape("/URI(https://example.test/docs/chapter-one.html)")).Count;
+            Assert.Equal(doc.PageCount, resolved);
         }
 
         [Fact]

--- a/src/PeachPDF/Html/Core/HtmlContainerInt.cs
+++ b/src/PeachPDF/Html/Core/HtmlContainerInt.cs
@@ -23,6 +23,7 @@ using PeachPDF.Html.Core.Handlers;
 using PeachPDF.Html.Core.Paint;
 using PeachPDF.Html.Core.Parse;
 using PeachPDF.Html.Core.Utils;
+using PeachPDF.Network;
 using PeachPDF.PdfSharpCore.Drawing;
 using System;
 using System.Collections.Generic;
@@ -129,6 +130,16 @@ namespace PeachPDF.Html.Core
         private Dictionary<string, CssBox>? _idIndex;
 
         private CssBox? _idIndexRoot;
+
+        /// <summary>
+        /// The document's own resolved <c>&lt;base href&gt;</c> backing <see cref="DocumentBaseUri"/>, or
+        /// null when it declares none - a document's <c>&lt;base&gt;</c> does not change mid-pass, and a
+        /// re-parse produces a new tree, so this is memoized against the tree's topmost box identity in
+        /// the same shape as <see cref="_idIndex"/>.
+        /// </summary>
+        private RUri? _documentBase;
+
+        private CssBox? _documentBaseRoot;
 
         #endregion
 
@@ -760,6 +771,58 @@ namespace PeachPDF.Html.Core
         internal WritingMode RootWritingMode { get; set; } = WritingMode.HorizontalTb;
 
         /// <summary>
+        /// The URI relative references in this document resolve against: its own <c>&lt;base href&gt;</c>
+        /// when it declares a usable one, else <see cref="RAdapter.BaseUri"/>. The single place that rule
+        /// lives - <see cref="CommonUtils.ResolveAgainstDocumentBase"/> (images, stylesheets),
+        /// <c>HtmlContainer.ResolveHref</c> (links, bookmark targets) and
+        /// <c>PdfGenerator.HandleRunningElementLinks</c> all read it from here.
+        /// <para>
+        /// The <c>&lt;base&gt;</c> lookup is memoized per box tree because it is a
+        /// <see cref="DomUtils.GetBoxByTagName"/> walk that cannot short-circuit when the document
+        /// declares no <c>&lt;base&gt;</c> at all - it visits every box in the tree - while callers ask
+        /// once per reference rather than once per document: a link inside a css-gcpm-3 running element is
+        /// re-resolved on every page its element was selected onto. Rendering a 188-page report with one
+        /// such link spent 5 525 506 box visits in that walk; it now spends 79 849, worth about 5% of the
+        /// whole render. The <see cref="RAdapter.BaseUri"/> fallback is deliberately re-read on each
+        /// access rather than frozen into the memo - it is a cheap property on the adapter, not a walk,
+        /// and a document that declares no base should keep answering whatever the adapter currently says.
+        /// </para>
+        /// <para>
+        /// The memo is keyed on <see cref="Root"/>'s object identity, which is replaced wholesale by every
+        /// re-parse (<see cref="SetHtml"/> clears first, and the <c>@container</c> convergence loop and
+        /// <c>PdfGenerator.SetContent</c>'s shrink-to-fit path both go through it) - not on
+        /// <see cref="Dom.CssBox.Id"/>, which is deliberately stable across those two back-to-back parses.
+        /// Unlike <see cref="_idIndex"/>, which walks up from an arbitrary box so that it also works while
+        /// <see cref="Root"/> is still null mid-parse, this gives up on a null root: see below.
+        /// </para>
+        /// </summary>
+        internal RUri? DocumentBaseUri
+        {
+            get
+            {
+                // Root is only assigned once SetHtml returns, so a <link>/@import stylesheet - loaded from
+                // inside DomParser.GenerateCssTree - resolves with no document base and falls back to the
+                // adapter's. Long-standing behaviour, kept as-is. (An <img> is not in that group: images
+                // are resolved during layout, via CssBoxImage.MeasureWordsSize, by which point Root is
+                // assigned and <base> is honoured.) The early return is only a fast path - the memo key
+                // already handles a null root, since the next read against a real tree fails
+                // ReferenceEquals and re-walks.
+                if (Root is null) return Adapter.BaseUri;
+
+                if (!ReferenceEquals(_documentBaseRoot, Root))
+                {
+                    var href = DomUtils.GetBoxByTagName(Root, "base")?.HtmlTag?.TryGetAttribute("href", "");
+                    // A malformed href still throws from exactly where it did before - and, since the key
+                    // is only committed afterwards, from every later read too rather than just the first.
+                    _documentBase = string.IsNullOrWhiteSpace(href) ? null : new RUri(href);
+                    _documentBaseRoot = Root;
+                }
+
+                return _documentBase ?? Adapter.BaseUri;
+            }
+        }
+
+        /// <summary>
         /// Metadata extracted from the HTML head elements.
         /// </summary>
         internal HtmlDocumentMetadata? DocumentMetadata { get; private set; }
@@ -851,6 +914,10 @@ namespace PeachPDF.Html.Core
             Root.Dispose();
             Root = null;
             DocumentLanguage = null;
+            // Dropped with the tree it was keyed on, so a disposed tree is not kept reachable by the memo
+            // until the next document happens to read through it.
+            _documentBase = null;
+            _documentBaseRoot = null;
             ClearNamedStrings();
             ClearRunningElements();
             ClearNamedPageElements();

--- a/src/PeachPDF/Html/Core/Utils/CommonUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/CommonUtils.cs
@@ -329,18 +329,7 @@ namespace PeachPDF.Html.Core.Utils
         /// <param name="overrideBaseUri">a base URI that takes precedence over the document's own base, if any</param>
         public static RUri? ResolveAgainstDocumentBase(HtmlContainerInt htmlContainer, string src, RUri? overrideBaseUri = null)
         {
-            RUri? baseUri;
-
-            if (overrideBaseUri is not null)
-            {
-                baseUri = overrideBaseUri;
-            }
-            else
-            {
-                var baseElement = DomUtils.GetBoxByTagName(htmlContainer.Root, "base");
-                var baseHref = baseElement?.HtmlTag?.TryGetAttribute("href", "");
-                baseUri = string.IsNullOrWhiteSpace(baseHref) ? htmlContainer.Adapter.BaseUri : new RUri(baseHref);
-            }
+            var baseUri = overrideBaseUri ?? htmlContainer.DocumentBaseUri;
 
             try
             {

--- a/src/PeachPDF/HtmlContainer.cs
+++ b/src/PeachPDF/HtmlContainer.cs
@@ -15,7 +15,6 @@ using PeachPDF.CSS;
 using PeachPDF.Html.Core;
 using PeachPDF.Html.Core.Dom;
 using PeachPDF.Html.Core.Entities;
-using PeachPDF.Html.Core.Utils;
 using PeachPDF.Network;
 using PeachPDF.PdfSharpCore.Drawing;
 using PeachPDF.Utilities;
@@ -201,9 +200,9 @@ namespace PeachPDF
         /// </summary>
         internal string ResolveHref(string href)
         {
-            var baseElement = DomUtils.GetBoxByTagName(HtmlContainerInt.Root, "base");
-            var baseUrl = baseElement?.HtmlTag?.TryGetAttribute("href", "") ?? "";
-            var baseUri = string.IsNullOrWhiteSpace(baseUrl) ? HtmlContainerInt.Adapter.BaseUri : new RUri(baseUrl);
+            // Read per link, so the document base has to be memoized rather than re-walked - see
+            // HtmlContainerInt.DocumentBaseUri.
+            var baseUri = HtmlContainerInt.DocumentBaseUri;
 
             return href.StartsWith('#') || baseUri is null ? href : new RUri(baseUri, href).AbsoluteUri;
         }

--- a/src/PeachPDF/PdfGenerator.cs
+++ b/src/PeachPDF/PdfGenerator.cs
@@ -946,9 +946,10 @@ namespace PeachPDF
                         }
                         else
                         {
-                            var baseElement = DomUtils.GetBoxByTagName(container.HtmlContainerInt.Root, "base");
-                            var baseUrl = baseElement?.HtmlTag?.TryGetAttribute("href", "");
-                            var baseUri = string.IsNullOrWhiteSpace(baseUrl) ? container.HtmlContainerInt.Adapter.BaseUri : new RUri(baseUrl);
+                            // Read once per external link per page (a running element's own link is
+                            // re-resolved for every page it was selected onto), so the document base has
+                            // to be memoized rather than re-walked - see HtmlContainerInt.DocumentBaseUri.
+                            var baseUri = container.HtmlContainerInt.DocumentBaseUri;
                             var resolvedHref = baseUri is null ? href : new RUri(baseUri, href).AbsoluteUri;
 
                             annotation = document.Pages[pageIndex].AddWebLink(new PdfRectangle(xRect), resolvedHref);


### PR DESCRIPTION
## Resolve the document base once per tree, not once per reference

`<base href>` is looked up with a fresh `DomUtils.GetBoxByTagName(Root, "base")` at each of the three
places that need it:

- `CommonUtils.ResolveAgainstDocumentBase` — images, stylesheets
- `HtmlContainer.ResolveHref` — links, bookmark targets
- `PdfGenerator.HandleRunningElementLinks` — a link inside a `content: element()` running element

All three ask **per reference**, not per document, and the walk cannot short-circuit when the
document declares no `<base>` at all — it visits every box in the tree before returning null. A
running element's own `<a href>` is re-resolved on every page its element was selected onto, so the
cost is `pages × links × boxes`.

This adds `HtmlContainerInt.DocumentBaseUri` as the single place that rule lives — memoized against
the tree's topmost box identity, in the same shape as `_idIndex` — and routes all three call sites
through it. `CommonUtils`' own doc comment already claimed to be "the single place this resolution
rule lives for images and stylesheets alike"; now it is one for links too.

### What it removes

Box visits inside `GetBoxByTagName` for one render, counted with a temporary counter, so this figure
is deterministic and machine-independent:

| Document | Before | After |
|---|---|---|
| 188-page paginated report, one link in its running footer | 5 525 506 | 79 849 |
| 7-page report | 19 127 | 4 815 |

In wall time that is **5–7 %** off the 188-page report (net10.0, Release, three interleaved rounds of
8 renders per side: median wall 4.07 s → 3.86 s, best-of-run process CPU 3.77 s → 3.50 s). On a 1–7
page document the difference is below this machine's run-to-run noise.

One caveat on profiling, since it would be easy to over-claim here: `dotnet-trace`'s sample profiler
puts `GetBoxByTagName` at 18.0 % inclusive of the render's CPU, all of it under
`HandleRunningElementLinks`. That figure is inflated — the function recurses to the depth of the box
tree, so its stacks are the deepest in the render and each sample taken inside it costs more to walk,
which inflates the frame's sampled share. The box-visit count is the honest measure of the work
removed; 5–7 % is what it was worth.

### Behaviour

Unchanged, deliberately. Three things worth naming:

- **`<base>` is still ignored for a `<link>`/`@import` stylesheet.** Those load from inside
  `DomParser.GenerateCssTree`, and `Root` is only assigned once `SetHtml` returns, so they reach
  `ResolveAgainstDocumentBase` with a null root and fall back to the adapter's base URI — existing
  behaviour, preserved. This does *not* apply to `<img>`, which resolves during layout with `Root`
  assigned and honours `<base>` today (`FileUriLoaderIntegrationTests.BaseHrefFileUri_UnderDefault
  LoaderRoutesFileResourcesThroughAdapter` reaches its image only through `<base href>`). The
  null-root early return in the getter is a fast path, not a correctness guard: the key already
  handles a null root, since the next read against a real tree fails `ReferenceEquals` and re-walks.
- **`RAdapter.BaseUri` is not frozen into the memo** — it is a cheap property on the adapter, not a
  walk, so a document with no `<base>` keeps answering whatever the adapter currently says. The
  *declared* base is memoized as an already-parsed `RUri`, so a document that has one does not
  re-parse it per reference either.
- **A malformed `<base href>`** still throws from the same point relative to each caller's own work,
  and — because the memo key is committed only after the `RUri` is constructed — from every later
  read too, not just the first.

`Clear()` now also drops the two memo fields, so a re-parse (the `@container` convergence loop, or
`SetContent`'s shrink-to-fit path) does not leave the previous, already-disposed tree reachable.

### Tests

- `Html/Core/DocumentBaseUriTests.cs` — no document at all, no `<base>`, a declared `<base>`, a
  whitespace-only `href`, a memoized read, and a second `SetHtml` replacing the first document's
  answer.
- `RunningElementLinksAndTaggingIntegrationTests.RunningElementLink_RelativeHref_ResolvesAgainstTheDocumentBase`
  — a relative `href` inside a running element, asserting the written `/URI` action is base-resolved
  rather than raw, and that it appears once per page. That branch had no base-resolution coverage.

Each was checked for discrimination rather than just coverage:
`WithinOneTree_TheBaseIsResolvedOnlyOnce` fails when the memo key is patched to always re-walk,
`ASecondDocumentReplacesTheFirstOnesBase` fails if it never invalidates, and
`WithABlankBaseHref_FallsBackToTheAdapterBaseUri` fails if the whitespace check is dropped.

Full net8.0 suite: 10 258 passed; every executable changed line is covered.
`dotnet build PeachPDF.slnx -t:Rebuild` is warning-free on both TFMs.

One pre-existing failure is unrelated and reproduces on unmodified `main`:
`FontSynthesisIntegrationTests.ObliqueWithExplicitAngle_RegularOnlyFamily_UsesDeclaredAngleNotFixedDefault`
builds its expected substring with `Math.Sin(...).ToString("0.####")` — current-culture formatting —
and looks for it in a PDF that writes numbers invariant, so it only passes on a period-decimal
culture. It passes here under `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1`. Happy to fix that in a
separate PR if you want it.
