### PR TITLE
A page re-emitted behind the frontier no longer skips its own content

### DIFF
--- a/.claude/invariants/fragmentation-a-pruning-answer-is-about-one-slot-and-every-later-one.md
+++ b/.claude/invariants/fragmentation-a-pruning-answer-is-about-one-slot-and-every-later-one.md
@@ -1,0 +1,25 @@
+# A pruning answer is about one slot and every later one
+
+`EmittedNothingAtOrBefore(S)` says "this subtree's fragments are all behind slot S". That is a claim
+about **S and every slot after it** — never about a slot before it, where the same subtree may hold
+real content. Every cache derived from that answer has to carry the slot it was taken at, or it
+silently answers the wrong question.
+
+`_liveChildStartIndex` did not. It records how many of a box's leading children were each confirmed
+`EmittedNothingAtOrBefore`, so a later slot's walk can start past them — and it stored the
+generation but not the slot. Emitting an *earlier* slot again is not hypothetical:
+`CatchUpStaleSlotsBehind` exists to do exactly that whenever a late relocation reopens a frozen
+fragmentainer.
+
+**The measured symptom.** A fifteen-page document whose page 1 was emitted three times — 169 words,
+169 words, then **51**. The prose container's cursor stood at 4 when slot 0 was rebuilt, so its
+first four children were skipped and their text appeared on no page at all: 660 characters gone,
+and a 420pt hole at the top of page 1 where they had been laid out.
+
+Two things follow for the next such cache:
+
+- **Store the slot next to the index.** Trust the cache only where the slot now being built is at or
+  after the slot the cache was derived at. Dropping to a lower slot must re-derive.
+- **The parity oracle does not cover this.** `VerifyAgainstTheFullWalk` runs only where `EmitSlot` is
+  called with `mayVerify: true`, and the catch-up re-emission is not — which is precisely the one
+  path that reads a cache at a lower slot than it was written at.

--- a/.claude/migration-notes/2026-09-08-content-dropped-from-a-re-emitted-page-comes-back.md
+++ b/.claude/migration-notes/2026-09-08-content-dropped-from-a-re-emitted-page-comes-back.md
@@ -1,0 +1,16 @@
+# Content dropped from a re-emitted page comes back
+
+A page whose content a later relocation disturbed is emitted again once layout settles. That second
+emission could skip a run of leading children in a container, and whatever they held was then drawn
+on no page at all — leaving a visible blank where the content had been laid out.
+
+**Before.** On a long document, the first few blocks of a container could be missing from the
+output entirely, with a gap of exactly their height in their place. Measured on a fifteen-page
+document: 660 characters absent and 420pt of blank at the top of page 1.
+
+**Now.** They are drawn.
+
+**When a document author would notice.** Only in a document long enough for a page to be finalised
+and then reopened — several pages at least, with something later in the flow (a `break-inside:
+avoid` box, a widows/orphans push, a table moved off a boundary) moving content that had already
+been placed. Nothing needs changing in a document; output that was silently missing text now has it.

--- a/.claude/recent-fixes/2026-09-08-a-live-child-cursor-outlived-the-slot-it-was-taken-at.md
+++ b/.claude/recent-fixes/2026-09-08-a-live-child-cursor-outlived-the-slot-it-was-taken-at.md
@@ -1,0 +1,36 @@
+# A live-child cursor outlived the slot it was taken at
+
+`ChildrenOf` starts a container's child walk past a prefix of children each already confirmed
+`EmittedNothingAtOrBefore`, caching how many in `CssBox._liveChildStartIndex`. The cache carried the
+layout generation but not the **slot** the answer was taken at, and "nothing at or after slot 6" is
+not "nothing at or after slot 0". `CatchUpStaleSlotsBehind` re-emits a frozen slot behind the
+frontier, read the cursor there, and skipped children whose content belonged to exactly that slot.
+
+`LiveChildStartFor(slot)` now returns the cached index only where `slot` is at or after the slot the
+index was derived at, and `RecordLiveChildStart` stores it.
+
+## What measuring it turned up
+
+- **The counts name the defect on their own.** On the document that found this, slot 0 was emitted
+  three times: 169 words, 169 words, then 51 after a relocation at slot 6 reopened it. The prose
+  container's cursor read 4 out of 146 children at that third emission — its first four children,
+  holding 660 characters, were never visited and appeared on no page.
+- **It leaves a hole, not a shuffle.** Those four children were laid out and occupy space: page 1
+  had 420pt of blank above its first surviving line. Content loss with a visible gap where the
+  content was, which is what distinguishes this from a pagination difference.
+- **The mark itself was fine.** `BuildDraft`'s own `EmittedNothingAtOrBefore` check never fired at
+  slot 0 — instrumented and confirmed, no hit at all. Only the cursor derived from it was wrong,
+  which is why the defect survived: the guarded, slot-aware check and the unguarded cache derived
+  from it disagree only on a path that runs backwards.
+- **Forcing the unpruned walk on the catch-up path also fixes it**, which is how the cursor was
+  identified — but that is the expensive full walk `CatchUpStaleSlotsBehind` exists to avoid
+  (`Finish`'s own replay is ~145,000 `BuildDraft` calls per stale slot on a large document), so it
+  is a diagnosis rather than a fix.
+- **The parity oracle could not have caught it.** `PEACHPDF_VERIFY_FRAGMENT_PRUNING` compares the
+  pruned and unpruned walks only where `EmitSlot` is given `mayVerify: true`, and the stale-slot
+  catch-up is not one of those calls. Noted as an invariant rather than changed here — widening the
+  oracle is its own change with its own risk.
+
+## Evidence
+
+`StaleSlotChildCursorTests`. Full suite green on net8.0, 0 new build warnings.

--- a/src/PeachPDF.Tests/Integration/StaleSlotChildCursorTests.cs
+++ b/src/PeachPDF.Tests/Integration/StaleSlotChildCursorTests.cs
@@ -1,0 +1,117 @@
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Fragments;
+using PeachPDF.Tests.TestSupport;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// A page emitted again after a later relocation reopened it still claims every word it holds.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>ChildrenOf</c> starts a container's child walk past a prefix of children each already
+    /// confirmed <c>EmittedNothingAtOrBefore</c>, caching how many in <c>CssBox.LiveChildStartFor</c>.
+    /// That answer is "this subtree's fragments are all behind slot S", which is a claim about S and
+    /// every slot after it and about no slot before it — and the cache stored the layout generation
+    /// but not S. <c>CatchUpStaleSlotsBehind</c> re-emits a frozen slot behind the frontier, read the
+    /// cursor there, and skipped children whose content belonged to exactly that slot. Their words
+    /// were then in no fragmentainer at all, leaving a gap of their own height where they had been
+    /// laid out.
+    /// </para>
+    /// <para>
+    /// The fixture is headings and paragraphs of varying length in a small page. The UA print
+    /// stylesheet's <c>h1-h6 { break-after: avoid }</c> is what supplies the relocations: a heading
+    /// that would be stranded at the foot of a page is taken to the next one together with the run
+    /// below it, which is a §4.3 retroactive mover reaching back into a page already frozen. Which
+    /// page that lands on, and how many pages the document takes, is left to whatever the platform's
+    /// font measures — the assertion does not depend on it.
+    /// </para>
+    /// <para>
+    /// <b>Why the assertion is a word census rather than a geometry check.</b> Content loss is the
+    /// symptom, and it is the one statement about this that is true whatever the pagination:
+    /// wherever the pages fall, every word the document laid out has to be on one of them. Stated as
+    /// a page number or a page count it would say something different on every platform — the same
+    /// trap <see cref="UnreachedWordClaimTests"/> avoids for the same reason, and whose invariant
+    /// this is a one-sided form of (a repeated running element genuinely is claimed more than once,
+    /// so this asks only that nothing is claimed less than once).
+    /// </para>
+    /// </remarks>
+    public class StaleSlotChildCursorTests
+    {
+        private const double PageWidth = 300;
+        private const double PageHeight = 200;
+        private const double Margin = 20;
+
+        /// <summary>
+        /// Paragraph lengths, in words. Each set paginates differently; the four here were drawn at
+        /// random and kept because they space the section boundaries differently against the page
+        /// boundary, which is what decides whether a heading is stranded and a relocation happens at
+        /// all. The first three lose words against a build without the fix on this machine; the
+        /// fourth does not, and is here as the case where nothing is disturbed.
+        /// </summary>
+        public static TheoryData<int[]> ParagraphLengths => new()
+        {
+            new[] { 23, 16, 31, 38, 12, 8, 38, 24, 22, 20, 38, 38, 33, 17 },
+            new[] { 16, 12, 24, 15, 39, 36, 38, 32, 21, 14, 39, 9, 32, 35 },
+            new[] { 10, 35, 38, 8, 21, 37, 39, 25, 18, 10, 39, 28, 12, 23 },
+            new[] { 36, 37, 36, 40, 20, 19, 40, 38, 19, 14, 36, 27, 17, 13 },
+        };
+
+        [Theory]
+        [MemberData(nameof(ParagraphLengths))]
+        public async Task EveryWordLaidOut_IsClaimedByAFragmentainer(int[] lengths)
+        {
+            var (root, container) = await LayoutHarness.LayoutAsync(
+                Document(lengths), pageWidth: PageWidth, pageHeight: PageHeight, margin: Margin);
+
+            Assert.True(container.FragmentTree!.Fragmentainers.Count > 2,
+                "the fixture must span enough pages for one to be frozen and reopened");
+
+            var claimed = ClaimedWords(container);
+            var missing = WordsIn(root).Where(w => !claimed.Contains(w)).ToList();
+
+            Assert.True(missing.Count == 0,
+                $"{missing.Count} words are in no fragmentainer at all, starting with "
+                + string.Join(" ", missing.Take(8).Select(w => $"'{w.Text}'")));
+        }
+
+        /// <summary>
+        /// Sections of a heading and a paragraph. Every word is distinct, so a missing one names
+        /// itself.
+        /// </summary>
+        private static string Document(int[] lengths) =>
+            LayoutHarness.Wrap(
+                "<div>"
+                + string.Concat(lengths.Select((words, i) =>
+                    $"<h3 style='font-size:12pt;margin:24pt 0 12pt 0'>Heading{i}</h3>"
+                    + $"<p style='margin:0 0 16pt 0;font-size:10pt'>"
+                    + string.Join(" ", Enumerable.Range(0, words).Select(j => $"s{i}w{j}"))
+                    + "</p>"))
+                + "</div>");
+
+        private static List<CssRect> WordsIn(CssBox box) =>
+            LayoutHarness.Descendants(box).SelectMany(b => b.Words).ToList();
+
+        private static HashSet<CssRect> ClaimedWords(HtmlContainerInt container) =>
+            container.FragmentTree!.Fragmentainers
+                .SelectMany(f => Flatten(f.Root))
+                .SelectMany(f => f.Words)
+                .Select(w => w.Word)
+                .ToHashSet<CssRect>(ReferenceEqualityComparer.Instance);
+
+        private static IEnumerable<BoxFragment> Flatten(BoxFragment fragment)
+        {
+            yield return fragment;
+
+            foreach (var child in fragment.Children)
+            {
+                foreach (var descendant in Flatten(child)) yield return descendant;
+            }
+        }
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -2556,6 +2556,7 @@ namespace PeachPDF.Html.Core.Dom
                 // read back later.
                 box._liveChildStartIndex = 0;
                 box._liveChildStartGeneration = -1;
+                box._liveChildStartSlot = -1;
 
                 // Every caller of this is a write that gives a box content or moves it, so it is also
                 // the signal layout has REACHED this box at all - which is what separates a subtree
@@ -2594,16 +2595,35 @@ namespace PeachPDF.Html.Core.Dom
         private int _liveChildStartGeneration = -1;
 
         /// <summary>
-        /// <see cref="_liveChildStartIndex"/> if it was computed in the current layout generation, else
-        /// <c>0</c> - a stale index from an earlier generation names nothing meaningful in <see cref="Boxes"/>
-        /// as it stands now.
+        /// The slot <see cref="_liveChildStartIndex"/> was derived at. The prefix it names was confirmed
+        /// <see cref="EmittedNothingAtOrBefore"/> <i>that slot</i>, which is a claim about that slot and
+        /// every later one — never about an earlier one, where the same children may hold real content.
         /// </summary>
-        internal int LiveChildStart =>
-            _liveChildStartGeneration == (HtmlContainer?.LayoutGeneration ?? 0) ? _liveChildStartIndex : 0;
+        private int _liveChildStartSlot = -1;
+
+        /// <summary>
+        /// <see cref="_liveChildStartIndex"/> where it can be trusted for <paramref name="slot"/>, else
+        /// <c>0</c>.
+        /// </summary>
+        /// <remarks>
+        /// Two things make it untrustworthy. A stale index from an earlier generation names nothing
+        /// meaningful in <see cref="Boxes"/> as it stands now. And an index derived at a <i>later</i> slot
+        /// answers a different question than the one being asked: the prefix it names was confirmed
+        /// "nothing at or after that slot", which says nothing about a slot before it — where those same
+        /// children may hold the content this walk is looking for. Emitting an earlier slot again is not
+        /// hypothetical; <see cref="Fragmentation.FragmentEmitter.CatchUpStaleSlotsBehind"/> exists to do
+        /// exactly that.
+        /// </remarks>
+        /// <param name="slot">the slot the walk asking for this is building</param>
+        internal int LiveChildStartFor(int slot) =>
+            _liveChildStartGeneration == (HtmlContainer?.LayoutGeneration ?? 0) && slot >= _liveChildStartSlot
+                ? _liveChildStartIndex
+                : 0;
 
         /// <summary>
         /// Records that <see cref="Boxes"/><c>[0, </c><paramref name="index"/><c>)</c> were each individually
-        /// confirmed <see cref="EmittedNothingAtOrBefore"/> as of the current layout generation.
+        /// confirmed <see cref="EmittedNothingAtOrBefore"/> <paramref name="slot"/>, as of the current
+        /// layout generation.
         /// </summary>
         /// <remarks>
         /// Safe to trust on a later call precisely because <see cref="DiscardEmittedNothing"/> resets this
@@ -2615,10 +2635,11 @@ namespace PeachPDF.Html.Core.Dom
         /// box out again, which is itself a write to this box and so passes through the same reset before
         /// any later reader could see a stale index.
         /// </remarks>
-        internal void RecordLiveChildStart(int index)
+        internal void RecordLiveChildStart(int index, int slot)
         {
             _liveChildStartIndex = index;
             _liveChildStartGeneration = HtmlContainer?.LayoutGeneration ?? 0;
+            _liveChildStartSlot = slot;
         }
 
         /// <summary>

--- a/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
@@ -2597,7 +2597,7 @@ namespace PeachPDF.Html.Core.Fragmentation
             {
                 var scopeOwner = ScopeOwnerOf(box);
                 var history = HistoryFor(scopeOwner);
-                startIndex = box.LiveChildStart;
+                startIndex = box.LiveChildStartFor(slot.Index);
 
                 while (startIndex < box.Boxes.Count)
                 {
@@ -2627,7 +2627,7 @@ namespace PeachPDF.Html.Core.Fragmentation
                     startIndex++;
                 }
 
-                box.RecordLiveChildStart(startIndex);
+                box.RecordLiveChildStart(startIndex, slot.Index);
             }
 
             for (var i = startIndex; i < box.Boxes.Count; i++)


### PR DESCRIPTION
`ChildrenOf` starts a container's child walk past a prefix of children each already confirmed `EmittedNothingAtOrBefore`, caching how many in `CssBox._liveChildStartIndex`. That answer is **"this subtree's fragments are all behind slot S"** — a claim about S and every slot *after* it, and about no slot before it. The cache stored the layout generation but not S.

`CatchUpStaleSlotsBehind` re-emits a frozen slot *behind* the frontier whenever a late relocation reopens one. It read the cursor there and skipped children whose content belonged to exactly that slot, so their words were in no fragmentainer at all — content drawn on no page, with a gap of its own height where it had been laid out.

## Measured

On the document that found this, slot 0 was emitted three times:

| emission | words in the root draft |
| --- | --- |
| first | 169 |
| after an early reopen | 169 |
| after a relocation at slot 6 reopened it | **51** |

At that third emission the prose container's cursor read **4** of its 146 children. The 660 characters those four held were drawn on no page, above 420pt of blank at the top of page 1.

## Why it survived

`BuildDraft`'s own `EmittedNothingAtOrBefore` check is already slot-aware and **never fired at slot 0** — instrumented and confirmed, not a single hit. Only the cache derived from it was wrong. The guarded check and the unguarded cache can only disagree on a path that runs backwards, and `CatchUpStaleSlotsBehind` is the only one.

Forcing `_forcingUnprunedReferenceWalk` on that path also fixes it, which is how the cursor was identified — but that is the expensive full walk the method exists to avoid (`Finish`'s own replay is ~145,000 `BuildDraft` calls per stale slot on a large document), so it was a diagnosis rather than a fix.

Worth noting separately: `PEACHPDF_VERIFY_FRAGMENT_PRUNING` could not have caught this. `VerifyAgainstTheFullWalk` runs only where `EmitSlot` is called with `mayVerify: true`, and the stale-slot catch-up is not one of those calls — precisely the one path that reads a pruning cache at a lower slot than it was written at. I have left that as an invariant note rather than widening the oracle here, since that is its own change with its own risk.

## The fix

`LiveChildStartFor(slot)` returns the cached index only where `slot` is at or after the slot it was derived at; `RecordLiveChildStart` stores it; `DiscardEmittedNothing` resets it alongside the index and generation it already reset. Forward emission is unaffected — an increasing slot always satisfies the guard — so the #917 pruning work this builds on keeps its benefit.

## Tests

`StaleSlotChildCursorTests` asserts the one thing that is true whatever the pagination: **every word the document laid out is claimed by some fragmentainer**. Nothing in it names a page number or a page count, so it says the same thing on every platform — the trap `UnreachedWordClaimTests` avoids for the same reason, and whose invariant this is a one-sided form of (a repeated running element genuinely is claimed more than once, so this asks only that nothing is claimed *less* than once).

The fixture is headings and paragraphs in a small page; the UA print stylesheet's `h1-h6 { break-after: avoid }` supplies the relocations. Four paragraph-length sets paginate differently; **three lose words against `main` — 74, 242 and 221** — and the fourth is the case where nothing is disturbed.

Full suite green on net8.0 (10,391 passed), 0 new build warnings, diff coverage 100%.
