### PR TITLE
Add PackageLicenseExpression for Nuget

### DIFF
--- a/src/PeachPDF/PeachPDF.csproj
+++ b/src/PeachPDF/PeachPDF.csproj
@@ -7,6 +7,7 @@
 		<PackageIcon>peach.png</PackageIcon>
 		<PackageProjectUrl>https://peachpdf.net/</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/jhaygood86/PeachPDF.git</RepositoryUrl>
+		<PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
 		<IncludeSymbols>true</IncludeSymbols>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>


### PR DESCRIPTION
Without PackageLicenseExpression some security tools will reject the nuget package. No functional changes.