### PR TITLE
Fix a broken doc anchor in the inline-block migration note

### DIFF
--- a/.claude/migration-notes/2026-09-08-width-on-an-inline-block-now-occupies-that-width-on-the-line.md
+++ b/.claude/migration-notes/2026-09-08-width-on-an-inline-block-now-occupies-that-width-on-the-line.md
@@ -19,4 +19,4 @@ second at 91.5pt (90pt plus its 1px borders). PeachPDF now agrees with both to w
 Content **wider** than the declared width still overflows rather than being pulled back, which is
 what `overflow: visible` means, and a **percentage** width is unaffected.
 
-See [Display](../../docs/html-css-support.md#display) in `docs/html-css-support.md`.
+See [Display & Layout](../../docs/html-css-support.md#display--layout) in `docs/html-css-support.md`.


### PR DESCRIPTION
`.claude/migration-notes/2026-09-08-width-on-an-inline-block-now-occupies-that-width-on-the-line.md` links `docs/html-css-support.md#display`, which does not exist. The heading is "Display & Layout" and its generated anchor is `#display--layout`.

Mine, from #951, and the same class as the two August notes you fixed in #959 — so I wrote a checker and swept every `docs/**` anchor cited from `.claude/**`. This is the only one left on `main`.

One thing worth passing on, because it cost me a round of false positives: GitHub drops punctuation and then maps each remaining **space** to a hyphen **without collapsing runs**. So "Display & Layout" is `display--layout` with two, and "Running elements (`position: running()` / `element()`)" is `running-elements-position-running--element`. Collapsing whitespace — the obvious way to write the check — reports every heading containing punctuation as broken; my first version flagged nine anchors that were all fine.