### PR TITLE
Match selectors via indexed cost order instead of LINQ

### DIFF
--- a/.claude/recent-fixes/2026-09-09-cost-ordered-zero-allocation-selector-matching.md
+++ b/.claude/recent-fixes/2026-09-09-cost-ordered-zero-allocation-selector-matching.md
@@ -1,0 +1,90 @@
+# Cost-ordered, zero-allocation selector matching
+
+`CssData.DoesSelectorMatch`'s `ListSelector`/`CompoundSelector` overloads called LINQ's
+`Any()`/`All()`/`Last()` over `Selectors`, which only implements `IEnumerable<ISelector>` (not
+`IList<ISelector>`) — so each call boxed an enumerator through the interface and allocated a closure,
+on the hottest path in the whole cascade (once per box per candidate rule). `Selectors` already
+exposes `Length` and an indexer, so the same logic is now an indexed loop with no interface dispatch
+and no closure. Reported (with a full GC profile and a repro attempt) in [issue
+#971](https://github.com/jhaygood86/PeachPDF/issues/971), whose author couldn't land a PR because
+every test they tried to isolate the effect gave no signal — see "What testing it turned up" below.
+
+On top of the allocation fix, `Selectors` gained a cached `MatchOrder`: an `int[]` of indices into
+`_selectors`, sorted once (lazily, on first use) by a new `SelectorMatchCost.Of(ISelector)` ranking —
+cheap checks (`IdSelector`/`ClassSelector`/`TypeSelector`) first, expensive ones (`HasSelector`,
+`NotSelector`/`MatchesSelector`, `LangSelector`, structural `ChildSelector`/`OnlyChildSelector`/
+`OnlyOfTypeSelector`) last. `DoesSelectorMatch`'s `All`/`Any` loops iterate in that order instead of
+source order, so a cheap conjunct/alternative short-circuits before an expensive one ever runs — the
+same technique real selector engines (e.g. WebKit's `SelectorChecker`) use. `MatchOrder` is a separate
+view layered on top of `_selectors`; it does not reorder `_selectors` itself, so `ToCss()`/`Text`,
+`Specificity`, and the CSS-grammar invariant that a trailing `PseudoElementSelector` is structurally
+last (found via `compoundSelector[compoundSelector.Length - 1]`, never via `MatchOrder`) all still see
+source order exactly as before.
+
+The same `Where()`/`Any()`/`Last()`-over-`Selectors` shape existed at four more call sites in the same
+file, some genuinely adjacent to the ones the issue measured — `GetMatchedSpecificity` (once per
+matched rule per box, on the same `ThenBy` sort as `DoesSelectorMatch`), `MatchesAsFirstLineSelector`/
+`HasFirstLineSubject` (per box, for `::first-line` rules), `CouldMatchAsFirstLineSelector` (once per
+rule at index-build time - never actually hot, fixed anyway for consistency), and `HasRelativeMatch`
+(`:has()`'s comma-separated relative-selector-list argument). All four are now indexed too, reusing
+`MatchOrder` where the call is a pure OR/AND (safe to reorder) and a plain loop where every alternative
+has to be examined regardless (`GetMatchedSpecificity` needs the *maximum* matched specificity, not
+just the first match, so cost-ordering doesn't help there — only the allocation removal does).
+
+**Left alone on purpose:** `ComplexSelector.LastOrDefault()` (`MatchesAsFirstLineSelector`,
+`CouldMatchAsFirstLineSelector`) has the identical allocation shape, but `ComplexSelector` is a
+different, unrelated type with no indexer of its own (only `IEnumerable<CombinatorSelector>` and a
+`Length` property) — fixing it means adding new API surface to a second class, not reusing the
+`Selectors`/`MatchOrder` infrastructure this PR built. Deferred as a separate, smaller follow-up rather
+than folded in here.
+
+## What testing it turned up
+
+The issue's own author tried four ways to isolate the effect and got no signal from any of them:
+measuring through the cascade (`GetUserAgentStyleRules`, whole-document allocation ratios, rule-count
+scaling) dilutes a diffuse, per-box saving below the noise of font loading, document setup, and
+per-document variance — the same class of problem `GposPositionerAllocationTests` and
+`GposTableSyntheticTests` already solved for the identical enumerator-through-an-interface shape in
+the GPOS positioner (see
+[2026-09-08-the-gpos-subtable-walk-allocated-an-enumerator-per-glyph.md](2026-09-08-the-gpos-subtable-walk-allocated-an-enumerator-per-glyph.md)
+and
+[2026-09-09-a-method-group-passed-to-getoradd-allocates-per-call.md](2026-09-09-a-method-group-passed-to-getoradd-allocates-per-call.md)).
+The fix here: bump the two `DoesSelectorMatch` overloads from `private` to `internal` (there's already
+a same-class precedent, `MatchesAsFirstLineSelector`), call them directly against a synthetic
+`ListSelector`/`CompoundSelector` and a real fixture box in a warmed, tight loop, and assert
+`GC.GetAllocatedBytesForCurrentThread()` deltas instead of measuring through the whole cascade. Verified
+non-vacuous by temporarily reverting each of the three rewritten bodies back to the original LINQ and
+re-running: 1,280,000–2,080,000 bytes over 10,000 calls unfixed, under 4 KB fixed, every time.
+
+`SelectorMatchCostTests`/`SelectorsMatchOrderTests` pin down the cost ranking and the resulting index
+permutation directly; `SelectorMatchOrderIndependenceTests` proves end-to-end (via rendered HTML) that
+a compound selector's AND result doesn't depend on which conjunct happens to be cheap, pairing `#id`
+against `:has()` (the largest gap in the cost table) in both orders.
+
+`PeachPDF.TestHarness` gained a reusable `--benchmark [--benchmark-iterations N]` mode (default 10)
+for exactly this kind of corpus-wide measurement in the future: it renders every showcase (the same
+`GeneratePdf` + `Save` a real caller does, no files written) N times each after one untimed warmup,
+and prints a per-showcase table plus corpus totals using `GC.GetTotalAllocatedBytes(precise: true)`
+(the process-wide counter is the right one here, unlike in the parallel xUnit suite, because nothing
+else runs concurrently in this process) and `Stopwatch`.
+
+## Evidence
+
+Full suite green on net8.0 (10,453 passed, 9 skipped - pre-existing platform-specific `MimeTypeResolver`
+skips), 0 build warnings solution-wide (net8.0/net10.0/net11.0). All new/changed lines covered per a
+manual line-by-line check of `coverage.cobertura.xml` (no local `diff-cover`/pip in this environment).
+
+**Corpus-wide, Release, `--benchmark --benchmark-iterations 10`** over all 111 showcases (a second
+worktree at the pre-fix commit, patched with only the new `--benchmark` flag itself so the comparison
+isolates the selector-matching change):
+
+| | main | fixed | delta |
+| --- | --- | --- | --- |
+| Wall time (one corpus pass) | 2674.06 ms | 2572.02 ms | -102.04 ms (-3.8%) |
+| Allocated (one corpus pass) | 2449.63 MB | 2172.23 MB | -277.40 MB (-11.3%) |
+
+Zero showcases allocated more after the fix. Biggest mover: `charts_css` (a large, selector-heavy
+stylesheet) at 570.2 MB → 350.8 MB (-38.5%) - the shape of document this fix helps most, a small
+number of boxes matched against many candidate rules with compound/list selectors. The 11.3% corpus-wide
+figure is well above the 3.2% the issue's own narrower "26 real documents" sample measured, consistent
+with the showcase corpus skewing more selector-heavy than an average document sample.

--- a/src/PeachPDF.TestHarness/Program.cs
+++ b/src/PeachPDF.TestHarness/Program.cs
@@ -1,5 +1,6 @@
 using PeachPDF;
 using PeachPDF.PdfSharpCore;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -14,10 +15,40 @@ PdfGenerateConfig pdfConfig = new()
 
 PdfGenerator generator = new();
 
-// Optional first argument: directory to write showcase output into (used by the
+// --benchmark [--benchmark-iterations N]: instead of writing any output, times and measures
+// allocation for every showcase's render (GeneratePdf + Save, the same two calls a real caller
+// makes), N times each (default 10), and prints a per-showcase report plus totals at the end. A
+// reusable regression tool for exactly the kind of corpus-wide allocation change issue #971 needed -
+// no files are written in this mode, so it's safe to point at any outputDir. Parsed out of args
+// before the positional outputDir argument below, so "--benchmark" is never mistaken for a directory.
+var positionalArgs = new List<string>();
+var benchmarkMode = false;
+var benchmarkIterations = 10;
+for (var i = 0; i < args.Length; i++)
+{
+    if (args[i] == "--benchmark")
+    {
+        benchmarkMode = true;
+    }
+    else if (args[i] == "--benchmark-iterations" && i + 1 < args.Length
+        && int.TryParse(args[i + 1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedIterations)
+        && parsedIterations > 0)
+    {
+        benchmarkIterations = parsedIterations;
+        i++;
+    }
+    else
+    {
+        positionalArgs.Add(args[i]);
+    }
+}
+
+List<BenchmarkResult> benchmarkResults = [];
+
+// Optional first (positional) argument: directory to write showcase output into (used by the
 // docs-site build to publish /showcase). Defaults to the current directory,
 // matching the historical local workflow.
-var outputDir = args.Length > 0 ? Path.GetFullPath(args[0]) : Directory.GetCurrentDirectory();
+var outputDir = positionalArgs.Count > 0 ? Path.GetFullPath(positionalArgs[0]) : Directory.GetCurrentDirectory();
 Directory.CreateDirectory(outputDir);
 
 // Opt-in PDF/A conformance sweep (PDFA_SWEEP=1) - alongside every showcase's normal PDF, also
@@ -72,6 +103,12 @@ List<ShowcaseEntry> showcaseManifest = [];
 // the website's /showcase page always matches the files actually written.
 async Task SaveShowcaseAsync(string slug, string category, string cardTitle, string cardDescription, string sourceHtml, PdfGenerateConfig renderConfig)
 {
+    if (benchmarkMode)
+    {
+        await BenchmarkShowcaseAsync(slug, sourceHtml, renderConfig);
+        return;
+    }
+
     var showcaseDocument = await generator.GeneratePdf(sourceHtml, renderConfig);
     using var pdfStream = new MemoryStream();
     showcaseDocument.Save(pdfStream);
@@ -95,6 +132,74 @@ async Task SaveShowcaseAsync(string slug, string category, string cardTitle, str
             Console.WriteLine($"PDF/A SWEEP GENERATION FAILED for {slug}: {ex.GetType().Name}: {ex.Message}");
         }
     }
+}
+
+// Renders sourceHtml the same way a real caller would - GeneratePdf, then Save to a stream - without
+// writing anything to disk. This, not just GeneratePdf alone, is what --benchmark times/measures: PDF
+// serialization is a real, distinct cost a caller always pays, not an artifact of the showcase harness.
+async Task RenderOnceAsync(string sourceHtml, PdfGenerateConfig renderConfig)
+{
+    var document = await generator.GeneratePdf(sourceHtml, renderConfig);
+    using var stream = new MemoryStream();
+    document.Save(stream);
+}
+
+async Task BenchmarkShowcaseAsync(string slug, string sourceHtml, PdfGenerateConfig renderConfig)
+{
+    // Warm: JIT the whole render path (parser, cascade, layout, PDF writer) before anything is
+    // counted - the first render of any process pays a one-time JIT/tiering cost that would otherwise
+    // swamp a real per-render number.
+    await RenderOnceAsync(sourceHtml, renderConfig);
+
+    var wallTimesMs = new double[benchmarkIterations];
+    var allocatedBytes = new long[benchmarkIterations];
+
+    for (var i = 0; i < benchmarkIterations; i++)
+    {
+        // GC.GetTotalAllocatedBytes(precise: true) rather than the per-thread counter this repo's
+        // xUnit allocation tests use (e.g. GposPositionerAllocationTests): those run under parallel
+        // test-class execution, where a process-wide counter would pick up unrelated tests'
+        // allocation. The TestHarness is a single-threaded console app with nothing else running
+        // concurrently, so the process-wide precise counter is the more complete measurement here -
+        // it also captures allocation on any thread-pool continuation the async render hops onto,
+        // which a per-thread counter would miss.
+        var before = GC.GetTotalAllocatedBytes(precise: true);
+        var stopwatch = Stopwatch.StartNew();
+        await RenderOnceAsync(sourceHtml, renderConfig);
+        stopwatch.Stop();
+        var after = GC.GetTotalAllocatedBytes(precise: true);
+
+        wallTimesMs[i] = stopwatch.Elapsed.TotalMilliseconds;
+        allocatedBytes[i] = after - before;
+    }
+
+    benchmarkResults.Add(new BenchmarkResult(slug, wallTimesMs, allocatedBytes));
+    Console.WriteLine($"Benchmarked {slug} ({benchmarkIterations} iterations)");
+}
+
+void PrintBenchmarkReport()
+{
+    Console.WriteLine();
+    Console.WriteLine($"=== Benchmark report ({benchmarkResults.Count} showcases x {benchmarkIterations} iterations) ===");
+    Console.WriteLine($"{"Showcase",-40} {"Mean ms",10} {"Median ms",10} {"Mean KB",10} {"Median KB",10}");
+
+    foreach (var result in benchmarkResults.OrderBy(r => r.Slug, StringComparer.Ordinal))
+    {
+        Console.WriteLine($"{result.Slug,-40} {result.MeanWallTimeMs,10:F2} {result.MedianWallTimeMs,10:F2} " +
+            $"{result.MeanAllocatedBytes / 1024.0,10:F1} {result.MedianAllocatedBytes / 1024.0,10:F1}");
+    }
+
+    // Totals sum each showcase's own mean, rather than averaging per-iteration numbers across
+    // showcases directly, so a showcase rendered zero or a different iteration count (were that ever
+    // to vary) still contributes its fair share - and because "total time/allocation for one pass
+    // over the whole corpus" (matching how this repo's other allocation fixes report a "per corpus
+    // pass" figure) is what a caller actually wants out of this report, not a per-iteration average.
+    var totalMeanMs = benchmarkResults.Sum(r => r.MeanWallTimeMs);
+    var totalMeanBytes = benchmarkResults.Sum(r => r.MeanAllocatedBytes);
+    Console.WriteLine(new string('-', 40 + 4 * 11));
+    Console.WriteLine($"{"TOTAL (one corpus pass)",-40} {totalMeanMs,10:F2} {"",10} " +
+        $"{totalMeanBytes / 1024.0,10:F1} {"",10}");
+    Console.WriteLine($"Total: {totalMeanMs:F2} ms, {totalMeanBytes / 1024.0 / 1024.0:F2} MB per pass over the corpus.");
 }
 
 static string Swatch(string desc, string css) =>
@@ -8881,11 +8986,34 @@ await SaveShowcaseAsync("interactive_pdf_forms", "Interactivity", "Interactive P
         EnableInteractivePdfForms = true
     });
 
-// The manifest that drives the website's /showcase page (see docs/showcase.html and
-// .github/workflows/pages.yml). Field names are camelCased for Liquid (site.data.showcases).
-var manifestJson = JsonSerializer.Serialize(showcaseManifest,
-    new JsonSerializerOptions { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
-File.WriteAllText(Path.Combine(outputDir, "showcases.json"), manifestJson);
-Console.WriteLine($"Saved showcases.json ({showcaseManifest.Count} showcases)");
+if (benchmarkMode)
+{
+    PrintBenchmarkReport();
+}
+else
+{
+    // The manifest that drives the website's /showcase page (see docs/showcase.html and
+    // .github/workflows/pages.yml). Field names are camelCased for Liquid (site.data.showcases).
+    var manifestJson = JsonSerializer.Serialize(showcaseManifest,
+        new JsonSerializerOptions { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+    File.WriteAllText(Path.Combine(outputDir, "showcases.json"), manifestJson);
+    Console.WriteLine($"Saved showcases.json ({showcaseManifest.Count} showcases)");
+}
 
 record ShowcaseEntry(string Slug, string Category, string Title, string Description, string Pdf, string Html);
+
+/// <summary>One showcase's --benchmark measurements: one wall-time (ms) and one allocated-bytes sample per iteration.</summary>
+record BenchmarkResult(string Slug, double[] WallTimesMs, long[] AllocatedBytes)
+{
+    public double MeanWallTimeMs => WallTimesMs.Average();
+    public double MedianWallTimeMs => Median(WallTimesMs);
+    public double MeanAllocatedBytes => AllocatedBytes.Average(b => (double)b);
+    public double MedianAllocatedBytes => Median(AllocatedBytes.Select(b => (double)b));
+
+    private static double Median(IEnumerable<double> values)
+    {
+        var sorted = values.OrderBy(v => v).ToArray();
+        var mid = sorted.Length / 2;
+        return sorted.Length % 2 == 0 ? (sorted[mid - 1] + sorted[mid]) / 2.0 : sorted[mid];
+    }
+}

--- a/src/PeachPDF.Tests/CSS/CssDataSelectorMatchAllocationTests.cs
+++ b/src/PeachPDF.Tests/CSS/CssDataSelectorMatchAllocationTests.cs
@@ -1,0 +1,134 @@
+using PeachPDF.Adapters;
+using PeachPDF.CSS;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Utils;
+using PeachPDF.PdfSharpCore.Drawing;
+using System;
+
+namespace PeachPDF.Tests.CSS;
+
+/// <summary>
+/// <c>CssData.DoesSelectorMatch(ListSelector, ICssDomNode?)</c>/<c>DoesSelectorMatch(CompoundSelector,
+/// ICssDomNode?)</c> run once per box per candidate rule - the hottest path in the whole cascade. Both
+/// used to enumerate through <c>ListSelector</c>/<c>CompoundSelector</c> via LINQ's <c>Any</c>/<c>All</c>,
+/// which allocates a boxed <c>IEnumerator&lt;ISelector&gt;</c> and a closure per call, because
+/// <c>Selectors</c> only implements <c>IEnumerable&lt;ISelector&gt;</c>, not <c>IList&lt;ISelector&gt;</c>
+/// (see issue #971).
+/// </summary>
+/// <remarks>
+/// Asserted by calling the (now internal) matching methods directly against a synthetic selector and a
+/// real fixture box, rather than through a rendered document or the cascade
+/// (<c>GetUserAgentStyleRules</c>/<c>GatherMatchedRules</c>). Measured end to end, the saving is real but
+/// not separable: it is diffuse (roughly a fixed cost per box, not per rule or per selector complexity),
+/// so any threshold built from document/box/rule counts is either loose or wrong depending on what else a
+/// given document allocates (font loading, layout, per-document setup). Called directly, with a fixture
+/// engineered so the only thing that can allocate is the loop itself, the assertion is exact and the same
+/// everywhere - the same approach as <c>GposPositionerAllocationTests</c> for the identical
+/// enumerator-through-an-interface problem in the GPOS positioner.
+/// </remarks>
+public class CssDataSelectorMatchAllocationTests
+{
+    [Fact]
+    public async Task ListSelectorAny_AllocatesNothingPerCall()
+    {
+        var box = await BuildDivFixture();
+
+        // None of these match a <div>, so Any's loop runs to completion every call rather than
+        // short-circuiting on the first alternative.
+        var list = new ListSelector();
+        list.Add(TypeSelector.Create("span"));
+        list.Add(TypeSelector.Create("p"));
+        list.Add(TypeSelector.Create("a"));
+        list.Add(TypeSelector.Create("ul"));
+        list.Add(TypeSelector.Create("table"));
+
+        // Warm: JIT the path and build/cache MatchOrder before anything is counted.
+        for (var i = 0; i < 3; i++) CssData.DoesSelectorMatch(list, box);
+
+        const int passes = 10_000;
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < passes; i++) CssData.DoesSelectorMatch(list, box);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.True(allocated < 4096,
+            $"matching a 5-alternative ListSelector allocated {allocated} bytes over {passes:N0} calls. "
+            + "It should allocate nothing: Selectors is IEnumerable-only, so LINQ's Any() boxes an "
+            + "enumerator and allocates a closure on every call.");
+    }
+
+    [Fact]
+    public async Task CompoundSelectorAll_PlainBranch_AllocatesNothingPerCall()
+    {
+        var box = await BuildDivFixture();
+
+        // All of these match a <div>, so All's loop runs to completion every call rather than
+        // short-circuiting on the first member. Deliberately all TypeSelector (rather than mixing in,
+        // say, ClassSelector): ClassSelector's own match allocates a Split() array regardless of this
+        // fix, which would swamp the signal this test is isolating - TypeSelector's match is a plain
+        // string compare with nothing else to allocate.
+        var compound = new CompoundSelector();
+        compound.Add(TypeSelector.Create("div"));
+        compound.Add(TypeSelector.Create("div"));
+        compound.Add(TypeSelector.Create("div"));
+        compound.Add(TypeSelector.Create("div"));
+
+        for (var i = 0; i < 3; i++) CssData.DoesSelectorMatch(compound, box);
+
+        const int passes = 10_000;
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < passes; i++) CssData.DoesSelectorMatch(compound, box);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.True(allocated < 4096,
+            $"matching a 4-member CompoundSelector allocated {allocated} bytes over {passes:N0} calls. "
+            + "It should allocate nothing: Selectors is IEnumerable-only, so LINQ's All() boxes an "
+            + "enumerator and allocates a closure on every call.");
+    }
+
+    [Fact]
+    public async Task CompoundSelectorAll_PseudoElementBranch_AllocatesNothingPerCall()
+    {
+        var box = await BuildDivFixture();
+
+        // The trailing PseudoElementSelector is handled separately (CssData.DoesSelectorMatch's
+        // pseudo-element branch); ::first-letter is used here (rather than ::before/::after/::marker)
+        // because its side effect is an idempotent bool flag set, not box-tree synthesis, so it stays
+        // safe to call thousands of times in a tight loop without mutating the fixture's box tree.
+        var compound = new CompoundSelector();
+        compound.Add(TypeSelector.Create("div"));
+        compound.Add(PseudoElementSelector.Create(PseudoElementNames.FirstLetter));
+
+        for (var i = 0; i < 3; i++) CssData.DoesSelectorMatch(compound, box);
+
+        const int passes = 10_000;
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < passes; i++) CssData.DoesSelectorMatch(compound, box);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.True(allocated < 4096,
+            $"matching a compound selector ending in ::first-letter allocated {allocated} bytes over "
+            + $"{passes:N0} calls. It should allocate nothing: the non-pseudo-element members were "
+            + "filtered with Where().All(), which boxes an enumerator and allocates a closure on every "
+            + "call in addition to the Where iterator itself.");
+    }
+
+    private static async Task<CssBox> BuildDivFixture()
+    {
+        var adapter = new PdfSharpAdapter();
+        var container = new HtmlContainerInt(adapter);
+        await container.SetHtml("<!DOCTYPE html><html><body><div class='a b c'>text</div></body></html>", null);
+
+        var size = new XSize(595, 842);
+        container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+        container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+        var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+        using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+        await container.PerformLayout(graphics);
+
+        var box = DomUtils.GetBoxByTagName(container.Root!, "div");
+        Assert.NotNull(box);
+        return box!;
+    }
+}

--- a/src/PeachPDF.Tests/CSS/SelectorMatchCostTests.cs
+++ b/src/PeachPDF.Tests/CSS/SelectorMatchCostTests.cs
@@ -1,0 +1,115 @@
+using PeachPDF.CSS;
+
+namespace PeachPDF.Tests.CSS;
+
+/// <summary>
+/// <see cref="SelectorMatchCost"/> ranks selector kinds cheapest-to-evaluate first so
+/// <c>CssData.DoesSelectorMatch</c>'s indexed <c>All</c>/<c>Any</c> loops (see
+/// <see cref="Selectors.MatchOrder"/>) can short-circuit on a cheap check before an expensive one ever
+/// runs. These tests pin down the ordering itself, independent of the allocation behavior asserted in
+/// <c>CssDataSelectorMatchAllocationTests</c>.
+/// </summary>
+public class SelectorMatchCostTests
+{
+    [Theory]
+    [InlineData("#id")]
+    [InlineData(".cls")]
+    [InlineData("div")]
+    [InlineData("*")]
+    public void Tier0Selectors_AreCheapestOfEverything(string selectorText)
+    {
+        var tier0 = ParseSelector(selectorText);
+        var tier1 = ParseSelector("[attr]");
+        var tier2 = ParseSelector(":root");
+        var tier3 = ParseSelector(":only-child");
+        var tier4 = ParseSelector(":lang(en)");
+        var tier5 = ParseSelector(":not(.x)");
+        var tier6 = ParseSelector(":has(.x)");
+
+        var cost = SelectorMatchCost.Of(tier0);
+        Assert.True(cost < SelectorMatchCost.Of(tier1));
+        Assert.True(cost < SelectorMatchCost.Of(tier2));
+        Assert.True(cost < SelectorMatchCost.Of(tier3));
+        Assert.True(cost < SelectorMatchCost.Of(tier4));
+        Assert.True(cost < SelectorMatchCost.Of(tier5));
+        Assert.True(cost < SelectorMatchCost.Of(tier6));
+    }
+
+    [Theory]
+    [InlineData("[attr]")]
+    [InlineData("[attr=val]")]
+    [InlineData("[attr~=val]")]
+    [InlineData("[attr^=val]")]
+    [InlineData("[attr$=val]")]
+    [InlineData("[attr*=val]")]
+    [InlineData("[attr|=val]")]
+    public void AttributeSelectors_CostMoreThanTier0ButLessThanPseudoClass(string selectorText)
+    {
+        var attr = ParseSelector(selectorText);
+        var tier0 = ParseSelector("div");
+        var pseudoClass = ParseSelector(":root");
+
+        var cost = SelectorMatchCost.Of(attr);
+        Assert.True(cost > SelectorMatchCost.Of(tier0));
+        Assert.True(cost < SelectorMatchCost.Of(pseudoClass));
+    }
+
+    [Fact]
+    public void PseudoClassSelector_CostsLessThanStructuralChildSelectors()
+    {
+        var root = ParseSelector(":root");
+        var onlyChild = ParseSelector(":only-child");
+
+        Assert.True(SelectorMatchCost.Of(root) < SelectorMatchCost.Of(onlyChild));
+    }
+
+    [Theory]
+    [InlineData(":nth-child(2)")]
+    [InlineData(":first-child")]
+    [InlineData(":last-child")]
+    [InlineData(":first-of-type")]
+    [InlineData(":last-of-type")]
+    [InlineData(":only-child")]
+    [InlineData(":only-of-type")]
+    public void StructuralSelectors_CostLessThanLangAndMoreThanPseudoClass(string selectorText)
+    {
+        var structural = ParseSelector(selectorText);
+        var pseudoClass = ParseSelector(":root");
+        var lang = ParseSelector(":lang(en)");
+
+        var cost = SelectorMatchCost.Of(structural);
+        Assert.True(cost > SelectorMatchCost.Of(pseudoClass));
+        Assert.True(cost < SelectorMatchCost.Of(lang));
+    }
+
+    [Fact]
+    public void LangSelector_CostsLessThanNotAndIs()
+    {
+        var lang = ParseSelector(":lang(en)");
+        var not = ParseSelector(":not(.x)");
+        var matches = ParseSelector(":is(.x)");
+
+        Assert.True(SelectorMatchCost.Of(lang) < SelectorMatchCost.Of(not));
+        Assert.True(SelectorMatchCost.Of(lang) < SelectorMatchCost.Of(matches));
+    }
+
+    [Fact]
+    public void HasSelector_IsTheMostExpensiveKind()
+    {
+        var has = ParseSelector(":has(.x)");
+        var not = ParseSelector(":not(.x)");
+        var matches = ParseSelector(":is(.x)");
+        var lang = ParseSelector(":lang(en)");
+
+        var cost = SelectorMatchCost.Of(has);
+        Assert.True(cost > SelectorMatchCost.Of(not));
+        Assert.True(cost > SelectorMatchCost.Of(matches));
+        Assert.True(cost > SelectorMatchCost.Of(lang));
+    }
+
+    private static ISelector ParseSelector(string selectorText)
+    {
+        var sheet = new StylesheetParser().Parse(selectorText + " { color: red }");
+        return ((StyleRule)sheet.Rules[0]).Selector;
+    }
+}

--- a/src/PeachPDF.Tests/CSS/SelectorMatchOrderIndependenceTests.cs
+++ b/src/PeachPDF.Tests/CSS/SelectorMatchOrderIndependenceTests.cs
@@ -1,0 +1,84 @@
+using PeachPDF.Adapters;
+using PeachPDF.Html.Core;
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Html.Core.Utils;
+using PeachPDF.PdfSharpCore.Drawing;
+
+namespace PeachPDF.Tests.CSS;
+
+/// <summary>
+/// <c>CssData.DoesSelectorMatch(CompoundSelector, ICssDomNode?)</c> now evaluates a compound selector's
+/// members in <see cref="Selectors.MatchOrder"/> (cheapest first) rather than source order - this is the
+/// first place this codebase intentionally evaluates selectors out of source order, so it's worth a
+/// direct end-to-end assertion that a compound selector's AND result is unaffected by which conjunct
+/// happens to be cheap, rather than relying only on the broader suite's implicit coverage. Every case
+/// below pairs a cheap selector (<c>#id</c>) with the single most expensive kind (<c>:has()</c>), since
+/// that's the pair with the largest gap in <see cref="SelectorMatchCost"/> and therefore the one most
+/// likely to actually reorder.
+/// </summary>
+public class SelectorMatchOrderIndependenceTests
+{
+    [Fact]
+    public async Task CheapSelectorFails_ExpensiveSelectorWouldPass_CompoundStillDoesNotMatch()
+    {
+        var html = Html(
+            "#wrong-id:has(.child) { background-color: #ff0000; }",
+            "<div id='real' class='parent'><span class='child'></span></div>");
+
+        var box = await FindBoxByTag(html, "div");
+
+        Assert.Equal("transparent", box.BackgroundColor);
+    }
+
+    [Fact]
+    public async Task CheapSelectorPasses_ExpensiveSelectorFails_CompoundStillDoesNotMatch()
+    {
+        var html = Html(
+            "#real:has(.missing) { background-color: #ff0000; }",
+            "<div id='real' class='parent'><span class='child'></span></div>");
+
+        var box = await FindBoxByTag(html, "div");
+
+        Assert.Equal("transparent", box.BackgroundColor);
+    }
+
+    [Fact]
+    public async Task BothCheapAndExpensiveSelectorPass_CompoundMatches()
+    {
+        var html = Html(
+            "#real:has(.child) { background-color: #ff0000; }",
+            "<div id='real' class='parent'><span class='child'></span></div>");
+
+        var box = await FindBoxByTag(html, "div");
+
+        Assert.NotEqual("transparent", box.BackgroundColor);
+    }
+
+    private static string Html(string css, string body) =>
+        $"<!DOCTYPE html><html><head><style>{css}</style></head><body>{body}</body></html>";
+
+    private async Task<CssBox> FindBoxByTag(string html, string tag)
+    {
+        var root = await BuildRoot(html);
+        var box = DomUtils.GetBoxByTagName(root, tag);
+        Assert.NotNull(box);
+        return box!;
+    }
+
+    private static async Task<CssBox> BuildRoot(string html)
+    {
+        var adapter = new PdfSharpAdapter();
+        var container = new HtmlContainerInt(adapter);
+        await container.SetHtml(html, null);
+
+        var size = new XSize(595, 842);
+        container.PageSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+        container.MaxSize = PeachPDF.Utilities.Utils.Convert(size, 1.0);
+
+        var measure = XGraphics.CreateMeasureContext(size, XGraphicsUnit.Point, XPageDirection.Downwards);
+        using var graphics = new GraphicsAdapter(adapter, measure, 1.0);
+        await container.PerformLayout(graphics);
+
+        return container.Root!;
+    }
+}

--- a/src/PeachPDF.Tests/CSS/SelectorsMatchOrderTests.cs
+++ b/src/PeachPDF.Tests/CSS/SelectorsMatchOrderTests.cs
@@ -1,0 +1,75 @@
+using PeachPDF.CSS;
+
+namespace PeachPDF.Tests.CSS;
+
+/// <summary>
+/// <see cref="Selectors.MatchOrder"/> is a cached, cost-sorted view over a compound/list selector's
+/// members, kept separate from their own source order (which <c>ToCss</c>/<c>Text</c>, <c>Specificity</c>,
+/// and the "a trailing PseudoElementSelector is structurally last" convention all still rely on
+/// unchanged). These tests build selectors by hand in a deliberately expensive-first order and assert
+/// <c>MatchOrder</c> re-ranks them cheapest first - correctness of the ranking itself, independent of the
+/// allocation behavior asserted in <c>CssDataSelectorMatchAllocationTests</c>.
+/// </summary>
+public class SelectorsMatchOrderTests
+{
+    [Fact]
+    public void CompoundSelector_RanksCheapSelectorBeforeExpensiveOne_RegardlessOfAddOrder()
+    {
+        var expensive = ParseSelector(":has(.x)");
+        var cheap = ParseSelector("#id");
+
+        var compound = new CompoundSelector();
+        compound.Add(expensive);
+        compound.Add(cheap);
+
+        var order = compound.MatchOrder;
+
+        Assert.Equal(2, order.Length);
+        Assert.Same(cheap, compound[order[0]]);
+        Assert.Same(expensive, compound[order[1]]);
+
+        // Source order (what ToCss/Text/Last() see) must be untouched by building MatchOrder.
+        Assert.Same(expensive, compound[0]);
+        Assert.Same(cheap, compound[1]);
+    }
+
+    [Fact]
+    public void ListSelector_RanksCheapAlternativeBeforeExpensiveOne_RegardlessOfAddOrder()
+    {
+        var expensive = ParseSelector(":has(.x)");
+        var cheap = ParseSelector(".cls");
+
+        var list = new ListSelector();
+        list.Add(expensive);
+        list.Add(cheap);
+
+        var order = list.MatchOrder;
+
+        Assert.Equal(2, order.Length);
+        Assert.Same(cheap, list[order[0]]);
+        Assert.Same(expensive, list[order[1]]);
+
+        Assert.Same(expensive, list[0]);
+        Assert.Same(cheap, list[1]);
+    }
+
+    [Fact]
+    public void MatchOrder_IsStableAcrossRepeatedAccess()
+    {
+        var compound = new CompoundSelector();
+        compound.Add(ParseSelector(":has(.x)"));
+        compound.Add(ParseSelector("#id"));
+        compound.Add(ParseSelector(".cls"));
+
+        var first = compound.MatchOrder;
+        var second = compound.MatchOrder;
+
+        Assert.Same(first, second);
+    }
+
+    private static ISelector ParseSelector(string selectorText)
+    {
+        var sheet = new StylesheetParser().Parse(selectorText + " { color: red }");
+        return ((StyleRule)sheet.Rules[0]).Selector;
+    }
+}

--- a/src/PeachPDF/CSS/Selectors/SelectorMatchCost.cs
+++ b/src/PeachPDF/CSS/Selectors/SelectorMatchCost.cs
@@ -1,0 +1,52 @@
+namespace PeachPDF.CSS
+{
+    /// <summary>
+    /// A static, ascending cost tier per <see cref="ISelector"/> kind, used to evaluate a compound or
+    /// list selector's members cheapest-first so an <c>All</c>/<c>Any</c> short-circuits before an
+    /// expensive check ever runs - the same technique real selector engines (e.g. WebKit's
+    /// <c>SelectorChecker</c>) use for the same reason. See <see cref="Selectors.MatchOrder"/>.
+    /// </summary>
+    /// <remarks>
+    /// Reordering is safe here specifically because matching every one of these kinds is a pure boolean
+    /// predicate with no observable side effect - the one real side effect in this area,
+    /// <c>CssData.DoesSelectorMatch(CompoundSelector, ICssDomNode?)</c>'s pseudo-element synthesis, only
+    /// ever fires for the trailing pseudo-element itself, which is always pinned and evaluated
+    /// separately from the members this cost function ranks. AND/OR over pure predicates is commutative,
+    /// so changing evaluation order cannot change the final boolean result, only which predicates get
+    /// skipped by short-circuiting.
+    /// </remarks>
+    internal static class SelectorMatchCost
+    {
+        public static int Of(ISelector selector) => selector switch
+        {
+            // Tier 0: O(1) direct field/string compare.
+            IdSelector or ClassSelector or TypeSelector or AllSelector => 0,
+
+            // Tier 1: attribute lookup plus a string/substring op.
+            AttrAvailableSelector or AttrMatchSelector or AttrListSelector or AttrBeginsSelector
+                or AttrEndsSelector or AttrHyphenSelector or AttrContainsSelector or AttrNotMatchSelector => 1,
+
+            // Tier 2: simple document-tree checks (:root, :empty, :link, ...).
+            PseudoClassSelector => 2,
+
+            // Tier 3: needs to enumerate/count siblings. Covers FirstChildSelector/LastChildSelector/
+            // FirstTypeSelector/LastTypeSelector/FirstColumnSelector/LastColumnSelector via subtype
+            // matching against their common ChildSelector base.
+            ChildSelector or OnlyChildSelector or OnlyOfTypeSelector => 3,
+
+            // Tier 4: walks ancestors to the document root.
+            LangSelector => 4,
+
+            // Tier 5: recursive re-entry into DoesSelectorMatch.
+            NotSelector or MatchesSelector => 5,
+
+            // Tier 6: relative/subtree search - the most expensive kind.
+            HasSelector => 6,
+
+            // Anything else (PseudoElementSelector - always pinned/handled separately by its caller
+            // rather than ranked here - and any unrecognized kind) sorts last, but is never actually
+            // ranked against real work in practice.
+            _ => 7
+        };
+    }
+}

--- a/src/PeachPDF/CSS/Selectors/Selectors.cs
+++ b/src/PeachPDF/CSS/Selectors/Selectors.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,10 +8,39 @@ namespace PeachPDF.CSS
     internal abstract class Selectors : StylesheetNode, IEnumerable<ISelector>
     {
         protected readonly List<ISelector> _selectors;
+        private int[]? _matchOrder;
 
         protected Selectors()
         {
             _selectors = new List<ISelector>();
+        }
+
+        /// <summary>
+        /// Indices into <see cref="_selectors"/>, cheapest-to-evaluate first per
+        /// <see cref="SelectorMatchCost"/>. Built once per selector instance and cached - selector cost
+        /// is static, so the same order applies to every node this selector is ever tested against, and
+        /// this is a one-time cost per parsed selector, not a per-box cost. A benign data race on first
+        /// use (two threads both computing it) is fine: the computation is pure and idempotent, and
+        /// <see cref="_selectors"/> is frozen after CSS parsing completes (<see cref="Add"/>/
+        /// <see cref="Remove"/> are only ever called by <c>SelectorConstructor</c> while building the
+        /// selector, before any matching can occur), so there is nothing to invalidate.
+        /// </summary>
+        internal int[] MatchOrder => _matchOrder ??= BuildMatchOrder();
+
+        private int[] BuildMatchOrder()
+        {
+            var order = new int[_selectors.Count];
+            var cost = new int[_selectors.Count];
+            for (var i = 0; i < order.Length; i++)
+            {
+                order[i] = i;
+                cost[i] = SelectorMatchCost.Of(_selectors[i]);
+            }
+            // Sorting the parallel cost array (rather than a Comparison<int> delegate re-deriving each
+            // selector's cost on every comparison) computes SelectorMatchCost.Of exactly once per
+            // selector instead of O(n log n) times; Array.Sort applies the same permutation to order.
+            Array.Sort(cost, order);
+            return order;
         }
 
         public virtual Priority Specificity

--- a/src/PeachPDF/Html/Core/CssData.cs
+++ b/src/PeachPDF/Html/Core/CssData.cs
@@ -684,11 +684,22 @@ namespace PeachPDF.Html.Core
         {
             if (selector is ListSelector list)
             {
-                return list
-                    .Where(s => DoesSelectorMatch(s, node))
-                    .Select(s => s.Specificity)
-                    .DefaultIfEmpty(Priority.Zero)
-                    .Max();
+                // Indexed rather than Where().Select().DefaultIfEmpty().Max(): Selectors is
+                // IEnumerable-only, so that chain boxes an enumerator and allocates per call. Every
+                // matching alternative's specificity has to be examined (not just the first), so this
+                // doesn't use MatchOrder's cost-first short-circuiting benefit - it's here purely to
+                // remove the allocation. Priority.Zero is already the minimum possible specificity (its
+                // components are non-negative counts), so seeding the running max with it and folding in
+                // only matched alternatives reproduces Where(...).DefaultIfEmpty(Priority.Zero).Max()
+                // exactly, including the "no alternative matched" case.
+                var max = Priority.Zero;
+                for (var i = 0; i < list.Length; i++)
+                {
+                    if (!DoesSelectorMatch(list[i], node)) continue;
+                    var specificity = list[i].Specificity;
+                    if (specificity > max) max = specificity;
+                }
+                return max;
             }
 
             return selector.Specificity;
@@ -767,9 +778,18 @@ namespace PeachPDF.Html.Core
             return null;
         }
 
-        private static bool DoesSelectorMatch(ListSelector listSelector, ICssDomNode? node)
+        internal static bool DoesSelectorMatch(ListSelector listSelector, ICssDomNode? node)
         {
-            return listSelector.Any(selector => DoesSelectorMatch(selector, node));
+            // Indexed via MatchOrder (cheapest alternative first, see SelectorMatchCost) rather than
+            // LINQ's Any(): Selectors only implements IEnumerable<ISelector>, so Any() boxes an
+            // enumerator and allocates a closure per call on what is the hottest path in the whole
+            // cascade (once per box per candidate rule).
+            var order = listSelector.MatchOrder;
+            for (var i = 0; i < order.Length; i++)
+            {
+                if (DoesSelectorMatch(listSelector[order[i]], node)) return true;
+            }
+            return false;
         }
 
         /// <summary>
@@ -802,15 +822,36 @@ namespace PeachPDF.Html.Core
             switch (selector)
             {
                 case ListSelector list:
-                    return list.Any(s => MatchesAsFirstLineSelector(s, box));
+                {
+                    // Indexed via MatchOrder rather than LINQ's Any() - see the DoesSelectorMatch
+                    // overloads above for why (Selectors is IEnumerable-only, so Any() allocates).
+                    var order = list.MatchOrder;
+                    for (var i = 0; i < order.Length; i++)
+                    {
+                        if (MatchesAsFirstLineSelector(list[order[i]], box)) return true;
+                    }
+                    return false;
+                }
 
                 case ComplexSelector complex:
                     var lastSegmentSelector = complex.LastOrDefault().Selector;
                     return lastSegmentSelector is not null && HasFirstLineSubject(lastSegmentSelector);
 
                 case CompoundSelector compound:
-                    return HasFirstLineSubject(compound) &&
-                           compound.Where(x => x is not PseudoElementSelector).All(s => DoesSelectorMatch(s, box));
+                {
+                    if (!HasFirstLineSubject(compound)) return false;
+
+                    // Indexed via MatchOrder rather than Where().All() - see the plain branch of
+                    // DoesSelectorMatch(CompoundSelector, ...) above for the same rewrite and why.
+                    var order = compound.MatchOrder;
+                    for (var i = 0; i < order.Length; i++)
+                    {
+                        var s = compound[order[i]];
+                        if (s is PseudoElementSelector) continue;
+                        if (!DoesSelectorMatch(s, box)) return false;
+                    }
+                    return true;
+                }
 
                 default:
                     return false;
@@ -829,15 +870,32 @@ namespace PeachPDF.Html.Core
         /// </summary>
         private static bool CouldMatchAsFirstLineSelector(ISelector selector) => selector switch
         {
-            ListSelector list => list.Any(CouldMatchAsFirstLineSelector),
+            ListSelector list => AnyCouldMatchAsFirstLineSelector(list),
             ComplexSelector complex => complex.LastOrDefault().Selector is { } last && HasFirstLineSubject(last),
             CompoundSelector compound => HasFirstLineSubject(compound),
             _ => false
         };
 
+        // Indexed rather than list.Any(CouldMatchAsFirstLineSelector) - see the DoesSelectorMatch
+        // overloads above for why (Selectors is IEnumerable-only, so Any() allocates). This method runs
+        // once per rule at EnsureIndex time rather than per box, so the allocation it used to cause was
+        // never actually hot - fixed anyway for consistency now that MatchOrder exists.
+        private static bool AnyCouldMatchAsFirstLineSelector(ListSelector list)
+        {
+            var order = list.MatchOrder;
+            for (var i = 0; i < order.Length; i++)
+            {
+                if (CouldMatchAsFirstLineSelector(list[order[i]])) return true;
+            }
+            return false;
+        }
+
         private static bool HasFirstLineSubject(ISelector selector) => selector switch
         {
-            CompoundSelector compound => compound.LastOrDefault() is PseudoElementSelector { Name: PseudoElementNames.FirstLine },
+            // Indexed rather than LINQ's LastOrDefault() - see the DoesSelectorMatch overloads above
+            // for why (Selectors is IEnumerable-only, so LastOrDefault() allocates).
+            CompoundSelector { Length: > 0 } compound =>
+                compound[compound.Length - 1] is PseudoElementSelector { Name: PseudoElementNames.FirstLine },
             PseudoElementSelector pseudo => pseudo.Name == PseudoElementNames.FirstLine,
             _ => false
         };
@@ -855,21 +913,32 @@ namespace PeachPDF.Html.Core
             _ => false
         };
 
-        private static bool DoesSelectorMatch(CompoundSelector compoundSelector, ICssDomNode? node)
+        internal static bool DoesSelectorMatch(CompoundSelector compoundSelector, ICssDomNode? node)
         {
             if (node is null)
             {
                 return false;
             }
 
-            var lastSelector = compoundSelector.Last();
+            var lastSelector = compoundSelector[compoundSelector.Length - 1];
 
             // Structural pseudo-classes (ChildSelector subtypes, OnlyChildSelector, OnlyOfTypeSelector)
             // are matched against `node` itself here, same as every other compound member - their own
             // DoesSelectorMatch overload re-derives sibling scope from `node` as needed, so no special
             // handling is required for them beyond the plain path below.
             if (lastSelector is not PseudoElementSelector)
-                return compoundSelector.All(selector => DoesSelectorMatch(selector, node));
+            {
+                // Indexed via MatchOrder (cheapest selector first, see SelectorMatchCost) rather than
+                // LINQ's All(): Selectors only implements IEnumerable<ISelector>, so All() boxes an
+                // enumerator and allocates a closure per call on what is the hottest path in the whole
+                // cascade (once per box per candidate rule).
+                var order = compoundSelector.MatchOrder;
+                for (var i = 0; i < order.Length; i++)
+                {
+                    if (!DoesSelectorMatch(compoundSelector[order[i]], node)) return false;
+                }
+                return true;
+            }
 
             // Pseudo-elements (::before/::after/::marker/::first-letter) exist only in the HTML box tree
             // and the synthesis below mutates it; an SVG node never has one, so a pseudo-element compound
@@ -883,9 +952,20 @@ namespace PeachPDF.Html.Core
                     : box.IsFootnoteCallPseudoElement || box.IsFootnoteMarkerPseudoElement ? box.FootnoteSourceBox
                     : box.IsPseudoElement ? box.ParentBox : box;
 
-                var isMatchWithoutPseudoElement = compoundSelector
-                    .Where(x => x is not PseudoElementSelector)
-                    .All(selector => DoesSelectorMatch(selector, referenceBox));
+                // Same indexed-order approach as the plain branch above, skipping the pseudo-element
+                // itself (still pinned/handled separately below) instead of LINQ's Where().All().
+                var isMatchWithoutPseudoElement = true;
+                var order = compoundSelector.MatchOrder;
+                for (var i = 0; i < order.Length; i++)
+                {
+                    var selector = compoundSelector[order[i]];
+                    if (selector is PseudoElementSelector) continue;
+                    if (!DoesSelectorMatch(selector, referenceBox))
+                    {
+                        isMatchWithoutPseudoElement = false;
+                        break;
+                    }
+                }
 
                 if (!isMatchWithoutPseudoElement) return false;
 
@@ -1301,7 +1381,17 @@ namespace PeachPDF.Html.Core
         /// </summary>
         private static bool HasRelativeMatch(ICssDomNode node, ISelector inner)
         {
-            if (inner is ListSelector list) return list.Any(alt => HasRelativeMatch(node, alt));
+            // Indexed via MatchOrder rather than LINQ's Any() - see the DoesSelectorMatch overloads
+            // above for why (Selectors is IEnumerable-only, so Any() allocates).
+            if (inner is ListSelector list)
+            {
+                var order = list.MatchOrder;
+                for (var i = 0; i < order.Length; i++)
+                {
+                    if (HasRelativeMatch(node, list[order[i]])) return true;
+                }
+                return false;
+            }
 
             if (inner is RelativeSelector relative)
                 return MatchesRelativeChain(node, relative.Combinator, relative.Selector);


### PR DESCRIPTION
## Summary

`CssData.DoesSelectorMatch`'s `ListSelector`/`CompoundSelector` overloads called LINQ's `Any()`/`All()`/`Last()` over `Selectors`, which only implements `IEnumerable<ISelector>` (not `IList<ISelector>`) — so every call boxed an enumerator through the interface and allocated a closure, on the hottest path in the whole cascade (once per box per candidate rule). `Selectors` already exposes `Length` and an indexer, so the same logic is now an indexed loop with no interface dispatch and no closure.

On top of the allocation fix, `Selectors` gained a cached `MatchOrder`: an `int[]` of indices sorted once by a new `SelectorMatchCost.Of(ISelector)` ranking — cheap checks (`IdSelector`/`ClassSelector`/`TypeSelector`) first, expensive ones (`HasSelector`, `NotSelector`/`MatchesSelector`, `LangSelector`, structural `ChildSelector`/`OnlyChildSelector`/`OnlyOfTypeSelector`) last. The `All`/`Any` loops iterate in that order, so a cheap conjunct/alternative short-circuits before an expensive one ever runs — the same technique real selector engines (e.g. WebKit's `SelectorChecker`) use. This is a separate view layered on top of `_selectors`; it does not reorder `_selectors` itself, so `ToCss()`/`Text`, `Specificity`, and the CSS-grammar invariant that a trailing `PseudoElementSelector` is structurally last all still see source order exactly as before.

The same allocation shape existed at four more call sites in the same file — `GetMatchedSpecificity` (once per matched rule per box, on the same sort `DoesSelectorMatch` feeds), `MatchesAsFirstLineSelector`/`HasFirstLineSubject` (per box, for `::first-line` rules), `CouldMatchAsFirstLineSelector`, and `HasRelativeMatch` (`:has()`'s comma-separated relative-selector-list argument) — all fixed too.

`ComplexSelector`'s identically-shaped `LastOrDefault()` calls are left alone on purpose: it's a different, unrelated type with no indexer of its own, so fixing it means adding new API surface to a second class rather than reusing this PR's `Selectors`/`MatchOrder` infrastructure. Deferred as a smaller follow-up.

`PeachPDF.TestHarness` gains a reusable `--benchmark [--benchmark-iterations N]` mode (default 10) for corpus-wide perf-regression checks like this one: it renders every showcase (`GeneratePdf` + `Save`, no files written) N times each after one untimed warmup, and prints a per-showcase table plus corpus totals.

## Why this was testable when the issue's own author couldn't land a PR

The issue's reporter tried four ways to isolate the effect (measuring through the cascade, whole-document allocation ratios, rule-count scaling) and got no signal from any of them — a diffuse, per-box saving is swamped by font loading, document setup, and per-document variance when measured that way. The fix here bumps the two `DoesSelectorMatch` overloads from `private` to `internal` and calls them directly against a synthetic selector and a real fixture box in a warmed, tight loop, asserting `GC.GetAllocatedBytesForCurrentThread()` deltas — the same technique this repo already used for the identical enumerator-through-an-interface shape in the GPOS positioner. Verified non-vacuous by temporarily reverting each rewritten body back to the original LINQ and re-running: 1.28–2.08 MB over 10,000 calls unfixed, under 4 KB fixed, every time.

## Corpus benchmark (main vs. this branch)

Release build, `--benchmark --benchmark-iterations 10`, all 111 showcases (a second worktree at the pre-fix commit, patched with only the new `--benchmark` flag itself, so the comparison isolates the selector-matching change):

| | main | this branch | delta |
| --- | --- | --- | --- |
| Wall time (one corpus pass) | 2674.06 ms | 2572.02 ms | **-102.04 ms (-3.8%)** |
| Allocated (one corpus pass) | 2449.63 MB | 2172.23 MB | **-277.40 MB (-11.3%)** |

Zero showcases allocated more after the fix. Biggest mover: `charts_css` (a large, selector-heavy stylesheet), 570.2 MB → 350.8 MB (-38.5%) — exactly the shape of document this fix helps most, a small number of boxes matched against many candidate rules with compound/list selectors. The 11.3% corpus-wide figure is well above the ~3.2% the issue's own narrower "26 real documents" sample measured, consistent with the showcase corpus skewing more selector-heavy than an average document.

## Corpus benchmark vs. the last published release (v0.9.17)

For context on how much the last several days of allocation-focused work (GPOS enumerator fixes, cascade re-defaulting, delegate caching, this PR, etc.) add up to, the same `--benchmark` tool run against the `v0.9.17` tag (its own 109-showcase corpus and its own, older library build):

| | v0.9.17 | this branch |
| --- | --- | --- |
| Wall time (one corpus pass) | 4492.68 ms | 2572.02 ms (**-42.8%**) |
| Allocated (one corpus pass) | 9717.69 MB | 2172.23 MB (**-77.6%**) |

Caveats on this row (unlike the main-vs-branch table above, which isolates just this PR): the corpora aren't quite identical (109 vs. 111 showcases — two were added since), and the gap spans 66 commits of unrelated work, not only this change. It's also only 3 iterations rather than 10 - `v0.9.17`'s binary segfaulted partway through a 10-iteration run, right before `charts_css` (its heaviest showcase by far), most likely GC pressure from repeatedly rendering the corpus's most allocation-heavy document under much-less-optimized old code; 3 iterations completed cleanly. Included as directional context, not as this PR's own measured effect.

## Test plan

- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` — full suite green (10,453 passed, 9 pre-existing platform-specific skips)
- [x] New allocation tests (`CssDataSelectorMatchAllocationTests`) verified non-vacuous by temporarily reverting to the original LINQ and confirming real allocation reappears
- [x] New tests pin down the cost ranking (`SelectorMatchCostTests`), the resulting index permutation (`SelectorsMatchOrderTests`), and end-to-end order-independence of a compound selector's AND result (`SelectorMatchOrderIndependenceTests`)
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` — 0 warnings solution-wide (net8.0/net10.0/net11.0)
- [x] Corpus-wide benchmark comparison above (`PeachPDF.TestHarness --benchmark`)
- [x] Multi-agent code review pass; both confirmed findings (redundant cost computation in the sort comparator, sibling LINQ call sites left unfixed) addressed in this PR
