### PR TITLE
The GPOS subtable walk no longer allocates an enumerator per glyph

### DIFF
--- a/.claude/recent-fixes/2026-09-08-the-gpos-subtable-walk-allocated-an-enumerator-per-glyph.md
+++ b/.claude/recent-fixes/2026-09-08-the-gpos-subtable-walk-allocated-an-enumerator-per-glyph.md
@@ -1,0 +1,33 @@
+# The GPOS subtable walk allocated an enumerator per glyph
+
+Every lookup's `Subtables` is declared `IReadOnlyList<T>`, so a `foreach` over it boxes an enumerator
+through the interface. `GposPositioner` does that once per glyph — `ApplyMarkToBase` calls straight
+into the loop for every glyph in the run — so the cost lands on every glyph of every text run,
+whether or not the font has anything to position. Eight such loops are now indexed instead.
+
+## What measuring it turned up
+
+- **Worth 85 MB per corpus pass**, 9% of everything upstream `main` allocates over 26 real
+  documents (930.16 MB down to 844.75 MB). Additive with the anonymous-box defaulting fix: the two
+  together take it to 733.25 MB.
+- **It fires on plain Latin text**, where there is nothing to attach at all. The enumerator is
+  allocated before any coverage check, so a document with no combining marks pays it in full.
+- **The first version of the test did not reproduce it**, and the reason is worth knowing:
+  `List<T>` hands back a *cached singleton* enumerator when it is empty, so a lookup with an empty
+  `Subtables` allocates nothing and the test passed against the unfixed code. It needs at least one
+  subtable — one whose coverage matches nothing keeps the loop body cold while still walking.
+- **`GC.GetTotalAllocatedBytes` is useless here.** It is process-wide, and this suite runs
+  collections in parallel, so the first passing run of the whole suite reported 1.2 MB of other
+  tests' allocation. `GC.GetAllocatedBytesForCurrentThread` is exact: 400,000 bytes against the
+  unfixed code, 40 per visit over 10,000 visits, and zero with the fix.
+- **One `foreach` was left alone.** `ApplyMatchedLookups` walks a `GposSequenceLookupRecord[]`, and
+  an array's enumerator is a struct that allocates nothing — converting it would have been noise.
+
+## Evidence
+
+`GposPositionerAllocationTests` calls `ApplyMarkToBase` directly against a lookup whose one subtable
+covers no glyph, so the only thing that can allocate is the walk. Asserted at the positioner rather
+than through a rendered document deliberately: allocation over a document scales with whatever font
+a machine resolves, so any end-to-end threshold is loose on one platform and wrong on another.
+
+Full suite green on net8.0 (10,388), 0 new build warnings.

--- a/src/PeachPDF.Tests/Text/GposPositionerAllocationTests.cs
+++ b/src/PeachPDF.Tests/Text/GposPositionerAllocationTests.cs
@@ -1,0 +1,85 @@
+using PeachPDF.Fonts.OpenType;
+using PeachPDF.Text;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace PeachPDF.Tests.Text
+{
+    /// <summary>
+    /// The GPOS positioner walks a lookup's subtables without allocating an enumerator per glyph.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A lookup's <c>Subtables</c> is declared as <see cref="IReadOnlyList{T}"/>, so <c>foreach</c>
+    /// over it boxes a fresh enumerator every time. The positioner runs that loop <b>once per glyph</b>
+    /// — <see cref="GposPositioner.ApplyMarkToBase"/> calls straight into it for every glyph in the run
+    /// — so the cost lands on every glyph of every text run in a document, whether or not the font has
+    /// anything to attach.
+    /// </para>
+    /// <para>
+    /// This is asserted at the positioner rather than through a rendered document on purpose. Measured
+    /// end to end it is real but not separable: allocation over a document scales with the font a
+    /// machine happens to resolve, so any threshold that catches it on one platform is either loose or
+    /// wrong on another. Called directly, with a lookup that has no subtables at all, the only thing
+    /// that can allocate is the loop itself — which makes the assertion exact and the same everywhere.
+    /// </para>
+    /// </remarks>
+    public class GposPositionerAllocationTests
+    {
+        [Fact]
+        public void WalkingALookupsSubtables_AllocatesNothingPerGlyph()
+        {
+            // One subtable whose coverage matches nothing, so the loop runs and finds no work: the
+            // only thing that can allocate is the walk itself. The descriptor is never dereferenced on
+            // this path, which is what lets it stay null.
+            //
+            // NOT an empty list, which was the first version of this and does not reproduce: List<T>
+            // hands back a cached singleton enumerator when it is empty, so the very allocation under
+            // test disappears. It needs at least one element.
+            var subtable = new GposMarkAttachmentSubtable
+            {
+                MarkCoverage = MatchesNothing(),
+                BaseCoverage = MatchesNothing(),
+                MarkClassCount = 0,
+                Marks = [],
+                BaseAnchorsByClass = [],
+            };
+
+            var lookup = new GposMarkToBaseLookup { Subtables = new List<GposMarkAttachmentSubtable> { subtable } };
+
+            var glyphs = new List<ShapedGlyph>();
+            for (var i = 0; i < 200; i++) glyphs.Add(new ShapedGlyph(i, i, 1));
+
+            // Warm: JIT the whole path before anything is counted.
+            for (var i = 0; i < 3; i++) GposPositioner.ApplyMarkToBase(null!, lookup, glyphs, gdef: null);
+
+            // Per THREAD, not process-wide: the suite runs collections in parallel, so
+            // GC.GetTotalAllocatedBytes counts whatever every other test is allocating at the same
+            // time and this reads over a megabyte of other people's work. This test body is
+            // synchronous and never awaits, so it stays on the one thread throughout.
+            const int passes = 50;
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            for (var i = 0; i < passes; i++) GposPositioner.ApplyMarkToBase(null!, lookup, glyphs, gdef: null);
+            var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+            // 200 glyphs x 50 passes is 10,000 trips through the subtable loop. One boxed enumerator
+            // each is ~320 KB; the indexed walk allocates nothing at all. A few hundred bytes of slack
+            // rather than zero, so this states "not per glyph" without depending on the runtime never
+            // allocating anything incidental.
+            Assert.True(allocated < 4096,
+                $"walking a lookup's subtables allocated {allocated} bytes over {passes * glyphs.Count:N0} "
+                + "glyph visits. It should allocate nothing: the list is interface-typed, so a foreach "
+                + "over it boxes an enumerator on every visit.");
+        }
+
+        /// <summary>
+        /// A <see cref="CoverageTable"/> covering no glyph at all. Its constructor is private and its
+        /// only public route in reads a real font, so this leaves both backing arrays null — the state
+        /// <see cref="CoverageTable.IndexOfGlyph"/> already answers -1 for.
+        /// </summary>
+        private static CoverageTable MatchesNothing() =>
+            (CoverageTable)RuntimeHelpers.GetUninitializedObject(typeof(CoverageTable));
+    }
+}

--- a/src/PeachPDF/Text/GposPositioner.cs
+++ b/src/PeachPDF/Text/GposPositioner.cs
@@ -13,6 +13,13 @@ namespace PeachPDF.Text
     /// glyph ids, matching universal real-shaper pipeline order. Like <see cref="GsubShaper"/>, this
     /// is general text-processing logic built from <c>PeachPDF.Fonts.OpenType</c>'s table data.
     /// </summary>
+    /// <remarks>
+    /// Every walk of a lookup's <c>Subtables</c> below is indexed rather than a <c>foreach</c>, and
+    /// deliberately: the property is declared as <see cref="IReadOnlyList{T}"/>, so a <c>foreach</c>
+    /// boxes a fresh enumerator through the interface every time, and these loops run <b>once per
+    /// glyph</b> — the cost lands on every glyph of every run in a document, whether or not the font
+    /// has anything to position. <c>GposPositionerAllocationTests</c> holds that to zero.
+    /// </remarks>
     internal static class GposPositioner
     {
         // Guards ApplySequenceContextLookup's own nested-lookup application against a pathological/
@@ -139,8 +146,9 @@ namespace PeachPDF.Text
         private static void ApplySingleAdjustmentAt(GposSingleAdjustmentLookup lookup, List<ShapedGlyph> glyphs, int i)
         {
             ushort glyphId = (ushort)glyphs[i].GlyphIndex;
-            foreach (GposSingleAdjustmentSubtable subtable in lookup.Subtables)
+            for (int subtableIndex = 0; subtableIndex < lookup.Subtables.Count; subtableIndex++)
             {
+                GposSingleAdjustmentSubtable subtable = lookup.Subtables[subtableIndex];
                 if (subtable.TryGetValue(glyphId, out GposValueRecord value))
                 {
                     glyphs[i] = AddValue(glyphs[i], value);
@@ -169,8 +177,9 @@ namespace PeachPDF.Text
             ushort first = (ushort)glyphs[i].GlyphIndex;
             ushort second = (ushort)glyphs[i + 1].GlyphIndex;
 
-            foreach (GposPairAdjustmentSubtable subtable in lookup.Subtables)
+            for (int subtableIndex = 0; subtableIndex < lookup.Subtables.Count; subtableIndex++)
             {
+                GposPairAdjustmentSubtable subtable = lookup.Subtables[subtableIndex];
                 if (subtable.TryGetValues(first, second, out GposValueRecord value1, out GposValueRecord value2))
                 {
                     glyphs[i] = AddValue(glyphs[i], value1);
@@ -207,8 +216,9 @@ namespace PeachPDF.Text
             ushort markGlyph = (ushort)glyphs[i].GlyphIndex;
             CoverageTable? markFilteringSet = lookup.MarkFilteringSetIndex is { } mfsIndex ? gdef?.GetMarkGlyphSet(mfsIndex) : null;
 
-            foreach (GposMarkAttachmentSubtable subtable in lookup.Subtables)
+            for (int subtableIndex = 0; subtableIndex < lookup.Subtables.Count; subtableIndex++)
             {
+                GposMarkAttachmentSubtable subtable = lookup.Subtables[subtableIndex];
                 int markIndex = subtable.MarkCoverage.IndexOfGlyph(markGlyph);
                 if (markIndex < 0 || markIndex >= subtable.Marks.Length)
                     continue;
@@ -245,8 +255,9 @@ namespace PeachPDF.Text
             ushort markGlyph = (ushort)glyphs[i].GlyphIndex;
             CoverageTable? markFilteringSet = lookup.MarkFilteringSetIndex is { } mfsIndex ? gdef?.GetMarkGlyphSet(mfsIndex) : null;
 
-            foreach (GposMarkToLigatureSubtable subtable in lookup.Subtables)
+            for (int subtableIndex = 0; subtableIndex < lookup.Subtables.Count; subtableIndex++)
             {
+                GposMarkToLigatureSubtable subtable = lookup.Subtables[subtableIndex];
                 int markIndex = subtable.MarkCoverage.IndexOfGlyph(markGlyph);
                 if (markIndex < 0 || markIndex >= subtable.Marks.Length)
                     continue;
@@ -324,8 +335,9 @@ namespace PeachPDF.Text
             int mark2Index = i - 1;
             ushort mark2Glyph = (ushort)glyphs[mark2Index].GlyphIndex;
 
-            foreach (GposMarkAttachmentSubtable subtable in lookup.Subtables)
+            for (int subtableIndex = 0; subtableIndex < lookup.Subtables.Count; subtableIndex++)
             {
+                GposMarkAttachmentSubtable subtable = lookup.Subtables[subtableIndex];
                 int markIndex = subtable.MarkCoverage.IndexOfGlyph(markGlyph);
                 if (markIndex < 0 || markIndex >= subtable.Marks.Length)
                     continue;
@@ -437,8 +449,9 @@ namespace PeachPDF.Text
 
         private static bool TryGetExitAnchor(GposCursiveAttachmentLookup lookup, ushort glyphId, out GposAnchor anchor)
         {
-            foreach (GposCursiveAttachmentSubtable subtable in lookup.Subtables)
+            for (int subtableIndex = 0; subtableIndex < lookup.Subtables.Count; subtableIndex++)
             {
+                GposCursiveAttachmentSubtable subtable = lookup.Subtables[subtableIndex];
                 int index = subtable.Coverage.IndexOfGlyph(glyphId);
                 if (index < 0 || index >= subtable.EntryExitRecords.Length)
                     continue;
@@ -454,8 +467,9 @@ namespace PeachPDF.Text
 
         private static bool TryGetEntryAnchor(GposCursiveAttachmentLookup lookup, ushort glyphId, out GposAnchor anchor)
         {
-            foreach (GposCursiveAttachmentSubtable subtable in lookup.Subtables)
+            for (int subtableIndex = 0; subtableIndex < lookup.Subtables.Count; subtableIndex++)
             {
+                GposCursiveAttachmentSubtable subtable = lookup.Subtables[subtableIndex];
                 int index = subtable.Coverage.IndexOfGlyph(glyphId);
                 if (index < 0 || index >= subtable.EntryExitRecords.Length)
                     continue;
@@ -564,8 +578,9 @@ namespace PeachPDF.Text
             IReadOnlyList<GposSequenceContextSubtable> subtables, List<ShapedGlyph> glyphs, int pos, GdefTable? gdef,
             ushort lookupFlag, CoverageTable? markFilteringSet)
         {
-            foreach (GposSequenceContextSubtable subtable in subtables)
+            for (int subtableIndex = 0; subtableIndex < subtables.Count; subtableIndex++)
             {
+                GposSequenceContextSubtable subtable = subtables[subtableIndex];
                 if (TryMatchSequenceContext(subtable, glyphs, pos, lookupFlag, gdef, markFilteringSet) is not
                     (int[] inputIndices, GposSequenceLookupRecord[] records))
                     continue;


### PR DESCRIPTION
Every lookup's `Subtables` is declared `IReadOnlyList<T>`, so a `foreach` over it boxes an enumerator through the interface. `GposPositioner` does that **once per glyph** — `ApplyMarkToBase` calls straight into the loop for every glyph in the run — so the cost lands on every glyph of every text run in a document.

It fires on **plain Latin text**, where there is nothing to attach at all, because the enumerator is allocated before any coverage check runs.

Eight such walks are now indexed. The ninth `foreach` in the file is deliberately left alone: it walks a `GposSequenceLookupRecord[]`, and an array's enumerator is a struct that allocates nothing.

## Measured

Over 26 real business documents, allocation per pass:

| | MB |
| --- | --- |
| `main` | 930.16 |
| with this change | **844.75** |

**−85 MB, 9% of the total.** No behaviour change — the loop visits the same subtables in the same order.

## Test

`GposPositionerAllocationTests` calls `ApplyMarkToBase` directly against a lookup whose single subtable covers no glyph, so the only thing that can allocate is the walk itself:

| | allocated over 10,000 glyph visits |
| --- | --- |
| `main` | **400,000 bytes** — exactly 40 per visit |
| with this change | 0 |

Two things about that test are worth flagging, because both bit me first:

- **It needs a non-empty subtable list.** `List<T>` hands back a *cached singleton* enumerator when it is empty, so a lookup with no subtables allocates nothing and the test passes against `main`. One subtable whose coverage matches nothing keeps the loop body cold while still walking.
- **It reads `GC.GetAllocatedBytesForCurrentThread`, not `GC.GetTotalAllocatedBytes`.** The latter is process-wide, and this suite runs collections in parallel — the first full-suite run reported 1.2 MB of other tests' allocation and failed a passing build.

It asserts at the positioner rather than through a rendered document on purpose: allocation over a document scales with whatever font a machine resolves, so an end-to-end threshold is loose on one platform and wrong on another.

Full suite green on net8.0 (10,388 passed), 0 new build warnings, diff coverage 100%.
