### PR TITLE
Cache the lookup-cache factory delegate instead of rebuilding it per call

### DIFF
--- a/.claude/recent-fixes/2026-09-09-a-method-group-passed-to-getoradd-allocates-per-call.md
+++ b/.claude/recent-fixes/2026-09-09-a-method-group-passed-to-getoradd-allocates-per-call.md
@@ -1,0 +1,36 @@
+# A method group passed to GetOrAdd allocates per call
+
+`GposTable` and `GsubTable` cache every parsed lookup —
+`_cache.GetOrAdd(lookupListIndex, ReadSomething)`. The second argument is a **method group**, and
+converting one to a `Func<>` allocates a fresh delegate on *every call*, including the
+overwhelmingly common one where the cache already holds the value and the factory is never
+invoked. The positioner and the shaper ask these questions once per glyph per lookup, so the
+delegate was allocated per glyph while the thing it existed to build was allocated once.
+
+Seventeen getters across the two tables now hold the delegate in a field (`??=` on first use, so no
+constructor changes).
+
+## What measuring it turned up
+
+- **Worth 57 MB per corpus pass, 7.7% of the total** — 734.6 MB down to 677.9 MB over 26 real
+  documents. Per-word allocation on a text-heavy document drops from **12.26 KB to 9.76 KB**, a
+  fifth of the shaping cost.
+- **It is exactly 64 bytes a call** — 6,000 cache hits allocated 384,000 bytes before, and zero
+  after. That is one delegate, which is what makes this testable to the byte rather than as a
+  percentage of a render.
+- **The profile pointed straight at it.** `GC/AllocationTick` with call stacks put
+  `System.Func<int,int>` and `System.Func<int,GposMarkToBaseLookup>` in the top ten allocated types
+  of a whole document render, which is not a shape anyone writes on purpose — a `Func` appearing
+  high in an allocation profile of a *layout engine* is the tell.
+- **Nineteen such sites exist**; the two remaining ones (`HyphenationEngine`, `MimeTypeResolver`)
+  are not on a per-glyph path and are left alone.
+
+## Evidence
+
+`GposTableSyntheticTests.ALookupCacheHit_AllocatesNothing` primes the caches against a synthetic
+face and then asserts 6,000 hits allocate under 4 KB — 384,000 bytes against `main`. Asserted at the
+table rather than through a rendered document because allocation over a document scales with
+whatever font a machine resolves; with the cache primed, the delegate is the only thing left that
+can allocate. Per-thread, because the suite runs collections in parallel.
+
+Full suite green on net8.0 (10,423), 0 new build warnings, corpus fidelity unchanged at 26/26.

--- a/src/PeachPDF.Tests/PdfSharpCore/Fonts/GposTableSyntheticTests.cs
+++ b/src/PeachPDF.Tests/PdfSharpCore/Fonts/GposTableSyntheticTests.cs
@@ -578,6 +578,59 @@ namespace PeachPDF.Tests.PdfSharpCoreTests.Fonts
             return combined;
         }
 
+        /// <summary>
+        /// A cache hit on a lookup getter allocates nothing.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Every one of these getters is <c>_cache.GetOrAdd(index, ReadSomething)</c>. The second
+        /// argument is a <b>method group</b>, and converting one to a <c>Func&lt;&gt;</c> allocates a
+        /// fresh delegate on <i>every call</i> — including the overwhelmingly common case where the
+        /// cache already holds the value and the factory is never invoked. The positioner asks these
+        /// questions once per glyph per lookup, so the delegate is allocated per glyph while the
+        /// thing it exists to build is allocated once.
+        /// </para>
+        /// <para>
+        /// Asserted here rather than through a rendered document because allocation over a document
+        /// scales with whatever font a machine resolves; against a synthetic face with the cache
+        /// already primed, the delegate is the only thing left that can allocate, which makes the
+        /// assertion exact and the same everywhere.
+        /// </para>
+        /// </remarks>
+        [Fact]
+        public void ALookupCacheHit_AllocatesNothing()
+        {
+            var (face, tableStart) = BuildFaceWithSyntheticGpos();
+            var gpos = new GposTable(face, tableStart);
+
+            // Prime every cache this touches, and JIT the path, before anything is counted.
+            for (var i = 0; i < 3; i++)
+            {
+                gpos.GetResolvedLookupType(0);
+                gpos.GetMarkToBaseLookup(0);
+                gpos.GetSingleAdjustmentLookup(0);
+            }
+
+            // Per THREAD, not process-wide: this suite runs collections in parallel, so
+            // GC.GetTotalAllocatedBytes would count whatever every other test is allocating.
+            const int calls = 2000;
+            var before = GC.GetAllocatedBytesForCurrentThread();
+
+            for (var i = 0; i < calls; i++)
+            {
+                gpos.GetResolvedLookupType(0);
+                gpos.GetMarkToBaseLookup(0);
+                gpos.GetSingleAdjustmentLookup(0);
+            }
+
+            var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+            Assert.True(allocated < 4096,
+                $"{calls * 3:N0} cache hits allocated {allocated:N0} bytes. They should allocate "
+                + "nothing: a method group passed to GetOrAdd becomes a new delegate on every call, "
+                + "even when the cache already has the value.");
+        }
+
         private static (OpenTypeFontface Face, int TableStart) BuildFaceWithSyntheticGpos()
         {
             byte[] fontBytes = File.ReadAllBytes(BundledFonts.Ttf);

--- a/src/PeachPDF/Fonts/OpenType/GposTable.cs
+++ b/src/PeachPDF/Fonts/OpenType/GposTable.cs
@@ -299,6 +299,16 @@ namespace PeachPDF.Fonts.OpenType
 
     internal sealed class GposTable
     {
+
+        private Func<int, GposSingleAdjustmentLookup?>? _readSingleAdjustmentLookupDelegate;
+        private Func<int, GposCursiveAttachmentLookup?>? _readCursiveAttachmentLookupDelegate;
+        private Func<int, GposPairAdjustmentLookup?>? _readPairAdjustmentLookupDelegate;
+        private Func<int, GposMarkToBaseLookup?>? _readMarkToBaseLookupDelegate;
+        private Func<int, GposMarkToMarkLookup?>? _readMarkToMarkLookupDelegate;
+        private Func<int, GposMarkToLigatureLookup?>? _readMarkToLigatureLookupDelegate;
+        private Func<int, GposContextualLookup?>? _readContextualLookupDelegate;
+        private Func<int, GposChainingContextLookup?>? _readChainingContextLookupDelegate;
+        private Func<int, int>? _readResolvedLookupTypeDelegate;
         private readonly OpenTypeFontface _face;
         private readonly int _scriptListOffset;
         private readonly int _featureListOffset;
@@ -392,33 +402,33 @@ namespace PeachPDF.Fonts.OpenType
         }
 
         public GposSingleAdjustmentLookup? GetSingleAdjustmentLookup(int lookupListIndex)
-            => _singleAdjustmentCache.GetOrAdd(lookupListIndex, ReadSingleAdjustmentLookup);
+            => _singleAdjustmentCache.GetOrAdd(lookupListIndex, _readSingleAdjustmentLookupDelegate ??= ReadSingleAdjustmentLookup);
 
         public GposCursiveAttachmentLookup? GetCursiveAttachmentLookup(int lookupListIndex)
-            => _cursiveAttachmentCache.GetOrAdd(lookupListIndex, ReadCursiveAttachmentLookup);
+            => _cursiveAttachmentCache.GetOrAdd(lookupListIndex, _readCursiveAttachmentLookupDelegate ??= ReadCursiveAttachmentLookup);
 
         public GposPairAdjustmentLookup? GetPairAdjustmentLookup(int lookupListIndex)
-            => _pairAdjustmentCache.GetOrAdd(lookupListIndex, ReadPairAdjustmentLookup);
+            => _pairAdjustmentCache.GetOrAdd(lookupListIndex, _readPairAdjustmentLookupDelegate ??= ReadPairAdjustmentLookup);
 
         public GposMarkToBaseLookup? GetMarkToBaseLookup(int lookupListIndex)
-            => _markToBaseCache.GetOrAdd(lookupListIndex, ReadMarkToBaseLookup);
+            => _markToBaseCache.GetOrAdd(lookupListIndex, _readMarkToBaseLookupDelegate ??= ReadMarkToBaseLookup);
 
         public GposMarkToMarkLookup? GetMarkToMarkLookup(int lookupListIndex)
-            => _markToMarkCache.GetOrAdd(lookupListIndex, ReadMarkToMarkLookup);
+            => _markToMarkCache.GetOrAdd(lookupListIndex, _readMarkToMarkLookupDelegate ??= ReadMarkToMarkLookup);
 
         public GposMarkToLigatureLookup? GetMarkToLigatureLookup(int lookupListIndex)
-            => _markToLigatureCache.GetOrAdd(lookupListIndex, ReadMarkToLigatureLookup);
+            => _markToLigatureCache.GetOrAdd(lookupListIndex, _readMarkToLigatureLookupDelegate ??= ReadMarkToLigatureLookup);
 
         public GposContextualLookup? GetContextualLookup(int lookupListIndex)
-            => _contextualLookupCache.GetOrAdd(lookupListIndex, ReadContextualLookup);
+            => _contextualLookupCache.GetOrAdd(lookupListIndex, _readContextualLookupDelegate ??= ReadContextualLookup);
 
         public GposChainingContextLookup? GetChainingContextLookup(int lookupListIndex)
-            => _chainingContextLookupCache.GetOrAdd(lookupListIndex, ReadChainingContextLookup);
+            => _chainingContextLookupCache.GetOrAdd(lookupListIndex, _readChainingContextLookupDelegate ??= ReadChainingContextLookup);
 
         /// <summary>The real lookup type at <paramref name="lookupListIndex"/> - a Type 9 (Extension
         /// Positioning) lookup resolves to whatever type it wraps. Returns -1 for an out-of-range index.</summary>
         public int GetResolvedLookupType(int lookupListIndex)
-            => _resolvedLookupTypeCache.GetOrAdd(lookupListIndex, ReadResolvedLookupType);
+            => _resolvedLookupTypeCache.GetOrAdd(lookupListIndex, _readResolvedLookupTypeDelegate ??= ReadResolvedLookupType);
 
         private (string Tag, int Offset)[] ReadFeatureRecords()
         {

--- a/src/PeachPDF/Fonts/OpenType/GsubTable.cs
+++ b/src/PeachPDF/Fonts/OpenType/GsubTable.cs
@@ -286,6 +286,15 @@ namespace PeachPDF.Fonts.OpenType
 
     internal sealed class GsubTable
     {
+
+        private Func<int, GsubLigatureLookup?>? _readLigatureLookupDelegate;
+        private Func<int, GsubSingleSubstitutionLookup?>? _readSingleSubstitutionLookupDelegate;
+        private Func<int, GsubAlternateSubstitutionLookup?>? _readAlternateSubstitutionLookupDelegate;
+        private Func<int, GsubMultipleSubstitutionLookup?>? _readMultipleSubstitutionLookupDelegate;
+        private Func<int, GsubContextualLookup?>? _readContextualLookupDelegate;
+        private Func<int, GsubChainingContextLookup?>? _readChainingContextLookupDelegate;
+        private Func<int, GsubReverseChainSingleSubstLookup?>? _readReverseChainSingleSubstLookupDelegate;
+        private Func<int, int>? _readResolvedLookupTypeDelegate;
         private readonly OpenTypeFontface _face;
         private readonly int _scriptListOffset;
         private readonly int _featureListOffset;
@@ -397,38 +406,38 @@ namespace PeachPDF.Fonts.OpenType
         /// <summary>Parses (and caches) the lookup at <paramref name="lookupListIndex"/> as a
         /// ligature-substitution lookup, or null if it isn't one (or is an unsupported lookup type).</summary>
         public GsubLigatureLookup? GetLigatureLookup(int lookupListIndex)
-            => _ligatureLookupCache.GetOrAdd(lookupListIndex, ReadLigatureLookup);
+            => _ligatureLookupCache.GetOrAdd(lookupListIndex, _readLigatureLookupDelegate ??= ReadLigatureLookup);
 
         /// <summary>Parses (and caches) the lookup at <paramref name="lookupListIndex"/> as a
         /// single-substitution lookup, or null if it isn't one (or is an unsupported lookup type).</summary>
         public GsubSingleSubstitutionLookup? GetSingleSubstitutionLookup(int lookupListIndex)
-            => _singleSubstitutionLookupCache.GetOrAdd(lookupListIndex, ReadSingleSubstitutionLookup);
+            => _singleSubstitutionLookupCache.GetOrAdd(lookupListIndex, _readSingleSubstitutionLookupDelegate ??= ReadSingleSubstitutionLookup);
 
         /// <summary>Parses (and caches) the lookup at <paramref name="lookupListIndex"/> as an
         /// alternate-substitution lookup, or null if it isn't one (or is an unsupported lookup type).</summary>
         public GsubAlternateSubstitutionLookup? GetAlternateSubstitutionLookup(int lookupListIndex)
-            => _alternateSubstitutionLookupCache.GetOrAdd(lookupListIndex, ReadAlternateSubstitutionLookup);
+            => _alternateSubstitutionLookupCache.GetOrAdd(lookupListIndex, _readAlternateSubstitutionLookupDelegate ??= ReadAlternateSubstitutionLookup);
 
         /// <summary>Parses (and caches) the lookup at <paramref name="lookupListIndex"/> as a
         /// multiple-substitution lookup, or null if it isn't one (or is an unsupported lookup type).</summary>
         public GsubMultipleSubstitutionLookup? GetMultipleSubstitutionLookup(int lookupListIndex)
-            => _multipleSubstitutionLookupCache.GetOrAdd(lookupListIndex, ReadMultipleSubstitutionLookup);
+            => _multipleSubstitutionLookupCache.GetOrAdd(lookupListIndex, _readMultipleSubstitutionLookupDelegate ??= ReadMultipleSubstitutionLookup);
 
         /// <summary>Parses (and caches) the lookup at <paramref name="lookupListIndex"/> as a
         /// contextual-substitution lookup, or null if it isn't one (or is an unsupported lookup type).</summary>
         public GsubContextualLookup? GetContextualLookup(int lookupListIndex)
-            => _contextualLookupCache.GetOrAdd(lookupListIndex, ReadContextualLookup);
+            => _contextualLookupCache.GetOrAdd(lookupListIndex, _readContextualLookupDelegate ??= ReadContextualLookup);
 
         /// <summary>Parses (and caches) the lookup at <paramref name="lookupListIndex"/> as a
         /// chaining-context-substitution lookup, or null if it isn't one (or is an unsupported type).</summary>
         public GsubChainingContextLookup? GetChainingContextLookup(int lookupListIndex)
-            => _chainingContextLookupCache.GetOrAdd(lookupListIndex, ReadChainingContextLookup);
+            => _chainingContextLookupCache.GetOrAdd(lookupListIndex, _readChainingContextLookupDelegate ??= ReadChainingContextLookup);
 
         /// <summary>Parses (and caches) the lookup at <paramref name="lookupListIndex"/> as a
         /// reverse-chaining-context single-substitution lookup, or null if it isn't one (or is an
         /// unsupported type).</summary>
         public GsubReverseChainSingleSubstLookup? GetReverseChainSingleSubstLookup(int lookupListIndex)
-            => _reverseChainSingleSubstLookupCache.GetOrAdd(lookupListIndex, ReadReverseChainSingleSubstLookup);
+            => _reverseChainSingleSubstLookupCache.GetOrAdd(lookupListIndex, _readReverseChainSingleSubstLookupDelegate ??= ReadReverseChainSingleSubstLookup);
 
         /// <summary>
         /// The real lookup type at <paramref name="lookupListIndex"/> - a Type 7 (Extension
@@ -437,7 +446,7 @@ namespace PeachPDF.Fonts.OpenType
         /// Returns -1 for an out-of-range index.
         /// </summary>
         public int GetResolvedLookupType(int lookupListIndex)
-            => _resolvedLookupTypeCache.GetOrAdd(lookupListIndex, ReadResolvedLookupType);
+            => _resolvedLookupTypeCache.GetOrAdd(lookupListIndex, _readResolvedLookupTypeDelegate ??= ReadResolvedLookupType);
 
         /// <summary>
         /// Whether every tag in <paramref name="requiredTags"/> independently resolves to at least


### PR DESCRIPTION
`GposTable` and `GsubTable` cache every parsed lookup:

```csharp
public GposMarkToBaseLookup? GetMarkToBaseLookup(int lookupListIndex)
    => _markToBaseCache.GetOrAdd(lookupListIndex, ReadMarkToBaseLookup);
```

The second argument is a **method group**, and converting one to a `Func<>` allocates a fresh delegate on **every call** — including the overwhelmingly common one where the cache already holds the value and the factory is never invoked. The positioner and the shaper ask these questions once per glyph per lookup, so the delegate was allocated per glyph while the thing it exists to build was allocated once.

Seventeen getters now hold the delegate in a field, assigned with `??=` on first use so no constructor changes are needed.

## Measured

Over 26 real business documents:

| | allocated per pass |
| --- | --- |
| `main` | 734.6 MB |
| with this change | **677.9 MB** |

**−57 MB, 7.7% of the total.** On a text-heavy document the per-word cost falls from **12.26 KB to 9.76 KB** — about a fifth of the shaping allocation. No behaviour change; corpus fidelity is unchanged at 26/26.

## How it was found

`GC/AllocationTick` with call stacks put `System.Func<int,int>` and `System.Func<int,GposMarkToBaseLookup>` in the top ten allocated **types** of a whole document render. A `Func` ranking that high in an allocation profile of a layout engine is not a shape anyone writes on purpose, and the stacks led straight here.

## Test

`ALookupCacheHit_AllocatesNothing` primes the caches against the synthetic face the neighbouring tests already build, then asserts 6,000 subsequent hits allocate under 4 KB:

| | allocated over 6,000 cache hits |
| --- | --- |
| `main` | **384,000 bytes** — exactly 64 per call, one delegate |
| with this change | 0 |

Asserted at the table rather than through a rendered document because allocation over a document scales with whatever font a machine resolves; with the cache primed, the delegate is the only thing left that can allocate. It reads `GC.GetAllocatedBytesForCurrentThread` rather than `GC.GetTotalAllocatedBytes`, since this suite runs collections in parallel.

## Scope

Nineteen `GetOrAdd(key, MethodGroup)` sites exist in the tree. The two outside these tables — `HyphenationEngine.PatternSetCache` and `MimeTypeResolver.Cache` — are not on a per-glyph path and are deliberately left alone.

Full suite green on net8.0 (10,423 passed), 0 new build warnings.