### PR TITLE
Optimize searchable COLR/CPAL glyph rendering

### DIFF
--- a/.claude/recent-fixes/2026-09-10-color-glyph-selection-avoids-redundant-work.md
+++ b/.claude/recent-fixes/2026-09-10-color-glyph-selection-avoids-redundant-work.md
@@ -1,0 +1,29 @@
+# Color-glyph selection avoids redundant shaping and transient buffers
+
+_Landed 2026-09-10._
+
+The invisible text added for searchable/selectable COLR glyphs originally repeated shaping after
+`DrawString` had already shaped the run for measurement. It also built cluster ownership through a
+sorted glyph-index list and one `StringBuilder` per glyph in the ordinary disjoint-cluster case, then
+created several temporary strings and byte arrays to serialize each `/ActualText` span and CID.
+
+The color path now shapes once and reuses that result for measurement, vector painting, source
+ownership, and invisible text. Disjoint clusters take a linear no-sort path and materialize their
+source ranges directly; overlapping clusters retain the widest-span precedence fallback. UTF-16BE
+hex strings and CIDs append directly to the content stream. Subsetting likewise reads contour counts
+without copying glyph data, allocates selection bookkeeping only for fonts that need it, and writes
+synthetic selection contours directly into the destination `glyf` table.
+
+A release-mode benchmark rendering and saving twenty 100-emoji documents measured median elapsed
+time falling from 888.2 ms to 800.0 ms (9.9%) and allocations from 424,484,096 to 420,372,992 bytes
+(1.0%). The isolated ownership mapper fell from 3,061,600 to 727,200 bytes over one hundred
+200-glyph mappings (76%). Targeted COLR/CPAL rendering and subsetting tests passed, and the generated
+PDF size remained unchanged at 756,801 bytes for the benchmark fixture.
+
+A follow-up measurement compared the four one-character appends used for each hexadecimal UTF-16
+code unit with one append from a stack-allocated four-character span. After tiered JIT compilation
+settled, the span version took about 52.7 ms rather than 76.3 ms over ten million code units (31%
+faster, with both allocating only the benchmark's 40 bytes). Font subsetting cannot return
+stack-allocated glyph data because that memory would outlive the method; it now returns a non-owning
+`ReadOnlySpan<byte>` over the immutable source font and copies that directly into the final subset.
+Ten full Source Sans subsets consequently fell from 14,704,528 to 11,898,752 allocated bytes (19%).

--- a/.claude/recent-fixes/2026-09-10-colr-path-serialization-avoids-boxing-and-copies.md
+++ b/.claude/recent-fixes/2026-09-10-colr-path-serialization-avoids-boxing-and-copies.md
@@ -1,0 +1,23 @@
+# COLR path serialization avoids boxing and transient point arrays
+
+_Landed 2026-09-10._
+
+Profiling searchable COLR/CPAL rendering showed that shaping was no longer material, but emitting the
+vector outlines still boxed every coordinate through `StringBuilder.AppendFormat`. Building each glyph
+path also repeatedly grew its point/type lists and then copied both lists to arrays solely so the PDF
+renderer could enumerate them.
+
+PDF coordinates now use `double.TryFormat` into a stack buffer and append that span directly to the
+content builder. The uncommon value whose fixed-point representation exceeds the buffer falls back to
+the same invariant `double.ToString` formatting, so large finite values retain the old behavior.
+`CoreGraphicsPath` exposes non-owning read-only spans to its renderer, and color-glyph paths pre-size
+their paired point/type lists from the decoded contour structure.
+
+On twenty documents containing one hundred Noto Color Emoji glyphs each, median render allocations fell
+from 343,345,800 to 251,512,824 bytes (26.7%, about 17.2 MB to 12.6 MB per document). Sequential
+release-mode runs measured render time falling from about 420 ms to 404 ms (about 4%); save allocations
+were unchanged. Generated PDFs had the same size and were byte-identical after normalizing timestamps,
+random font-subset tags, and document IDs. Focused tests cover exact path syntax and precision, the
+allocation-free numeric fast path plus its large-number fallback, and pre-sized path storage. The full
+net8.0 suite passed (10,548 tests, 9 platform skips), diff coverage was 97%, and the solution rebuilt
+with zero warnings.

--- a/src/PeachPDF.Tests/Integration/ColorGlyphRenderingIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/ColorGlyphRenderingIntegrationTests.cs
@@ -152,8 +152,8 @@ namespace PeachPDF.Tests.Integration
             Assert.True(Count(pdf, "\nf\n") >= 1, "emoji should paint vector fills");
             Assert.Contains("/ShadingType", pdf);        // real Noto emoji use gradients
             Assert.Contains("/FontFile2", pdf);
-            Assert.Contains("/ActualText <FEFFD83DDE00>", pdf); // grin
-            Assert.Contains("/ActualText <FEFFD83CDF08>", pdf); // rainbow
+            Assert.Contains("/ActualText <FEFFD83DDE00>>>BDC", pdf); // grin
+            Assert.Contains("/ActualText <FEFFD83CDF08>>>BDC", pdf); // rainbow
         }
 
         [Fact]
@@ -201,6 +201,57 @@ namespace PeachPDF.Tests.Integration
             string?[] actualText = ColorGlyphPainter.BuildActualTextByGlyph("(BA)", ")BA(", glyphs);
 
             Assert.Equal(new string?[] { ")", "B", "A", "(" }, actualText);
+        }
+
+        [Fact]
+        public void ActualTextOwnership_DisjointClusters_DoesNotAllocatePerGlyphBuildersOrSortState()
+        {
+            const int glyphCount = 200;
+            var glyphs = new ShapedGlyph[glyphCount];
+            for (int i = 0; i < glyphs.Length; i++)
+                glyphs[i] = new ShapedGlyph(i + 1, i, 1);
+            string text = new('A', glyphCount);
+
+            for (int i = 0; i < 3; i++)
+                ColorGlyphPainter.BuildActualTextByGlyph(text, null, glyphs);
+
+            const int passes = 100;
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            for (int i = 0; i < passes; i++)
+                ColorGlyphPainter.BuildActualTextByGlyph(text, null, glyphs);
+            long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+            Assert.True(allocated < 1_200_000,
+                $"Mapping {passes * glyphCount:N0} disjoint clusters allocated {allocated:N0} bytes. "
+                + "The common path should not allocate a sort list, comparison closure, or one "
+                + "StringBuilder per glyph.");
+        }
+
+        [Fact]
+        public void ActualTextOwnership_OverlappingClusterPrefersWidestSourceSpan()
+        {
+            ShapedGlyph[] glyphs =
+            [
+                new(1, 1, 1),
+                new(2, 0, 3),
+            ];
+
+            string?[] actualText = ColorGlyphPainter.BuildActualTextByGlyph("ABC", null, glyphs);
+
+            Assert.Equal(new string?[] { null, "ABC" }, actualText);
+        }
+
+        [Fact]
+        public void ActualTextOwnership_AttachesDeletedCharactersToAdjacentCluster()
+        {
+            ShapedGlyph[] trailingGap = [new(1, 0, 1)];
+            ShapedGlyph[] leadingGap = [new(1, 1, 1)];
+
+            string?[] trailingActualText = ColorGlyphPainter.BuildActualTextByGlyph("A\uFE0F", null, trailingGap);
+            string?[] leadingActualText = ColorGlyphPainter.BuildActualTextByGlyph("\u200DA", null, leadingGap);
+
+            Assert.Equal(new string?[] { "A\uFE0F" }, trailingActualText);
+            Assert.Equal(new string?[] { "\u200DA" }, leadingActualText);
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/PdfSharpCore/Drawing/XGraphicsTests.cs
+++ b/src/PeachPDF.Tests/PdfSharpCore/Drawing/XGraphicsTests.cs
@@ -1,9 +1,12 @@
 using PeachPDF.PdfSharpCore.Drawing;
+using PeachPDF.PdfSharpCore.Drawing.Pdf;
 using PeachPDF.PdfSharpCore.Pdf;
 using PeachPDF.PdfSharpCore.Utils;
 using PeachPDF.Tests.TestSupport;
 
 using PeachPDF.Fonts;
+using System.Globalization;
+using System.Text;
 
 namespace PeachPDF.Tests.PdfSharpCoreTests.Drawing
 {
@@ -184,6 +187,79 @@ namespace PeachPDF.Tests.PdfSharpCoreTests.Drawing
             using var stream = new MemoryStream();
             document.Save(stream);
             Assert.True(stream.Length > 0);
+        }
+
+        [Fact]
+        public void DrawPath_WritesInvariantCoordinatesWithExistingPrecision()
+        {
+            var (document, page) = NewPage();
+            document.Options.CompressContentStreams = false;
+
+#pragma warning disable CS0618
+            using (var gfx = XGraphics.FromPdfPage(page, XPageDirection.Upwards))
+#pragma warning restore CS0618
+            {
+                var path = new XGraphicsPath();
+                path.AddMove(1.23456, 2.34567);
+                path.AddBezier(
+                    1.23456, 2.34567,
+                    3.45678, 4.56789,
+                    5.67891, 6.78912,
+                    7.89123, 8.91234);
+                path.CloseFigure();
+                gfx.DrawPath(XBrushes.Black, path);
+            }
+
+            using var stream = new MemoryStream();
+            document.Save(stream);
+            string pdf = Encoding.Latin1.GetString(stream.ToArray());
+
+            Assert.Contains(
+                "1.2346 -2.3457 m\n3.4568 -4.5679 5.6789 -6.7891 7.8912 -8.9123 c\nh\n",
+                pdf);
+        }
+
+        [Fact]
+        public void AppendPdfNumber_UsesAllocationFreeFastPathAndPreservesFallbackFormatting()
+        {
+            var content = new StringBuilder(100_000);
+            XGraphicsPdfRenderer.AppendPdfNumber(content, 1.23456, "0.####");
+            content.Clear();
+
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            for (int i = 0; i < 10_000; i++)
+                XGraphicsPdfRenderer.AppendPdfNumber(content, 1.23456, "0.####");
+            long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+            Assert.Equal(string.Concat(Enumerable.Repeat("1.2346", 10_000)), content.ToString());
+            Assert.True(allocated < 1_024,
+                $"Formatting 10,000 ordinary coordinates allocated {allocated:N0} bytes.");
+
+            content.Clear();
+            XGraphicsPdfRenderer.AppendPdfNumber(content, double.MaxValue, "0.####");
+            Assert.Equal(double.MaxValue.ToString("0.####", CultureInfo.InvariantCulture), content.ToString());
+        }
+
+        [Fact]
+        public void PresizedCoreGraphicsPath_DoesNotGrowOrCopyWhileBuilding()
+        {
+            var warmup = new CoreGraphicsPath(2);
+            warmup.MoveTo(0, 0);
+            warmup.LineTo(1, 1, false);
+
+            var path = new CoreGraphicsPath(1_000);
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            path.MoveTo(0, 0);
+            for (int i = 1; i < 1_000; i++)
+                path.LineTo(i, i, false);
+            ReadOnlySpan<XPoint> points = path.PathPointsSpan;
+            ReadOnlySpan<byte> types = path.PathTypesSpan;
+            long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+            Assert.Equal(1_000, points.Length);
+            Assert.Equal(points.Length, types.Length);
+            Assert.Equal(new XPoint(999, 999), points[^1]);
+            Assert.Equal(0, allocated);
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/PdfSharpCore/Fonts/ColrCpalTableTests.cs
+++ b/src/PeachPDF.Tests/PdfSharpCore/Fonts/ColrCpalTableTests.cs
@@ -255,6 +255,29 @@ namespace PeachPDF.Tests.PdfSharpCoreTests.Fonts
             Assert.Null(face.cpal);
         }
 
+        [Fact]
+        public void FullFontSubset_DoesNotAllocateOneTemporaryArrayPerGlyph()
+        {
+            OpenTypeFontface face = Face(BundledFonts.Ttf);
+            var selected = new Dictionary<int, object>();
+            for (int glyph = 0; glyph < face.maxp.numGlyphs; glyph++)
+                selected[glyph] = null!;
+
+            for (int i = 0; i < 3; i++)
+                face.CreateFontSubSet(selected, cidFont: true);
+
+            const int passes = 10;
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            for (int i = 0; i < passes; i++)
+                face.CreateFontSubSet(selected, cidFont: true);
+            long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+            Assert.True(allocated < 13_000_000,
+                $"Creating {passes:N0} full-font subsets allocated {allocated:N0} bytes. Glyph data "
+                + "should copy directly from the source font into the subset, without one temporary "
+                + "byte array per glyph.");
+        }
+
         private static void AssertColor(CpalTable cpal, int entry, byte r, byte g, byte b, byte a)
         {
             Assert.True(cpal.TryGetColor(0, entry, out var color));

--- a/src/PeachPDF/Fonts/OpenType/GlyphDataTable.cs
+++ b/src/PeachPDF/Fonts/OpenType/GlyphDataTable.cs
@@ -71,17 +71,13 @@ namespace PeachPDF.Fonts.OpenType
         }
 
         /// <summary>
-        /// Gets the data of the specified glyph.
+        /// Gets a non-owning view of the specified glyph's bytes in the source font.
         /// </summary>
-        public byte[] GetGlyphData(int glyph)
+        public ReadOnlySpan<byte> GetGlyphData(int glyph)
         {
-            IndexToLocationTable loca = _fontData.loca;
             int start = GetOffset(glyph);
-            int next = GetOffset(glyph + 1);
-            int count = next - start;
-            byte[] bytes = new byte[count];
-            Buffer.BlockCopy(_fontData.FontSource.Bytes, start, bytes, 0, count);
-            return bytes;
+            int count = GetOffset(glyph + 1) - start;
+            return _fontData.FontSource.Bytes.AsSpan(start, count);
         }
 
         /// <summary>
@@ -91,6 +87,16 @@ namespace PeachPDF.Fonts.OpenType
         {
             IndexToLocationTable loca = _fontData.loca;
             return GetOffset(glyph + 1) - GetOffset(glyph);
+        }
+
+        /// <summary>Returns whether the glyph has no contours without copying its table bytes.</summary>
+        public bool HasNoContours(int glyph)
+        {
+            ReadOnlySpan<byte> glyphData = GetGlyphData(glyph);
+            if (glyphData.Length < 2)
+                return true;
+
+            return (short)((glyphData[0] << 8) | glyphData[1]) == 0;
         }
 
         /// <summary>

--- a/src/PeachPDF/Fonts/OpenType/OpenTypeFontface.cs
+++ b/src/PeachPDF/Fonts/OpenType/OpenTypeFontface.cs
@@ -393,13 +393,13 @@ namespace PeachPDF.Fonts.OpenType
             // remember only the selected empty bases so the embedded, mode-3-only subset can give them
             // a valid contour. Embedding the real layer closure would not help: no Tj references those
             // layer CIDs, and their outlines are already emitted directly as PDF vector paths.
-            Dictionary<int, byte[]> syntheticSelectionGlyphs = [];
+            HashSet<int>? syntheticSelectionGlyphs = null;
             if (colr != null)
             {
                 foreach (int glyphId in glyphs.Keys)
                 {
-                    if (colr.HasColorGlyph(glyphId) && HasNoContours(glyf.GetGlyphData(glyphId)))
-                        syntheticSelectionGlyphs[glyphId] = BuildInvisibleSelectionGlyph(glyphId);
+                    if (colr.HasColorGlyph(glyphId) && glyf.HasNoContours(glyphId))
+                        (syntheticSelectionGlyphs ??= []).Add(glyphId);
                 }
             }
 
@@ -417,8 +417,8 @@ namespace PeachPDF.Fonts.OpenType
             for (int idx = 0; idx < glyphCount; idx++)
             {
                 int glyphId = glyphArray[idx];
-                size += syntheticSelectionGlyphs.TryGetValue(glyphId, out byte[]? synthetic)
-                    ? synthetic.Length
+                size += syntheticSelectionGlyphs?.Contains(glyphId) == true
+                    ? InvisibleSelectionGlyphSize
                     : glyf.GetGlyphSize(glyphId);
             }
             glyfNew.DirectoryEntry.Length = size;
@@ -439,14 +439,19 @@ namespace PeachPDF.Fonts.OpenType
                 if (glyphIndex < glyphCount && glyphArray[glyphIndex] == idx)
                 {
                     glyphIndex++;
-                    byte[] bytes = syntheticSelectionGlyphs.TryGetValue(idx, out byte[]? synthetic)
-                        ? synthetic
-                        : glyf.GetGlyphData(idx);
-                    int length = bytes.Length;
-                    if (length > 0)
+                    if (syntheticSelectionGlyphs?.Contains(idx) == true)
                     {
-                        Buffer.BlockCopy(bytes, 0, glyfNew.GlyphTable, glyphOffset, length);
-                        glyphOffset += length;
+                        WriteInvisibleSelectionGlyph(idx, glyfNew.GlyphTable, glyphOffset);
+                        glyphOffset += InvisibleSelectionGlyphSize;
+                    }
+                    else
+                    {
+                        ReadOnlySpan<byte> glyphData = glyf.GetGlyphData(idx);
+                        if (!glyphData.IsEmpty)
+                        {
+                            glyphData.CopyTo(glyfNew.GlyphTable.AsSpan(glyphOffset));
+                            glyphOffset += glyphData.Length;
+                        }
                     }
                 }
             }
@@ -458,17 +463,10 @@ namespace PeachPDF.Fonts.OpenType
             return fontData;
         }
 
-        private static bool HasNoContours(byte[] glyphData)
-        {
-            if (glyphData.Length < 2)
-                return true;
-
-            short numberOfContours = (short)((glyphData[0] << 8) | glyphData[1]);
-            return numberOfContours == 0;
-        }
+        private const int InvisibleSelectionGlyphSize = 34;
 
         /// <summary>
-        /// Builds the stand-in outline embedded for one empty COLR base glyph: a single on-curve
+        /// Writes the stand-in outline embedded for one empty COLR base glyph: a single on-curve
         /// rectangle spanning that glyph's own advance width and the font's ascent/descent. It exists
         /// only in a PDF's embedded color-font subset and is shown exclusively with text rendering
         /// mode 3, so it paints no ink - it exists purely so a viewer has glyph geometry to select.
@@ -477,7 +475,7 @@ namespace PeachPDF.Fonts.OpenType
         /// character's box from the contour extents, so a 1x1-unit contour yields a hit target
         /// thousands of times smaller than the visible artwork.
         /// </summary>
-        private byte[] BuildInvisibleSelectionGlyph(int glyphId)
+        private void WriteInvisibleSelectionGlyph(int glyphId, byte[] destination, int destinationOffset)
         {
             int unitsPerEm = head.unitsPerEm;
 
@@ -510,13 +508,12 @@ namespace PeachPDF.Fonts.OpenType
             // only ON_CURVE_POINT, so each coordinate is a plain int16 delta from the previous point -
             // the short/same-value encodings cannot express a full-size box. The resulting length is
             // even, which keeps the glyph valid when the source font uses short loca offsets.
-            byte[] glyphData = new byte[34];
-            int offset = 0;
+            int offset = destinationOffset;
 
             void WriteInt16(int value)
             {
-                glyphData[offset++] = (byte)(value >> 8);
-                glyphData[offset++] = (byte)value;
+                destination[offset++] = (byte)(value >> 8);
+                destination[offset++] = (byte)value;
             }
 
             WriteInt16(1);      // numberOfContours
@@ -528,7 +525,7 @@ namespace PeachPDF.Fonts.OpenType
             WriteInt16(0);      // instructionLength
 
             for (int i = 0; i < 4; i++)
-                glyphData[offset++] = 0x01; // ON_CURVE_POINT
+                destination[offset++] = 0x01; // ON_CURVE_POINT
 
             WriteInt16(0);      // x deltas, reaching (0, bottom)
             WriteInt16(width);  //                    (width, bottom)
@@ -539,8 +536,6 @@ namespace PeachPDF.Fonts.OpenType
             WriteInt16(0);
             WriteInt16(top - bottom);
             WriteInt16(0);
-
-            return glyphData;
         }
 
         /// <summary>

--- a/src/PeachPDF/PdfSharpCore/Drawing.Pdf/ColorGlyphPainter.cs
+++ b/src/PeachPDF/PdfSharpCore/Drawing.Pdf/ColorGlyphPainter.cs
@@ -19,7 +19,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using PeachPDF.Fonts.OpenType;
 using PeachPDF.PdfSharpCore.Drawing;
 using PeachPDF.Text;
@@ -70,9 +69,8 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
         /// The vector paths remain the only visible ink; the text show adds selection geometry and
         /// <c>/ActualText</c> preserves the exact per-occurrence Unicode sequence.
         /// </summary>
-        public void Paint(string text, TextShapingFeatures features, string? logicalText = null)
+        public void Paint(string text, IReadOnlyList<ShapedGlyph> glyphs, string? logicalText = null)
         {
-            IReadOnlyList<ShapedGlyph> glyphs = _descriptor.Shape(text, features);
             string?[] actualTextByGlyph = BuildActualTextByGlyph(text, logicalText, glyphs);
             double penX = 0;
             for (int i = 0; i < glyphs.Count; i++)
@@ -156,31 +154,60 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
 
             // A ligature span can overlap a separately-painted skipped mark. Let the widest span own
             // those characters first; the mark then contributes its vector ink without duplicating text.
-            var sourceBearingGlyphs = new List<int>(glyphs.Count);
+            // Shaped runs almost always have disjoint clusters, so claim those directly and only allocate
+            // and sort an index list when an overlap proves that precedence is actually needed.
+            bool hasOverlappingClusters = false;
             for (int i = 0; i < glyphs.Count; i++)
             {
-                if (glyphs[i].ClusterLength > 0)
-                    sourceBearingGlyphs.Add(i);
-            }
-            sourceBearingGlyphs.Sort((left, right) =>
-            {
-                int byLength = glyphs[right].ClusterLength.CompareTo(glyphs[left].ClusterLength);
-                if (byLength != 0)
-                    return byLength;
+                ShapedGlyph glyph = glyphs[i];
+                if (glyph.ClusterLength <= 0)
+                    continue;
 
-                int byStart = glyphs[left].ClusterStart.CompareTo(glyphs[right].ClusterStart);
-                return byStart != 0 ? byStart : left.CompareTo(right);
-            });
-
-            foreach (int glyphIndex in sourceBearingGlyphs)
-            {
-                ShapedGlyph glyph = glyphs[glyphIndex];
                 int start = Math.Clamp(glyph.ClusterStart, 0, text.Length);
                 int end = Math.Clamp(glyph.ClusterStart + glyph.ClusterLength, start, text.Length);
                 for (int codeUnit = start; codeUnit < end; codeUnit++)
                 {
-                    if (ownerByCodeUnit[codeUnit] < 0)
-                        ownerByCodeUnit[codeUnit] = glyphIndex;
+                    if (ownerByCodeUnit[codeUnit] >= 0)
+                    {
+                        hasOverlappingClusters = true;
+                    }
+                    else
+                    {
+                        ownerByCodeUnit[codeUnit] = i;
+                    }
+                }
+            }
+
+            if (hasOverlappingClusters)
+            {
+                Array.Fill(ownerByCodeUnit, -1);
+                var sourceBearingGlyphs = new List<int>(glyphs.Count);
+                for (int i = 0; i < glyphs.Count; i++)
+                {
+                    if (glyphs[i].ClusterLength > 0)
+                        sourceBearingGlyphs.Add(i);
+                }
+
+                sourceBearingGlyphs.Sort((left, right) =>
+                {
+                    int byLength = glyphs[right].ClusterLength.CompareTo(glyphs[left].ClusterLength);
+                    if (byLength != 0)
+                        return byLength;
+
+                    int byStart = glyphs[left].ClusterStart.CompareTo(glyphs[right].ClusterStart);
+                    return byStart != 0 ? byStart : left.CompareTo(right);
+                });
+
+                foreach (int glyphIndex in sourceBearingGlyphs)
+                {
+                    ShapedGlyph glyph = glyphs[glyphIndex];
+                    int start = Math.Clamp(glyph.ClusterStart, 0, text.Length);
+                    int end = Math.Clamp(glyph.ClusterStart + glyph.ClusterLength, start, text.Length);
+                    for (int codeUnit = start; codeUnit < end; codeUnit++)
+                    {
+                        if (ownerByCodeUnit[codeUnit] < 0)
+                            ownerByCodeUnit[codeUnit] = glyphIndex;
+                    }
                 }
             }
 
@@ -213,19 +240,28 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
                 gapStart = gapEnd;
             }
 
-            var builders = new StringBuilder?[glyphs.Count];
-            for (int codeUnit = 0; codeUnit < source.Length; codeUnit++)
+            // Ownership normally consists of one contiguous source range per glyph, so take that range
+            // directly instead of allocating a StringBuilder for every glyph.
+            int rangeStart = 0;
+            while (rangeStart < source.Length)
             {
-                int owner = ownerByCodeUnit[codeUnit];
+                int owner = ownerByCodeUnit[rangeStart];
                 if (owner < 0)
+                {
+                    rangeStart++;
                     continue;
+                }
 
-                builders[owner] ??= new StringBuilder();
-                builders[owner]!.Append(source[codeUnit]);
+                int rangeEnd = rangeStart + 1;
+                while (rangeEnd < source.Length && ownerByCodeUnit[rangeEnd] == owner)
+                    rangeEnd++;
+
+                string ownedText = source.Substring(rangeStart, rangeEnd - rangeStart);
+                result[owner] = result[owner] is null
+                    ? ownedText
+                    : string.Concat(result[owner], ownedText);
+                rangeStart = rangeEnd;
             }
-
-            for (int i = 0; i < builders.Length; i++)
-                result[i] = builders[i]?.ToString();
 
             return result;
         }

--- a/src/PeachPDF/PdfSharpCore/Drawing.Pdf/ColorGlyphPainter.cs
+++ b/src/PeachPDF/PdfSharpCore/Drawing.Pdf/ColorGlyphPainter.cs
@@ -302,7 +302,14 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
 
         private static XGraphicsPath BuildPath(GlyphOutline outline, ColrAffine transform)
         {
-            var path = new XGraphicsPath { FillMode = XFillMode.Winding };
+            int pointCount = outline.Contours.Count;
+            foreach (GlyphContour contour in outline.Contours)
+            {
+                foreach (GlyphSegment segment in contour.Segments)
+                    pointCount += segment.IsCubic ? 3 : 1;
+            }
+
+            var path = new XGraphicsPath(pointCount) { FillMode = XFillMode.Winding };
 
             foreach (GlyphContour contour in outline.Contours)
             {

--- a/src/PeachPDF/PdfSharpCore/Drawing.Pdf/XGraphicsPdfRenderer.cs
+++ b/src/PeachPDF/PdfSharpCore/Drawing.Pdf/XGraphicsPdfRenderer.cs
@@ -144,10 +144,9 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
 
             Realize(pen);
 
-            const string format = Config.SignificantFigures4;
-            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", points[0].X, points[0].Y);
+            AppendPathPoint(points[0].X, points[0].Y, 'm');
             for (int idx = 1; idx < count; idx++)
-                AppendFormatPoint("{0:" + format + "} {1:" + format + "} l\n", points[idx].X, points[idx].Y);
+                AppendPathPoint(points[idx].X, points[idx].Y, 'l');
             _content.Append("S\n");
         }
 
@@ -176,10 +175,9 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
 
             Realize(pen);
 
-            const string format = Config.SignificantFigures4;
-            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", points[0].X, points[0].Y);
+            AppendPathPoint(points[0].X, points[0].Y, 'm');
             for (int idx = 1; idx < count; idx += 3)
-                AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
+                AppendBezier(
                     points[idx].X, points[idx].Y,
                     points[idx + 1].X, points[idx + 1].Y,
                     points[idx + 2].X, points[idx + 2].Y);
@@ -207,8 +205,7 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
 
             Realize(pen);
 
-            const string format = Config.SignificantFigures4;
-            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", points[0].X, points[0].Y);
+            AppendPathPoint(points[0].X, points[0].Y, 'm');
             if (count == 2)
             {
                 // Just draws a line.
@@ -297,15 +294,14 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             double y0 = rect.Y + δy;
 
             // Approximate an ellipse by drawing four cubic splines.
-            const string format = Config.SignificantFigures4;
-            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", x0 + δx, y0);
-            AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
+            AppendPathPoint(x0 + δx, y0, 'm');
+            AppendBezier(
               x0 + δx, y0 + fy, x0 + fx, y0 + δy, x0, y0 + δy);
-            AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
+            AppendBezier(
               x0 - fx, y0 + δy, x0 - δx, y0 + fy, x0 - δx, y0);
-            AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
+            AppendBezier(
               x0 - δx, y0 - fy, x0 - fx, y0 - δy, x0, y0 - δy);
-            AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
+            AppendBezier(
               x0 + fx, y0 - δy, x0 + δx, y0 - fy, x0 + δx, y0);
             AppendStrokeFill(pen, brush, XFillMode.Winding, true);
         }
@@ -320,10 +316,9 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             if (points.Length < 2)
                 throw new ArgumentException("points", PSSR.PointArrayAtLeast(2));
 
-            const string format = Config.SignificantFigures4;
-            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", points[0].X, points[0].Y);
+            AppendPathPoint(points[0].X, points[0].Y, 'm');
             for (int idx = 1; idx < count; idx++)
-                AppendFormatPoint("{0:" + format + "} {1:" + format + "} l\n", points[idx].X, points[idx].Y);
+                AppendPathPoint(points[idx].X, points[idx].Y, 'l');
 
             AppendStrokeFill(pen, brush, fillmode, true);
         }
@@ -335,8 +330,7 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
         {
             Realize(pen, brush);
 
-            const string format = Config.SignificantFigures4;
-            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", x + width / 2, y + height / 2);
+            AppendPathPoint(x + width / 2, y + height / 2, 'm');
             AppendPartialArc(x, y, width, height, startAngle, sweepAngle, PathStart.LineTo1st, new XMatrix());
             AppendStrokeFill(pen, brush, XFillMode.Alternate, true);
         }
@@ -356,8 +350,7 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
 
             Realize(pen, brush);
 
-            const string format = Config.SignificantFigures4;
-            AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", points[0].X, points[0].Y);
+            AppendPathPoint(points[0].X, points[0].Y, 'm');
             if (count == 2)
             {
                 // Just draw a line.
@@ -1220,8 +1213,8 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             sinβ = Math.Sin(β);
             double cosβ = Math.Cos(β);
 
-            const string format = Config.SignificantFigures3;
             XPoint pt1, pt2, pt3;
+            const string format = Config.SignificantFigures3;
             if (!reflect)
             {
                 // Calculation for quarter 0 and 1
@@ -1229,12 +1222,12 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
                 {
                     case PathStart.MoveTo1st:
                         pt1 = matrix.Transform(new XPoint(x0 + δx * cosα, y0 + δy * sinα));
-                        AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", pt1.X, pt1.Y);
+                        AppendPathPoint(pt1.X, pt1.Y, 'm', format);
                         break;
 
                     case PathStart.LineTo1st:
                         pt1 = matrix.Transform(new XPoint(x0 + δx * cosα, y0 + δy * sinα));
-                        AppendFormatPoint("{0:" + format + "} {1:" + format + "} l\n", pt1.X, pt1.Y);
+                        AppendPathPoint(pt1.X, pt1.Y, 'l', format);
                         break;
 
                     case PathStart.Ignore1st:
@@ -1243,8 +1236,8 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
                 pt1 = matrix.Transform(new XPoint(x0 + δx * (cosα - κ * sinα), y0 + δy * (sinα + κ * cosα)));
                 pt2 = matrix.Transform(new XPoint(x0 + δx * (cosβ + κ * sinβ), y0 + δy * (sinβ - κ * cosβ)));
                 pt3 = matrix.Transform(new XPoint(x0 + δx * cosβ, y0 + δy * sinβ));
-                AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
-                  pt1.X, pt1.Y, pt2.X, pt2.Y, pt3.X, pt3.Y);
+                AppendBezier(
+                  pt1.X, pt1.Y, pt2.X, pt2.Y, pt3.X, pt3.Y, format);
             }
             else
             {
@@ -1253,12 +1246,12 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
                 {
                     case PathStart.MoveTo1st:
                         pt1 = matrix.Transform(new XPoint(x0 - δx * cosα, y0 - δy * sinα));
-                        AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", pt1.X, pt1.Y);
+                        AppendPathPoint(pt1.X, pt1.Y, 'm', format);
                         break;
 
                     case PathStart.LineTo1st:
                         pt1 = matrix.Transform(new XPoint(x0 - δx * cosα, y0 - δy * sinα));
-                        AppendFormatPoint("{0:" + format + "} {1:" + format + "} l\n", pt1.X, pt1.Y);
+                        AppendPathPoint(pt1.X, pt1.Y, 'l', format);
                         break;
 
                     case PathStart.Ignore1st:
@@ -1267,8 +1260,8 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
                 pt1 = matrix.Transform(new XPoint(x0 - δx * (cosα - κ * sinα), y0 - δy * (sinα + κ * cosα)));
                 pt2 = matrix.Transform(new XPoint(x0 - δx * (cosβ + κ * sinβ), y0 - δy * (sinβ - κ * cosβ)));
                 pt3 = matrix.Transform(new XPoint(x0 - δx * cosβ, y0 - δy * sinβ));
-                AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
-                    pt1.X, pt1.Y, pt2.X, pt2.Y, pt3.X, pt3.Y);
+                AppendBezier(
+                    pt1.X, pt1.Y, pt2.X, pt2.Y, pt3.X, pt3.Y, format);
             }
         }
 
@@ -1277,8 +1270,7 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
         /// </summary>
         void AppendCurveSegment(XPoint pt0, XPoint pt1, XPoint pt2, XPoint pt3, double tension3)
         {
-            const string format = Config.SignificantFigures4;
-            AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n",
+            AppendBezier(
                 pt1.X + tension3 * (pt2.X - pt0.X), pt1.Y + tension3 * (pt2.Y - pt0.Y),
                 pt2.X - tension3 * (pt3.X - pt1.X), pt2.Y - tension3 * (pt3.Y - pt1.Y),
                 pt2.X, pt2.Y);
@@ -1289,7 +1281,7 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
         /// </summary>
         internal void AppendPath(CoreGraphicsPath path)
         {
-            AppendPath(path.PathPoints, path.PathTypes);
+            AppendPath(path.PathPointsSpan, path.PathTypesSpan);
             //XPoint[] points = path.PathPoints;
             //Byte[] types = path.PathTypes;
 
@@ -1337,12 +1329,12 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             //}
         }
 
-        void AppendPath(XPoint[] points, Byte[] types)
+        void AppendPath(ReadOnlySpan<XPoint> points, ReadOnlySpan<byte> types)
         {
-            const string format = Config.SignificantFigures4;
             int count = points.Length;
             if (count == 0)
                 return;
+            Debug.Assert(types.Length == count);
 
             for (int idx = 0; idx < count; idx++)
             {
@@ -1362,12 +1354,12 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
                 {
                     case PathPointTypeStart:
                         //PDF_moveto(pdf, points[idx].X, points[idx].Y);
-                        AppendFormatPoint("{0:" + format + "} {1:" + format + "} m\n", points[idx].X, points[idx].Y);
+                        AppendPathPoint(points[idx].X, points[idx].Y, 'm');
                         break;
 
                     case PathPointTypeLine:
                         //PDF_lineto(pdf, points[idx].X, points[idx].Y);
-                        AppendFormatPoint("{0:" + format + "} {1:" + format + "} l\n", points[idx].X, points[idx].Y);
+                        AppendPathPoint(points[idx].X, points[idx].Y, 'l');
                         if ((type & PathPointTypeCloseSubpath) != 0)
                             Append("h\n");
                         break;
@@ -1377,7 +1369,7 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
                         //PDF_curveto(pdf, points[idx].X, points[idx].Y, 
                         //                 points[idx + 1].X, points[idx + 1].Y, 
                         //                 points[idx + 2].X, points[idx + 2].Y);
-                        AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} c\n", points[idx].X, points[idx].Y,
+                        AppendBezier(points[idx].X, points[idx].Y,
                             points[++idx].X, points[idx].Y, points[++idx].X, points[idx].Y);
                         if ((types[idx] & PathPointTypeCloseSubpath) != 0)
                             Append("h\n");
@@ -1421,10 +1413,13 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             _content.AppendFormat(CultureInfo.InvariantCulture, format, d);
         }
 
-        internal void AppendFormatPoint(string format, double x, double y)
+        private void AppendPathPoint(double x, double y, char operation, string format = Config.SignificantFigures4)
         {
             XPoint result = WorldToView(new XPoint(x, y));
-            _content.AppendFormat(CultureInfo.InvariantCulture, format, result.X, result.Y);
+            AppendPdfNumber(_content, result.X, format);
+            _content.Append(' ');
+            AppendPdfNumber(_content, result.Y, format);
+            _content.Append(' ').Append(operation).Append('\n');
         }
 
         internal void AppendFormatRect(string format, double x, double y, double width, double height)
@@ -1433,12 +1428,55 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             _content.AppendFormat(CultureInfo.InvariantCulture, format, point1.X, point1.Y, width, height);
         }
 
-        internal void AppendFormat3Points(string format, double x1, double y1, double x2, double y2, double x3, double y3)
+        private void AppendBezier(double x1, double y1, double x2, double y2, double x3, double y3,
+            string format = Config.SignificantFigures4)
         {
             XPoint point1 = WorldToView(new XPoint(x1, y1));
             XPoint point2 = WorldToView(new XPoint(x2, y2));
             XPoint point3 = WorldToView(new XPoint(x3, y3));
-            _content.AppendFormat(CultureInfo.InvariantCulture, format, point1.X, point1.Y, point2.X, point2.Y, point3.X, point3.Y);
+            AppendPdfNumber(_content, point1.X, format);
+            _content.Append(' ');
+            AppendPdfNumber(_content, point1.Y, format);
+            _content.Append(' ');
+            AppendPdfNumber(_content, point2.X, format);
+            _content.Append(' ');
+            AppendPdfNumber(_content, point2.Y, format);
+            _content.Append(' ');
+            AppendPdfNumber(_content, point3.X, format);
+            _content.Append(' ');
+            AppendPdfNumber(_content, point3.Y, format);
+            _content.Append(" c\n");
+        }
+
+        private void AppendMatrix(double x1, double y1, double x2, double y2, double x3, double y3)
+        {
+            XPoint point1 = WorldToView(new XPoint(x1, y1));
+            XPoint point2 = WorldToView(new XPoint(x2, y2));
+            XPoint point3 = WorldToView(new XPoint(x3, y3));
+            AppendPdfNumber(_content, point1.X, Config.SignificantFigures7);
+            _content.Append(' ');
+            AppendPdfNumber(_content, point1.Y, Config.SignificantFigures7);
+            _content.Append(' ');
+            AppendPdfNumber(_content, point2.X, Config.SignificantFigures7);
+            _content.Append(' ');
+            AppendPdfNumber(_content, point2.Y, Config.SignificantFigures7);
+            _content.Append(' ');
+            AppendPdfNumber(_content, point3.X, Config.SignificantFigures7);
+            _content.Append(' ');
+            AppendPdfNumber(_content, point3.Y, Config.SignificantFigures7);
+            _content.Append(" cm ");
+        }
+
+        internal static void AppendPdfNumber(StringBuilder content, double value, string format)
+        {
+            Span<char> buffer = stackalloc char[64];
+            if (value.TryFormat(buffer, out int written, format.AsSpan(), CultureInfo.InvariantCulture))
+            {
+                content.Append(buffer[..written]);
+                return;
+            }
+
+            content.Append(value.ToString(format, CultureInfo.InvariantCulture));
         }
 
         internal void AppendFormat(string format, XPoint point)
@@ -1559,10 +1597,8 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             // Save initial graphic state.
             SaveState();
             // Set page transformation.
-            const string format = Config.SignificantFigures7;
             double[] cm = DefaultViewMatrix.GetElements();
-            AppendFormat3Points("{0:" + format + "} {1:" + format + "} {2:" + format + "} {3:" + format + "} {4:" + format + "} {5:" + format + "} cm ",
-                cm[0], cm[1], cm[2], cm[3], cm[4], cm[5]);
+            AppendMatrix(cm[0], cm[1], cm[2], cm[3], cm[4], cm[5]);
         }
 
         /// <summary>

--- a/src/PeachPDF/PdfSharpCore/Drawing.Pdf/XGraphicsPdfRenderer.cs
+++ b/src/PeachPDF/PdfSharpCore/Drawing.Pdf/XGraphicsPdfRenderer.cs
@@ -418,7 +418,6 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             double lineSpace = font.GetHeight();
             double cyAscent = lineSpace * font.CellAscent / font.CellSpace;
             double cyDescent = lineSpace * font.CellDescent / font.CellSpace;
-            double width = _gfx.MeasureString(s, font, features).Width;
 
             //bool bold = (font.Style & XFontStyle.Bold) != 0;
             //bool italic = (font.Style & XFontStyle.Italic) != 0;
@@ -433,6 +432,10 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             // Merely reading the descriptor does not realize/embed the color font below.
             OpenTypeDescriptor descriptor = font.Descriptor;
             bool isColorFont = font.Unicode && descriptor.IsColorFont;
+            IReadOnlyList<ShapedGlyph>? colorGlyphs = isColorFont ? descriptor.Shape(s, features) : null;
+            double width = colorGlyphs is not null && CanMeasureAsSingleShapedRun(s)
+                ? MeasureShapedRunWidth(s, font, descriptor, colorGlyphs)
+                : _gfx.MeasureString(s, font, features).Width;
 
             if (!isColorFont)
                 Realize(font, brush, boldSimulation ? 2 : 0, letterSpacing);
@@ -509,7 +512,7 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
                 int paletteIndex = fontPalette?.BasePaletteIndex ?? 0;
                 var colorPainter = new ColorGlyphPainter(this, descriptor, font, brush, x, y,
                     letterSpacing, Gfx.PageDirection, paletteIndex, fontPalette?.Overrides);
-                colorPainter.Paint(s, features, logicalText);
+                colorPainter.Paint(s, colorGlyphs!, logicalText);
             }
             else
             {
@@ -631,6 +634,39 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
                     : y + strikeoutPosition - strikeoutSize;
                 DrawRectangle(null, brush, x, strikeoutRectY, width, strikeoutSize);
             }
+        }
+
+        private static bool CanMeasureAsSingleShapedRun(string text)
+        {
+            foreach (Rune rune in text.EnumerateRunes())
+            {
+                if (rune.Value < 32)
+                    return false;
+            }
+
+            return true;
+        }
+
+        private static double MeasureShapedRunWidth(string text, XFont font, OpenTypeDescriptor descriptor,
+            IReadOnlyList<ShapedGlyph> glyphs)
+        {
+            int designWidth = 0;
+            for (int i = 0; i < glyphs.Count; i++)
+            {
+                ShapedGlyph glyph = glyphs[i];
+                designWidth += (int)Math.Round(descriptor.GlyphIndexToWidth(glyph.GlyphIndex) + glyph.XAdvanceDelta);
+            }
+
+            double width = designWidth * font.Size / descriptor.UnitsPerEm;
+            if ((font.GlyphTypeface.StyleSimulations & XStyleSimulations.BoldSimulation) != 0)
+            {
+                int characterCount = 0;
+                foreach (Rune _ in text.EnumerateRunes())
+                    characterCount++;
+                width += characterCount * font.Size * Const.BoldEmphasis;
+            }
+
+            return width;
         }
 
         /// <summary>
@@ -1617,8 +1653,10 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
         {
             Debug.Assert(_streamMode == StreamMode.Text);
 
-            string value = PdfEncoders.ToHexStringLiteral(actualText, PdfStringEncoding.Unicode);
-            _content.Append($"/Span<</ActualText {value}>>BDC\n");
+            _content.Append("/Span<</ActualText <FEFF");
+            for (int i = 0; i < actualText.Length; i++)
+                AppendHexCodeUnit(actualText[i]);
+            _content.Append(">>>BDC\n");
         }
 
         /// <summary>Begins the shared rendering-mode-3 text object for one color-glyph run.</summary>
@@ -1652,11 +1690,21 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             XPoint pos = WorldToView(new XPoint(x, y));
             AdjustTdOffset(ref pos, 0, null);
 
-            byte[] bytes = PdfEncoders.RawUnicodeEncoding.GetBytes(((char)glyph.GlyphIndex).ToString());
-            bytes = PdfEncoders.FormatStringLiteral(bytes, true, false, true);
-            string glyphText = PdfEncoders.RawEncoding.GetString(bytes, 0, bytes.Length);
-            AppendFormatArgs("{0:" + Config.SignificantFigures4 + "} {1:" + Config.SignificantFigures4 + "} Td {2} Tj\n",
-                pos.X, pos.Y, glyphText);
+            _content.AppendFormat(CultureInfo.InvariantCulture, "{0:0.####} {1:0.####} Td <", pos.X, pos.Y);
+            AppendHexCodeUnit((char)glyph.GlyphIndex);
+            _content.Append("> Tj\n");
+        }
+
+        private static ReadOnlySpan<char> HexDigits => "0123456789ABCDEF";
+
+        private void AppendHexCodeUnit(char value)
+        {
+            Span<char> buffer = stackalloc char[4];
+            buffer[0] = HexDigits[(value >> 12) & 0xF];
+            buffer[1] = HexDigits[(value >> 8) & 0xF];
+            buffer[2] = HexDigits[(value >> 4) & 0xF];
+            buffer[3] = HexDigits[value & 0xF];
+            _content.Append(buffer);
         }
 
         /// <summary>

--- a/src/PeachPDF/PdfSharpCore/Drawing/CoreGraphicsPath.cs
+++ b/src/PeachPDF/PdfSharpCore/Drawing/CoreGraphicsPath.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace PeachPDF.PdfSharpCore.Drawing
 {
@@ -45,7 +46,16 @@ namespace PeachPDF.PdfSharpCore.Drawing
         const byte PathPointTypeCloseSubpath = 0x80;  // closed flag
 
         public CoreGraphicsPath()
-        { }
+        {
+            _points = new List<XPoint>();
+            _types = new List<byte>();
+        }
+
+        public CoreGraphicsPath(int capacity)
+        {
+            _points = new List<XPoint>(capacity);
+            _types = new List<byte>(capacity);
+        }
 
         public CoreGraphicsPath(CoreGraphicsPath path)
         {
@@ -316,7 +326,11 @@ namespace PeachPDF.PdfSharpCore.Drawing
         /// </summary>
         public byte[] PathTypes { get { return _types.ToArray(); } }
 
-        readonly List<XPoint> _points = new List<XPoint>();
-        readonly List<byte> _types = new List<byte>();
+        internal ReadOnlySpan<XPoint> PathPointsSpan => CollectionsMarshal.AsSpan(_points);
+
+        internal ReadOnlySpan<byte> PathTypesSpan => CollectionsMarshal.AsSpan(_types);
+
+        readonly List<XPoint> _points;
+        readonly List<byte> _types;
     }
 }

--- a/src/PeachPDF/PdfSharpCore/Drawing/XGraphicsPath.cs
+++ b/src/PeachPDF/PdfSharpCore/Drawing/XGraphicsPath.cs
@@ -45,6 +45,11 @@ namespace PeachPDF.PdfSharpCore.Drawing
             _corePath = new CoreGraphicsPath();
         }
 
+        internal XGraphicsPath(int pointCapacity)
+        {
+            _corePath = new CoreGraphicsPath(pointCapacity);
+        }
+
         /// <summary>
         /// Clones this instance.
         /// </summary>


### PR DESCRIPTION
Reduces CPU time and allocations across searchable/selectable COLR/CPAL glyph rendering, font subsetting, vector-path construction, and PDF serialization.

## Changes

- Reuse shaped glyph runs instead of shaping twice.
- Avoid sorting and per-glyph `StringBuilder` allocations for disjoint clusters.
- Write UTF-16 hex values using stack-allocated buffers.
- Return glyph data as `ReadOnlySpan<byte>` and copy directly into font subsets.
- Avoid unnecessary subset bookkeeping and temporary arrays.
- Format PDF path coordinates with stack-buffered `double.TryFormat`, avoiding boxing and composite formatting.
- Pre-size color-glyph path storage from decoded outlines.
- Pass path points and types to the renderer as read-only spans, eliminating per-path `ToArray()` copies.
- Add allocation, formatting, path-syntax, and ownership regression coverage.

## Performance

Initial searchable/selectable glyph optimizations:

- End-to-end color-glyph rendering: **9.9% faster**
- Ownership mapping allocations: **76% lower**
- Full-font subsetting allocations: **19% lower**
- UTF-16 hex serialization microbenchmark: **31% faster**

Follow-up vector-path optimizations, measured over 20 documents containing 100 Noto Color Emoji glyphs each:

| Metric | Before | After | Improvement |
|---|---:|---:|---:|
| Render allocations per document | 17.2 MB | 12.6 MB | **26.7% lower** |
| Total allocations per document | 21.0 MB | 16.4 MB | **21.8% lower** |
| Render time per document | ~21.0 ms | ~20.2 ms | **~4% faster** |

The generated PDF remained 756,801 bytes and was byte-identical after normalizing timestamps, random font-subset tags, and document IDs.

## Verification

- 10,548 net8.0 tests passed; 9 platform-specific tests skipped
- 97% diff coverage
- Full solution rebuild with zero warnings and errors
- Independent final code review found no issues