### PR TITLE
Fix broken doc anchors in two August migration notes

### DIFF
--- a/.claude/migration-notes/2026-08-06-text-align-center-with-text-indent-under-rtl.md
+++ b/.claude/migration-notes/2026-08-06-text-align-center-with-text-indent-under-rtl.md
@@ -1,7 +1,7 @@
 # `text-align: center` now reserves the full `text-indent` on the line-start side under RTL
 
 **Landed:** 2026-08-06 — Fix open alignment issues (#623)
-**Doc section:** docs/html-css-support.md § [text-indent row](../../docs/html-css-support.md#text)
+**Doc section:** docs/html-css-support.md § [text-indent row](../../docs/html-css-support.md#text-layout)
 
 `ApplyCenterAlignment` didn't inset its flush target for `direction: rtl`, unlike `ApplyRightAlignment`/
 `ApplyJustifyAlignment` (both already RTL-aware since issue #607). For LTR content this was already

--- a/.claude/migration-notes/2026-08-06-vertical-align-length-percentage-support.md
+++ b/.claude/migration-notes/2026-08-06-vertical-align-length-percentage-support.md
@@ -1,7 +1,7 @@
 # `vertical-align` now supports length and percentage values
 
 **Landed:** 2026-08-06 — Fix open alignment issues (#603)
-**Doc section:** docs/html-css-support.md § [vertical-align row](../../docs/html-css-support.md#text)
+**Doc section:** docs/html-css-support.md § [vertical-align row](../../docs/html-css-support.md#color--typography)
 
 `vertical-align`'s cascade storage (`css-properties.json`'s `vertical-align` entry) was keyword-only —
 a `<length>`/`<percentage>` value (CSS 2.1 §10.8.1: "raises (or lowers, if the value is negative) the box


### PR DESCRIPTION
Both `.claude/migration-notes/2026-08-06-vertical-align-length-percentage-support.md` and `.claude/migration-notes/2026-08-06-text-align-center-with-text-indent-under-rtl.md` linked to `docs/html-css-support.md#text`, which doesn't exist — flagged by an external contributor's anchor sweep on #952.

- `vertical-align` row lives under **Color & Typography** → `#color--typography`
- `text-indent` row lives under **Text Layout** → `#text-layout`

Verified both anchors against their existing correct uses elsewhere in `docs/` (`usage-examples.md` and `html-css-support.md` itself both already link to `#color--typography`; `html-css-support.md` itself links to `#text-layout`).