### PR TITLE
A relocated table no longer draws its abandoned run's header

### DIFF
--- a/.claude/invariants/proxy-undoing-a-runs-proxies-means-dropping-the-instances-they-recorded.md
+++ b/.claude/invariants/proxy-undoing-a-runs-proxies-means-dropping-the-instances-they-recorded.md
@@ -1,0 +1,20 @@
+# Undoing a run's proxies means dropping the instances they recorded
+
+A `CssProxyBox` is a layout-time placeholder, not what paint reads. Every proxy that lays out also
+calls `HtmlContainerInt.RecordRepeatingGroupInstance`, and it is that record — a `CapturedInstance`
+held by `FragmentEmitter`, keyed `(tableBox, slot)` — that becomes a fragment and gets painted.
+
+So a pass that abandons a run's output has **two** things to undo, and removing the proxies from
+`CssBox.Boxes` is only the first. The second is `ClearCapturedInstances(root)`, which
+`CssLayoutEngineColumns` has always called and `CssLayoutEngineTable` did not.
+
+**The measured symptom.** A table carrying `break-inside: avoid` that does not fit in what is left
+of a page is laid out again on the next one. `RestoreStructureFromAnyPreviousRun` dropped the
+abandoned run's proxies, and a test counting `DisplayMode.TableHeaderGroup` boxes in the tree
+therefore passed — while the PDF drew the `<thead>` **three** times: once stranded on the page the
+table had left, at the position the abandoned run gave it, and twice on top of itself at the top of
+the page it moved to, where the abandoned run's page break had been.
+
+The census that sees it counts words per fragmentainer in `FragmentTree`, not boxes in the tree.
+Any assertion about how often a repeating group is drawn has to be taken from the fragment tree for
+the same reason.

--- a/.claude/migration-notes/2026-09-08-a-relocated-table-no-longer-repeats-its-abandoned-header.md
+++ b/.claude/migration-notes/2026-09-08-a-relocated-table-no-longer-repeats-its-abandoned-header.md
@@ -1,0 +1,21 @@
+# A relocated table no longer repeats its abandoned header
+
+A table that carries `break-inside: avoid` (or `page-break-inside: avoid`) and does not fit in what
+is left of a page moves whole to the next one. When such a table also repeats a `<thead>`, the
+headers belonging to the abandoned attempt were drawn as well.
+
+**Before.** Three copies of the header row: one stranded near the bottom of the page the table had
+left, with no table beneath it, and two drawn exactly on top of each other at the top of the page
+the table moved to. Overprinted text looks bolder or slightly smudged rather than obviously
+doubled, so the usual first sign was the stray header on the previous page.
+
+**Now.** One header, at the top of the page the table lands on — which is what a browser draws.
+
+**When a document author would notice.** Only where all three hold: a table with a `<thead>`, an
+avoiding `break-inside` on it (a common house style for keeping a small table together, and note
+that the UA print stylesheet supplies it for the header group itself, not for the table), and a
+position on the page that leaves too little room. A table that splits across the boundary is
+unaffected and repeated its header correctly before and after.
+
+Nothing needs changing in a document. Output that was previously worked around by removing
+`break-inside: avoid` from such tables can have it back.

--- a/.claude/recent-fixes/2026-09-08-a-relocated-table-left-its-abandoned-headers-behind.md
+++ b/.claude/recent-fixes/2026-09-08-a-relocated-table-left-its-abandoned-headers-behind.md
@@ -1,0 +1,40 @@
+# A relocated table left its abandoned headers behind
+
+A table with `break-inside: avoid` (or the `page-break-inside` alias) that does not fit in the rest
+of a page is laid out again from the start on the next one, per
+[css-break-3 §4.2](https://www.w3.org/TR/css-break-3/#break-within). If it repeats a `<thead>`, the
+abandoned run's headers were still drawn.
+
+`CssLayoutEngineTable.RestoreStructureFromAnyPreviousRun` already undid the visible half — the
+proxies the last run put in the table's child list. But a proxy is not what paint reads: laying one
+out also records a `CapturedInstance` with `FragmentEmitter`, and nothing dropped those. One call to
+`ClearCapturedInstances(_tableBox)` on a fresh pass, exactly as `CssLayoutEngineColumns` has always
+made for the same reason, fixes it.
+
+## What measuring it turned up
+
+- **The header was drawn three times, not twice.** Once stranded on the page the table had *left*,
+  at the position the abandoned run gave it — a header floating alone above the bottom margin with
+  no table under it — and twice on top of itself at the top of the page it moved to, where the
+  abandoned run's page break had put the repeat. Traced by printing every `CreateHeaderProxy` call
+  site: the first run produced two (the in-flow one and the break's), the second run one, and all
+  three reached paint.
+- **The box tree was already right, which is how it survived.** `RepeatingTableRelayoutTests`
+  counts `DisplayMode.TableHeaderGroup` boxes under the root and asserts 1–2. That count was
+  correct — the restore does remove the proxies — while the output was wrong. Instrumenting the
+  restore confirmed it: proxies before 2, after 0, and the run that followed added exactly one.
+  So the new test counts words per fragmentainer in `FragmentTree` instead, which is the only place
+  the defect is visible. That is now written down as an invariant.
+- **Only a *relocated* table is affected.** The same table allowed to split across the boundary
+  repeats its header once per page and always did. That case is the second test here, so a fix that
+  suppressed repetition outright rather than dropping stale records would fail it.
+- **Chrome agrees exactly.** The repro rendered against Chrome 152 gives one header, on the page the
+  table lands on, at the same coordinates this now produces (39.9 vs 39.8pt, the usual rounding).
+
+## Evidence
+
+`RelocatedTableHeaderInstanceTests`: three filler heights that each push the table over the
+boundary, asserting nothing on the page it left and exactly one where it landed, plus the
+split-table control. All three relocation cases fail against `main` (0 expected / 1 actual on the
+abandoned page, 1 / 2 on the landing page); the control passes there and here. Full suite green on
+net8.0 (10,391), 0 new build warnings.

--- a/src/PeachPDF.Tests/Integration/RelocatedTableHeaderInstanceTests.cs
+++ b/src/PeachPDF.Tests/Integration/RelocatedTableHeaderInstanceTests.cs
@@ -1,0 +1,137 @@
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Fragments;
+using PeachPDF.Tests.TestSupport;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// A table relocated whole by <c>break-inside: avoid</c> draws its repeating
+    /// <c>&lt;thead&gt;</c> or <c>&lt;tfoot&gt;</c> once per page it ends up on, and on no page it has
+    /// left.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A table that does not fit in what is left of a band is laid out again from the start on the next
+    /// one (<see href="https://www.w3.org/TR/css-break-3/#break-within">css-break-3 §4.2</see>). The
+    /// abandoned run's proxies were already dropped from the table's children, but a proxy is not what
+    /// paint reads: each one also recorded a repeating-group instance with the fragment emitter, and
+    /// those survived. A three-row table pushed onto the next page therefore drew its header three
+    /// times — once stranded on the page the table had left, at the position the abandoned run gave it,
+    /// and twice on top of itself where the abandoned run's page break had been.
+    /// </para>
+    /// <para>
+    /// The counts here are the whole assertion, so they are taken from the fragment tree rather than
+    /// from the table's box list: the box list was already right while the output was wrong, which is
+    /// how this survived <see cref="RepeatingTableRelayoutTests"/>.
+    /// </para>
+    /// <para>
+    /// Every assertion is stated against the pages the table's own <i>rows</i> reach rather than
+    /// against page numbers, so it says the same thing whatever the platform's font metrics do to
+    /// where the table lands. A first version named page 1 and page 2 outright and failed on Windows,
+    /// where the same fixture put nothing at all of the table on the first page.
+    /// </para>
+    /// </remarks>
+    public class RelocatedTableHeaderInstanceTests
+    {
+        private const double PageHeight = 200;
+        private const double Margin = 20;
+
+        /// <summary>
+        /// <paramref name="fillerHeight"/> leaves too little of the first page for the table, which
+        /// carries <c>break-inside: avoid</c>, so the whole table moves to the next one and the run
+        /// that placed it on the first is abandoned.
+        /// </summary>
+        private static string PushedTable(double fillerHeight, string group) =>
+            LayoutHarness.Wrap(
+                $"<div style='height:{fillerHeight}pt'>filler</div>"
+                + "<table style='width:100pt;break-inside:avoid;font-size:10pt'>"
+                + $"<{group}><tr><th>HEADWORD</th></tr></{group}>"
+                + "<tbody><tr><td>ROWWORD</td></tr><tr><td>ROWWORD</td></tr><tr><td>ROWWORD</td></tr>"
+                + "</tbody></table>");
+
+        [Theory]
+        [InlineData(120, "thead")]
+        [InlineData(130, "thead")]
+        [InlineData(140, "thead")]
+        [InlineData(120, "tfoot")]
+        [InlineData(130, "tfoot")]
+        [InlineData(140, "tfoot")]
+        public async Task ATableRelocatedWhole_DrawsItsRepeatingGroupOnceOnThePageItLandsOn(
+            double fillerHeight, string group)
+        {
+            var (_, container) = await LayoutHarness.LayoutAsync(
+                PushedTable(fillerHeight, group), pageHeight: PageHeight, margin: Margin);
+
+            var headers = CountPerPage(container, "HEADWORD");
+            var rows = CountPerPage(container, "ROWWORD");
+
+            Assert.True(headers.Count > 1, "fixture does not paginate, so it asserts nothing");
+
+            // The relocation itself: no part of the table is left on the page it was pushed off.
+            Assert.Equal(0, rows[0]);
+
+            AssertOneGroupPerPageTheRowsReach(headers, rows);
+        }
+
+        /// <summary>
+        /// The control: the same table without <c>break-inside: avoid</c> splits across the boundary
+        /// and repeats its header per
+        /// <see href="https://www.w3.org/TR/css-tables-3/#repeated-headers">css-tables-3 §6.2</see>. It
+        /// shares every ingredient with the fixture above except the relocation, so a fix that
+        /// suppressed repetition outright rather than dropping stale records would fail here. Enough
+        /// rows that the table has to span two pages whatever a row measures.
+        /// </summary>
+        [Fact]
+        public async Task ATableAllowedToSplit_StillRepeatsItsHeaderOnEveryPageItSpans()
+        {
+            var rowMarkup = string.Concat(Enumerable.Repeat("<tr><td>ROWWORD</td></tr>", 30));
+
+            var (_, container) = await LayoutHarness.LayoutAsync(
+                LayoutHarness.Wrap(
+                    "<table style='width:100pt;font-size:10pt'>"
+                    + "<thead><tr><th>HEADWORD</th></tr></thead>"
+                    + $"<tbody>{rowMarkup}</tbody></table>"),
+                pageHeight: PageHeight, margin: Margin);
+
+            var headers = CountPerPage(container, "HEADWORD");
+            var rows = CountPerPage(container, "ROWWORD");
+
+            Assert.True(rows.Count(n => n > 0) > 1, "the table does not split, so this asserts nothing");
+
+            AssertOneGroupPerPageTheRowsReach(headers, rows);
+        }
+
+        /// <summary>
+        /// css-tables-3 §6.2 repeats the group on each page the table spans — so exactly one wherever
+        /// a row of it lands, and none anywhere else. A stranded copy fails the second half; a copy
+        /// drawn on top of itself fails the first.
+        /// </summary>
+        private static void AssertOneGroupPerPageTheRowsReach(
+            IReadOnlyList<int> headers, IReadOnlyList<int> rows)
+        {
+            Assert.Equal(rows.Select(n => n > 0 ? 1 : 0), headers);
+        }
+
+        private static List<int> CountPerPage(HtmlContainerInt container, string word) =>
+            container.FragmentTree!.Fragmentainers
+                .OrderBy(f => f.SlotIndex)
+                .Select(f => Flatten(f.Root)
+                    .SelectMany(b => b.Words)
+                    .Count(w => w.Word.Text == word))
+                .ToList();
+
+        private static IEnumerable<BoxFragment> Flatten(BoxFragment fragment)
+        {
+            yield return fragment;
+
+            foreach (var child in fragment.Children)
+            {
+                foreach (var descendant in Flatten(child)) yield return descendant;
+            }
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineTable.cs
@@ -483,7 +483,21 @@ namespace PeachPDF.Html.Core.Dom
             // output is undone first. A resumed pass is the one run that is not starting from the markup:
             // it continues the table this output belongs to, and the proxies it would drop here are the
             // only surviving reference to the detached group every earlier page repeats.
-            if (!_continuesAPreviousPass) RestoreStructureFromAnyPreviousRun();
+            if (!_continuesAPreviousPass)
+            {
+                RestoreStructureFromAnyPreviousRun();
+
+                // Dropping the proxies undoes only half of the last run's output. Each one also recorded a
+                // repeating-group instance with the emitter (RecordRepeatingGroupFragmentInstance), and it is
+                // those records - not the proxies - that paint reads. A table laid out again from the start
+                // may span different pages than the run before it, so every instance the last run recorded
+                // describes a header or footer that is no longer anywhere, and leaving them behind draws the
+                // group once more for each one, on top of the real one. Same case, and the same call, as the
+                // multi-column engine's own re-run (CssLayoutEngineColumns). A resumed pass is excluded for
+                // the reason it is excluded above: the instances it would drop are the ones every earlier
+                // page of this same table repeats.
+                _tableBox.HtmlContainer?.ClearCapturedInstances(_tableBox);
+            }
 
             // get the table boxes into the proper fields
             AssignBoxKinds();


### PR DESCRIPTION
A table carrying `break-inside: avoid` that does not fit in what is left of a page is laid out again from the start on the next one ([css-break-3 §4.2](https://www.w3.org/TR/css-break-3/#break-within)). If it repeats a `<thead>` or `<tfoot>`, the abandoned run's copies were drawn too — **three** headers for a table pushed onto the next page:

- one stranded near the bottom of the page the table had **left**, with no table beneath it, at the position the abandoned run gave it;
- two drawn exactly on top of each other at the top of the page it moved to, where the abandoned run's page break had been.

Reproduced against a plain 3-row table with a `<thead>` under a 660pt filler; Chrome 152 draws one header, on the landing page, at the coordinates this now produces.

## The cause

`RestoreStructureFromAnyPreviousRun` already undoes the visible half of a previous run — the `CssProxyBox`es it left in the table's child list. But a proxy is not what paint reads: laying one out also records a `CapturedInstance` with `FragmentEmitter` (`RecordRepeatingGroupFragmentInstance` → `HtmlContainerInt.RecordRepeatingGroupInstance`), and it is that record which becomes a fragment. Nothing dropped them.

`CssLayoutEngineColumns` has always made the matching call on its own re-run, with the comment that says exactly why:

> A container laid out again from the start may land in a different slot altogether, and the fragmentainers it recorded in the slot it has left describe geometry that no longer exists anywhere.

The table engine now does the same on a fresh pass. A resumed pass is excluded for the reason it is already excluded from the structure restore: the instances it would drop are the ones every earlier page of that same table repeats.

## Why this survived the existing test

`RepeatingTableRelayoutTests.TheTableInsideARelocatedCard_StillRepeatsItsHeaderExactlyOnce` counts `DisplayMode.TableHeaderGroup` boxes under the root. That count was **correct** — instrumenting the restore shows proxies before 2, after 0, and the following run adding exactly one — while the output was wrong. Any assertion about how often a repeating group is drawn has to come from the fragment tree, so the new test counts the group's words per fragmentainer. I have added that as an invariant note.

## Tests

`RelocatedTableHeaderInstanceTests`:

- six relocation cases — three filler heights × `<thead>`/`<tfoot>` — asserting nothing on the page the table left and exactly one where it landed. **All six fail against `main`** (0 expected / 1 actual on the abandoned page, 1 / 2 on the landing page).
- one control: the same table allowed to split across the boundary still repeats its header on both pages per [css-tables-3 §6.2](https://www.w3.org/TR/css-tables-3/#repeated-headers). It passes before and after, so a fix that suppressed repetition outright rather than dropping stale records would fail it.

Full suite green on net8.0 (10,394 passed), 0 new build warnings, diff coverage 100%.

Docs describe the intended behaviour already and needed no change; `.claude/` carries a recent-fixes entry, a migration note and the invariant.
