### PR TITLE
Add full-pipeline regression test for large inline data: URI images

### DIFF
--- a/src/PeachPDF.Tests/Integration/DataUriImageIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/DataUriImageIntegrationTests.cs
@@ -1,0 +1,53 @@
+using PeachPDF.Tests.TestSupport;
+using PeachPDF;
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PeachPDF.Tests.Integration
+{
+    public class DataUriImageIntegrationTests
+    {
+        // Random, incompressible pixel data so the encoded PNG - and therefore the base64 data URI -
+        // stays comfortably past System.Uri's pre-.NET-10 65,519-character ceiling regardless of the
+        // codec's compression ratio on a given run.
+        private static string LargeDataUri()
+        {
+            const int width = 200;
+            const int height = 200;
+            var noise = new byte[width * height * 3];
+            new Random(42).NextBytes(noise);
+
+            var pngBytes = RasterPngFixture.MakeRgbaPngBytes(width, height, (x, y) =>
+            {
+                var i = (y * width + x) * 3;
+                return (noise[i], noise[i + 1], noise[i + 2], (byte)255);
+            });
+
+            return "data:image/png;base64," + Convert.ToBase64String(pngBytes);
+        }
+
+        [Fact]
+        public async Task Img_WithDataUriPastNet8UriLengthLimit_RendersAsImageXObject()
+        {
+            var dataUri = LargeDataUri();
+
+            // Guards the test's own premise: this is the exact ceiling RUri's data: bypass exists to
+            // avoid (see RUri.cs and RUriTests.cs) - a payload under it wouldn't reproduce issue #980.
+            Assert.True(dataUri.Length > 65_519, $"Fixture data URI was only {dataUri.Length} characters.");
+
+            var html = $"<!DOCTYPE html><html><body><img src=\"{dataUri}\"></body></html>";
+
+            var generator = new PdfGenerator();
+            var config = new PdfGenerateConfig { PageSize = PageSize.A4, CompressContentStreams = false };
+            var doc = await generator.GeneratePdf(html, config);
+            var ms = new MemoryStream();
+            doc.Save(ms);
+            var pdfText = Encoding.Latin1.GetString(ms.ToArray());
+
+            Assert.Contains("/Subtype /Image", pdfText);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Issue #980 reports that a `<img>` with a large base64 `data:` URI renders fine in a browser, the
PeachPDF Blazor WASM demo, and on Android, but is completely missing from the PDF produced on
Windows by PeachPDF 0.9.17.

This turns out to already be fixed on `main`, not a live bug: commit ff4546c7 ("A data: URI has no
length limit", #934, merged three days after the `v0.9.17` tag was cut) fixed exactly this symptom.
Before .NET 10, `System.Uri` throws `UriFormatException` ("The Uri string is too long") for any URI
over 65,519 characters (~48 KB of base64 payload); `RUri`'s two base-relative constructors - the ones
`CommonUtils.ResolveAgainstDocumentBase` calls to resolve every `<img src="data:...">` - had no
`data:` special-casing, so the exception was silently caught upstream and the image dropped with no
error. The reporter's attached HTML contains one `<img>` with a 98,998-character base64 data URI,
comfortably past that ceiling, matching the fixed bug precisely. The published `0.9.17` package
predates the fix; current `main` does not have the bug.

What was still missing: every existing test for this fix (`RUriTests.cs`) stops at the `RUri`/
`DataUriNetworkLoader` level - nothing proved the full HTML -> PDF pipeline actually paints such an
image as a real `/Image` XObject, which is the concrete, real-world failure mode from the issue. This
PR adds that missing end-to-end regression test.

## Changes

- `DataUriImageIntegrationTests.cs`: builds a real PNG with high-entropy (incompressible) pixel data
  sized so its base64 data URI is well past the 65,519-character ceiling, renders it through an
  `<img>` tag via `PdfGenerator.GeneratePdf`, and asserts the output PDF contains a real
  `/Subtype /Image` XObject - proving the full pipeline paints it, not just that `RUri` parses it.

## Test plan

- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~DataUriImage"` passes
- [x] Full net8.0 suite passes (10,454 passed, 0 failed)
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` - 0 warnings, 0 errors

Fixes #980