### PR TITLE
Point two comments at LiveChildStartFor's real name

### DIFF
--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -2591,7 +2591,7 @@ namespace PeachPDF.Html.Core.Dom
                 box._emittedNothingAtSlot = -1;
                 box._emittedNothingScopeOwner = null;
 
-                // A box only ever advances past a child via LiveChildStart once that child itself earned
+                // A box only ever advances past a child via LiveChildStartFor once that child itself earned
                 // an "emitted nothing" mark (see the accessor's own remarks), so a write that reaches this
                 // box on the way up from a rewritten descendant means whatever prefix of ITS OWN children
                 // this box's own cursor advanced past may itself be stale - discarded here for the same

--- a/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
+++ b/src/PeachPDF/Html/Core/Fragmentation/FragmentEmitter.cs
@@ -2585,7 +2585,7 @@ namespace PeachPDF.Html.Core.Fragmentation
 
             // Ordinary content: start past any leading run of children already individually confirmed to
             // hold nothing at or before this slot, rather than re-checking (and re-yielding a BuildDraft
-            // call for) each of them again on every later slot - see CssBox.LiveChildStart's own remarks.
+            // call for) each of them again on every later slot - see CssBox.LiveChildStartFor's own remarks.
             // Safe for the same reason trusting a single box's own mark is: a skipped child was reached and
             // observed empty by an earlier slot's walk, and nothing has written to it since - a write would
             // have discarded both the child's own mark and this box's cursor together


### PR DESCRIPTION
Follow-up to the minor point in your [#965 review](https://github.com/jhaygood86/PeachPDF/pull/965#issuecomment-5593726449).

#965 renamed `CssBox.LiveChildStart` to `LiveChildStartFor(slot)`, and two prose comments kept the old name:

- `CssBox.cs` ~2594 — "advances past a child via LiveChildStart once that child itself earned..."
- `FragmentEmitter.cs` ~2588 — "see CssBox.LiveChildStart's own remarks"

Neither is a `<see cref>`, so neither broke the build; both now point at a symbol that no longer exists. Comments only — no behaviour, no test change.

The one pre-existing `CS1998` in `CssBox.cs` (line 5922) is on `main` already and is untouched by this.