### PR TITLE
Measure the anonymous-box saving as a slope, not a whole-document ratio

### DIFF
--- a/.claude/recent-fixes/2026-09-09-an-allocation-ratio-that-still-carried-the-machines-baseline.md
+++ b/.claude/recent-fixes/2026-09-09-an-allocation-ratio-that-still-carried-the-machines-baseline.md
@@ -1,0 +1,33 @@
+# An allocation ratio that still carried the machine's baseline
+
+`AnonymousBoxDefaultingTests` compared one list document against one plain document and asserted the
+ratio. That is self-calibrating only for what the two documents share, and they shared less than the
+comment claimed: the fixed cost of rendering anything at all — document setup, font loading, the page
+machinery — sat in both numerator and denominator, so the ratio moved with whatever that costs on a
+given machine.
+
+It measured **1.71x** here against a bound of 2.05, and **2.06x** on a reviewer's machine, repeatably,
+across four runs. Same build, same direction, right on the bound — a merged test that fails for one
+of the two people who run it.
+
+It now takes each shape at two sizes and asserts the ratio of the **slopes**. The fixed baseline drops
+out of each slope, and dividing the list's by a plain block's cancels the per-item text work as well,
+leaving the list machinery itself.
+
+| | list | plain | ratio |
+| --- | --- | --- | --- |
+| with the fast path | 102.3 KB/item | 54.4 KB/item | **1.88** |
+| without | 157.3 KB/item | 54.8 KB/item | **2.87** |
+
+Repeatable to three decimal places, and the window is 53% wide against the old form's 41% — of which
+the reviewer's machine had already eaten most.
+
+## What this is really an instance of
+
+A ratio is only self-calibrating for the terms that actually cancel. Both documents rendering "the
+same text" is not enough when the thing being measured is a per-item cost and the baseline is not:
+the baseline is a constant added to both, and a constant added to both does **not** cancel in a
+ratio — it drags it toward 1 by however much the machine charges for it. Taking a slope removes it;
+that is the whole difference between the two forms.
+
+Nothing about the fix under test changed. This is only the instrument.

--- a/src/PeachPDF.Tests/Integration/AnonymousBoxDefaultingTests.cs
+++ b/src/PeachPDF.Tests/Integration/AnonymousBoxDefaultingTests.cs
@@ -1,9 +1,7 @@
 using PeachPDF;
 using PeachPDF.PdfSharpCore;
 using System;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace PeachPDF.Tests.Integration
@@ -28,23 +26,34 @@ namespace PeachPDF.Tests.Integration
     /// few hundred initial values it already held.
     /// </para>
     /// <para>
-    /// <b>Why the assertion is a ratio.</b> Allocated bytes are deterministic for a given build and
-    /// input, but their absolute value depends on the font a machine resolves. Both documents here
-    /// are measured in the same run on the same machine and carry the same text; they differ only in
-    /// whether that text sits in list items. That makes the comparison self-calibrating, so this
-    /// says the same thing on every platform.
+    /// <b>Why the assertion is a ratio of slopes.</b> Allocated bytes are deterministic for a given
+    /// build and input, but their absolute value depends on the font a machine resolves. So this
+    /// measures each shape at two sizes and takes the <i>marginal</i> cost per item, which subtracts
+    /// the fixed baseline — document setup, font loading, the page machinery — and then divides the
+    /// list's slope by a plain block's, which cancels the per-item text work as well. What is left is
+    /// the list machinery itself.
+    /// </para>
+    /// <para>
+    /// The plainer form this replaced — one list document over one plain document — left both of
+    /// those in the numbers, and measured <b>1.71x</b> here against a <b>2.06x</b> a reviewer saw
+    /// repeatably on their own machine, against a 2.05x bound. Same build, same direction, a fifth of
+    /// the window apart purely from what the two machines' baselines cost.
     /// </para>
     /// </remarks>
     public class AnonymousBoxDefaultingTests
     {
-        private const int Items = 400;
+        /// <summary>The two document sizes the slope is taken between.</summary>
+        private const int Small = 200;
+
+        /// <inheritdoc cref="Small"/>
+        private const int Large = 600;
 
         /// <summary>
-        /// Measured on this fixture: <b>1.71x</b> with the fast path and <b>2.41x</b> without, so the
-        /// bound sits between them with roughly 20% of margin either side. Stable to the second decimal
-        /// place both in isolation and with the whole suite running in parallel around it — but only
-        /// because the measurement is per-thread; see <see cref="AllocatedMbPerRender"/> for what that
-        /// is guarding against.
+        /// Measured: <b>1.88x</b> with the fast path and <b>2.87x</b> without — repeatable to three
+        /// decimal places — so the bound sits between them with 25% of margin below and 18% above.
+        /// Stable both in isolation and with the whole suite running in parallel around it, but only
+        /// because the measurement is per-thread; see <see cref="MarginalKbPerItem"/> for what that is
+        /// guarding against.
         ///
         /// The item text is one character on purpose. The saving is a fixed cost per list item, so the
         /// longer the text the more font work dilutes it: at 200 items of a full sentence the same
@@ -55,44 +64,57 @@ namespace PeachPDF.Tests.Integration
         /// It is a ratchet, not a law — if a change makes lists legitimately dearer, move it in the
         /// same commit and say why.
         /// </summary>
-        private const double MaxListOverhead = 2.05;
+        private const double MaxListOverhead = 2.35;
 
         [Fact]
-        public void AListCostsLittleMoreThanTheSameTextWithoutOne()
+        public void AListItemCostsLittleMoreThanAPlainBlock()
         {
-            var lines = Enumerable.Range(0, Items)
-                .Select(i => "x")
-                .ToList();
-
-            var list = Document("<ul>" + string.Concat(lines.Select(l => $"<li>{l}</li>")) + "</ul>");
-            var plain = Document(string.Concat(lines.Select(l => $"<div>{l}</div>")));
-
-            var listMb = AllocatedMbPerRender(list);
-            var plainMb = AllocatedMbPerRender(plain);
-            var overhead = listMb / plainMb;
+            var listSlope = MarginalKbPerItem(list: true);
+            var plainSlope = MarginalKbPerItem(list: false);
+            var overhead = listSlope / plainSlope;
 
             Assert.True(overhead <= MaxListOverhead,
-                $"{Items} list items allocate {overhead:F2}x what the same text costs without a list "
-                + $"({listMb:F1} MB against {plainMb:F1} MB), over the {MaxListOverhead:F2}x bound. Each "
-                + "list item generates an anonymous box, and this is what re-defaulting every one of "
-                + "them from scratch looks like.");
+                $"a list item costs {overhead:F2}x what a plain block costs at the margin "
+                + $"({listSlope:F1} KB against {plainSlope:F1} KB per item), over the {MaxListOverhead:F2}x "
+                + "bound. Each list item generates an anonymous box, and this is what re-defaulting "
+                + "every one of them from scratch looks like.");
         }
 
-        private static string Document(string body) =>
-            $"<html><body style=\"font-family:sans-serif\">{body}</body></html>";
-
         /// <summary>
-        /// Allocated megabytes per render, measured <b>per thread</b> and synchronously.
+        /// Allocated kilobytes per additional item — the slope between two document sizes, so the
+        /// fixed cost of rendering anything at all drops out.
         /// </summary>
         /// <remarks>
-        /// Both of those matter and the first version of this had neither. <c>GC.GetTotalAllocatedBytes</c>
-        /// is process-wide, and this suite runs collections in parallel, so it counts whatever every
-        /// other test is allocating at the same moment — which is how a measurement claimed here to be
-        /// stable to a fraction of a percent was reported swinging between 2.05x and 4.59x on a
-        /// reviewer's machine. <c>GetAllocatedBytesForCurrentThread</c> is immune to that, and blocking
-        /// on the render rather than awaiting it keeps the whole measured region on the one thread it
-        /// counts.
+        /// Measured <b>per thread</b> and synchronously, and both of those matter.
+        /// <c>GC.GetTotalAllocatedBytes</c> is process-wide, and this suite runs collections in
+        /// parallel, so it counts whatever every other test is allocating at the same moment — which
+        /// is how an earlier version of this, stable to a fraction of a percent in isolation, was
+        /// reported swinging between 2.05x and 4.59x with the suite running.
+        /// <c>GetAllocatedBytesForCurrentThread</c> is immune to that, and blocking on the render
+        /// rather than awaiting it keeps the whole measured region on the one thread it counts.
         /// </remarks>
+        private static double MarginalKbPerItem(bool list) =>
+            (AllocatedMbPerRender(Document(Large, list)) - AllocatedMbPerRender(Document(Small, list)))
+            / (Large - Small) * 1024;
+
+        /// <summary>
+        /// The same single character in each item either way, so the two shapes differ only in whether
+        /// it sits in a list. One character on purpose: the saving is a fixed cost per item, so longer
+        /// text dilutes it into the font work.
+        /// </summary>
+        private static string Document(int items, bool list)
+        {
+            var sb = new StringBuilder("<html><body style=\"font-family:sans-serif\">");
+
+            if (list) sb.Append("<ul>");
+
+            for (var i = 0; i < items; i++) sb.Append(list ? "<li>x</li>" : "<div>x</div>");
+
+            if (list) sb.Append("</ul>");
+
+            return sb.Append("</body></html>").ToString();
+        }
+
         private static double AllocatedMbPerRender(string html)
         {
             // Warm the JIT, the font cache and every static table: none of it is per-render cost, and


### PR DESCRIPTION
Follow-up to the heads-up on [#967](https://github.com/jhaygood86/PeachPDF/pull/967#pullrequestreview) — the 2.06x you measured repeatably against the 2.05x bound. I could not reproduce it here, so rather than just widen the bound I went after why the two machines disagree at all, and the test was wrong about its own premise.

## The old form was not as self-calibrating as it claimed

It compared one list document against one plain document. That cancels what the two documents *share* — but the fixed cost of rendering anything at all (document setup, font loading, the page machinery) sat in **both** numerator and denominator. A constant added to both does not cancel in a ratio; it drags it toward 1 by however much the machine charges for it. So the number moves with the baseline, which is exactly the machine-dependent part it was supposed to be immune to. Your 2.06 against my 1.71 is that, not a hardware quirk.

## What it does now

Each shape is measured at two sizes and the ratio is taken between the **slopes**. The fixed baseline drops out of each slope; dividing the list slope by a plain block's cancels the per-item text work too. What is left is the list machinery.

| | list | plain block | ratio |
| --- | --- | --- | --- |
| with the fast path | 102.3 KB/item | 54.4 KB/item | **1.88x** |
| without | 157.3 KB/item | 54.8 KB/item | **2.87x** |

Repeatable to three decimal places (1.880, 1.879), in isolation and with the whole suite running in parallel around it.

The bound moves to **2.35x** — 25% of margin below, 18% above. The window is 53% wide where the old form's was 41%, and most of that had already gone on your machine.

**Nothing about the code under test changes.** This is the instrument only. Still mutation-checked against the pre-#967 engine: 2.85x without, 1.88x with.

Worth saying plainly: I cannot verify this fixes it on *your* machine, only that it removes the term I believe caused the divergence. If it still lands near the bound for you, that would be genuinely useful to know — it would mean the remaining per-item cost differs between us, which is a different and more interesting problem than a baseline offset.

Full suite green on net8.0 (10,420), run twice, 0 new build warnings.