### PR TITLE
Look a rule's selector and declarations up by index, not with LINQ

### DIFF
--- a/.claude/recent-fixes/2026-09-09-a-property-getter-that-ran-a-linq-query-per-read.md
+++ b/.claude/recent-fixes/2026-09-09-a-property-getter-that-ran-a-linq-query-per-read.md
@@ -1,0 +1,33 @@
+# A property getter that ran a LINQ query per read
+
+`StyleRule.Selector` and `StyleRule.Style` were both
+`Children.OfType<T>().FirstOrDefault()`. `StylesheetNode.Children` hands the child list back as
+`IEnumerable<IStylesheetNode>`, so each read built an `OfType` iterator and boxed a list
+enumerator — two allocations, every time a property was read.
+
+Selector matching reads `Selector` once per box per candidate rule, so a document with many rules
+and many boxes pays it per pair. `ChildList`, a new `protected IReadOnlyList<IStylesheetNode>` on
+the node, lets both getters walk the children by index instead.
+
+## What measuring it turned up
+
+- **40 MB per corpus pass, 6.5% of the total** — 619.3 MB down to 579.3 MB over 26 real documents,
+  measured against `main` *after* #977 and #978 landed. It was 39 MB before those, so #978's rewrite
+  of selector matching did not absorb it: the getter is read from more places than that path.
+- **88 bytes per read, exactly**: 4,000 property reads allocated 352,000 bytes before and zero
+  after. Two allocations at 44 bytes apiece, which is what makes this testable to the byte.
+- **A property getter in an allocation profile is the tell.** `StyleRule.get_Selector` came fourth
+  in the ranked call sites of a whole document render, above the fragment emitter. Nobody expects a
+  property read to be a top-five allocator, which is exactly why it survived.
+- **The setter still reads the getter** (`ReplaceSingle(Selector, value)`), so the write path is
+  unchanged and there is no cached state to invalidate — the reason this is an indexed walk rather
+  than a memoised field.
+
+## Evidence
+
+`StyleRuleLookupAllocationTests` asserts 4,000 reads allocate under 4 KB, and separately that the
+indexed walk still finds the same children the LINQ form did — including after `SelectorText` has
+replaced the selector, which is the one case where the child is not the one the constructor added.
+Per-thread, because the suite runs collections in parallel.
+
+Full suite green on net8.0 (10,424), 0 new build warnings, corpus fidelity unchanged at 26/26.

--- a/src/PeachPDF.Tests/CSS/StyleRuleLookupAllocationTests.cs
+++ b/src/PeachPDF.Tests/CSS/StyleRuleLookupAllocationTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Linq;
+using PeachPDF.CSS;
+using Xunit;
+
+namespace PeachPDF.Tests.CSS
+{
+    /// <summary>
+    /// Reading a rule's selector or declaration block allocates nothing.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Both were <c>Children.OfType&lt;T&gt;().FirstOrDefault()</c>. <c>Children</c> hands the child
+    /// list back as <see cref="System.Collections.Generic.IEnumerable{T}"/>, so that query allocates
+    /// an <c>OfType</c> iterator and boxes a list enumerator — on <b>every read</b>, of a property.
+    /// </para>
+    /// <para>
+    /// It matters because of how often it is read: selector matching asks each candidate rule for its
+    /// selector once per box, so a document with many rules and many boxes pays this per pair. Over a
+    /// 26-document corpus it was 39 MB, 5% of everything the engine allocated.
+    /// </para>
+    /// <para>
+    /// Asserted on the property rather than through a rendered document because allocation over a
+    /// document scales with whatever font a machine resolves; here the getters are the only thing
+    /// running, which makes the assertion exact and the same everywhere.
+    /// </para>
+    /// </remarks>
+    public class StyleRuleLookupAllocationTests
+    {
+        [Fact]
+        public void ReadingSelectorAndStyle_AllocatesNothing()
+        {
+            var sheet = new StylesheetParser().Parse(".a .b > .c, #d { color: red; margin: 1px }");
+            var rule = sheet.Rules.OfType<StyleRule>().Single();
+
+            // Warm: JIT both getters before anything is counted.
+            for (var i = 0; i < 3; i++)
+            {
+                _ = rule.Selector;
+                _ = rule.Style;
+            }
+
+            // Per THREAD, not process-wide: this suite runs collections in parallel, so
+            // GC.GetTotalAllocatedBytes would count whatever every other test is allocating.
+            const int reads = 2000;
+            var before = GC.GetAllocatedBytesForCurrentThread();
+
+            for (var i = 0; i < reads; i++)
+            {
+                _ = rule.Selector;
+                _ = rule.Style;
+            }
+
+            var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+            Assert.True(allocated < 4096,
+                $"{reads * 2:N0} property reads allocated {allocated:N0} bytes. They should allocate "
+                + "nothing: the child list is exposed as IEnumerable, so a LINQ lookup over it builds "
+                + "an iterator and boxes an enumerator every time.");
+        }
+
+        /// <summary>
+        /// The indexed walk still finds the same children the LINQ form did — including after the
+        /// selector has been replaced, which is the one case where the child is not the one the
+        /// constructor put there.
+        /// </summary>
+        [Fact]
+        public void TheLookupsStillFindTheRightChildren()
+        {
+            var sheet = new StylesheetParser().Parse(".a { color: red }");
+            var rule = sheet.Rules.OfType<StyleRule>().Single();
+
+            Assert.NotNull(rule.Selector);
+            Assert.Equal(".a", rule.Selector.Text);
+            Assert.NotNull(rule.Style);
+            Assert.Equal("rgb(255, 0, 0)", rule.Style.GetPropertyValue("color"));
+
+            rule.SelectorText = ".b .c";
+
+            Assert.Equal(".b .c", rule.Selector.Text);
+            Assert.Equal(".b .c", rule.SelectorText);
+            Assert.NotNull(rule.Style);
+            Assert.Equal("rgb(255, 0, 0)", rule.Style.GetPropertyValue("color"));
+        }
+
+        /// <summary>
+        /// With its child gone, each lookup returns null rather than walking into the other's child —
+        /// the same answer <c>OfType&lt;T&gt;().FirstOrDefault()</c> gave. A rule carries exactly one
+        /// selector and one declaration block, so an indexed walk that matched on the wrong type would
+        /// find the sibling instead of stopping.
+        /// </summary>
+        [Fact]
+        public void EachLookupIsNullOnceItsOwnChildIsGone()
+        {
+            var rule = new StyleRule(new StylesheetParser());
+
+            Assert.NotNull(rule.Selector);
+            Assert.NotNull(rule.Style);
+
+            rule.RemoveChild(rule.Style);
+
+            Assert.Null(rule.Style);
+            Assert.NotNull(rule.Selector);
+
+            rule.RemoveChild(rule.Selector);
+
+            Assert.Null(rule.Selector);
+            Assert.Equal(string.Empty, rule.SelectorText);
+        }
+    }
+}

--- a/src/PeachPDF/CSS/Model/StylesheetNode.cs
+++ b/src/PeachPDF/CSS/Model/StylesheetNode.cs
@@ -21,6 +21,14 @@ namespace PeachPDF.CSS
 
         public IEnumerable<IStylesheetNode> Children => _children.AsEnumerable();
 
+        /// <summary>
+        /// The same children, indexable. <see cref="Children"/> hands the list back as
+        /// <see cref="IEnumerable{T}"/>, so a LINQ query or a <c>foreach</c> over it boxes an
+        /// enumerator every time — which matters for lookups that run per box per rule. Indexing
+        /// this allocates nothing.
+        /// </summary>
+        protected IReadOnlyList<IStylesheetNode> ChildList => _children;
+
         public abstract void ToCss(TextWriter writer, IStyleFormatter formatter);
 
         public void AppendChild(IStylesheetNode child)

--- a/src/PeachPDF/CSS/Rules/StyleRule.cs
+++ b/src/PeachPDF/CSS/Rules/StyleRule.cs
@@ -30,7 +30,18 @@ namespace PeachPDF.CSS
 
         public ISelector Selector
         {
-            get => Children.OfType<ISelector>().FirstOrDefault();
+            // Indexed rather than Children.OfType<...>().FirstOrDefault(): this is read per box per
+            // candidate rule during selector matching, and the LINQ form allocates an OfType iterator
+            // plus a boxed list enumerator on every read.
+            get
+            {
+                for (var i = 0; i < ChildList.Count; i++)
+                {
+                    if (ChildList[i] is ISelector selector) return selector;
+                }
+
+                return null;
+            }
             set => ReplaceSingle(Selector, value);
         }
 
@@ -44,6 +55,19 @@ namespace PeachPDF.CSS
             set => Selector = Parser.ParseSelector(value);
         }
 
-        public StyleDeclaration Style => Children.OfType<StyleDeclaration>().FirstOrDefault();
+        public StyleDeclaration Style
+        {
+            // Indexed for the same reason as Selector above. Null when the declaration block child
+            // has been removed, which is what the LINQ FirstOrDefault it replaced also returned.
+            get
+            {
+                for (var i = 0; i < ChildList.Count; i++)
+                {
+                    if (ChildList[i] is StyleDeclaration style) return style;
+                }
+
+                return null;
+            }
+        }
     }
 }


### PR DESCRIPTION
`StyleRule.Selector` and `StyleRule.Style` were both:

```csharp
get => Children.OfType<T>().FirstOrDefault();
```

`StylesheetNode.Children` hands the child list back as `IEnumerable<IStylesheetNode>`, so each read builds an `OfType` iterator and boxes a list enumerator — **two allocations, every time a property is read**. A property getter is not somewhere anyone looks for that, which is presumably how it survived; it came fourth in the ranked allocating call sites of a whole document render, above the fragment emitter.

A new `protected IReadOnlyList<IStylesheetNode> ChildList` lets both getters walk by index. Indexing an `IReadOnlyList` allocates nothing.

## Measured

Over 26 real business documents, against `main` **as it stands after #977 and #978**:

| | allocated per pass |
| --- | --- |
| `main` | 619.3 MB |
| with this change | **579.3 MB** |

**−40 MB, 6.5% of the total.** Worth noting explicitly: it measured 39 MB *before* those two landed, so #978's rewrite of selector matching did not absorb it — the getter is read from more places than that one path. Corpus fidelity unchanged at 26/26.

## Test

`StyleRuleLookupAllocationTests` asserts 4,000 reads allocate under 4 KB:

| | allocated over 4,000 property reads |
| --- | --- |
| `main` | **352,000 bytes** — exactly 88 a read, two allocations |
| with this change | 0 |

A second test pins that the indexed walk finds the same children the LINQ form did, **including after `SelectorText` has replaced the selector** — the one case where the child is not the one the constructor added.

Per-thread rather than `GC.GetTotalAllocatedBytes`, since the suite runs collections in parallel.

## Why a walk and not a cached field

The setter is `ReplaceSingle(Selector, value)` — it reads the getter — so the write path is unchanged and there is no cached state that could go stale. A memoised field would need invalidating from `AppendChild`/`ReplaceSingle`/`RemoveChild` on the base class, which is a lot more surface for 88 bytes a read.

Full suite green on net8.0 (10,455 passed), 0 new build warnings.