### PR TITLE
Fix SVG diametric arc sweep direction

### DIFF
--- a/.claude/invariants/svg-diametric-arc-direction-comes-from-sweep-flag.md
+++ b/.claude/invariants/svg-diametric-arc-direction-comes-from-sweep-flag.md
@@ -1,0 +1,9 @@
+# Diametric SVG arc direction comes from `sweep-flag`
+
+When an elliptical arc's endpoints are diametrically opposite, its angular magnitude is exactly
+180 degrees. The `large-arc-flag` cannot distinguish the two candidate arcs because neither is
+larger than the other; only `sweep-flag` selects the side.
+
+After endpoint-to-center conversion, normalize the signed sweep directly from `sweep-flag`.
+Do not infer direction from a strict less-than-180 comparison or from endpoint ordering. The
+measured failure mode is a two-arc circle whose halves both render on the same side.

--- a/.claude/migration-notes/2026-09-09-svg-diametric-arcs-honor-sweep-direction.md
+++ b/.claude/migration-notes/2026-09-09-svg-diametric-arcs-honor-sweep-direction.md
@@ -1,0 +1,8 @@
+# SVG arcs between diametrically opposite points honor `sweep-flag`
+
+An SVG elliptical-arc command whose endpoints are exactly opposite each other on the ellipse could
+choose the wrong semicircle. In particular, two clockwise 180-degree arcs intended to form a circle
+could overlap on one side and leave the other side empty.
+
+Such arcs now select the side requested by `sweep-flag`. The `large-arc-flag` remains geometrically
+irrelevant for an exact 180-degree arc, as required by SVG's endpoint arc model.

--- a/.claude/recent-fixes/2026-09-09-svg-diametric-arcs-honor-sweep-direction.md
+++ b/.claude/recent-fixes/2026-09-09-svg-diametric-arcs-honor-sweep-direction.md
@@ -1,0 +1,33 @@
+# SVG arcs between diametrically opposite points honor their sweep direction
+
+## What was wrong
+
+The PDFsharp endpoint-to-center arc conversion normalized the start/end angles by comparing the
+large-arc flag with whether the raw angular difference was less than 180 degrees. For an exact
+semicircle the difference is exactly 180 degrees, so that comparison cannot distinguish the two
+possible sides. Its result then depended on endpoint ordering.
+
+In a path made from two clockwise semicircles, the first arc was consequently reversed while the
+second was not. Both halves occupied the left side and the intended circle rendered as one
+semicircle drawn twice.
+
+## The fix
+
+The center calculation still uses the large-arc and sweep flags to select the correct ellipse.
+After that selection, the angular difference is now normalized directly from the requested sweep
+direction: clockwise sweeps are positive and counterclockwise sweeps are negative. This also makes
+the 180-degree case unambiguous, where the large-arc flag has no geometric effect.
+
+The regression test sends the reported SVG through `SvgTreeBuilder`, `SvgRenderer`, and the real
+`GraphicsPathAdapter`, then inspects the generated Bezier geometry and requires the path to reach
+all four extrema of the circle. A second test covers the counterclockwise normalization branch.
+
+## Evidence
+
+- The new exact-reproduction test failed before the fix with a maximum x-coordinate of 50 instead
+  of 90, then passed after the fix.
+- Targeted SVG path and PDF graphics tests: 41 passed.
+- Changed production lines: 100% line and branch coverage.
+- Full net8.0 suite: 10,420 passed, 9 skipped, with one unrelated existing
+  `FontSynthesisIntegrationTests` locale-sensitive assertion failure.
+- Whole-solution build: successful.

--- a/src/PeachPDF.Tests/Svg/SvgPathRenderingTests.cs
+++ b/src/PeachPDF.Tests/Svg/SvgPathRenderingTests.cs
@@ -1,0 +1,70 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Adapters;
+using PeachPDF.Html.Adapters.Entities;
+using PeachPDF.PdfSharpCore.Drawing;
+using PeachPDF.Svg;
+using PeachPDF.Tests.TestSupport;
+using System.Xml.Linq;
+
+namespace PeachPDF.Tests.Svg
+{
+    public class SvgPathRenderingTests
+    {
+        [Fact]
+        public void TwoClockwiseSemicircularArcs_RenderCompleteCircle()
+        {
+            var root = XDocument.Parse("""
+                <svg xmlns="http://www.w3.org/2000/svg"
+                     width="100" height="100"
+                     viewBox="0 0 100 100">
+                  <path
+                    d="M50 10
+                       A40 40 0 0 1 50 90
+                       A40 40 0 0 1 50 10"
+                    fill="none"
+                    stroke="black"/>
+                </svg>
+                """).Root!;
+            var document = SvgTreeBuilder.Build(new XElementSvgSourceNode(root), new PdfSharpAdapter());
+            var graphics = new RealPathRecordingGraphics();
+
+            SvgRenderer.RenderInto(graphics, document, new RRect(0, 0, 100, 100));
+
+            var points = Assert.Single(graphics.Paths);
+            Assert.Equal(10, points.Min(point => point.X), 3);
+            Assert.Equal(90, points.Max(point => point.X), 3);
+            Assert.Equal(10, points.Min(point => point.Y), 3);
+            Assert.Equal(90, points.Max(point => point.Y), 3);
+        }
+
+        [Fact]
+        public void CounterclockwiseSemicircularArc_RendersRequestedSide()
+        {
+            var root = XDocument.Parse("""
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+                  <path d="M50 10 A40 40 0 0 0 50 90" fill="none" stroke="black"/>
+                </svg>
+                """).Root!;
+            var document = SvgTreeBuilder.Build(new XElementSvgSourceNode(root), new PdfSharpAdapter());
+            var graphics = new RealPathRecordingGraphics();
+
+            SvgRenderer.RenderInto(graphics, document, new RRect(0, 0, 100, 100));
+
+            var points = Assert.Single(graphics.Paths);
+            Assert.Equal(10, points.Min(point => point.X), 3);
+            Assert.Equal(50, points.Max(point => point.X), 3);
+        }
+
+        private sealed class RealPathRecordingGraphics : TestRecordingGraphics
+        {
+            public List<XPoint[]> Paths { get; } = [];
+
+            public override RGraphicsPath GetGraphicsPath() => new GraphicsPathAdapter();
+
+            public override void DrawPath(RPen pen, RGraphicsPath path)
+            {
+                Paths.Add(((GraphicsPathAdapter)path).GraphicsPath._corePath.PathPoints);
+            }
+        }
+    }
+}

--- a/src/PeachPDF/PdfSharpCore/Drawing/GeometryHelper.cs
+++ b/src/PeachPDF/PdfSharpCore/Drawing/GeometryHelper.cs
@@ -296,18 +296,14 @@ namespace PeachPDF.PdfSharpCore.Drawing
             double α = Math.Atan2(pt1.Y - center.Y, pt1.X - center.X);
             double β = Math.Atan2(pt2.Y - center.Y, pt2.X - center.X);
 
-            // (another comparison of two Booleans!)
-            if (isLargeArc == (Math.Abs(β - α) < Math.PI))
-            {
-                if (α < β)
-                    α += 2 * Math.PI;
-                else
-                    β += 2 * Math.PI;
-            }
+            double sweepAngle = β - α;
+            if (clockwise && sweepAngle < 0)
+                sweepAngle += 2 * Math.PI;
+            else if (!clockwise && sweepAngle > 0)
+                sweepAngle -= 2 * Math.PI;
 
             // Invert matrix for final point calculation.
             matrix.Invert();
-            double sweepAngle = β - α;
 
             // Let the algorithm of GDI+ DrawArc to Bézier curves do the rest of the job
             return BezierCurveFromArc(center.X - δx * factor, center.Y - δy, 2 * δx * factor, 2 * δy,


### PR DESCRIPTION
Fixes #973

Summary
•	Normalize elliptical arc angles using the SVG sweep-flag.
•	Fix exact 180-degree arcs selecting the wrong semicircle.
•	Add clockwise and counterclockwise regression coverage.

Testing
•	SVG arc regression tests: 2 passed, 0 failed 