### PR TITLE
Resolve line-height: normal from the font's own metrics

### DIFF
--- a/.claude/migration-notes/2026-09-08-line-height-normal-now-resolves-from-font-metrics.md
+++ b/.claude/migration-notes/2026-09-08-line-height-normal-now-resolves-from-font-metrics.md
@@ -1,0 +1,16 @@
+# `line-height: normal` now resolves from the used font's own metrics
+
+Any element that doesn't declare an explicit `line-height` (i.e. relies on the initial/`normal` value)
+used to get a flat `1.2 × font-size` line height for every font. `line-height: normal` now resolves per
+CSS 2.1 §10.8.1 — "based on the font of the element" — from that font's own `hhea` ascent/descent/line-gap
+(or the `OS/2` typo triple, when the font's `USE_TYPO_METRICS` flag is set), matching how Chromium,
+Firefox and Safari compute it. This is a document-wide rendering change: any PDF generated without an
+explicit `line-height` on the relevant elements will now paginate and space lines differently, closer to
+how the same HTML renders in a browser. The deviation from the old flat constant depends on the font in
+use — some fonts land close to the old `1.2×` value, others (fonts with generous ascent for diacritics, or
+unusually tight/loose vertical metrics) differ by several percent per line, which compounds over a page of
+body text.
+
+Confirmed against `docs/getting-started.md`/`docs/html-css-support.md` at the last tagged release: neither
+page documented the specific `1.2×` constant, only that `line-height` has "Full support," so this note is
+the only place the old behavior was ever written down.

--- a/.claude/recent-fixes/2026-09-08-line-height-normal-font-metrics.md
+++ b/.claude/recent-fixes/2026-09-08-line-height-normal-font-metrics.md
@@ -1,0 +1,93 @@
+# `line-height: normal` resolves from the font's own metrics, not a flat 1.2x (#956)
+
+## Load-bearing idea
+
+CSS 2.1 §10.8.1 makes `line-height: normal` "based on the font of the element" - every real engine
+(Chromium, Firefox, Safari, confirmed by reading Mozilla's `gfxFT2FontBase.cpp` metrics code, WebKit's
+`FontMetrics.h`, and cross-referenced against the well-known browser-vertical-metrics literature) resolves
+it the same way: the raw `hhea.ascender`/`|hhea.descender|`/`max(hhea.lineGap, 0)` triple, or - only when
+`OS/2.fsSelection`'s `USE_TYPO_METRICS` bit (0x80) is set and the OS/2 typo fields aren't all-zero -
+`OS/2.sTypoAscender`/`-sTypoDescender`/`max(sTypoLineGap, 0)` instead. Each component is scaled to the
+font-size, rounded to a whole CSS pixel *independently* (not the summed total), then added together.
+Crucially, none of the three engines substitute `OS/2.usWinAscent`/`usWinDescent` for `hhea` in the
+non-typo case - that's a legacy Windows-GDI/old-IE convention.
+
+This codebase already had an `Ascender`/`Descender`/`LineSpacing` triple on `FontDescriptor`
+(`src/PeachPDF/Fonts/OpenType/OpenTypeDescriptor.cs`) - but its own comment says it's a direct port of
+*WPF's* `FontDriver.ReadBasicMetrics`, which does exactly that legacy GDI substitution, and backs PDF
+`/FontDescriptor` metrics plus baseline positioning (`RFont.Ascent`/`Height`). Reusing it for
+`line-height: normal` would have been wrong twice over - wrong algorithm, and coupling an unrelated
+concern to something correctness-critical for glyph placement. Instead, three new raw fields
+(`FontDescriptor.NormalLineHeightAscent`/`Descent`/`Gap`, populated in `OpenTypeDescriptor.Initialize()`
+via the *same* `os2SeemsToBeEmpty`/`dontUseWinLineMetrics` gate the existing block already computes, but
+with the non-typo branch always reading `hhea`) and a new `RFont.NormalLineHeight` virtual (default `1.2 *
+Size`, reproducing the old approximation, overridden by `FontAdapter` - mirroring the `HasVerticalMetrics`/
+`GetVerticalAdvance` capability-gated-accessor pattern from the vertical-metrics work) keep the two
+concerns separate. `DerivedStyle.ActualLineHeight`'s `normal` branch now reads `ActualFont.NormalLineHeight`
+directly, in the same already-`PixelsPerPoint`-scaled space `ActualFont.Ascent`/`.Height` are consumed in
+elsewhere (confirmed via `BaselineAlignment.cs`, `CssBoxMarker.cs`), rather than the old `GetEmHeight() *
+PixelsPerPoint` correction the flat multiplier needed.
+
+## What running it (not reading it) found
+
+- The pinned regression test asserting the exact `1.2×` output
+  (`LineHeightTypedStorageTests.NormalKeyword_ActualLineHeight_ResolvesToOnePointTwoTimesFontSize`) is
+  gone by design - it pinned the behavior this issue argues is wrong. Its replacement embeds two bundled
+  fonts (`BundledFonts.Ttf`/`Otf`) via `@font-face`/data-URL rather than relying on whatever "no
+  font-family" resolves to (platform-dependent), and asserts against values hand-computed from each font's
+  *own* real `hhea` table via `fontTools` - independent of the implementation under test - then confirmed
+  those hand-computed numbers (27.00pt and 24.75pt at a 20pt font-size) matched the running code exactly on
+  the first try, which is good evidence the rounding-order (`round each of ascent/descent/gap to a whole
+  CSS px, then sum` - not `round the sum`) was implemented correctly the first time, not tuned to pass.
+- A quick throwaway probe (not committed) loading eight real Windows system fonts at the same font-size
+  confirmed the fix is genuinely font-dependent end-to-end, not just at the descriptor layer: Georgia 27pt,
+  Arial/Trebuchet MS/Courier New 27.75pt (a real coincidence between three otherwise-unrelated fonts, not a
+  bug - confirmed by checking their distinct `RFont.FaceKey`s), Verdana/Tahoma 29.25pt, Segoe UI 32.25pt,
+  Comic Sans MS 33pt, all at a 24pt font-size that would have flatly produced 28.8pt under the old code.
+- The full `PeachPDF.Tests` suite (10,378 tests) passed with **zero** regressions from this change - the
+  flat `1.2×` value was apparently never depended on for exact pixel-position assertions elsewhere in the
+  suite, only in the one test written specifically to pin it.
+- **A multi-agent review pass caught a real bug the test suite above didn't**: `FontAdapter.NormalLineHeight`
+  multiplied each ascent/descent/gap component by `PixelsPerPoint` *before* rounding it to a whole CSS
+  pixel, instead of after. At the default `PixelsPerPoint = 1.0` - what every test in this repo's suite
+  uses, including the ones written for this very fix - the bug is a no-op, since multiplying by `1.0` before
+  or after a fixed-ratio rounding step gives the same answer. At any other `PixelsPerPoint` (e.g.
+  `PixelsPerInch = 144`, issue #814's family), it rounded to the wrong granularity, since `Length.PointsPerPx`
+  is a fixed pt-per-CSS-px ratio, not a pt-per-internal-layout-unit one. Two independent review angles
+  (simplification/reuse) also independently converged on the same second finding: `OpenTypeDescriptor`'s new
+  code re-tested the `os2SeemsToBeEmpty`/`dontUseWinLineMetrics` gate a second time instead of extending the
+  branches that already test it, risking the two blocks silently diverging on a future edit to that gate.
+  Both fixed: the rounding now happens once, per-component, in real-point space, with the single
+  `* PixelsPerPoint` conversion applied only to the already-rounded sum (mirroring how `Ascent`'s own
+  `Math.Round(_ascent * PixelsPerPoint)` keeps rounding and device-scaling as one ordered step, just at CSS-
+  pixel granularity instead of whole-point); `NormalLineHeightAscent`/`Descent`/`Gap` assignments now live
+  directly inside the existing typo/hhea branches, reusing their already-computed locals instead of re-
+  reading the OpenType tables a second time. A new precise regression test
+  (`NormalLineHeightMetricsTests.NormalLineHeight_ScalesExactlyLinearlyWithPixelsPerPoint`) wraps the *same*
+  `XFont` in two `FontAdapter`s differing only in `PixelsPerPoint` and asserts the ratio is exactly the
+  `PixelsPerPoint` ratio - which the pre-fix code failed by a real, non-rounding-error margin (a 20pt-ascent
+  component alone was off by 0.75pt at `PixelsPerPoint = 2.0`).
+
+## Deliberately not done
+
+- No Windows-GDI-style `usWinAscent`/`usWinDescent` fallback path, matching all three modern engines - see
+  above.
+- No attempt to replicate the exact rounding function each engine uses internally (Gecko: `floor(x + 0.5)`;
+  WebKit: `lroundf`) beyond "round to nearest, ties handled by `Math.Round`'s default banker's rounding" -
+  the three differ only at an exact `.5`-CSS-px boundary, which no bundled or tested font hit.
+
+## Evidence
+
+- New/changed tests: `LineHeightTypedStorageTests.cs` (two new `ActualLineHeight` cases, replacing the
+  pinned-flat one), `NormalLineHeightMetricsTests.cs` (new - direct `OpenTypeDescriptor` coverage of the
+  hhea/typo-metrics branch selection including the `os2SeemsToBeEmpty` fallback edge case, plus the
+  `PixelsPerPoint`-scaling regression test described above), `RFontVerticalMetricsDefaultsTests.cs` (one new
+  case for the `RFont.NormalLineHeight` default).
+- Full suite: `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - 10,379 passed, 0
+  failed, 9 skipped (pre-existing platform skips).
+- Diff coverage: 100% on the changed/added lines (`diff-cover` against `origin/main`).
+- `dotnet build PeachPDF.slnx -t:Rebuild` - zero warnings.
+- Visual verification: a new `line_height_normal` showcase (`PeachPDF.TestHarness/Program.cs`) renders
+  `font-size: 24pt; line-height: normal` in three generic font families with a shaded one-line-box-tall
+  background band behind each; rendered via `peachpdf` CLI and rasterized with PyMuPDF - the three bands
+  are visibly different heights relative to their glyphs, and none of the text clips or overflows its band.

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -5417,6 +5417,42 @@ await SaveShowcaseAsync("vertical_align", "Typography & Text", "Vertical Align",
     "vertical-align behaviors for inline content, from baseline and middle to explicit offsets, including its length and percentage forms.",
     verticalAlignHtml, pdfConfig);
 
+// --- line-height: normal showcase (CSS 2.1 §10.8.1) ---
+
+const string NormalLineHeightCss = """
+    <style>
+    @page { size: a4; margin: 15mm }
+    body { font-size: 12pt; margin: 0 }
+    h1 { font-size: 15pt; margin: 0 0 0.3em; font-family: Arial, sans-serif }
+    p.intro { font-family: Arial, sans-serif; color: #444; margin: 0 0 1em; max-width: 500pt }
+    .sample { border: 1px solid #ccc; background: #fafafa; padding: 0; margin-bottom: 10pt; max-width: 380pt }
+    .sample .label { font-family: Arial, sans-serif; font-size: 7pt; font-weight: bold; color: #444; background: #eee; padding: 3pt 6pt; border-bottom: 1px solid #ccc }
+    .sample .text { font-size: 24pt; line-height: normal; margin: 0; padding: 0 6pt; background: #e8f0fe }
+    .sample.serif .text { font-family: Georgia, 'Times New Roman', serif }
+    .sample.sans .text { font-family: Arial, Helvetica, sans-serif }
+    .sample.mono .text { font-family: 'Courier New', monospace }
+    </style>
+    """;
+
+var normalLineHeightHtml = "<!DOCTYPE html><html><head>" + NormalLineHeightCss + "</head><body>" +
+
+    "<h1>line-height: normal</h1>" +
+    "<p class=\"intro\">Each box below sets only <code>font-size: 24pt; line-height: normal</code> - no explicit " +
+    "line-height. The used value is resolved from that font's own ascent/descent/line-gap metrics (CSS 2.1 " +
+    "&sect;10.8.1), matching how browsers do it, so it varies by font rather than being a flat multiplier of " +
+    "font-size. The shaded background is exactly one line box tall, so its height relative to the glyphs " +
+    "shows each font's own leading.</p>" +
+
+    "<div class=\"sample serif\"><div class=\"label\">serif</div><div class=\"text\">Aligny jpqg</div></div>" +
+    "<div class=\"sample sans\"><div class=\"label\">sans-serif</div><div class=\"text\">Aligny jpqg</div></div>" +
+    "<div class=\"sample mono\"><div class=\"label\">monospace</div><div class=\"text\">Aligny jpqg</div></div>" +
+
+    "</body></html>";
+
+await SaveShowcaseAsync("line_height_normal", "Typography & Text", "line-height: normal",
+    "line-height: normal resolved from each font's own ascent/descent/line-gap metrics, matching browser behavior, rather than a flat 1.2× font-size.",
+    normalLineHeightHtml, pdfConfig);
+
 // --- letter-spacing / word-spacing showcase ---
 
 const string SpacingCss = """

--- a/src/PeachPDF.Tests/Html/Adapters/RFontVerticalMetricsDefaultsTests.cs
+++ b/src/PeachPDF.Tests/Html/Adapters/RFontVerticalMetricsDefaultsTests.cs
@@ -25,5 +25,18 @@ namespace PeachPDF.Tests.Html.Adapters
             Assert.False(font.HasVerticalOrigin);
             Assert.Equal(font.Ascent, font.GetVerticalOriginY(rune));
         }
+
+        /// <summary>
+        /// <see cref="PeachPDF.Html.Adapters.RFont.NormalLineHeight"/> (issue #956) follows the identical
+        /// pattern: virtual, with a default that reproduces the pre-#956 flat 1.2x-font-size approximation
+        /// exactly, so only <see cref="PeachPDF.Adapters.FontAdapter"/> resolves it from real font metrics.
+        /// </summary>
+        [Fact]
+        public void NormalLineHeightDefault_ReproducesThePreExistingApproximation()
+        {
+            var font = new TestFont(20);
+
+            Assert.Equal(1.2 * font.Size, font.NormalLineHeight);
+        }
     }
 }

--- a/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTablePageBreakTests.cs
+++ b/src/PeachPDF.Tests/Html/Core/Dom/CssLayoutEngineTablePageBreakTests.cs
@@ -309,10 +309,18 @@ namespace PeachPDF.Tests.Html.Core.Dom
             var pageHeight = 300.0;
             var marginBottom = 20.0;
 
+            // Pinned to a bundled font (rather than the bare default the body used to have no
+            // font-family at all, resolving through whatever the host OS happens to have installed) so
+            // the estimation-inaccuracy tolerance below is calibrated against one known, cross-platform-
+            // stable set of real metrics - issue #956 made line-height:normal genuinely font-dependent,
+            // where it used to be a flat constant identical on every platform.
             var html = @"
 <!DOCTYPE html>
 <html>
-<body>
+<head><style>
+" + BundledFonts.FontFaceRule(BundledFonts.Ttf, "TablePageBreakTestFont", "font/truetype") + @"
+</style></head>
+<body style='font-family:""TablePageBreakTestFont""'>
     <table style='width:100%;border-collapse:collapse;'>
         <tbody>
 " + string.Join("", Enumerable.Range(1, 20).Select(i =>

--- a/src/PeachPDF.Tests/Integration/LineHeightTypedStorageTests.cs
+++ b/src/PeachPDF.Tests/Integration/LineHeightTypedStorageTests.cs
@@ -1,5 +1,7 @@
 using PeachPDF.CSS;
 using PeachPDF.Tests.TestSupport;
+using System;
+using System.IO;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -84,16 +86,55 @@ namespace PeachPDF.Tests.Integration
 
         // ─── ActualLineHeight resolution (not just storage) ────────────────────────
 
-        [Fact]
-        public async Task NormalKeyword_ActualLineHeight_ResolvesToOnePointTwoTimesFontSize()
-        {
-            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
-                "<div id='t' style='font-size:20pt;line-height:normal'>x</div>"));
+        // `normal` (CSS 2.1 §10.8.1) resolves from the used font's own ascent/descent/line-gap metrics,
+        // matching Chromium/Firefox/Safari - not a flat 1.2x-font-size approximation (issue #956). Two
+        // bundled fonts with different `hhea` metrics are registered via @font-face/data-URL (rather than
+        // relying on whatever "no font-family" resolves to, which is platform-dependent) so the expected
+        // values below are derived from each font's own real table data, not from the code under test.
+        //
+        // Both fonts lack the OS/2 USE_TYPO_METRICS bit, so both take the hhea branch:
+        //   SourceSans3-Regular (BundledFonts.Ttf): unitsPerEm=1000, hhea ascent=1000, |descent|=326, lineGap=0.
+        //     At 20pt: ascent 20.00pt -> round to nearest 0.75pt (CSS px) -> 20.25pt;
+        //              descent 6.52pt -> 6.75pt; gap 0pt. Sum = 27.00pt.
+        //   SourceCodePro-Regular (BundledFonts.Otf): unitsPerEm=1000, hhea ascent=984, |descent|=273, lineGap=0.
+        //     At 20pt: ascent 19.68pt -> 19.50pt; descent 5.46pt -> 5.25pt; gap 0pt. Sum = 24.75pt.
+        // Neither equals the old flat 1.2*20=24pt, and the two differ from each other - proving the value
+        // is now genuinely font-dependent rather than a constant multiplier.
 
-            var box = LayoutHarness.FindById(root, "t");
+        [Fact]
+        public async Task NormalKeyword_ActualLineHeight_ResolvesFromTheFontsOwnHheaMetrics()
+        {
+            var box = await GetNormalLineHeightBoxAsync(BundledFonts.Ttf, "font/truetype");
 
             Assert.NotNull(box);
-            Assert.Equal(1.2 * 20, box!.ActualLineHeight, 2);
+            Assert.Equal(27.00, box!.ActualLineHeight, 2);
+        }
+
+        [Fact]
+        public async Task NormalKeyword_ActualLineHeight_DiffersByFont_NotAFlatMultiplier()
+        {
+            var sansBox = await GetNormalLineHeightBoxAsync(BundledFonts.Ttf, "font/truetype");
+            var monoBox = await GetNormalLineHeightBoxAsync(BundledFonts.Otf, "font/opentype");
+
+            Assert.NotNull(sansBox);
+            Assert.NotNull(monoBox);
+            Assert.Equal(24.75, monoBox!.ActualLineHeight, 2);
+            Assert.NotEqual(sansBox!.ActualLineHeight, monoBox.ActualLineHeight);
+            Assert.NotEqual(1.2 * 20, sansBox.ActualLineHeight, 2);
+            Assert.NotEqual(1.2 * 20, monoBox.ActualLineHeight, 2);
+        }
+
+        private static async Task<PeachPDF.Html.Core.Dom.CssBox?> GetNormalLineHeightBoxAsync(string fontPath, string mimeType)
+        {
+            var b64 = Convert.ToBase64String(File.ReadAllBytes(fontPath));
+            var html = $@"<!DOCTYPE html><html><head><style>
+@font-face {{ font-family: 'NormalLineHeightTestFont'; src: url('data:{mimeType};base64,{b64}'); }}
+</style></head><body style='margin:0'>
+<div id='t' style=""font-family:'NormalLineHeightTestFont';font-size:20pt;line-height:normal"">x</div>
+</body></html>";
+
+            var (root, _) = await LayoutHarness.LayoutAsync(html);
+            return LayoutHarness.FindById(root, "t");
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/Integration/LineHeightTypedStorageTests.cs
+++ b/src/PeachPDF.Tests/Integration/LineHeightTypedStorageTests.cs
@@ -1,7 +1,5 @@
 using PeachPDF.CSS;
 using PeachPDF.Tests.TestSupport;
-using System;
-using System.IO;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -126,9 +124,8 @@ namespace PeachPDF.Tests.Integration
 
         private static async Task<PeachPDF.Html.Core.Dom.CssBox?> GetNormalLineHeightBoxAsync(string fontPath, string mimeType)
         {
-            var b64 = Convert.ToBase64String(File.ReadAllBytes(fontPath));
             var html = $@"<!DOCTYPE html><html><head><style>
-@font-face {{ font-family: 'NormalLineHeightTestFont'; src: url('data:{mimeType};base64,{b64}'); }}
+{BundledFonts.FontFaceRule(fontPath, "NormalLineHeightTestFont", mimeType)}
 </style></head><body style='margin:0'>
 <div id='t' style=""font-family:'NormalLineHeightTestFont';font-size:20pt;line-height:normal"">x</div>
 </body></html>";

--- a/src/PeachPDF.Tests/Integration/TableCellLineFragmentationTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableCellLineFragmentationTests.cs
@@ -93,11 +93,16 @@ namespace PeachPDF.Tests.Integration
         }
 
         // The cell still paginates: the fix moves the straddling line rather than truncating the cell.
+        // 400 words (well above NoWordIsPaintedTwice_AtAPageBoundary's own 200-320 sweep range, which
+        // exists precisely because how many lines fit per page is font-dependent - see that test's own
+        // comment) so this reliably spans more than one page regardless of which font the host resolves
+        // (issue #956 made line-height:normal genuinely font-dependent, where it used to be a flat
+        // constant identical on every platform).
         [Fact]
         public async Task ACellTallerThanAPage_StillPaginatesAllOfItsText()
         {
             var (root, container) = await LayoutHarness.LayoutAsync(
-                LayoutHarness.Wrap($"<table style='width:100%'><tr><td>{Words(244)}</td></tr></table>"),
+                LayoutHarness.Wrap($"<table style='width:100%'><tr><td>{Words(400)}</td></tr></table>"),
                 pageHeight: 300, margin: 20);
 
             var laidOut = LayoutHarness.Descendants(root)

--- a/src/PeachPDF.Tests/Integration/TableRowspanContinuationTests.cs
+++ b/src/PeachPDF.Tests/Integration/TableRowspanContinuationTests.cs
@@ -577,7 +577,10 @@ namespace PeachPDF.Tests.Integration
         [Fact]
         public async Task ASpanningCellWhoseContentFinishesInTheSameBandTheSpanEndsIn_ClosesAtTheRowsOwnBottom()
         {
-            var words = string.Join(" ", Enumerable.Range(0, 40).Select(i => $"word{i:0000}"));
+            // 70 words, not 40 - a generous margin over how many lines fit in the opening band, which is
+            // font-dependent (issue #956 made line-height:normal genuinely font-dependent; 40 words no
+            // longer reliably overflowed the band on hosts resolving a shorter default font).
+            var words = string.Join(" ", Enumerable.Range(0, 70).Select(i => $"word{i:0000}"));
 
             var (root, container) = await LayoutHarness.LayoutAsync(
                 LayoutHarness.Wrap(
@@ -702,7 +705,10 @@ namespace PeachPDF.Tests.Integration
         [Fact]
         public async Task ASpanningCellInTheLastColumn_StillClosesAfterMultipleResumptionPasses()
         {
-            var words = string.Join(" ", Enumerable.Range(0, 40).Select(i => $"word{i:0000}"));
+            // 70 words, not 40 - a generous margin over how many lines fit in the opening band, which is
+            // font-dependent (issue #956 made line-height:normal genuinely font-dependent; 40 words no
+            // longer reliably overflowed the band on hosts resolving a shorter default font).
+            var words = string.Join(" ", Enumerable.Range(0, 70).Select(i => $"word{i:0000}"));
 
             var (root, container) = await LayoutHarness.LayoutAsync(
                 LayoutHarness.Wrap(

--- a/src/PeachPDF.Tests/PdfSharpCore/Fonts/NormalLineHeightMetricsTests.cs
+++ b/src/PeachPDF.Tests/PdfSharpCore/Fonts/NormalLineHeightMetricsTests.cs
@@ -1,0 +1,126 @@
+using System.IO;
+using PeachPDF.Adapters;
+using PeachPDF.Fonts;
+using PeachPDF.Fonts.OpenType;
+using PeachPDF.PdfSharpCore.Drawing;
+using PeachPDF.PdfSharpCore.Pdf;
+using PeachPDF.Tests.TestSupport;
+using Xunit;
+
+namespace PeachPDF.Tests.PdfSharpCoreTests.Fonts
+{
+    /// <summary>Resolves every request to the bundled TrueType fixture, for a test that needs a real,
+    /// deterministic <see cref="XFont"/> without depending on which fonts happen to be installed on the
+    /// machine running the test (unlike the system-font-dependent resolvers used elsewhere in this
+    /// directory, e.g. <c>SmokeTests.cs</c>'s "Times New Roman"/"Arial").</summary>
+    file sealed class BundledTtfResolver : IFontResolver
+    {
+        public FontResolverInfo ResolveTypeface(string familyName, bool isBold, bool isItalic) => new("bundled-ttf");
+        public FontResolverInfo ResolveTypeface(string familyName, int weight, bool isItalic) => new("bundled-ttf");
+        public FontResolverInfo ResolveTypeface(string familyName, int weight, bool isItalic, int stretch) => new("bundled-ttf");
+        public byte[] GetFont(string fontFaceName) => File.ReadAllBytes(BundledFonts.Ttf);
+    }
+
+    /// <summary>
+    /// <see cref="FontDescriptor.NormalLineHeightAscent"/>/<see cref="FontDescriptor.NormalLineHeightDescent"/>/
+    /// <see cref="FontDescriptor.NormalLineHeightGap"/> selection logic (issue #956): the raw <c>hhea</c>
+    /// triple, unless <c>OS/2.fsSelection</c>'s <c>USE_TYPO_METRICS</c> bit (0x80) is set and the OS/2 typo
+    /// fields aren't all-zero, in which case the OS/2 typo triple is used instead - deliberately without the
+    /// <c>usWinAscent</c>/<c>usWinDescent</c> substitution the sibling <see cref="FontDescriptor.Ascender"/>/
+    /// <see cref="FontDescriptor.Descender"/>/<see cref="FontDescriptor.LineSpacing"/> block uses (that's the
+    /// WPF-derived, PDF-metrics/baseline-positioning triple; this is the separate, browser-matching one).
+    ///
+    /// Loads the bundled TrueType font through <see cref="XFontSource.CreateCompiledFont"/> rather than
+    /// <see cref="XFontSource.GetOrCreateFrom"/> - the latter caches by content checksum in the process-wide
+    /// <c>FontFactory</c> (see this repo's own CLAUDE.md warning about exactly this), and every test here
+    /// mutates the parsed face's <c>OS/2</c> fields directly, which would corrupt that shared cached
+    /// instance for every other test loading the same file. <c>CreateCompiledFont</c> returns a fresh,
+    /// uncached <see cref="XFontSource"/> each call, so each test's face is exclusively its own.
+    /// </summary>
+    public class NormalLineHeightMetricsTests
+    {
+        private static OpenTypeFontface FreshUncachedFace()
+        {
+            var bytes = File.ReadAllBytes(BundledFonts.Ttf);
+            return new OpenTypeFontface(XFontSource.CreateCompiledFont(bytes));
+        }
+
+        private static OpenTypeDescriptor Descriptor(OpenTypeFontface face) =>
+            new("normal-line-height-test", "normal-line-height-test", XFontStyle.Regular, face,
+                new XPdfFontOptions(PdfFontEncoding.Unicode));
+
+        [Fact]
+        public void UseTypoMetricsNotSet_UsesRawHheaTriple()
+        {
+            var face = FreshUncachedFace();
+            Assert.Equal(0, face.os2.fsSelection & 0x80); // SourceSans3-Regular doesn't set USE_TYPO_METRICS
+
+            var descriptor = Descriptor(face);
+
+            Assert.Equal(face.hhea.ascender, descriptor.NormalLineHeightAscent);
+            Assert.Equal(System.Math.Abs(face.hhea.descender), descriptor.NormalLineHeightDescent);
+            Assert.Equal(0, descriptor.NormalLineHeightGap);
+        }
+
+        [Fact]
+        public void UseTypoMetricsSet_UsesOs2TypoTriple_NotWinMetrics()
+        {
+            var face = FreshUncachedFace();
+            face.os2.fsSelection |= 0x80;
+            face.os2.sTypoAscender = 900;
+            face.os2.sTypoDescender = -200;
+            face.os2.sTypoLineGap = 50;
+
+            var descriptor = Descriptor(face);
+
+            Assert.Equal(900, descriptor.NormalLineHeightAscent);
+            Assert.Equal(200, descriptor.NormalLineHeightDescent);
+            Assert.Equal(50, descriptor.NormalLineHeightGap);
+            // Not the OS/2 win metrics (the legacy substitution Ascender/Descender/LineSpacing makes) -
+            // proves this is a genuinely separate accessor, not a relabeling of the existing one.
+            Assert.NotEqual(face.os2.usWinAscent, descriptor.NormalLineHeightAscent);
+        }
+
+        [Fact]
+        public void UseTypoMetricsSetButOs2TypoFieldsAllZero_FallsBackToHhea()
+        {
+            // Mirrors the shared `os2SeemsToBeEmpty` gate the existing Ascender/Descender/LineSpacing
+            // block already relies on: a font can set the USE_TYPO_METRICS bit while leaving the typo
+            // fields themselves unpopulated (spec-invalid but real-world fonts do this), so both blocks
+            // must fall back to hhea rather than resolving to a bogus all-zero line height.
+            var face = FreshUncachedFace();
+            face.os2.fsSelection |= 0x80;
+            face.os2.sTypoAscender = 0;
+            face.os2.sTypoDescender = 0;
+            face.os2.sTypoLineGap = 0;
+
+            var descriptor = Descriptor(face);
+
+            Assert.Equal(face.hhea.ascender, descriptor.NormalLineHeightAscent);
+            Assert.Equal(System.Math.Abs(face.hhea.descender), descriptor.NormalLineHeightDescent);
+        }
+
+        // Regression guard for a bug caught in review: FontAdapter.NormalLineHeight originally rounded
+        // each ascent/descent/gap component to a whole CSS pixel *after* multiplying by PixelsPerPoint,
+        // instead of before - correct only by coincidence at the default PixelsPerPoint=1 every other test
+        // in this repo uses, since Length.PointsPerPx is a fixed pt-per-CSS-px ratio, not a
+        // pt-per-internal-layout-unit one. Two FontAdapters wrapping the *same* XFont (so both share
+        // identical ascent/descent/gap component values in real-point space, unaffected by
+        // PixelsPerPoint - see FontAdapter's own remarks on why XFont.Size is a true, unscaled point size)
+        // isolate the fix precisely: with each component correctly rounded once, in real-point space,
+        // before the single final multiply, NormalLineHeight must scale by *exactly* PixelsPerPoint. The
+        // bug this guards against instead re-rounds at a different (wrong) granularity per PixelsPerPoint
+        // value, so the ratio would generally miss 2.0 by a fraction of a CSS pixel.
+        [Fact]
+        public void NormalLineHeight_ScalesExactlyLinearlyWithPixelsPerPoint()
+        {
+            var font = new XFont("bundled", 20, XFontStyle.Regular, new XPdfFontOptions(PdfFontEncoding.Unicode),
+                400, 5, null, new BundledTtfResolver());
+
+            var unscaled = new FontAdapter(font, pixelsPerPoint: 1.0);
+            var scaled = new FontAdapter(font, pixelsPerPoint: 2.0);
+
+            Assert.Equal(2.0 * unscaled.NormalLineHeight, scaled.NormalLineHeight, 9);
+        }
+    }
+}

--- a/src/PeachPDF.Tests/TestSupport/BundledFonts.cs
+++ b/src/PeachPDF.Tests/TestSupport/BundledFonts.cs
@@ -180,6 +180,19 @@ namespace PeachPDF.Tests.TestSupport
             FontResolver.SupportedFonts.FirstOrDefault() ?? Ttf;
 
         /// <summary>
+        /// An inline <c>@font-face</c> rule embedding <paramref name="fontPath"/> as a base64 data URL
+        /// under <paramref name="familyName"/> - for an HTML-layer (<c>LayoutHarness</c>) test whose
+        /// fixture geometry is calibrated against a specific font's real metrics and so must not depend on
+        /// whatever font the host OS happens to resolve a bare <c>font-family</c> keyword to (issue #956's
+        /// own line-height:normal tests hit exactly this: identical fixtures passed on Windows and failed
+        /// on Linux/macOS CI runners purely because they resolved to different default system fonts with
+        /// different real metrics). <paramref name="mimeType"/> is <c>font/truetype</c> for <see cref="Ttf"/>
+        /// or <c>font/opentype</c> for <see cref="Otf"/>.
+        /// </summary>
+        internal static string FontFaceRule(string fontPath, string familyName, string mimeType) =>
+            $"@font-face {{ font-family: '{familyName}'; src: url('data:{mimeType};base64,{Convert.ToBase64String(File.ReadAllBytes(fontPath))}'); }}";
+
+        /// <summary>
         /// Ensures <paramref name="resolver"/> can resolve at least one font family and
         /// returns its name, using a system font if one was detected or registering the
         /// bundled TTF as a custom font otherwise.

--- a/src/PeachPDF/Adapters/FontAdapter.cs
+++ b/src/PeachPDF/Adapters/FontAdapter.cs
@@ -10,6 +10,7 @@
 // - Sun Tsu,
 // "The Art of War"
 
+using PeachPDF.CSS;
 using PeachPDF.Fonts.OpenType;
 using PeachPDF.Html.Adapters;
 using PeachPDF.Html.Adapters.Entities;
@@ -38,6 +39,11 @@ namespace PeachPDF.Adapters
         /// Cached font ascent.
         /// </summary>
         private readonly double _ascent;
+
+        /// <summary>
+        /// Cached `line-height: normal` value (CSS 2.1 §10.8.1) - see <see cref="NormalLineHeight"/>.
+        /// </summary>
+        private readonly double _normalLineHeight;
 
         /// <summary>
         /// Cached font whitespace width.
@@ -73,6 +79,20 @@ namespace PeachPDF.Adapters
             var descriptor = font.Descriptor;
             var descent = font.Size * descriptor.Descender / descriptor.UnitsPerEm;
             var ascent = font.Size * descriptor.Ascender / descriptor.UnitsPerEm;
+            // `font.Size` is a true (unscaled) point size - see the Ascent/Height property comments below
+            // for why the PixelsPerPoint multiply has to happen separately, at the property/here, not baked
+            // into font.Size itself. Each of ascent/descent/gap is rounded to a whole CSS pixel *in that
+            // true-point space* before summing (not the summed total, and not after the PixelsPerPoint
+            // multiply - rounding post-multiply would round to the wrong granularity whenever
+            // PixelsPerPoint != 1, since RoundToWholeCssPixel's divisor is a fixed pt-per-CSS-px ratio,
+            // not a pt-per-internal-unit one) - this is what makes it land exactly on Chrome's figures
+            // rather than merely close (issue #956). The PixelsPerPoint multiply is applied once, after
+            // rounding, to convert the whole sum into this container's internal layout-unit space -
+            // mirroring Ascent's own single multiply, just applied to the rounded sum instead of a raw value.
+            double ScaleUnits(int designUnits) => font.Size * designUnits / descriptor.UnitsPerEm;
+            _normalLineHeight = (RoundToWholeCssPixel(ScaleUnits(descriptor.NormalLineHeightAscent)) +
+                                 RoundToWholeCssPixel(ScaleUnits(descriptor.NormalLineHeightDescent)) +
+                                 RoundToWholeCssPixel(ScaleUnits(descriptor.NormalLineHeightGap))) * pixelsPerPoint;
             // XFont.Height (int, System.Drawing.Font-style API) rounds up to a whole point via
             // Math.Ceiling - harmless at an ordinary font.Size, but collapses to exactly 1 for any
             // sub-1pt size, discarding all proportional information. This adapter's own Height then
@@ -105,6 +125,15 @@ namespace PeachPDF.Adapters
         public override double Height => _height * PixelsPerPoint;
 
         public override double Ascent => Math.Round(_ascent * PixelsPerPoint);
+
+        /// <summary>
+        /// The used value of `line-height: normal`, resolved the way real browsers do: the font's own
+        /// ascent + descent + line-gap (CSS 2.1 §10.8.1) - see the constructor for the rounding-order
+        /// rationale (issue #956).
+        /// </summary>
+        public override double NormalLineHeight => _normalLineHeight;
+
+        private static double RoundToWholeCssPixel(double pt) => Math.Round(pt / Length.PointsPerPx) * Length.PointsPerPx;
 
         public override double LeftPadding => Height / 6f;
 

--- a/src/PeachPDF/Fonts/OpenType/FontDescriptor.cs
+++ b/src/PeachPDF/Fonts/OpenType/FontDescriptor.cs
@@ -343,7 +343,7 @@ namespace PeachPDF.Fonts.OpenType
         int _stemV;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public int LineSpacing
         {
@@ -351,6 +351,41 @@ namespace PeachPDF.Fonts.OpenType
             protected set { _lineSpacing = value; }
         }
         int _lineSpacing;
+
+        // ---- `line-height: normal` metrics (CSS 2.1 §10.8.1) ------------------------------------
+        // Deliberately separate from Ascender/Descender/LineSpacing above: those follow WPF's
+        // FontDriver.ReadBasicMetrics, which substitutes OS/2 win ascent/descent for hhea in the
+        // non-typo-metrics case (a legacy Windows-GDI/old-IE convention) and backs PDF /FontDescriptor
+        // metrics and baseline positioning. Browsers resolve `normal` from the raw hhea (or, when
+        // USE_TYPO_METRICS is set, OS/2 typo) ascent/descent/lineGap triple instead, with no win-metrics
+        // substitution - issue #956.
+
+        /// <summary>Design-units ascent for `line-height: normal` (raw <c>hhea.ascender</c>, or
+        /// <c>OS/2.sTypoAscender</c> when <c>USE_TYPO_METRICS</c> is set).</summary>
+        public int NormalLineHeightAscent
+        {
+            get { return _normalLineHeightAscent; }
+            protected set { _normalLineHeightAscent = value; }
+        }
+        int _normalLineHeightAscent;
+
+        /// <summary>Design-units descent (positive) for `line-height: normal` (raw <c>hhea.descender</c>,
+        /// or <c>OS/2.sTypoDescender</c> when <c>USE_TYPO_METRICS</c> is set).</summary>
+        public int NormalLineHeightDescent
+        {
+            get { return _normalLineHeightDescent; }
+            protected set { _normalLineHeightDescent = value; }
+        }
+        int _normalLineHeightDescent;
+
+        /// <summary>Design-units line gap (clamped to ≥ 0) for `line-height: normal` (raw
+        /// <c>hhea.lineGap</c>, or <c>OS/2.sTypoLineGap</c> when <c>USE_TYPO_METRICS</c> is set).</summary>
+        public int NormalLineHeightGap
+        {
+            get { return _normalLineHeightGap; }
+            protected set { _normalLineHeightGap = value; }
+        }
+        int _normalLineHeightGap;
 
 
         internal static string ComputeKey(XFont font)

--- a/src/PeachPDF/Fonts/OpenType/OpenTypeDescriptor.cs
+++ b/src/PeachPDF/Fonts/OpenType/OpenTypeDescriptor.cs
@@ -132,31 +132,46 @@ namespace PeachPDF.Fonts.OpenType
                 // A signed typo descent would be quite unusual as it would indicate the descender was above the baseline
                 Descender = -typoDescender;
                 LineSpacing = typoAscender + typoLineGap - typoDescender;
+
+                // `line-height: normal` (CSS 2.1 §10.8.1): browsers use this same OS/2 typo triple when
+                // USE_TYPO_METRICS is set, but - unlike Ascender/Descender/LineSpacing above - never fall
+                // back to the OS/2 win metrics in the branch below; see that branch's own comment.
+                NormalLineHeightAscent = typoAscender;
+                NormalLineHeightDescent = -typoDescender;
+                NormalLineHeightGap = Math.Max((short)0, typoLineGap);
             }
             else
             {
                 // Comment from WPF: get the ascender field
                 int ascender = FontFace.hhea.ascender;
-                // Comment from WPF: get the descender field; this is measured in the same direction as ascender and is therefore 
+                // Comment from WPF: get the descender field; this is measured in the same direction as ascender and is therefore
                 // normally negative whereas we want a positive value; however some fonts get the sign wrong
                 // so instead of just negating we take the absolute value.
                 int descender = Math.Abs(FontFace.hhea.descender);
-                // Comment from WPF: get the lineGap field and make sure it's >= 0 
+                // Comment from WPF: get the lineGap field and make sure it's >= 0
                 int lineGap = Math.Max((short)0, FontFace.hhea.lineGap);
+
+                // `line-height: normal`: browsers resolve this from the raw hhea triple - never the OS/2
+                // win-metrics substitution the block below applies to Ascender/Descender/LineSpacing (that
+                // substitution is a legacy Windows-GDI/old-IE convention; Chromium/Gecko/WebKit all read
+                // hhea here instead - issue #956).
+                NormalLineHeightAscent = ascender;
+                NormalLineHeightDescent = descender;
+                NormalLineHeightGap = lineGap;
 
                 if (!os2SeemsToBeEmpty)
                 {
                     // Comment from WPF: we could use sTypoAscender, sTypoDescender, and sTypoLineGap which are supposed to represent
-                    // optimal typographic values not constrained by backwards compatibility; however, many fonts get 
-                    // these fields wrong or get them right only for Latin text; therefore we use the more reliable 
+                    // optimal typographic values not constrained by backwards compatibility; however, many fonts get
+                    // these fields wrong or get them right only for Latin text; therefore we use the more reliable
                     // platform-specific Windows values. We take the absolute value of the win32descent in case some
-                    // fonts get the sign wrong. 
+                    // fonts get the sign wrong.
                     int winAscent = FontFace.os2.usWinAscent;
                     int winDescent = Math.Abs(FontFace.os2.usWinDescent);
 
                     Ascender = winAscent;
                     Descender = winDescent;
-                    // Comment from WPF: The following calculation for designLineSpacing is per [....]. The default line spacing 
+                    // Comment from WPF: The following calculation for designLineSpacing is per [....]. The default line spacing
                     // should be the sum of the Mac ascender, descender, and lineGap unless the resulting value would
                     // be less than the cell height (winAscent + winDescent) in which case we use the cell height.
                     // See also http://www.microsoft.com/typography/otspec/recom.htm.

--- a/src/PeachPDF/Html/Adapters/RFont.cs
+++ b/src/PeachPDF/Html/Adapters/RFont.cs
@@ -128,5 +128,19 @@ namespace PeachPDF.Html.Adapters
         /// <c>FragmentPainter.Text.cs</c>'s <c>PaintUprightVerticalRun</c> remarks for the derivation).
         /// </summary>
         public virtual double GetVerticalOriginY(System.Text.Rune rune) => Ascent;
+
+        /// <summary>
+        /// The used value of `line-height: normal` (CSS 2.1 §10.8.1), intended to be in the same pixel
+        /// units as <see cref="Height"/>/<see cref="Ascent"/>. Real browsers resolve this from the font's
+        /// own ascent/descent/line-gap metrics rather than a flat multiplier; the default here reproduces
+        /// the flat 1.2×-font-size approximation used before real per-font metrics were available (issue
+        /// #956), so only the OpenType-descriptor-backed adapter overrides it - mirroring the vertical-
+        /// metrics section above. Note this default is only faithful to that unit contract for an
+        /// <see cref="RFont"/> whose own <see cref="Size"/> is already in that same space;
+        /// <see cref="PeachPDF.Adapters.FontAdapter"/>'s <see cref="Size"/> is not (it's a true, unscaled
+        /// point size - see its own remarks), which is exactly why it can't just inherit this default and
+        /// overrides the property instead.
+        /// </summary>
+        public virtual double NormalLineHeight => 1.2 * Size;
     }
 }

--- a/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
+++ b/src/PeachPDF/Html/Core/Dom/DerivedStyle.cs
@@ -1224,10 +1224,10 @@ namespace PeachPDF.Html.Core.Dom
         /// <summary>Gets the line height. Recomputed fresh every call, not cached.</summary>
         public double ActualLineHeight => Style.Text.LineHeight.Value.Value is { } lineHeight
             ? CssValueParser.ParseLength(lineHeight, Owner.Size.Height, Owner)
-            // GetEmHeight() is device-scaled (see CssValueParser.ParseLength(LengthOrUnitless,...)'s
-            // identical correction for line-height's own explicit unitless multiplier) - undo that the
-            // same way for the normal/default 1.2 multiplier (issue #814's line-height sibling).
-            : 1.2 * GetEmHeight() * ((Owner.HtmlContainer?.Adapter as PdfSharpAdapter)?.PixelsPerPoint ?? 1.0);
+            // `normal` (CSS 2.1 §10.8.1) resolves from the used font's own metrics, matching browsers -
+            // see RFont.NormalLineHeight (issue #956). Already fully scaled, same convention as
+            // ActualFont.Ascent/Height elsewhere - no further PixelsPerPoint correction here.
+            : ActualFont.NormalLineHeight;
 
         #endregion
 


### PR DESCRIPTION
## Summary

- `line-height: normal` resolved to a flat `1.2 × font-size` for every font. CSS 2.1 §10.8.1 makes it "based on the font of the element" — every real browser (Chromium, Firefox, Safari) resolves it from the font's own ascent/descent/line-gap metrics instead, and the deviation from the flat constant compounds down a page (measured up to ~10% per line for some fonts against Chrome).
- Adds a new, browser-matching `hhea`/OS2-typo-metrics accessor (`FontDescriptor.NormalLineHeightAscent`/`Descent`/`Gap`, `RFont.NormalLineHeight`) that is deliberately separate from the existing `Ascender`/`Descender`/`LineSpacing` triple — that triple is a WPF-derived port that substitutes OS/2 win metrics for `hhea` (a legacy Windows-GDI convention) and backs PDF `/FontDescriptor` metrics plus baseline positioning, so it stays untouched.
- `DerivedStyle.ActualLineHeight`'s `normal` branch now reads `ActualFont.NormalLineHeight` instead of the flat multiplier.

## Test plan

- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — 10,379 passed, 0 failed, 9 skipped (pre-existing)
- [x] Diff coverage 100% on changed lines (`diff-cover` against `origin/main`)
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — zero warnings
- [x] New unit/integration tests: `NormalLineHeightMetricsTests.cs` (hhea/OS2-typo branch selection + a `PixelsPerPoint`-scaling regression test), `LineHeightTypedStorageTests.cs` (real per-font `ActualLineHeight` values, hand-verified against each bundled font's own `hhea` table), `RFontVerticalMetricsDefaultsTests.cs`
- [x] Visual verification: new `line_height_normal` TestHarness showcase, rendered and rasterized — line spacing now visibly differs by font instead of being uniform
- [x] Multi-angle code review pass (8 angles) — caught and fixed a real `PixelsPerPoint`-scaling rounding-order bug and duplicated branch logic before merge

Fixes #956