### PR TITLE
Match ligatures without allocating per glyph position

### DIFF
--- a/.claude/recent-fixes/2026-09-10-a-ligature-lookup-allocates-nothing-per-position.md
+++ b/.claude/recent-fixes/2026-09-10-a-ligature-lookup-allocates-nothing-per-position.md
@@ -1,0 +1,81 @@
+# A ligature lookup allocates nothing per glyph position
+
+Pure performance. No output byte changes.
+
+## What was wrong
+
+`GsubShaper.ApplyLigatureLookup` tries a match at every position in the glyph run, and every attempt
+allocated before it had looked at anything:
+
+- `TryMatchLigature` set `skippedOffsets = []` as its first statement, ahead of the coverage test
+  that decides whether there is any work at all. Most positions match nothing, so most of those
+  lists were built and dropped without ever being written to.
+- Each candidate ligature allocated its own `matched` and `skipped` lists, again before knowing
+  whether the candidate would match.
+- `lookup.Subtables` is typed `IReadOnlyList<T>`, so the `foreach` over it boxed `List<T>`'s struct
+  enumerator once per position. The same defect, in the same shape, as the GPOS subtable walks fixed
+  in #968 - GSUB was simply not looked at then.
+
+Five sibling subtable walks in the same file (single, multiple, alternate, reverse-chain, sequence
+context) had the identical boxing and are converted the same way.
+
+## Why it started mattering now
+
+None of this is new, but #984 made it hot. `ccmp` and `locl` are Type 4 (ligature) lookups in real
+fonts, and that change enables them for every run rather than only for Arabic and USE text. Ordinary
+Latin text that previously ran no ligature lookup at all now runs one over every glyph position, so a
+per-position allocation that used to be paid by a minority of runs is now paid by all of them.
+
+## The load-bearing idea
+
+`skippedOffsets` is `null` on the failure path rather than an empty list, declared
+`[NotNullWhen(true)]` so the compiler knows the caller may only read it after a `true`. The two
+match lists become a `LigatureMatchScratch` owned by `ApplyLigatureLookup` and cleared per candidate
+rather than reallocated - they are created lazily, on the first candidate actually tried, so a run
+whose glyphs no subtable covers still allocates nothing.
+
+Clearing per candidate, not per position, is what makes reuse safe: a candidate that fails partway
+leaves entries behind that the next candidate must not see, and `skipped` is handed out to
+`ApplyLigatureAt` on a match and read there before the next call, so nothing ever observes a stale
+buffer. `TwoLigaturesInOneRun_DoNotCarryTheFirstMatchsSkippedGlyph` is the test that holds this: two
+ligatures form in one run, the first over a skipped mark, and an uncleared list re-inserts that mark
+after the second ligature as well.
+
+`ApplyLigatureAt` also skips building its `skippedGlyphs` list when nothing was skipped, which is the
+ordinary case even on a match.
+
+## Evidence
+
+Measured on a 26-document corpus, medians of 3 interleaved reps, Release, net8.0, server GC,
+`FONTCONFIG_FILE` pinned so font resolution cannot drift between runs:
+
+| | allocated | vs `main` |
+| --- | ---: | ---: |
+| `main` | 2,638.5 MB | - |
+| this change | 2,444.4 MB | **-194.1 MB, -7.4%** |
+
+Run-to-run spread was under 0.1% on each side. For scale, that is more than the whole of #984's own
+cost (+181 MB): the correctness fix now runs at a net saving rather than a net cost, because the
+per-position allocation it exposed had been there all along on the `liga`/`clig` path.
+
+Both new tests are mutation-verified - each of the four parts of the change was reverted in turn and
+the suite failed each time:
+
+| reverted | result |
+| --- | --- |
+| eager `skippedOffsets = []` | allocation test fails |
+| `foreach` over `Subtables` | allocation test fails |
+| `skipped.Clear()` | reuse test fails |
+| `matched.Clear()` | reuse test fails |
+
+A third test, `ALigatureInvokedFromAContextualRule_StillForms`, drives the other route into
+`ApplyLigatureAt` - a Type 5 contextual rule invoking a ligature lookup as a nested lookup at one
+position, which owns its own scratch rather than the run walk's.
+
+- Full net8.0 suite: 10,534 passed, 9 skipped, 0 failed - including #984's own
+  `DefaultIgnorableShapingTests` and `EmojiSequenceCompositionTests`, so emoji sequence composition
+  and default-ignorable hiding are unchanged.
+- Rendered PDFs are byte-identical to `main` across all 26 corpus documents after normalising
+  `/CreationDate`, `/ID` and the random font subset tags.
+- Diff coverage on the changed source: 100% (28 of 28 coverable added lines).
+- Rebuild is 0 warnings, 0 errors.

--- a/src/PeachPDF.Tests/Text/GsubLigatureMatchAllocationTests.cs
+++ b/src/PeachPDF.Tests/Text/GsubLigatureMatchAllocationTests.cs
@@ -1,0 +1,304 @@
+using PeachPDF.Fonts.OpenType;
+using PeachPDF.PdfSharpCore.Drawing;
+using PeachPDF.Tests.TestSupport;
+using PeachPDF.Text;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace PeachPDF.Tests.Text
+{
+    /// <summary>
+    /// A ligature lookup walks the glyph run without allocating per glyph position, and reuses its
+    /// match buffers across positions without carrying anything between them.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="GsubShaper.ApplyLigatureLookup"/> tries a match at <b>every</b> position in the run,
+    /// and every attempt used to allocate: an empty <c>skippedOffsets</c> list before it had even
+    /// looked at a coverage table, a fresh pair of match lists per candidate ligature, and a boxed
+    /// enumerator for the interface-typed <c>Subtables</c> walk. Almost every one of those attempts
+    /// fails - a run of ordinary text matches no ligature at most positions - so the whole cost was
+    /// paid to discard it.
+    /// </para>
+    /// <para>
+    /// It became worth fixing when <c>ccmp</c>/<c>locl</c> started applying to every run rather than
+    /// only to Arabic and USE text. Those features are Type 4 (ligature) lookups in real fonts, so
+    /// text that previously ran no ligature lookup at all now runs one over every position.
+    /// </para>
+    /// <para>
+    /// Asserted against the lookup rather than a rendered document because allocation over a document
+    /// scales with whatever font a machine resolves. Here the walk is the only thing running, which
+    /// makes the bound exact and identical on every platform.
+    /// </para>
+    /// </remarks>
+    public class GsubLigatureMatchAllocationTests
+    {
+        [Fact]
+        public void WalkingARunForLigatures_AllocatesNothingPerPosition()
+        {
+            // One subtable whose coverage matches nothing, so every position is tried and every
+            // attempt fails - the only thing left that can allocate is the walk itself.
+            //
+            // NOT an empty subtable list: List<T> hands back a cached singleton enumerator when it is
+            // empty, so the boxing under test disappears and the test passes against unfixed code.
+            var subtable = new GsubLigatureSubtable
+            {
+                Coverage = MatchesNothing(),
+                LigatureSets = [],
+            };
+            var lookup = new GsubLigatureLookup
+            {
+                Subtables = new List<GsubLigatureSubtable> { subtable },
+            };
+
+            var glyphs = new List<ShapedGlyph>();
+            for (var i = 0; i < 200; i++) glyphs.Add(new ShapedGlyph(i, i, 1));
+
+            // Warm: JIT the whole path before anything is counted.
+            for (var i = 0; i < 3; i++) GsubShaper.ApplyLigatureLookup(lookup, glyphs, gdef: null);
+
+            // Per THREAD, not process-wide: the suite runs collections in parallel, so
+            // GC.GetTotalAllocatedBytes would count whatever every other test is allocating at the
+            // same time. This body is synchronous and never awaits, so it stays on one thread.
+            const int passes = 50;
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            for (var i = 0; i < passes; i++) GsubShaper.ApplyLigatureLookup(lookup, glyphs, gdef: null);
+            var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+            // 200 positions x 50 passes is 10,000 match attempts. Unfixed that is an empty list plus a
+            // boxed enumerator each, over half a megabyte; fixed it is nothing at all. A few hundred
+            // bytes of slack rather than zero, so this states "not per position" without depending on
+            // the runtime never allocating anything incidental.
+            Assert.True(allocated < 4096,
+                $"{passes * glyphs.Count:N0} ligature match attempts allocated {allocated:N0} bytes. They "
+                + "should allocate nothing: a position that matches nothing has no result to build, and "
+                + "the subtable list is interface-typed so a foreach over it boxes an enumerator.");
+        }
+
+        /// <summary>
+        /// Two ligatures forming in one run, the first of them over a skipped mark. The match buffers
+        /// are reused across positions now, so this is what would show it if anything survived from
+        /// one match into the next: the second ligature would re-insert the first one's skipped glyph.
+        /// </summary>
+        [Fact]
+        public void TwoLigaturesInOneRun_DoNotCarryTheFirstMatchsSkippedGlyph()
+        {
+            byte[] fontBytes = File.ReadAllBytes(BundledFonts.Ttf);
+            byte[] gdefBytes = BuildGdefMarkingGlyph460();
+            byte[] gsubBytes = BuildLigatureGsub();
+
+            int gdefStart = fontBytes.Length;
+            int gsubStart = gdefStart + gdefBytes.Length;
+            var face = XFontSource.GetOrCreateFrom(Concat(fontBytes, gdefBytes, gsubBytes)).Fontface;
+
+            var gdef = new GdefTable(face, gdefStart);
+            var lookup = new GsubTable(face, gsubStart).GetLigatureLookup(0);
+            Assert.NotNull(lookup);
+
+            // 400 460 401 | 400 401 - the first pair straddles the mark, the second does not.
+            var glyphs = new List<ShapedGlyph>
+            {
+                new(400, 0, 1),
+                new(460, 1, 1),
+                new(401, 2, 1),
+                new(400, 3, 1),
+                new(401, 4, 1),
+            };
+
+            GsubShaper.ApplyLigatureLookup(lookup, glyphs, gdef);
+
+            // Both pairs merge to 450. The mark stays in the stream, immediately after the ligature it
+            // was skipped inside - and appears exactly once. A skipped-offset list left uncleared
+            // between matches puts it back a second time, after the second ligature as well.
+            Assert.Equal([450, 460, 450], glyphs.ConvertAll(g => g.GlyphIndex));
+
+            // Each ligature reports its own two component cluster starts, not the first match's.
+            Assert.Equal([0, 2], glyphs[0].LigatureComponentClusterStarts!);
+            Assert.Equal([3, 4], glyphs[2].LigatureComponentClusterStarts!);
+        }
+
+        /// <summary>
+        /// A ligature applied as a <b>nested</b> lookup, invoked by a Type 5 contextual rule rather
+        /// than by the run walk. That path reaches <c>ApplyLigatureAt</c> for a single position and so
+        /// owns its own scratch, which starts empty and is filled only if a candidate is tried.
+        /// </summary>
+        [Fact]
+        public void ALigatureInvokedFromAContextualRule_StillForms()
+        {
+            byte[] fontBytes = File.ReadAllBytes(BundledFonts.Ttf);
+            byte[] gsubBytes = BuildContextualIntoLigatureGsub();
+
+            int gsubStart = fontBytes.Length;
+            var face = XFontSource.GetOrCreateFrom(Concat(fontBytes, gsubBytes)).Fontface;
+            var gsub = new GsubTable(face, gsubStart);
+
+            var contextual = gsub.GetContextualLookup(0);
+            Assert.NotNull(contextual);
+
+            var glyphs = new List<ShapedGlyph> { new(400, 0, 1), new(401, 1, 1) };
+
+            GsubShaper.ApplySequenceContextLookup(gsub, contextual.Subtables, glyphs, gdef: null,
+                contextual.LookupFlag, markFilteringSet: null);
+
+            // The contextual rule matched 400 401 and ran lookup 1 - the ligature - at position 0.
+            Assert.Equal([450], glyphs.ConvertAll(g => g.GlyphIndex));
+            Assert.Equal([0, 1], glyphs[0].LigatureComponentClusterStarts!);
+        }
+
+        /// <summary>Two lookups: index 0 is a Type 5 (sequence context, format 1) whose only rule
+        /// matches 400 401 and invokes lookup 1 at sequence index 0; index 1 is the Type 4 ligature
+        /// 400 + 401 -&gt; 450.</summary>
+        private static byte[] BuildContextualIntoLigatureGsub()
+        {
+            var b = new SfntByteBuilder();
+            b.U16(1); b.U16(0);
+            int scriptListOffsetAt = b.PlaceholderU16();
+            int featureListOffsetAt = b.PlaceholderU16();
+            int lookupListOffsetAt = b.PlaceholderU16();
+            b.PatchU16(scriptListOffsetAt, b.Position); b.U16(0);
+            b.PatchU16(featureListOffsetAt, b.Position); b.U16(0);
+
+            int lookupListStart = b.Position;
+            b.PatchU16(lookupListOffsetAt, lookupListStart);
+            b.U16(2); // lookupCount
+            int lookup0At = b.PlaceholderU16();
+            int lookup1At = b.PlaceholderU16();
+
+            // ---- lookup 0: Type 5, format 1 ----
+            int lookup0Start = b.Position;
+            b.PatchU16(lookup0At, lookup0Start - lookupListStart);
+            b.U16(5); b.U16(0); b.U16(1); // lookupType=5, no flags, subtableCount=1
+            int sub0OffsetAt = b.PlaceholderU16();
+
+            int sub0Start = b.Position;
+            b.PatchU16(sub0OffsetAt, sub0Start - lookup0Start);
+            b.U16(1); // format 1
+            int ctxCoverageOffsetAt = b.PlaceholderU16();
+            b.U16(1); // seqRuleSetCount
+            int ruleSetOffsetAt = b.PlaceholderU16();
+
+            int ruleSetStart = b.Position;
+            b.PatchU16(ruleSetOffsetAt, ruleSetStart - sub0Start);
+            b.U16(1); // seqRuleCount
+            int ruleOffsetAt = b.PlaceholderU16();
+
+            b.PatchU16(ruleOffsetAt, b.Position - ruleSetStart);
+            b.U16(2);   // glyphCount, counting the coverage-matched first glyph
+            b.U16(1);   // seqLookupCount
+            b.U16(401); // the one further input glyph
+            b.U16(0); b.U16(1); // record: at sequence index 0, run lookup 1
+
+            b.PatchU16(ctxCoverageOffsetAt, b.Position - sub0Start);
+            b.U16(1); b.U16(1); b.U16(400);
+
+            // ---- lookup 1: Type 4 ligature ----
+            int lookup1Start = b.Position;
+            b.PatchU16(lookup1At, lookup1Start - lookupListStart);
+            b.U16(4); b.U16(0); b.U16(1);
+            int sub1OffsetAt = b.PlaceholderU16();
+
+            int sub1Start = b.Position;
+            b.PatchU16(sub1OffsetAt, sub1Start - lookup1Start);
+            b.U16(1); // substFormat
+            int ligCoverageOffsetAt = b.PlaceholderU16();
+            b.U16(1); // ligatureSetCount
+            int ligSetOffsetAt = b.PlaceholderU16();
+
+            int ligSetStart = b.Position;
+            b.PatchU16(ligSetOffsetAt, ligSetStart - sub1Start);
+            b.U16(1); // ligatureCount
+            int ligOffsetAt = b.PlaceholderU16();
+
+            b.PatchU16(ligOffsetAt, b.Position - ligSetStart);
+            b.U16(450); b.U16(2); b.U16(401);
+
+            b.PatchU16(ligCoverageOffsetAt, b.Position - sub1Start);
+            b.U16(1); b.U16(1); b.U16(400);
+
+            return b.ToArray();
+        }
+
+        /// <summary>GDEF classifying glyph 460 as a Mark, which is what <c>IGNORE_MARKS</c> on the
+        /// lookup below acts on.</summary>
+        private static byte[] BuildGdefMarkingGlyph460()
+        {
+            var b = new SfntByteBuilder();
+            b.U16(1); b.U16(0); // version 1.0
+            int glyphClassDefOffsetAt = b.PlaceholderU16();
+            b.U16(0); b.U16(0); b.U16(0); // attachList, ligCaretList, markAttachClassDef - all null
+            int glyphClassDefStart = b.Position;
+            b.PatchU16(glyphClassDefOffsetAt, glyphClassDefStart);
+            b.U16(2); // ClassDef format 2
+            b.U16(1); // classRangeCount
+            b.U16(460); b.U16(460); b.U16(3); // glyph 460 -> class 3 (Mark)
+            return b.ToArray();
+        }
+
+        /// <summary>A single Type 4 (Ligature) lookup with <c>IGNORE_MARKS</c>: coverage {400},
+        /// component glyph 401, ligature glyph 450.</summary>
+        private static byte[] BuildLigatureGsub()
+        {
+            var b = new SfntByteBuilder();
+            b.U16(1); b.U16(0);
+            int scriptListOffsetAt = b.PlaceholderU16();
+            int featureListOffsetAt = b.PlaceholderU16();
+            int lookupListOffsetAt = b.PlaceholderU16();
+            b.PatchU16(scriptListOffsetAt, b.Position); b.U16(0);
+            b.PatchU16(featureListOffsetAt, b.Position); b.U16(0);
+
+            int lookupListStart = b.Position;
+            b.PatchU16(lookupListOffsetAt, lookupListStart);
+            b.U16(1); // lookupCount
+            int lookup0At = b.PlaceholderU16();
+
+            int lookup0Start = b.Position;
+            b.PatchU16(lookup0At, lookup0Start - lookupListStart);
+            const ushort ignoreMarks = 0x0008;
+            b.U16(4); b.U16(ignoreMarks); b.U16(1); // lookupType=4, IGNORE_MARKS, subtableCount=1
+            int subOffsetAt = b.PlaceholderU16();
+
+            int subtableStart = b.Position;
+            b.PatchU16(subOffsetAt, subtableStart - lookup0Start);
+            b.U16(1); // substFormat
+            int coverageOffsetAt = b.PlaceholderU16();
+            b.U16(1); // ligatureSetCount
+            int ligSetOffsetAt = b.PlaceholderU16();
+
+            int ligSetStart = b.Position;
+            b.PatchU16(ligSetOffsetAt, ligSetStart - subtableStart);
+            b.U16(1); // ligatureCount
+            int ligOffsetAt = b.PlaceholderU16();
+
+            b.PatchU16(ligOffsetAt, b.Position - ligSetStart);
+            b.U16(450); // ligatureGlyph
+            b.U16(2);   // componentCount (the coverage-matched glyph plus one component)
+            b.U16(401); // component glyph
+
+            b.PatchU16(coverageOffsetAt, b.Position - subtableStart);
+            b.U16(1); b.U16(1); b.U16(400); // coverage format 1, one glyph: 400
+
+            return b.ToArray();
+        }
+
+        private static byte[] Concat(params byte[][] chunks)
+        {
+            var total = 0;
+            foreach (var c in chunks) total += c.Length;
+            var result = new byte[total];
+            var pos = 0;
+            foreach (var c in chunks) { c.CopyTo(result, pos); pos += c.Length; }
+            return result;
+        }
+
+        /// <summary>
+        /// A <see cref="CoverageTable"/> covering no glyph at all. Its constructor is private and its
+        /// only route in reads a real font, so this leaves both backing arrays null - the state
+        /// <see cref="CoverageTable.IndexOfGlyph"/> already answers -1 for.
+        /// </summary>
+        private static CoverageTable MatchesNothing() =>
+            (CoverageTable)RuntimeHelpers.GetUninitializedObject(typeof(CoverageTable));
+    }
+}

--- a/src/PeachPDF/Text/GsubShaper.cs
+++ b/src/PeachPDF/Text/GsubShaper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
 using PeachPDF.Fonts.OpenType;
@@ -806,7 +807,10 @@ namespace PeachPDF.Text
                         }
                         break;
                     case 4:
-                        if (gsub.GetLigatureLookup(lookupIndex) is { } ligature && ApplyLigatureAt(ligature, glyphs, start, gdef) > 0)
+                        // A single position, so the scratch lists start null and are allocated only if a
+                        // candidate ligature is actually tried - see ApplyLigatureLookup's own remarks.
+                        var ligatureScratch = new LigatureMatchScratch();
+                        if (gsub.GetLigatureLookup(lookupIndex) is { } ligature && ApplyLigatureAt(ligature, glyphs, start, gdef, ref ligatureScratch) > 0)
                             return true;
                         break;
                 }
@@ -841,12 +845,34 @@ namespace PeachPDF.Text
         // (here, testing the lookupFlag/GDEF mark-skip retrofit directly).
         internal static void ApplyLigatureLookup(GsubLigatureLookup lookup, List<ShapedGlyph> glyphs, GdefTable? gdef)
         {
+            // One pair of scratch lists for the whole lookup, not a fresh pair per candidate ligature
+            // per glyph position. The match walk below runs once for every position and on all but a
+            // handful throws away everything it built: most positions are covered by no subtable at
+            // all, and a covered one still usually fails partway through a candidate's component list.
+            // They are created on the first candidate that is actually tried, so a run whose glyphs no
+            // subtable covers - the common case for ccmp/locl on Latin text, which every run now
+            // applies - allocates nothing here at all.
+            var scratch = new LigatureMatchScratch();
+
             int i = 0;
             while (i < glyphs.Count)
             {
-                int consumed = ApplyLigatureAt(lookup, glyphs, i, gdef);
+                int consumed = ApplyLigatureAt(lookup, glyphs, i, gdef, ref scratch);
                 i += consumed > 0 ? consumed : 1;
             }
+        }
+
+        /// <summary>
+        /// The two lists <see cref="TryMatchLigature"/> fills while walking one candidate ligature's
+        /// components. Held by <see cref="ApplyLigatureLookup"/> and cleared per candidate rather than
+        /// reallocated, since a candidate that fails leaves nothing worth keeping. <see cref="Skipped"/>
+        /// is handed to <see cref="ApplyLigatureAt"/> on a match and read there before the next call,
+        /// so reuse is never observable.
+        /// </summary>
+        private struct LigatureMatchScratch
+        {
+            public List<int>? Matched;
+            public List<int>? Skipped;
         }
 
         /// <summary>
@@ -856,10 +882,18 @@ namespace PeachPDF.Text
         /// between two ligature-forming base glyphs), which stays in the glyph stream rather than
         /// being consumed by the ligature, moved to immediately after it - or 0 if nothing matched.
         /// </summary>
-        private static int ApplyLigatureAt(GsubLigatureLookup lookup, List<ShapedGlyph> glyphs, int index, GdefTable? gdef)
+        private static int ApplyLigatureAt(GsubLigatureLookup lookup, List<ShapedGlyph> glyphs, int index, GdefTable? gdef,
+            ref LigatureMatchScratch scratch)
         {
-            if (!TryMatchLigature(lookup, glyphs, index, gdef, out ShapedGlyph merged, out int spanLength, out List<int> skippedOffsets))
+            if (!TryMatchLigature(lookup, glyphs, index, gdef, ref scratch, out ShapedGlyph merged, out int spanLength, out var skippedOffsets))
                 return 0;
+
+            if (skippedOffsets.Count == 0)
+            {
+                glyphs.RemoveRange(index, spanLength);
+                glyphs.Insert(index, merged);
+                return 1;
+            }
 
             var skippedGlyphs = new List<ShapedGlyph>(skippedOffsets.Count);
             foreach (int offset in skippedOffsets)
@@ -873,24 +907,35 @@ namespace PeachPDF.Text
         }
 
         private static bool TryMatchLigature(GsubLigatureLookup lookup, List<ShapedGlyph> glyphs, int index, GdefTable? gdef,
-            out ShapedGlyph merged, out int spanLength, out List<int> skippedOffsets)
+            ref LigatureMatchScratch scratch,
+            out ShapedGlyph merged, out int spanLength, [NotNullWhen(true)] out List<int>? skippedOffsets)
         {
             merged = default;
             spanLength = 0;
-            skippedOffsets = [];
+            // Null, not an empty list: this returns false for the great majority of the positions it is
+            // called on, and an allocation on that path is the whole cost being removed here. The caller
+            // reads skippedOffsets only after a true, which NotNullWhen states for the compiler.
+            skippedOffsets = null;
             var firstGlyph = (ushort)glyphs[index].GlyphIndex;
             CoverageTable? markFilteringSet = lookup.MarkFilteringSetIndex is { } mfsIndex ? gdef?.GetMarkGlyphSet(mfsIndex) : null;
 
-            foreach (GsubLigatureSubtable subtable in lookup.Subtables)
+            // Indexed rather than foreach: Subtables is typed IReadOnlyList<T>, so a foreach over it
+            // boxes List<T>'s struct enumerator on the heap. That is once per glyph position per
+            // lookup - the single hottest count in the shaper, and now hotter still since ccmp/locl
+            // apply to every run. Same change, same reason, as GposPositioner's own subtable walks.
+            for (var s = 0; s < lookup.Subtables.Count; s++)
             {
+                GsubLigatureSubtable subtable = lookup.Subtables[s];
                 int coverageIndex = subtable.Coverage.IndexOfGlyph(firstGlyph);
                 if (coverageIndex < 0 || coverageIndex >= subtable.LigatureSets.Length)
                     continue;
 
                 foreach (GsubLigature ligature in subtable.LigatureSets[coverageIndex])
                 {
-                    var matched = new List<int>(ligature.ComponentGlyphIds.Length);
-                    var skipped = new List<int>();
+                    List<int> matched = scratch.Matched ??= [];
+                    List<int> skipped = scratch.Skipped ??= [];
+                    matched.Clear();
+                    skipped.Clear();
                     int pos = index + 1;
                     int compIdx = 0;
 
@@ -966,8 +1011,9 @@ namespace PeachPDF.Text
             {
                 ushort glyphId = (ushort)glyphs[i].GlyphIndex;
 
-                foreach (GsubReverseChainSingleSubstSubtable subtable in lookup.Subtables)
+                for (var s = 0; s < lookup.Subtables.Count; s++)
                 {
+                    GsubReverseChainSingleSubstSubtable subtable = lookup.Subtables[s];
                     int coverageIndex = subtable.Coverage.IndexOfGlyph(glyphId);
                     if (coverageIndex < 0 || coverageIndex >= subtable.SubstituteGlyphIds.Length)
                         continue;
@@ -1011,8 +1057,9 @@ namespace PeachPDF.Text
         private static void ApplySingleSubstitutionAt(GsubSingleSubstitutionLookup lookup, List<ShapedGlyph> glyphs, int i)
         {
             ushort glyphId = (ushort)glyphs[i].GlyphIndex;
-            foreach (GsubSingleSubstitutionSubtable subtable in lookup.Subtables)
+            for (var s = 0; s < lookup.Subtables.Count; s++)
             {
+                GsubSingleSubstitutionSubtable subtable = lookup.Subtables[s];
                 if (subtable.TryGetSubstitute(glyphId, out ushort substitute))
                 {
                     // See ApplyReverseChainSingleSubstitutionLookup's identical comment on why
@@ -1038,8 +1085,9 @@ namespace PeachPDF.Text
         private static void ApplyAlternateSubstitutionAt(GsubAlternateSubstitutionLookup lookup, List<ShapedGlyph> glyphs, int i, int alternateIndex)
         {
             ushort glyphId = (ushort)glyphs[i].GlyphIndex;
-            foreach (GsubAlternateSubstitutionSubtable subtable in lookup.Subtables)
+            for (var s = 0; s < lookup.Subtables.Count; s++)
             {
+                GsubAlternateSubstitutionSubtable subtable = lookup.Subtables[s];
                 if (subtable.TryGetAlternate(glyphId, alternateIndex, out ushort substitute))
                 {
                     // See ApplyReverseChainSingleSubstitutionLookup's identical comment on why
@@ -1073,8 +1121,9 @@ namespace PeachPDF.Text
         private static int ApplyMultipleSubstitutionAt(GsubMultipleSubstitutionLookup lookup, List<ShapedGlyph> glyphs, int i)
         {
             ushort glyphId = (ushort)glyphs[i].GlyphIndex;
-            foreach (GsubMultipleSubstitutionSubtable subtable in lookup.Subtables)
+            for (var s = 0; s < lookup.Subtables.Count; s++)
             {
+                GsubMultipleSubstitutionSubtable subtable = lookup.Subtables[s];
                 int coverageIndex = subtable.Coverage.IndexOfGlyph(glyphId);
                 if (coverageIndex < 0 || coverageIndex >= subtable.Sequences.Length)
                     continue;
@@ -1147,8 +1196,9 @@ namespace PeachPDF.Text
         private static int TryApplySequenceContextAt(GsubTable gsub, IReadOnlyList<GsubSequenceContextSubtable> subtables,
             List<ShapedGlyph> glyphs, int pos, GdefTable? gdef, ushort lookupFlag, CoverageTable? markFilteringSet, int depth)
         {
-            foreach (GsubSequenceContextSubtable subtable in subtables)
+            for (var s = 0; s < subtables.Count; s++)
             {
+                GsubSequenceContextSubtable subtable = subtables[s];
                 if (TryMatchSequenceContext(subtable, glyphs, pos, lookupFlag, gdef, markFilteringSet) is not
                     (int[] inputIndices, GsubSequenceLookupRecord[] records))
                     continue;
@@ -1438,8 +1488,9 @@ namespace PeachPDF.Text
                         ApplyAlternateSubstitutionAt(alt, glyphs, position, alternateIndex: 0);
                     break;
                 case 4:
+                    var nestedLigatureScratch = new LigatureMatchScratch();
                     if (gsub.GetLigatureLookup(lookupListIndex) is { } lig)
-                        ApplyLigatureAt(lig, glyphs, position, gdef);
+                        ApplyLigatureAt(lig, glyphs, position, gdef, ref nestedLigatureScratch);
                     break;
                 case 5:
                     if (gsub.GetContextualLookup(lookupListIndex) is { } nestedContextual)


### PR DESCRIPTION
Pure performance. No output byte changes.

## What was wrong

`ApplyLigatureLookup` tries a match at every position in the glyph run, and every attempt allocated before it had looked at anything:

- `TryMatchLigature`'s **first statement** was `skippedOffsets = []`, ahead of the coverage test that decides whether there is any work at all. Most positions match nothing, so most of those lists were built and dropped without ever being written to.
- Each candidate ligature then allocated its own `matched` and `skipped` lists, again before knowing whether it would match.
- `lookup.Subtables` is typed `IReadOnlyList<T>`, so the `foreach` over it boxed `List<T>`'s struct enumerator once more per position. Same defect, same shape, as the GPOS subtable walks in #968 — GSUB simply wasn't looked at then. Five sibling walks in this file (single, multiple, alternate, reverse-chain, sequence context) have it too and are converted the same way.

## Why it started mattering now

None of this is new, but **#984 made it hot**. `ccmp` and `locl` are Type 4 (ligature) lookups in real fonts, and that change enables them for *every* run rather than only for Arabic and USE text. Ordinary Latin text that previously ran no ligature lookup at all now runs one over every glyph position, so a per-position allocation that used to be paid by a minority of runs is now paid by all of them.

Measured on a 26-document corpus, `main` before and after #984: 2,457 MB → 2,638 MB, **+181 MB**, bisected to that single commit and reproducible to within 0.1%.

## The change

`skippedOffsets` is `null` on the failure path rather than an empty list, declared `[NotNullWhen(true)]` so the compiler knows the caller may only read it after a `true`. The two match lists become a `LigatureMatchScratch` owned by `ApplyLigatureLookup`, created lazily on the first candidate actually tried — so a run whose glyphs no subtable covers allocates nothing at all — and cleared per candidate rather than reallocated.

Clearing **per candidate, not per position**, is the load-bearing part: a candidate that fails partway leaves entries the next one must not see. `skipped` is handed to `ApplyLigatureAt` on a match and read there before the next call, so nothing ever observes a stale buffer.

`ApplyLigatureAt` also skips building its `skippedGlyphs` list when nothing was skipped, which is the ordinary case even on a match.

## Measurements

26-document corpus, medians of 3 interleaved reps, Release, net8.0, server GC, `FONTCONFIG_FILE` pinned so font resolution cannot drift between runs:

| | allocated | vs `main` |
| --- | ---: | ---: |
| `main` | 2,638.5 MB | — |
| this change | 2,444.4 MB | **−194.1 MB, −7.4%** |

Run-to-run spread under 0.1% on each side. That is more than the whole of #984's own cost — the correctness fix now runs at a **net saving** rather than a net cost, because the per-position allocation it exposed had been there all along on the `liga`/`clig` path.

Wall time trended lower too but I would not quote a figure from it: the c4 spread on this machine was wide enough that allocation is the only number here I would stand behind.

## Proof

Three tests, and each part of the change was reverted in turn to confirm the suite catches it:

| reverted | result |
| --- | --- |
| eager `skippedOffsets = []` | allocation test fails |
| `foreach` over `Subtables` | allocation test fails |
| `skipped.Clear()` | reuse test fails |
| `matched.Clear()` | reuse test fails |

- `WalkingARunForLigatures_AllocatesNothingPerPosition` — 10,000 match attempts against a coverage that matches nothing. Deliberately **not** an empty subtable list: `List<T>` hands back a cached singleton enumerator when empty, so the boxing under test disappears and the test passes against unfixed code. (That trap cost me a first attempt at #968's test.)
- `TwoLigaturesInOneRun_DoNotCarryTheFirstMatchsSkippedGlyph` — two ligatures form in one run, the first over a skipped mark. An uncleared skipped-offset list re-inserts that mark after the second ligature as well.
- `ALigatureInvokedFromAContextualRule_StillForms` — the other route into `ApplyLigatureAt`, a Type 5 contextual rule invoking a ligature lookup as a nested lookup at a single position.

- **Full net8.0 suite: 10,534 passed, 9 skipped, 0 failed** — including #984's own `DefaultIgnorableShapingTests` and `EmojiSequenceCompositionTests`, so emoji sequence composition and default-ignorable hiding are unchanged.
- Rendered PDFs are **byte-identical to `main`** across all 26 corpus documents after normalising `/CreationDate`, `/ID` and the random font subset tags.
- Diff coverage on the changed source: **100%** (28 of 28 coverable added lines), measured with `diff-cover` against the merge-base.
- Rebuild: 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gBHScYW9yHeYbkuLwEUq2
