### PR TITLE
A forced break at the end of a block no longer opens a line

### DIFF
--- a/.claude/migration-notes/2026-09-08-a-trailing-br-no-longer-adds-a-line.md
+++ b/.claude/migration-notes/2026-09-08-a-trailing-br-no-longer-adds-a-line.md
@@ -1,0 +1,20 @@
+# A trailing `<br>` no longer adds a line
+
+A `<br>` with nothing after it in its block used to leave an empty line behind it, making the block
+one line taller than a browser renders it. It now ends the line it falls on and opens none. CSS 2.1
+[§9.4.2](https://www.w3.org/TR/CSS21/visuren.html#inline-formatting) requires a line box holding no
+content to "be treated as not existing for any other purpose".
+
+| markup | before | now, and in a browser |
+| --- | --- | --- |
+| `x<br>` | 2 lines | 1 line |
+| `<br>` | 2 lines | 1 line |
+| `x<br><br>` | 3 lines | 2 lines |
+| `x<br>` then a `display: block` sibling | 2 lines + the block | 1 line + the block |
+| `x<br><br>c` | 3 lines | 3 lines — unchanged |
+
+**When a document author would notice.** Any block whose inline content ends in a `<br>` is now one
+line shorter. The shape that shows it most is a table cell holding a label above an image —
+`label<br><img style="display:block">` — where every row of the table loses a line's height, and a
+long table can gain back a page. Content that relied on a trailing `<br>` for spacing will close up;
+use a margin, or a second `<br>` (which still leaves one empty line, as it does in a browser).

--- a/.claude/recent-fixes/2026-09-08-a-forced-break-at-the-end-of-a-block-opened-a-line.md
+++ b/.claude/recent-fixes/2026-09-08-a-forced-break-at-the-end-of-a-block-opened-a-line.md
@@ -1,0 +1,45 @@
+# A forced break at the end of a block opened a line
+
+A forced line break ([css-text-3 §5.5](https://www.w3.org/TR/css-text-3/#forced-line-break)) *ends*
+the line it falls on. `CssLayoutEngine` instead closes that line and starts the next one with the
+break's own word, so a break was always followed by a line — including where the break is the last
+thing in the block and there is nothing for that line to hold. CSS 2.1
+[§9.4.2](https://www.w3.org/TR/CSS21/visuren.html#inline-formatting) requires such a line to "be
+treated as not existing for any other purpose", and a `<br>` is not the preserved newline that
+sentence carves out. Every such block came out one line taller than a browser makes it.
+
+`DropATrailingForcedBreaksOwnLine` takes that line back at the point the block finishes.
+
+## What measuring it turned up
+
+- **The line-box shapes say it plainly.** Printing every finished block's lines:
+  `<div>x<br></div>` is `['x'] | [<BR>]`, `<div><br></div>` is `[] | [<BR>]`, and
+  `<div><br><br></div>` is `[] | [<BR>] | [<BR>]`. The break's word never shares a line with the
+  content it follows, and the trailing one always has a line to itself.
+- **Only the last break, and only when its line holds nothing else.** `x<br><br>` really is two
+  lines in a browser and `x<br><br>c` three — measured against Chrome 152, along with `x<br>`,
+  a bare `<br>`, and `x<br>` in front of a `display: block` sibling. Every one of the five now
+  matches Chrome to the point.
+- **A block with no inline content is not this case** and is deliberately excluded: its single line
+  box has no words, and dropping it would collapse a block rather than shorten it.
+- **The common shape is a table cell holding a label and an image.**
+  `label<br><img style="display:block">` gained a whole line in every row of such a table. On a
+  seven-row routing table that is 70pt, enough to push the table after it onto a second page.
+
+## Evidence
+
+`TrailingForcedBreakLineTests`: seven content shapes asserted as a multiple of the block's own line
+height, taken from a single-line control in the same document, plus the block-sibling case and the
+empty-block exclusion. `line-height` is pinned in the fixture — a break-only line and a text line
+differ by a quarter of a point under `normal`, which is the font's metrics and not this test's
+subject. Five of the nine fail against `main`; the four that do not are the controls. Full suite
+green on net8.0 (10,387 before the new tests), 0 new build warnings.
+
+## Correction
+
+The first version of this cited CSS 2.1 §16.6.1 for "a forced break ends a line". That is wrong and
+the maintainer caught it: §16.6.1 is "The 'white-space' processing model", entirely about collapsing
+tabs, spaces and linefeeds, and it never mentions `<br>` or a forced break. Verified by fetching the
+section. The term is defined in css-text-3 §5.5, and the rule this fix actually implements — an empty
+line box "must be treated as not existing" — is CSS 2.1 §9.4.2. Both verified the same way before
+being written here.

--- a/docs/html-css-support.md
+++ b/docs/html-css-support.md
@@ -145,7 +145,7 @@ Example:
 | `bdi` | [bdi](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi) | Full support — isolates its content from the surrounding paragraph's Unicode Bidi Algorithm resolution (`unicode-bidi: isolate`, per the UA stylesheet), and when it has no `dir` attribute of its own, its base direction is auto-detected from its content's first strong character, same as an explicit `dir="auto"` |
 | `bdo` | [bdo](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdo) | Full support |
 | `big` | [big](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/big) | Deprecated element; rendered with a larger font size |
-| `br` | [br](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br) | Full support |
+| `br` | [br](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br) | Full support. A forced break ends the line it falls on, so one with nothing after it in its block leaves no line behind it: `x<br>` is one line tall, and so is `x<br>` followed by a block-level sibling. Only the last break in a run is taken back this way — `x<br><br>` is two lines and `x<br><br>c` is three |
 | `cite` | [cite](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite) | Rendered as italic |
 | `code` | [code](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code) | Rendered in a monospace font |
 | `del` | [del](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del) | Rendered with strikethrough |

--- a/src/PeachPDF.Tests/Integration/TrailingForcedBreakLineTests.cs
+++ b/src/PeachPDF.Tests/Integration/TrailingForcedBreakLineTests.cs
@@ -1,0 +1,101 @@
+using PeachPDF.Tests.TestSupport;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// A forced break ends the line it falls on, so one at the very end of a block's content leaves
+    /// no line behind it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A forced line break (<see href="https://www.w3.org/TR/css-text-3/#forced-line-break">css-text-3
+    /// §5.5</see>) ends the line it falls on. This engine closes that line and starts the next one with
+    /// the break's own word, so a break was always <i>followed</i> by a line — including where the break
+    /// is the last thing in the block and there is nothing for that line to hold. CSS 2.1
+    /// <see href="https://www.w3.org/TR/CSS21/visuren.html#inline-formatting">§9.4.2</see> requires such
+    /// a line to "be treated as not existing for any other purpose"; every such block measured one line
+    /// taller than a browser makes it.
+    /// </para>
+    /// <para>
+    /// The heights here are all stated as multiples of the block's own line, taken from a
+    /// single-line control in the same document, so the test says nothing about what a line
+    /// happens to measure.
+    /// </para>
+    /// </remarks>
+    public class TrailingForcedBreakLineTests
+    {
+        // line-height is pinned well clear of anything the font's own metrics could ask for, so a
+        // line box is exactly that height whatever it holds. Both halves matter: under `normal` a
+        // break-only line and a text line differ by a fraction of a point, and a line-height merely
+        // close to the font's own extent leaves a text line taller than the declared value on some
+        // platforms while an empty one still measures it exactly — 13.3pt against 12pt on Windows,
+        // which is what a first version of this fixture failed on. Neither difference is this
+        // test's subject; the number of lines is.
+        private const string Sizing = "width:200pt;font-size:10pt;line-height:30pt";
+
+        /// <param name="content">the probe block's inline content</param>
+        /// <param name="lines">the number of line boxes a browser gives it</param>
+        [Theory]
+        // A break with nothing after it ends the line it is on and opens none.
+        [InlineData("x<br>", 1)]
+        [InlineData("<br>", 1)]
+        // Only the last one: each earlier break still opens the line that follows it.
+        [InlineData("x<br><br>", 2)]
+        [InlineData("<br><br>", 2)]
+        // A break that something does follow keeps its line, wherever the content comes from.
+        [InlineData("x<br><br>c", 3)]
+        [InlineData("x<br>c", 2)]
+        // The control: no break at all.
+        [InlineData("x", 1)]
+        public async Task ABlockIsAsTallAsTheLinesABrowserGivesIt(string content, int lines)
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                $"<div id='one' style='{Sizing}'>x</div>"
+                + $"<div id='probe' style='{Sizing}'>{content}</div>"));
+
+            var one = LayoutHarness.FindById(root, "one")!;
+            var probe = LayoutHarness.FindById(root, "probe")!;
+            var lineHeight = one.ActualBottom - one.Location.Y;
+
+            Assert.Equal(lines * lineHeight, probe.ActualBottom - probe.Location.Y, 3);
+        }
+
+        /// <summary>
+        /// A block-level sibling after the break starts its own line, so the break's own line is as
+        /// absent as it is at the end of the block — the case a barcode or logo drawn as
+        /// <c>label&lt;br&gt;&lt;img style="display:block"&gt;</c> hits on every row of a table.
+        /// </summary>
+        [Fact]
+        public async Task ABreakBeforeABlockSiblingOpensNoLineEither()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                $"<div id='one' style='{Sizing}'>x</div>"
+                + $"<div id='probe' style='{Sizing}'>x<br><span style='display:block'>y</span></div>"));
+
+            var one = LayoutHarness.FindById(root, "one")!;
+            var probe = LayoutHarness.FindById(root, "probe")!;
+            var lineHeight = one.ActualBottom - one.Location.Y;
+
+            // The "x" line and the block's own line, and nothing between them.
+            Assert.Equal(2 * lineHeight, probe.ActualBottom - probe.Location.Y, 3);
+        }
+
+        /// <summary>
+        /// A block with no inline content at all has no line to take back — its own empty line box is
+        /// not a break's leftover, and removing it would collapse a block that is already zero-height
+        /// into something the walk below it does not expect.
+        /// </summary>
+        [Fact]
+        public async Task AnEmptyBlockIsUntouched()
+        {
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                $"<div id='probe' style='{Sizing}'></div>"));
+
+            var probe = LayoutHarness.FindById(root, "probe")!;
+
+            Assert.Equal(0, probe.ActualBottom - probe.Location.Y, 3);
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngine.cs
@@ -437,6 +437,8 @@ namespace PeachPDF.Html.Core.Dom
                 blockBox.ActualRight = coordinates.MaxRight + blockBox.ActualPaddingRight + blockBox.ActualBorderRightWidth;
             }
 
+            DropATrailingForcedBreaksOwnLine(blockBox, coordinates);
+
             FinalizeLineBoxes(blockBox, completedLines);
 
             blockBox.ActualBottom = coordinates.MaxBottom + blockBox.ActualPaddingBottom + blockBox.ActualBorderBottomWidth;
@@ -1082,6 +1084,50 @@ namespace PeachPDF.Html.Core.Dom
                 if (child.DerivedStyle.ActualDisplay == Keywords.None) continue;
                 await blockBox.LayoutBlockChild(g, child);
             }
+        }
+
+        /// <summary>
+        /// Takes back the line a forced break at the very end of a block's content opened, which
+        /// CSS 2.1 <see href="https://www.w3.org/TR/CSS21/visuren.html#inline-formatting">§9.4.2</see>
+        /// says is not there.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// A forced line break (<see href="https://www.w3.org/TR/css-text-3/#forced-line-break">css-text-3
+        /// §5.5</see>) ends the line it falls on. This engine instead closes that line and places the
+        /// break's own word at the start of the next one, so a break is always <i>followed</i> by a
+        /// line — including where nothing follows it in the block, and that line holds nothing.
+        /// §9.4.2 is explicit about such a line: one with "no text, no preserved white space, no
+        /// inline elements with non-zero margins, padding, or borders, and no other in-flow content"
+        /// must "be treated as not existing for any other purpose". A <c>&lt;br&gt;</c> is not the
+        /// preserved newline that section carves out. The block measured one line taller than a
+        /// browser makes it, for <c>x&lt;br&gt;</c> as much as for a bare <c>&lt;br&gt;</c>.
+        /// </para>
+        /// <para>
+        /// Only ever the last line, and only when it holds nothing but breaks: <c>a&lt;br&gt;&lt;br&gt;</c>
+        /// is genuinely two lines and <c>a&lt;br&gt;&lt;br&gt;c</c> three, so each break but the final
+        /// one keeps the line it opened. A line with no words at all is left alone too — that is a
+        /// block with no inline content, not a break's leftover.
+        /// </para>
+        /// </remarks>
+        private static void DropATrailingForcedBreaksOwnLine(CssBox blockBox, CssLineBoxCoordinates coordinates)
+        {
+            if (blockBox.LineBoxes.Count <= 1) return;
+
+            var last = blockBox.LineBoxes[^1];
+
+            if (last.Words.Count == 0) return;
+
+            foreach (var word in last.Words)
+            {
+                if (!word.IsLineBreak) return;
+            }
+
+            blockBox.LineBoxes.Remove(last);
+
+            // The block now ends where the line it just lost began, which is the bottom of the line
+            // the break actually terminated.
+            coordinates.MaxBottom = last.Words[0].Top;
         }
 
         /// <summary>


### PR DESCRIPTION
A forced line break ([css-text-3 §5.5](https://www.w3.org/TR/css-text-3/#forced-line-break)) **ends** the line it falls on. `CssLayoutEngine` instead closes that line and starts the next one with the break's own word, so a break was always *followed* by a line — including where the break is the last thing in the block and there is nothing for that line to hold.

Printing a finished block's line boxes shows it plainly:

| markup | line boxes | browser |
| --- | --- | --- |
| `<div>x<br></div>` | `['x'] \| [<BR>]` | one line |
| `<div><br></div>` | `[] \| [<BR>]` | one line |
| `<div><br><br></div>` | `[] \| [<BR>] \| [<BR>]` | two lines |

The break's word never shares a line with the content it follows, and the trailing one always has a line to itself — holding nothing. CSS 2.1 [§9.4.2](https://www.w3.org/TR/CSS21/visuren.html#inline-formatting) is explicit about such a line: one with "no text, no preserved white space, no inline elements with non-zero margins, padding, or borders, and no other in-flow content" must "be treated as not existing for any other purpose". A `<br>` is not the preserved newline that sentence carves out. Every such block came out one line taller than a browser makes it.

## The fix

`DropATrailingForcedBreaksOwnLine` takes that line back where the block finishes, moving the block's bottom up to the line the break actually terminated.

Only the last line, and only when it holds nothing but breaks — `x<br><br>` really is two lines and `x<br><br>c` three, so every break but the final one keeps the line it opened. A block with **no inline content at all** is excluded: its single wordless line box is not a break's leftover, and dropping it would collapse a zero-height block rather than shorten it.

## Measured against Chrome 152

Five shapes, all now matching to the point where before each was one line out:

| markup | before | now, and Chrome |
| --- | --- | --- |
| `x<br>` | 2 lines | 1 |
| `<br>` | 2 lines | 1 |
| `x<br><br>` | 3 lines | 2 |
| `x<br>` + a `display: block` sibling | 2 lines + the block | 1 + the block |
| `x<br><br>c` | 3 lines | 3 — unchanged |

The shape this hits in practice is a table cell holding a label above an image, `label<br><img style="display:block">`: every row of such a table gained a line, and on a long one that is enough to push what follows onto another page.

## Tests

`TrailingForcedBreakLineTests` states each height as a multiple of the block's own line height, taken from a single-line control in the same document, so it asserts the line **count** and nothing about what a line measures. `line-height` is pinned in the fixture — a break-only line and a text line differ by a quarter of a point under `normal`, which is the font's own metrics and not this test's subject. **Five of the nine cases fail against `main`**; the four that do not are the controls (`x<br><br>c`, `x<br>c`, `x`, and the empty block).

Full suite green on net8.0 (10,396 passed), 0 new build warnings, diff coverage 100%. The `br` row in `docs/html-css-support.md` now states the rule, and `.claude/` carries a recent-fixes entry and a migration note.
