### PR TITLE
The cascade no longer re-defaults every list item's anonymous box

### DIFF
--- a/.claude/invariants/cascade-a-synthetic-fixture-can-miss-a-path-real-documents-take.md
+++ b/.claude/invariants/cascade-a-synthetic-fixture-can-miss-a-path-real-documents-take.md
@@ -1,0 +1,31 @@
+# A synthetic fixture can miss a path real documents take
+
+Twice the same wrong conclusion has been reached about the cascade's defaulting loop, in opposite
+directions, and both times from a fixture written to exercise it.
+
+- It was once recorded as **no longer reached** on `main`, from a fixture of 1,681 anonymous boxes
+  where allocation measured 53.88 MB against 53.83 MB per render.
+- Writing the fix, three fresh fixtures — anonymous blocks from mixed inline/block content, tables,
+  flex/grid utility markup — again showed **no difference at all**.
+
+Both were true of the fixture and false of the engine. The real corpus takes that branch **2,031
+times** and the patch is worth **112 MB per pass**, 12% of everything `main` allocates.
+
+**So: count the branch before concluding it is cold.** A counter behind the `if` and one run over
+real documents is minutes of work and is the only thing that distinguishes "this path is not hot"
+from "my fixture does not reach this path". An allocation delta of zero proves the second, not the
+first.
+
+## And count it before explaining *why* it is reached
+
+The same counter, kept in place a little longer, would have caught a wrong explanation as well as a
+wrong measurement. The fix's first justification said an anonymous box reaches the loop "for exactly
+one reason: box generation assigned its display structurally". Instrumented over the corpus, **2,005
+of the 2,031 still hold the initial display** — they are pseudo-elements (1,971 `::before`/`::after`,
+34 `::marker`) that `CssData`'s synthesis forked by calling `InheritStyle` on them, out of band,
+before their own cascade pass ran.
+
+The fix was still correct, but for a broader reason than the one written down: it is a **full state
+overwrite, equivalent to the old loop for any prior divergence**, not for one known cause. A
+justification that names a single mechanism is a claim about every box that reaches the code, and
+it is as measurable as the hit count is.

--- a/.claude/recent-fixes/2026-09-08-the-cascade-re-defaulted-every-list-items-anonymous-box.md
+++ b/.claude/recent-fixes/2026-09-08-the-cascade-re-defaulted-every-list-items-anonymous-box.md
@@ -1,0 +1,52 @@
+# The cascade re-defaulted every list item's anonymous box
+
+The cascade's defaulting step walks `CssDefaults.InitialValues` and sets each property back to its
+initial value. It is skipped for a box still on the shared `ComputedStyle.Default`, which is most of
+them — but an **anonymous** box that anything has already forked off `Default` took the full walk to
+reconstruct a state it was one assignment away from.
+
+Re-pointing at `ComputedStyle.Default` and restoring the structural display is that same state,
+directly. Every area is copy-on-write, so the display assignment forks it straight back.
+
+## What measuring it turned up
+
+- **The reason they are forked is not what this first claimed.** The original justification said box
+  generation had assigned the display structurally. Instrumented over the corpus, 2,005 of the 2,031
+  hits still hold the *initial* display: they are pseudo-elements (1,971 `::before`/`::after`, 34
+  `::marker`) forked by `CssData`'s synthesis calling `InheritStyle` on them before their own cascade
+  ran. The fix is safe for a broader reason — it is a full state overwrite, equivalent to the old
+  loop for **any** prior divergence, and `InheritStyle` re-runs immediately after it either way.
+  Caught in review, and only because the reviewer instrumented the branch rather than reading the
+  comment.
+- **The shape that hits it is a list, and nothing else I tried.** Counting the branch over eight
+  markup shapes — anonymous blocks from mixed inline/block content, a well-formed table, a table
+  missing its rows, loose text inside a table, `display: table-cell` outside a row, floats — every
+  one took it **once**. A hundred `<li>` took it **101 times**. It is one forked anonymous box per
+  list item, and `list-style: none` does not avoid it.
+- **On real documents that is the bulk of the cascade's allocation.** Across a 26-document corpus
+  the branch is taken **2,031 times** against 3 for element-backed boxes, and the patch takes the
+  corpus from **930 MB to 818 MB** of allocation per pass — 12% of everything, reproduced across
+  four alternating measurements (929.85/929.92 against 818.40/818.35).
+- **A synthetic fixture nearly missed it entirely.** The first three I wrote — anonymous blocks,
+  tables, flex/grid utility markup — showed no difference at all, because none of them generates a
+  *forked* anonymous box. Had I stopped there I would have concluded the path was cold, which is
+  the opposite of what the corpus says.
+- **The premise is already tested.** `ComputedStyleTests.CascadeDefaultingLoop_OnAFreshBox_OnlyKnownExceptionsAreNotNoOps`
+  establishes that setting a property to its own initial value leaves a box on `Default`. That is
+  exactly why re-pointing at `Default` reconstructs what the loop reconstructs.
+
+## Evidence
+
+`AnonymousBoxDefaultingTests` compares 400 list items against the same text in plain `<div>`s,
+measured in the same run so the comparison is self-calibrating and says the same thing whatever font
+a machine resolves: **1.72x with the fast path, 2.41x without**, bound at 2.05x. The item text is one
+character deliberately — the saving is fixed per item, so longer text dilutes it (at 200 items of a
+sentence the window narrows to 1.48 against 1.60, too tight to gate across platforms).
+
+The measurement is **per-thread and synchronous**. The first version used
+`GC.GetTotalAllocatedBytes`, which is process-wide, in a suite that runs collections in parallel:
+stable in isolation, and reported by a reviewer swinging between 2.05x and 4.59x with the suite
+running. Reproduced here — 1.50x, 4.89x, 2.26x over three full-suite runs, against 1.71x twice with
+the per-thread counter.
+
+Full suite green on net8.0, 0 new build warnings.

--- a/src/PeachPDF.Tests/Integration/AnonymousBoxDefaultingTests.cs
+++ b/src/PeachPDF.Tests/Integration/AnonymousBoxDefaultingTests.cs
@@ -1,0 +1,113 @@
+using PeachPDF;
+using PeachPDF.PdfSharpCore;
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// The cascade's defaulting step does not re-parse the whole initial-value table for an
+    /// anonymous box that holds nothing but its structural display.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="ComputedStyleTests.CascadeDefaultingLoop_OnAFreshBox_OnlyKnownExceptionsAreNotNoOps"/>
+    /// already establishes the fact this rests on: setting a property to its own initial value leaves
+    /// the box on the shared <c>ComputedStyle.Default</c>. So the loop reconstructs, one property parse
+    /// at a time, a state that re-pointing at <c>Default</c> gives directly — and it is equivalent for
+    /// <i>any</i> prior divergence, not just one known cause, because it is a full state overwrite and
+    /// the loop discarded every non-display property unconditionally too.
+    /// </para>
+    /// <para>
+    /// <b>Every list item is one such box</b>, which is what makes this worth gating rather than
+    /// leaving to a profiler. An ordinary <c>&lt;ul&gt;</c> generates one forked anonymous box per
+    /// item — measured at 2,031 of them across a 26-document corpus — and each one was re-parsing a
+    /// few hundred initial values it already held.
+    /// </para>
+    /// <para>
+    /// <b>Why the assertion is a ratio.</b> Allocated bytes are deterministic for a given build and
+    /// input, but their absolute value depends on the font a machine resolves. Both documents here
+    /// are measured in the same run on the same machine and carry the same text; they differ only in
+    /// whether that text sits in list items. That makes the comparison self-calibrating, so this
+    /// says the same thing on every platform.
+    /// </para>
+    /// </remarks>
+    public class AnonymousBoxDefaultingTests
+    {
+        private const int Items = 400;
+
+        /// <summary>
+        /// Measured on this fixture: <b>1.71x</b> with the fast path and <b>2.41x</b> without, so the
+        /// bound sits between them with roughly 20% of margin either side. Stable to the second decimal
+        /// place both in isolation and with the whole suite running in parallel around it — but only
+        /// because the measurement is per-thread; see <see cref="AllocatedMbPerRender"/> for what that
+        /// is guarding against.
+        ///
+        /// The item text is one character on purpose. The saving is a fixed cost per list item, so the
+        /// longer the text the more font work dilutes it: at 200 items of a full sentence the same
+        /// patch only moves the ratio from 1.60 to 1.48, which is too narrow a window to gate on
+        /// across machines that resolve different fonts. Short text makes the thing being measured the
+        /// dominant term.
+        ///
+        /// It is a ratchet, not a law — if a change makes lists legitimately dearer, move it in the
+        /// same commit and say why.
+        /// </summary>
+        private const double MaxListOverhead = 2.05;
+
+        [Fact]
+        public void AListCostsLittleMoreThanTheSameTextWithoutOne()
+        {
+            var lines = Enumerable.Range(0, Items)
+                .Select(i => "x")
+                .ToList();
+
+            var list = Document("<ul>" + string.Concat(lines.Select(l => $"<li>{l}</li>")) + "</ul>");
+            var plain = Document(string.Concat(lines.Select(l => $"<div>{l}</div>")));
+
+            var listMb = AllocatedMbPerRender(list);
+            var plainMb = AllocatedMbPerRender(plain);
+            var overhead = listMb / plainMb;
+
+            Assert.True(overhead <= MaxListOverhead,
+                $"{Items} list items allocate {overhead:F2}x what the same text costs without a list "
+                + $"({listMb:F1} MB against {plainMb:F1} MB), over the {MaxListOverhead:F2}x bound. Each "
+                + "list item generates an anonymous box, and this is what re-defaulting every one of "
+                + "them from scratch looks like.");
+        }
+
+        private static string Document(string body) =>
+            $"<html><body style=\"font-family:sans-serif\">{body}</body></html>";
+
+        /// <summary>
+        /// Allocated megabytes per render, measured <b>per thread</b> and synchronously.
+        /// </summary>
+        /// <remarks>
+        /// Both of those matter and the first version of this had neither. <c>GC.GetTotalAllocatedBytes</c>
+        /// is process-wide, and this suite runs collections in parallel, so it counts whatever every
+        /// other test is allocating at the same moment — which is how a measurement claimed here to be
+        /// stable to a fraction of a percent was reported swinging between 2.05x and 4.59x on a
+        /// reviewer's machine. <c>GetAllocatedBytesForCurrentThread</c> is immune to that, and blocking
+        /// on the render rather than awaiting it keeps the whole measured region on the one thread it
+        /// counts.
+        /// </remarks>
+        private static double AllocatedMbPerRender(string html)
+        {
+            // Warm the JIT, the font cache and every static table: none of it is per-render cost, and
+            // all of it would otherwise land in the first measured iteration.
+            for (var i = 0; i < 3; i++) Render(html);
+
+            const int renders = 5;
+            var before = GC.GetAllocatedBytesForCurrentThread();
+
+            for (var i = 0; i < renders; i++) Render(html);
+
+            return (GC.GetAllocatedBytesForCurrentThread() - before) / (double)renders / 1024 / 1024;
+        }
+
+        private static void Render(string html) =>
+            new PdfGenerator().GeneratePdf(html, PageSize.Letter, margin: 36).GetAwaiter().GetResult();
+    }
+}

--- a/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.StyleProperties.cs
@@ -35,6 +35,18 @@ namespace PeachPDF.Html.Core.Dom
         internal ComputedStyle ComputedStyle => _computedStyle;
 
         /// <summary>
+        /// Puts every property back to its initial value by re-pointing at the shared
+        /// <see cref="Dom.ComputedStyle.Default"/>, which <i>is</i> the all-initial state.
+        /// </summary>
+        /// <remarks>
+        /// The cascade's defaulting step (CSS Cascade 4 §2.1) otherwise re-parses the whole
+        /// initial-value table one property at a time for any box that has already been touched. Every
+        /// area is copy-on-write, so sharing the singleton is safe and the first later write forks it —
+        /// the same thing a never-touched box already does.
+        /// </remarks>
+        internal void ResetComputedStyleToInitial() => _computedStyle = ComputedStyle.Default;
+
+        /// <summary>
         /// Adopts <paramref name="source"/>'s entire Border and Background style areas by reference -
         /// safe because each area is copy-on-write (see <see cref="InheritStyle"/>'s own remarks). Used
         /// to give a table's grid-only decoration box (<see cref="CssLayoutEngineTable"/>,

--- a/src/PeachPDF/Html/Core/Parse/DomParser.cs
+++ b/src/PeachPDF/Html/Core/Parse/DomParser.cs
@@ -674,14 +674,44 @@ namespace PeachPDF.Html.Core.Parse
             //    ComputedStyleTests.CascadeDefaultingLoop_OnAFreshBox_OnlyKnownExceptionsAreNotNoOps.
             if (!ReferenceEquals(box.ComputedStyle, ComputedStyle.Default))
             {
-                foreach (var (name, initial) in CssDefaults.InitialValues)
+                // Re-pointing at ComputedStyle.Default IS the all-initial state this loop reconstructs,
+                // so for an anonymous box the loop is several hundred property parses to reach a state
+                // one assignment away. Every area is copy-on-write, so restoring the display below forks
+                // it straight back.
+                //
+                // WHY THIS IS SAFE, and it is not "because the only divergence is a structural display
+                // write" - that was the original justification here and it is wrong. Instrumenting the
+                // branch over a 26-document corpus: of 2,031 boxes reaching it, 2,005 still hold the
+                // INITIAL display. They are pseudo-elements (1,971 ::before/::after, 34 ::marker) that
+                // CssData's synthesis forked by calling InheritStyle on them, out of band, before their
+                // own cascade pass ever ran.
+                //
+                // It is safe for a broader reason: this is a full state overwrite, equivalent to the old
+                // loop for ANY prior divergence rather than for one known cause. The loop discarded every
+                // non-display property unconditionally too, and box.InheritStyle() re-runs immediately
+                // below regardless of which branch is taken, so whatever an out-of-band write left behind
+                // is re-derived either way. An element-backed box still takes the loop: it has author
+                // declarations to apply over the top.
+                if (box.HtmlTag is null)
                 {
-                    if (initial is null) continue;
-                    if (name == PropertyNames.Display && box.HtmlTag is null) continue;
-                    CssUtils.SetPropertyValue(valueParser, box, name, initial);
+                    var structuralDisplay = box.Display;
+                    box.ResetComputedStyleToInitial();
+                    box.Display = structuralDisplay;
+                }
+                else
+                {
+                    foreach (var (name, initial) in CssDefaults.InitialValues)
+                    {
+                        if (initial is null) continue;
+                        CssUtils.SetPropertyValue(valueParser, box, name, initial);
+                    }
                 }
             }
-            else
+
+            // The three properties whose Default-singleton state is NOT what re-parsing their initial
+            // value produces (see the audit above) - now needed on the reset path too, which lands a box
+            // in exactly the same state a never-touched one is in.
+            if (ReferenceEquals(box.ComputedStyle, ComputedStyle.Default) || box.HtmlTag is null)
             {
                 CssUtils.SetPropertyValue(valueParser, box, PropertyNames.FontFamily, CssDefaults.GetInitialValue(PropertyNames.FontFamily)!);
                 CssUtils.SetPropertyValue(valueParser, box, PropertyNames.GridTemplateColumns, CssDefaults.GetInitialValue(PropertyNames.GridTemplateColumns)!);


### PR DESCRIPTION
The cascade's defaulting step walks `CssDefaults.InitialValues` and sets every property back to its initial value. It is already skipped for a box still on the shared `ComputedStyle.Default` — but an **anonymous** box that box generation gave a structural display to has *already* forked off `Default`, so it took the full walk to rebuild a state it was one assignment away from.

Re-pointing at `ComputedStyle.Default` and restoring the display gives that state directly. Every area is copy-on-write, so the display assignment forks it straight back. An element-backed box still takes the loop — it has author declarations to apply over the top.

**Why it is safe** — corrected from the first version of this PR, which said an anonymous box reaches the loop "for exactly one reason: box generation assigned its display structurally". You were right that that is wrong, and instrumenting it makes it stark: of the **2,031** boxes reaching the branch over the corpus, **2,005 still hold the *initial* display**. They are pseudo-elements forked by `CssData`'s synthesis calling `InheritStyle` on them, out of band, before their own cascade pass runs.

One refinement to your finding: on the real corpus the dominant case is not `::marker` but **`::before`/`::after` — 1,971 of them, against 34 markers**. Same mechanism you identified (`InheritStyle` at synthesis, lines 906/918/946), different pseudo-element; `::marker` dominates the *list* fixture this PR's test uses (100 of 101), which is presumably what made it look dominant.

The real invariant is the one you stated: this is a **full state overwrite, equivalent to the old loop for any prior divergence**, not for one known cause. The loop discarded every non-display property unconditionally too, and `box.InheritStyle()` re-runs immediately after this regardless of branch. That framing is now in the code comment, the invariant file and the recent-fixes note.

The premise is already yours: [`CascadeDefaultingLoop_OnAFreshBox_OnlyKnownExceptionsAreNotNoOps`](../blob/main/src/PeachPDF.Tests/Html/Core/Dom/ComputedStyleTests.cs) establishes that setting a property to its own initial value leaves a box on `Default`.

## The shape that reaches it is a list

I counted the branch across eight markup shapes. Every one of these takes it **once**:

anonymous blocks from mixed inline/block content · a well-formed table · a table missing its `<tr>`s · loose text inside a table · `display: table-cell` outside a row · a float between two text runs · a plain `<div>` wall

A hundred `<li>` take it **101 times**. It is one forked anonymous box per list item, and `list-style: none` does not avoid it.

On real documents that is most of the cascade's allocation. Over a 26-document corpus of ordinary business documents the branch is taken **2,031 times**, against 3 for element-backed boxes, and this change takes the corpus from **930 MB to 818 MB** allocated per pass — **12% of the total** — across four alternating measurements (929.85 / 929.92 against 818.40 / 818.35).

## A warning about measuring this one

The first three fixtures I wrote showed **no difference at all**, because none of them generates a *forked* anonymous box. There is also an older note in my own records concluding this path was "no longer reached", from a synthetic fixture of 1,681 anonymous boxes measuring 53.88 MB against 53.83 MB per render. Both were true of the fixture and false of the engine. If you want to check this yourself, put a counter behind the `if` and run real documents through it — an allocation delta of zero proves the fixture misses the path, not that the path is cold.

## Test

`AnonymousBoxDefaultingTests` compares 400 list items against the same text in plain `<div>`s, **both measured in the same run**, so the comparison is self-calibrating and says the same thing whatever font a machine resolves:

| | list vs plain |
| --- | --- |
| with this change | **1.71x** |
| without | **2.41x** |
| bound | 2.05x |

About 20% of margin either side. The item text is one character deliberately: the saving is a fixed cost per item, so longer text dilutes it — at 200 items of a full sentence the window narrows to 1.48 against 1.60, too tight to gate on.

**The flakiness you hit is fixed, and it was a real bug in the test.** It used `GC.GetTotalAllocatedBytes`, which is **process-wide**, in a suite that runs collections in parallel — so it was counting whatever else was allocating at that moment. Stable in isolation, meaningless with the suite running. I reproduced your numbers exactly:

| counter | three full-suite runs |
| --- | --- |
| `GetTotalAllocatedBytes` (process-wide) | 1.50x, 4.89x, 2.26x |
| `GetAllocatedBytesForCurrentThread` | 1.71x, 1.71x |

The absolutes give it away too — the process-wide runs reported 1062 MB, 647 MB and 132 MB for a fixture that actually costs 53 MB. The measured region is now synchronous (`GetAwaiter().GetResult()`) so it stays on the thread it counts.

Full suite green on net8.0 (10,388 passed), 0 new build warnings, diff coverage 100%.
