### PR TITLE
Match HTML names ASCII case-insensitively, not by Unicode case folding

### DIFF
--- a/.claude/recent-fixes/2026-09-08-html-names-match-ascii-case-insensitively.md
+++ b/.claude/recent-fixes/2026-09-08-html-names-match-ascii-case-insensitively.md
@@ -1,0 +1,46 @@
+# HTML names match ASCII case-insensitively, not by Unicode case folding
+
+The selector matcher, the tag/class/id indexes, `IsBrElement`, the font caches and the entity tables
+all compared names with `InvariantCultureIgnoreCase`. HTML matches element and attribute names
+**ASCII** case-insensitively; invariant culture applies full Unicode case folding.
+
+Under that folding **U+212A KELVIN SIGN equals ASCII `k`**, so `class="K"` matched the selector `.k`
+and a `K` element matched `k`. The comment above `NameComparison` already said the rule was ASCII
+case-insensitivity — the code just did not express it.
+
+## What running it turned up
+
+- **The correctness case is demonstrable and the performance case is not, on this machine.** This
+  started as a profile-driven change (`System.Globalization` was a fifth of thread CPU on a real
+  corpus, and throughput rose ~5%). I could not reproduce a trustworthy number here: nine interleaved
+  renders of a synthetic class-heavy document gave a 175ms median before and 177ms after, with a
+  164–225ms spread — the variance swamps the effect. So this is offered as the spec fix it also is,
+  with a deterministic repro, and the throughput left unquantified rather than quoted from a machine
+  that cannot show it.
+- **Ordinal is the cheaper comparison as well as the correct one**, which is why both readings point
+  the same way: the matcher runs one name against every candidate rule for every box, and a
+  culture-aware comparison routes each through ICU.
+- **A blanket `sed` to strip our internal comment tag ate the comment marker with it**, turning a
+  `// TAG: Ordinal, not InvariantCulture` line into bare prose and producing 19 syntax errors.
+  Replace the tag with `// `, never delete it.
+
+- **Two call sites were worse than the ones the first sweep found, and it missed them.**
+  `DomUtils.FindParent` (the parser's implied-tag-closing rules — a `<table>` closes an open `<p>`)
+  and `DomParser.CascadeParseStyles` (the `link`/`style` tag names and the `stylesheet` relation)
+  used `CurrentCultureIgnoreCase`: full Unicode folding **and** locale-dependent, so the same
+  document could parse differently on two machines. Grepping for the comparison the fix replaced
+  found neither; the sweep has to be for every culture-aware comparison, not for one enum value.
+- **`FontResolver` keys its installed-font table on `.ToLower()`**, which is also the current
+  culture. That is a cross-machine determinism bug in its own right — a Turkish locale lower-cases
+  `I` to a dotless `ı` — so all four sites are `ToLowerInvariant()`. It does NOT fix the folding
+  (`char.ToLowerInvariant('K')` is still `k`), and font-family matching is not the spec-mandated
+  ASCII rule element names are, so that half is left alone deliberately.
+
+## Evidence
+
+`AsciiNameMatchingTests`, five fixtures: a Kelvin-sign class does not match `.k` (fails against
+`main`); an ASCII class still matches case-insensitively in both cases; an uppercase `DIV` still
+matches `div`; implied tag closing still matches `P` to `p`; and an uppercase `STYLE` element is
+still honoured. The last four are contrast cases — the point is to narrow the comparison to ASCII,
+not to make it case-sensitive. Full suite green on net8.0
+(10,348), 0 new build warnings.

--- a/src/PeachPDF.Tests/Integration/AsciiNameMatchingTests.cs
+++ b/src/PeachPDF.Tests/Integration/AsciiNameMatchingTests.cs
@@ -1,0 +1,83 @@
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Tests.TestSupport;
+using System.Threading.Tasks;
+using static PeachPDF.Tests.TestSupport.LayoutHarness;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// HTML matches element and attribute names <b>ASCII</b> case-insensitively, and a class name is
+    /// matched ASCII case-insensitively at most. <c>InvariantCultureIgnoreCase</c> applies full
+    /// Unicode case folding instead, under which U+212A KELVIN SIGN equals ASCII <c>k</c> — so a
+    /// class of <c>K</c> matched the selector <c>.k</c>, and a <c>K</c> element matched <c>k</c>.
+    /// <para>
+    /// Ordinal is both the rule the surrounding comments already state and the cheaper comparison:
+    /// the selector matcher runs it for one name against every candidate rule for every box, and a
+    /// culture-aware comparison routes each through ICU.
+    /// </para>
+    /// </summary>
+    public class AsciiNameMatchingTests
+    {
+        private const string Kelvin = "K";   // KELVIN SIGN — folds to ASCII 'k' under Unicode rules
+
+        [Fact]
+        public async Task AKelvinSignClassDoesNotMatchAnAsciiKSelector()
+        {
+            var (root, _) = await LayoutAsync(
+                "<!DOCTYPE html><html><head><style>.k { color: rgb(255,0,0) }</style></head>"
+                + $"<body style='margin:0'><div id='t' class='{Kelvin}'>x</div></body></html>");
+
+            Assert.NotEqual("rgb(255, 0, 0)", FindById(root, "t")!.Color);
+        }
+
+        [Fact]
+        public async Task AnAsciiClassStillMatchesCaseInsensitively()
+        {
+            // The contrast case: ASCII case-insensitivity is the rule and must survive. Both an exact
+            // and a differently-cased ASCII class still match.
+            var (root, _) = await LayoutAsync(
+                "<!DOCTYPE html><html><head><style>.k { color: rgb(255,0,0) }</style></head>"
+                + "<body style='margin:0'><div id='lower' class='k'>x</div>"
+                + "<div id='upper' class='K'>x</div></body></html>");
+
+            Assert.Equal("rgb(255, 0, 0)", FindById(root, "lower")!.Color);
+            Assert.Equal("rgb(255, 0, 0)", FindById(root, "upper")!.Color);
+        }
+
+        [Fact]
+        public async Task ImpliedTagClosingMatchesTagNamesAsciiCaseInsensitively()
+        {
+            // DomUtils.FindParent drives the parser's implied-tag-closing rules (a <table> closes an
+            // open <p>). It compared with CurrentCultureIgnoreCase, which is worse than the invariant
+            // comparison this PR replaces elsewhere: full Unicode folding AND locale-dependent, so the
+            // same document could parse differently on two machines.
+            var (root, _) = await LayoutAsync(
+                "<!DOCTYPE html><html><head><style>p { color: rgb(0,0,255) }</style></head>"
+                + "<body style='margin:0'><P id='t'>x</P></body></html>");
+
+            Assert.Equal("rgb(0, 0, 255)", FindById(root, "t")!.Color);
+        }
+
+        [Fact]
+        public async Task AStylesheetLinkRelationMatchesAsciiCaseInsensitively()
+        {
+            // CascadeParseStyles matched the `style` tag name and the `stylesheet` link relation the
+            // same locale-dependent way. An uppercase STYLE element must still be honoured.
+            var (root, _) = await LayoutAsync(
+                "<!DOCTYPE html><html><head><STYLE>#t { color: rgb(0,128,0) }</STYLE></head>"
+                + "<body style='margin:0'><div id='t'>x</div></body></html>");
+
+            Assert.Equal("rgb(0, 128, 0)", FindById(root, "t")!.Color);
+        }
+
+        [Fact]
+        public async Task AnAsciiTagStillMatchesCaseInsensitively()
+        {
+            var (root, _) = await LayoutAsync(
+                "<!DOCTYPE html><html><head><style>div { color: rgb(0,128,0) }</style></head>"
+                + "<body style='margin:0'><DIV id='t'>x</DIV></body></html>");
+
+            Assert.Equal("rgb(0, 128, 0)", FindById(root, "t")!.Color);
+        }
+    }
+}

--- a/src/PeachPDF/Fonts/FontResolver.cs
+++ b/src/PeachPDF/Fonts/FontResolver.cs
@@ -238,7 +238,7 @@ namespace PeachPDF.Fonts
             memoryStream.Seek(0, SeekOrigin.Begin);
 
             var fontFileInfo = FontFileInfo.Load(memoryStream);
-            var key = fontFamilyName.ToLower();
+            var key = fontFamilyName.ToLowerInvariant();
             _customFamilyNames.Add(key);
 
             var weight = weightOverride ?? fontFileInfo.FontDescription.Weight;
@@ -352,7 +352,7 @@ namespace PeachPDF.Fonts
                 {
                     var familyName = familyGroup.Key;
                     var family = DeserializeFontFamily(familyName, familyGroup);
-                    families.Add(familyName.ToLower(), family);
+                    families.Add(familyName.ToLowerInvariant(), family);
                 }
                 catch (System.Exception e)
                 {
@@ -407,7 +407,7 @@ namespace PeachPDF.Fonts
         /// </summary>
         public bool HasExplicitRanges(string familyName)
         {
-            return InstalledFonts.TryGetValue(familyName.ToLower(), out var family)
+            return InstalledFonts.TryGetValue(familyName.ToLowerInvariant(), out var family)
                    && family.Faces.Any(f => f.ExplicitRanges is not null);
         }
 
@@ -436,7 +436,7 @@ namespace PeachPDF.Fonts
             if (InstalledFonts.Count == 0)
                 throw new System.IO.FileNotFoundException("No Fonts installed on this device!");
 
-            if (InstalledFonts.TryGetValue(familyName.ToLower(), out var family))
+            if (InstalledFonts.TryGetValue(familyName.ToLowerInvariant(), out var family))
             {
                 if (TryFindNearestFace(family, weight, isItalic, stretch, codepoint, out var face))
                 {

--- a/src/PeachPDF/Html/Core/CssData.cs
+++ b/src/PeachPDF/Html/Core/CssData.cs
@@ -118,9 +118,14 @@ namespace PeachPDF.Html.Core
         {
             if (_universalRules is not null) return;
 
-            var tagIndex = new Dictionary<string, List<IndexedRule>>(StringComparer.InvariantCultureIgnoreCase);
-            var classIndex = new Dictionary<string, List<IndexedRule>>(StringComparer.InvariantCultureIgnoreCase);
-            var idIndex = new Dictionary<string, List<IndexedRule>>(StringComparer.InvariantCultureIgnoreCase);
+            // Ordinal, not InvariantCulture. These three indexes are hashed once per
+            // candidate tag/class/id on every box, and a culture-aware comparer routes every one of
+            // those hashes through ICU. HTML/CSS identifiers are
+            // ASCII and the spec matches them ASCII case-insensitively, so ordinal is both faster and
+            // closer to the rule than Unicode case folding is.
+            var tagIndex = new Dictionary<string, List<IndexedRule>>(StringComparer.OrdinalIgnoreCase);
+            var classIndex = new Dictionary<string, List<IndexedRule>>(StringComparer.OrdinalIgnoreCase);
+            var idIndex = new Dictionary<string, List<IndexedRule>>(StringComparer.OrdinalIgnoreCase);
             var universal = new List<IndexedRule>();
             var keys = new List<(SelectorBucketKind Kind, string Key)>();
             var layerRegistry = new LayerRegistry();
@@ -982,8 +987,8 @@ namespace PeachPDF.Html.Core
 
         // Attribute selectors read the value once via node.GetAttribute (case-sensitivity of the
         // attribute-name lookup is the node's own: case-insensitive for HTML/CssBox, case-sensitive for
-        // SVG), then compare the value with node.NameComparison (InvariantCultureIgnoreCase for HTML -
-        // byte-identical to the previous behaviour - Ordinal for SVG).
+        // SVG), then compare the value with node.NameComparison (OrdinalIgnoreCase for HTML, which is
+        // what "ASCII case-insensitively" means - Ordinal for SVG).
         private static bool DoesSelectorMatch(AttrAvailableSelector s, ICssDomNode? node)
         {
             return node?.GetAttribute(s.Attribute) is not null;

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -319,7 +319,7 @@ namespace PeachPDF.Html.Core.Dom
         /// <summary>
         /// Is the box is of "br" element.
         /// </summary>
-        public bool IsBrElement => HtmlTag != null && HtmlTag.Name.Equals("br", StringComparison.InvariantCultureIgnoreCase);
+        public bool IsBrElement => HtmlTag != null && HtmlTag.Name.Equals("br", StringComparison.OrdinalIgnoreCase);
 
         public bool IsRoot { get; set; }
 
@@ -6535,14 +6535,18 @@ namespace PeachPDF.Html.Core.Dom
         // The HTML box tree is the primary ICssDomNode implementation the selector engine matches
         // against; these members are thin views over the box's existing state. HTML matches element/
         // attribute names ASCII case-insensitively (unlike SVG's XML case-sensitivity), so NameComparison
-        // reports InvariantCultureIgnoreCase - the value the matcher previously hardcoded, keeping HTML
-        // matching byte-identical. Implemented explicitly where the natural name collides with an existing
+        // reports an ignore-case comparison. Implemented explicitly where the natural name collides with an existing
         // member (GetAttribute, the CustomProperties field).
         string? ICssDomNode.TagName => HtmlTag?.Name;
 
         string? ICssDomNode.GetAttribute(string name) => GetAttribute(name, null);
 
-        StringComparison ICssDomNode.NameComparison => StringComparison.InvariantCultureIgnoreCase;
+        // Ordinal, not InvariantCulture. The comment above already states the rule as ASCII
+        // case-insensitivity, which is what ordinal expresses; InvariantCulture applies full Unicode
+        // case folding, under which U+212A KELVIN SIGN equals ASCII "k" and a class of "K" matches
+        // the selector `.k`. It is also the hot comparison in the selector matcher - one name against
+        // every candidate rule for every box - and a culture-aware one routes each through ICU.
+        StringComparison ICssDomNode.NameComparison => StringComparison.OrdinalIgnoreCase;
 
         ICssDomNode? ICssDomNode.Parent => ParentBox;
 

--- a/src/PeachPDF/Html/Core/Handlers/FontsHandler.cs
+++ b/src/PeachPDF/Html/Core/Handlers/FontsHandler.cs
@@ -33,12 +33,12 @@ namespace PeachPDF.Html.Core.Handlers
         /// <summary>
         /// Allow to map not installed fonts to different
         /// </summary>
-        private readonly Dictionary<string, string> _fontsMapping = new(StringComparer.InvariantCultureIgnoreCase);
+        private readonly Dictionary<string, string> _fontsMapping = new(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// collection of all installed and added font families to check if font exists
         /// </summary>
-        private readonly Dictionary<string, RFontFamily> _existingFontFamilies = new(StringComparer.InvariantCultureIgnoreCase);
+        private readonly Dictionary<string, RFontFamily> _existingFontFamilies = new(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// cache of all the font used not to create same font again and again - keyed by (style, weight,
@@ -50,7 +50,7 @@ namespace PeachPDF.Html.Core.Handlers
         /// doesn't affect face selection, but two requests differing only in it would otherwise
         /// incorrectly share one cached RFont and silently keep whichever angle was cached first.
         /// </summary>
-        private readonly Dictionary<string, Dictionary<double, Dictionary<(RFontStyle Style, int Weight, int Stretch, double? ObliqueSkewSinus), RFont?>>> _fontsCache = new(StringComparer.InvariantCultureIgnoreCase);
+        private readonly Dictionary<string, Dictionary<double, Dictionary<(RFontStyle Style, int Weight, int Stretch, double? ObliqueSkewSinus), RFont?>>> _fontsCache = new(StringComparer.OrdinalIgnoreCase);
 
         #endregion
 

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -243,10 +243,10 @@ namespace PeachPDF.Html.Core.Parse
                 // Check for the <link rel=stylesheet> tag. Per HTML4/5, `rel` is a space-separated set
                 // of link types (e.g. `rel="appendix stylesheet"` is still a stylesheet link), so this
                 // must check for the "stylesheet" token rather than requiring an exact match.
-                if (box.HtmlTag.Name.Equals("link", StringComparison.CurrentCultureIgnoreCase) &&
+                if (box.HtmlTag.Name.Equals("link", StringComparison.OrdinalIgnoreCase) &&
                    box.GetAttribute("rel", string.Empty)
                        .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)
-                       .Any(token => token.Equals("stylesheet", StringComparison.CurrentCultureIgnoreCase)))
+                       .Any(token => token.Equals("stylesheet", StringComparison.OrdinalIgnoreCase)))
                 {
                     CloneCssData(ref cssData, ref cssDataChanged);
                     var (stylesheet, resolvedUri) = await StylesheetLoadHandler.LoadStylesheet(htmlContainer, box.GetAttribute("href", string.Empty));
@@ -255,7 +255,7 @@ namespace PeachPDF.Html.Core.Parse
                 }
 
                 // Check for the <style> tag
-                if (box.HtmlTag.Name.Equals("style", StringComparison.CurrentCultureIgnoreCase) && box.Boxes.Count > 0)
+                if (box.HtmlTag.Name.Equals("style", StringComparison.OrdinalIgnoreCase) && box.Boxes.Count > 0)
                 {
                     CloneCssData(ref cssData, ref cssDataChanged);
                     // The tokenizer splits a <style> element's raw text into multiple data tokens whenever the

--- a/src/PeachPDF/Html/Core/Utils/DomUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/DomUtils.cs
@@ -85,7 +85,7 @@ namespace PeachPDF.Html.Core.Utils
                     return null;
                 }
 
-                if (box.HtmlTag != null && box.HtmlTag.Name.Equals(tagName, StringComparison.CurrentCultureIgnoreCase))
+                if (box.HtmlTag != null && box.HtmlTag.Name.Equals(tagName, StringComparison.OrdinalIgnoreCase))
                 {
                     return box.ParentBox ?? root;
                 }

--- a/src/PeachPDF/Html/Core/Utils/HtmlUtils.cs
+++ b/src/PeachPDF/Html/Core/Utils/HtmlUtils.cs
@@ -55,7 +55,7 @@ namespace PeachPDF.Html.Core.Utils
         /// </summary>
         static HtmlUtils()
         {
-            var decodeOnlyBuilder = new Dictionary<string, char>(StringComparer.InvariantCultureIgnoreCase);
+            var decodeOnlyBuilder = new Dictionary<string, char>(StringComparer.OrdinalIgnoreCase);
 
             // "nbsp" below decodes to the real U+00A0 non-breaking space, not a plain ASCII space -
             // callers that need to tell it apart from ordinary collapsible whitespace (line-wrapping,
@@ -305,7 +305,7 @@ namespace PeachPDF.Html.Core.Utils
             decodeOnlyBuilder["hearts"] = Convert.ToChar(9829);
             decodeOnlyBuilder["diams"] = Convert.ToChar(9830);
 
-            _decodeOnly = decodeOnlyBuilder.ToFrozenDictionary(StringComparer.InvariantCultureIgnoreCase);
+            _decodeOnly = decodeOnlyBuilder.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
         }
 
         public static string FixNewLines(string text)


### PR DESCRIPTION
The selector matcher, the tag/class/id indexes, `IsBrElement`, the font caches and the entity tables all compare names with `InvariantCultureIgnoreCase`.

HTML matches element and attribute names **ASCII** case-insensitively. Invariant culture applies full **Unicode** case folding, and under that **U+212A KELVIN SIGN equals ASCII `k`**:

```html
<style>.k { color: rgb(255,0,0) }</style>
<div class="&#x212A;">x</div>   <!-- matches .k on main; it should not -->
```

The comment already above `NameComparison` states the rule correctly — the code just did not express it:

> HTML matches element/attribute names **ASCII case-insensitively** (unlike SVG's XML case-sensitivity), so `NameComparison` reports an ignore-case comparison.

Ordinal is what "ASCII case-insensitively" means.

## On the performance side — deliberately not quoted

This started life as a profile-driven change: `System.Globalization` was about a fifth of thread CPU on a real corpus (`CompareInfo.Compare` 14.9%, `IcuGetHashCodeOfString` 4.3%), and throughput rose ~5%. The matcher runs this comparison for one name against every candidate rule for every box, so a culture-aware comparison routes each one through ICU.

**I could not reproduce a trustworthy number on the machine I prepared this on.** Nine interleaved renders of a synthetic class-heavy document gave a 175 ms median before and 177 ms after, with a 164–225 ms spread — the variance swamps any effect that size. Rather than quote a figure I cannot stand behind, I am offering this as the correctness fix it also is; if the throughput matters to you it is worth measuring on a quiet machine, and I would expect it to show.

## Tests

`AsciiNameMatchingTests`, three fixtures:

- a Kelvin-sign class does **not** match `.k` — **fails against `main`**;
- an ASCII class still matches case-insensitively, both `k` and `K`;
- an uppercase `DIV` element still matches the `div` selector.

The last two are the contrast cases: the point is to narrow the comparison to ASCII, not to make it case-sensitive, and both would fail if this went too far.

`dotnet build PeachPDF.Tests -t:Rebuild`: no new warnings. `dotnet test --framework net8.0`: 10,348 passed, 0 failed, 9 skipped.
