### PR TITLE
Write PDF content streams directly as bytes

### DIFF
--- a/.claude/invariants/fonts-composite-closure-does-not-move-the-shared-face-cursor.md
+++ b/.claude/invariants/fonts-composite-closure-does-not-move-the-shared-face-cursor.md
@@ -1,0 +1,10 @@
+# Composite glyph closure does not move the shared font-face cursor
+
+`OpenTypeFontface` instances are cached process-wide, and `Position` is one mutable cursor shared by all
+table readers. `GlyphDataTable.CompleteGlyphClosure` runs during PDF font subsetting while another render
+or xUnit class can shape text against the same face.
+
+Composite closure must parse the `ReadOnlySpan<byte>` returned by `GetGlyphData`; it must not seek or read
+through `OpenTypeFontface.Position`. Locking the glyph-table method does not coordinate with GSUB's
+font-face lock. The measured failure was simultaneous `IndexOutOfRangeException` crashes in full-font
+subsetting and SVG small-caps GSUB lookup on Ubuntu CI.

--- a/.claude/invariants/pdf-standard-fixed-format-is-not-custom-optional-decimal-format.md
+++ b/.claude/invariants/pdf-standard-fixed-format-is-not-custom-optional-decimal-format.md
@@ -1,0 +1,13 @@
+# Standard fixed-point formatting is not the PDF writer's custom format
+
+The PDF graphics writer historically formats coordinates with custom invariant patterns such as
+`0.####`. Do not replace that with `Utf8Formatter`'s `F4` output followed by trimming trailing zeroes.
+
+A randomized comparison found real finite coordinates where the last emitted decimal differed (for
+example, one path produced `-225163.6761824` with the custom format but `-225163.6761823` through the
+apparently equivalent fixed-point route). Both APIs ultimately perform decimal conversion, but their
+rounding paths are not interchangeable.
+
+Any numeric-writer optimization must compare against `double.ToString`/`TryFormat` using the exact
+existing custom format over boundary cases and a broad finite-value sample. PDF byte equivalence is the
+contract; visually indistinguishable coordinates are not sufficient.

--- a/.claude/recent-fixes/2026-09-10-font-subsetting-no-longer-races-shaping.md
+++ b/.claude/recent-fixes/2026-09-10-font-subsetting-no-longer-races-shaping.md
@@ -1,0 +1,18 @@
+# Font subsetting no longer races shaping
+
+`GlyphDataTable.CompleteGlyphClosure` used the process-wide cached `OpenTypeFontface.Position` cursor to
+read composite-glyph components. Its method-level synchronization locked the glyph table, not the font
+face, so it did not coordinate with GSUB readers that correctly lock the shared face.
+
+The full-font allocation test repeatedly subset Source Sans while an SVG small-caps test read that same
+cached face's GSUB table. On Ubuntu CI, their cursor writes interleaved: both tests failed with
+`IndexOutOfRangeException`, one in `CreateFontSubSet` and one in `GetActiveLookupIndices`. Adding bounds
+checks would only have changed the symptom.
+
+Composite closure now parses each glyph's existing `ReadOnlySpan<byte>` directly with big-endian span
+readers. It neither moves nor locks the shared cursor and removes the old synchronized-method overhead.
+A deterministic regression test verifies that closure leaves `OpenTypeFontface.Position` unchanged.
+
+The focused COLR/CPAL and SVG font-variant classes passed together (24 tests), followed by all 10,551
+runnable net8.0 tests. The complete branch retained 100% diff coverage, the solution rebuilt with zero
+warnings, and the independent diff review found no actionable issues.

--- a/.claude/recent-fixes/2026-09-10-pdf-content-streams-write-bytes-directly.md
+++ b/.claude/recent-fixes/2026-09-10-pdf-content-streams-write-bytes-directly.md
@@ -1,0 +1,36 @@
+# PDF content streams write raw bytes directly
+
+_Landed 2026-09-10._
+
+`XGraphicsPdfRenderer` formerly accumulated every page or form in a `StringBuilder`, materialized one
+large string at close, and raw-encoded that string into a new byte array. For a 100-emoji document this
+character pipeline remained the largest allocation source after path formatting stopped boxing its
+coordinates.
+
+The renderer now writes into `PdfContentWriter`, a chunked raw-byte accumulator. Small streams begin
+with a 256-byte chunk while larger streams grow to fixed 16 KiB chunks, avoiding both a large minimum
+allocation and large-object-heap growth copies. Existing composite-format call sites use one reusable
+scratch `StringBuilder`; path coordinates still use the exact invariant custom numeric format, then copy
+their stack-formatted characters directly into the byte chunks. Closing a renderer performs one
+exact-sized byte copy into the `PdfStream`, with no whole-content `char[]`, string, or encoding pass.
+
+A tempting direct UTF-8 fixed-point formatter was rejected after randomized equivalence testing found a
+last-decimal difference for ordinary coordinates: standard `F` formatting plus zero trimming is not
+identical to the existing `0.####` custom format.
+
+Against the preceding path-optimization commit, twenty 100-emoji documents reduced median render
+allocations from about 251.5 MB to 150.2 MB (40.3%, or 12.6 MB to 7.5 MB per document) and rendered about
+10% faster. Save allocations remained about 3.1 MB per document. The generated PDF size stayed 756,801
+bytes and its bytes matched after normalizing timestamps, random font-subset tags, and document IDs.
+A follow-up allocation trace measured `char[]`, `string`, and `StringBuilder` volume falling by roughly
+90%, 82%, and 91%, respectively; byte arrays rose as expected because they now are the primary content
+storage.
+
+The anonymous-box allocation ratio guard moved from 2.35x to 2.55x. The writer reduces the common plain
+block allocation slope more than the list-specific slope, moving the healthy ratio to 2.36x even though
+both document shapes allocate less; the known no-fast-path regression remains clearly separated at
+2.87x.
+
+Verification covered all 10,550 runnable net8.0 tests, 100% diff coverage across 146 changed production
+lines, and a full solution rebuild with zero warnings. The final independent diff review found no
+actionable issues.

--- a/src/PeachPDF.Tests/Integration/AnonymousBoxDefaultingTests.cs
+++ b/src/PeachPDF.Tests/Integration/AnonymousBoxDefaultingTests.cs
@@ -49,11 +49,12 @@ namespace PeachPDF.Tests.Integration
         private const int Large = 600;
 
         /// <summary>
-        /// Measured: <b>1.88x</b> with the fast path and <b>2.87x</b> without — repeatable to three
-        /// decimal places — so the bound sits between them with 25% of margin below and 18% above.
-        /// Stable both in isolation and with the whole suite running in parallel around it, but only
-        /// because the measurement is per-thread; see <see cref="MarginalKbPerItem"/> for what that is
-        /// guarding against.
+        /// Measured: <b>2.36x</b> with the fast path and direct byte content writer, and <b>2.87x</b>
+        /// without the fast path. Removing the renderer's common UTF-16 content buffer lowers the plain
+        /// block slope more than the list slope, so the ratio rose from its former 1.88x even though both
+        /// shapes allocate less. The bound remains between the working and regressed measurements.
+        /// The result is stable because the measurement is per-thread; see
+        /// <see cref="MarginalKbPerItem"/> for what that is guarding against.
         ///
         /// The item text is one character on purpose. The saving is a fixed cost per list item, so the
         /// longer the text the more font work dilutes it: at 200 items of a full sentence the same
@@ -64,7 +65,7 @@ namespace PeachPDF.Tests.Integration
         /// It is a ratchet, not a law — if a change makes lists legitimately dearer, move it in the
         /// same commit and say why.
         /// </summary>
-        private const double MaxListOverhead = 2.35;
+        private const double MaxListOverhead = 2.55;
 
         [Fact]
         public void AListItemCostsLittleMoreThanAPlainBlock()

--- a/src/PeachPDF.Tests/PdfSharpCore/Drawing.Pdf/PdfContentWriterTests.cs
+++ b/src/PeachPDF.Tests/PdfSharpCore/Drawing.Pdf/PdfContentWriterTests.cs
@@ -1,0 +1,213 @@
+using System.Globalization;
+using System.Text;
+using PeachPDF.PdfSharpCore.Drawing.Pdf;
+
+namespace PeachPDF.Tests.PdfSharpCoreTests.Drawing.Pdf
+{
+    public class PdfContentWriterTests
+    {
+        [Fact]
+        public void ConstructorsStartEmpty()
+        {
+            PdfContentWriter[] writers = [new PdfContentWriter(), new PdfContentWriter(17)];
+
+            foreach (PdfContentWriter writer in writers)
+            {
+                Assert.Equal(0, writer.Length);
+                Assert.Empty(writer.ToArray());
+                Assert.Equal(string.Empty, writer.ToString());
+            }
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void FixedChunkConstructorRejectsNonPositiveSize(int chunkSize)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new PdfContentWriter(chunkSize));
+        }
+
+        [Fact]
+        public void AppendCharWritesRawLowByteAndSupportsRepeatedAppends()
+        {
+            var content = new PdfContentWriter(2);
+
+            Assert.Same(content, content.Append('A'));
+            content.Append('\u0101');
+            content.Append('B');
+
+            Assert.Equal([(byte)'A', 0x01, (byte)'B'], content.ToArray());
+        }
+
+        [Fact]
+        public void AppendStringHandlesNullEmptyAndOrdinaryContent()
+        {
+            var content = new PdfContentWriter();
+            content.Append("before");
+            int length = content.Length;
+
+            Assert.Same(content, content.Append((string?)null));
+            Assert.Same(content, content.Append(string.Empty));
+            Assert.Equal(length, content.Length);
+
+            content.Append(" after");
+            Assert.Equal("before after", content.ToString());
+        }
+
+        [Fact]
+        public void AppendCharSpanHandlesEmptyExactFitAndMultiChunkInput()
+        {
+            var content = new PdfContentWriter(4);
+            content.Append('A');
+
+            Assert.Same(content, content.Append(ReadOnlySpan<char>.Empty));
+            content.Append("BCD".AsSpan());
+            Assert.Equal(4, content.Length);
+
+            content.Append("EFGHI".AsSpan());
+            Assert.Equal("ABCDEFGHI", content.ToString());
+        }
+
+        [Fact]
+        public void AppendByteSpanHandlesEmptyExactFitMultiChunkInputAndEveryByteValue()
+        {
+            var content = new PdfContentWriter(16);
+            var expected = new byte[256];
+            for (int i = 0; i < expected.Length; i++)
+                expected[i] = (byte)i;
+
+            Assert.Same(content, content.Append(ReadOnlySpan<byte>.Empty));
+            content.Append(expected.AsSpan(0, 1));
+            content.Append(expected.AsSpan(1, 15));
+            Assert.Equal(16, content.Length);
+
+            content.Append(expected.AsSpan(16));
+            Assert.Equal(expected, content.ToArray());
+        }
+
+        [Fact]
+        public void AppendFormatOverloadsUseProviderAndResetSharedBuffer()
+        {
+            CultureInfo originalCulture = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("nl-NL");
+                var content = new PdfContentWriter();
+                object?[] arguments = ["array", 1.25];
+
+                Assert.Same(content,
+                    content.AppendFormat(CultureInfo.InvariantCulture, "{0}:{1:0.00};", arguments));
+                Assert.Same(content,
+                    content.AppendFormat(CultureInfo.InvariantCulture, "{0:0.00};", 2.5));
+                Assert.Same(content,
+                    content.AppendFormat(CultureInfo.InvariantCulture, "{0}:{1:0.00};", "two", 3.5));
+                Assert.Same(content,
+                    content.AppendFormat(CultureInfo.InvariantCulture, "{0}:{1}:{2:0.00}", "three", "args", 4.5));
+
+                Assert.Equal("array:1.25;2.50;two:3.50;three:args:4.50", content.ToString());
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
+        }
+
+        [Fact]
+        public void AppendFormatCanCrossAdaptiveGrowthBoundaryInOneCall()
+        {
+            string value = new('x', 600);
+            var content = new PdfContentWriter();
+
+            content.AppendFormat(CultureInfo.InvariantCulture, "<{0}>", value);
+
+            Assert.Equal($"<{value}>", content.ToString());
+            Assert.Equal(602, content.Length);
+        }
+
+        [Fact]
+        public void AdaptiveChunksPreserveContentAcrossEveryGrowthBoundary()
+        {
+            int[] checkpoints = [255, 256, 1_279, 1_280, 5_375, 5_376, 21_759, 21_760, 38_143, 38_144, 38_145];
+            var content = new PdfContentWriter();
+            var expected = new StringBuilder(checkpoints[^1]);
+
+            foreach (int checkpoint in checkpoints)
+            {
+                while (expected.Length < checkpoint)
+                {
+                    char value = (char)('!' + expected.Length % 90);
+                    content.Append(value);
+                    expected.Append(value);
+                }
+
+                Assert.Equal(checkpoint, content.Length);
+            }
+
+            string expectedText = expected.ToString();
+            Assert.Equal(Encoding.ASCII.GetBytes(expectedText), content.ToArray());
+            Assert.Equal(expectedText, content.ToString());
+        }
+
+        [Fact]
+        public void ToStringPreservesHighByteValues()
+        {
+            var bytes = new byte[128];
+            for (int i = 0; i < bytes.Length; i++)
+                bytes[i] = (byte)(i + 0x80);
+
+            var content = new PdfContentWriter(17);
+            content.Append(bytes);
+
+            string text = content.ToString();
+            Assert.Equal(bytes.Length, text.Length);
+            for (int i = 0; i < bytes.Length; i++)
+                Assert.Equal((char)bytes[i], text[i]);
+        }
+
+        [Fact]
+        public void ClearResetsAdaptiveGrowthAndSupportsReuse()
+        {
+            var empty = new PdfContentWriter();
+            empty.Clear();
+            Assert.Equal(0, empty.Length);
+            Assert.Empty(empty.ToArray());
+            Assert.Equal(string.Empty, empty.ToString());
+
+            var content = new PdfContentWriter();
+            content.Append(new byte[6_000]);
+            content.Clear();
+
+            Assert.Equal(0, content.Length);
+            Assert.Empty(content.ToArray());
+            Assert.Equal(string.Empty, content.ToString());
+
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            content.Append('R');
+            long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+            Assert.True(allocated < 1_024,
+                $"The first chunk after Clear allocated {allocated:N0} bytes instead of resetting to 256 bytes.");
+
+            string reused = "Reused after growth " + new string('z', 300);
+            content.Append(reused.AsSpan(1));
+            Assert.Equal(reused, content.ToString());
+            Assert.Equal(Encoding.ASCII.GetBytes(reused), content.ToArray());
+            Assert.Equal(reused.Length, content.Length);
+        }
+
+        [Fact]
+        public void AppendMethodsSupportFluentChaining()
+        {
+            var content = new PdfContentWriter();
+
+            PdfContentWriter returned = content
+                .Append('A')
+                .Append("B")
+                .Append("C".AsSpan())
+                .Append([(byte)'D'])
+                .AppendFormat(CultureInfo.InvariantCulture, "{0}", "E");
+
+            Assert.Same(content, returned);
+            Assert.Equal("ABCDE", content.ToString());
+        }
+    }
+}

--- a/src/PeachPDF.Tests/PdfSharpCore/Drawing/XGraphicsTests.cs
+++ b/src/PeachPDF.Tests/PdfSharpCore/Drawing/XGraphicsTests.cs
@@ -222,22 +222,85 @@ namespace PeachPDF.Tests.PdfSharpCoreTests.Drawing
         [Fact]
         public void AppendPdfNumber_UsesAllocationFreeFastPathAndPreservesFallbackFormatting()
         {
-            var content = new StringBuilder(100_000);
+            var content = new PdfContentWriter(100_000);
+            content.Append('x');
             XGraphicsPdfRenderer.AppendPdfNumber(content, 1.23456, "0.####");
-            content.Clear();
 
             long before = GC.GetAllocatedBytesForCurrentThread();
             for (int i = 0; i < 10_000; i++)
                 XGraphicsPdfRenderer.AppendPdfNumber(content, 1.23456, "0.####");
             long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
 
-            Assert.Equal(string.Concat(Enumerable.Repeat("1.2346", 10_000)), content.ToString());
+            Assert.Equal("x1.2346" + string.Concat(Enumerable.Repeat("1.2346", 10_000)), content.ToString());
             Assert.True(allocated < 1_024,
                 $"Formatting 10,000 ordinary coordinates allocated {allocated:N0} bytes.");
 
+            var fallback = new PdfContentWriter();
+            XGraphicsPdfRenderer.AppendPdfNumber(fallback, double.MaxValue, "0.####");
+            Assert.Equal(double.MaxValue.ToString("0.####", CultureInfo.InvariantCulture), fallback.ToString());
+        }
+
+        [Fact]
+        public void AppendPdfNumber_MatchesInvariantCustomFormatting()
+        {
+            string[] formats = ["0.##", "0.###", "0.####", "0.#######", "0.##########"];
+            var expected = new StringBuilder();
+            var actual = new PdfContentWriter(128);
+            var random = new Random(42);
+
+            foreach (string format in formats)
+            {
+                double[] boundaryValues =
+                [
+                    -0.0,
+                    0,
+                    0.00004,
+                    0.00005,
+                    -0.00005,
+                    1.23445,
+                    1.23455,
+                    double.NaN,
+                    double.NegativeInfinity,
+                    double.PositiveInfinity,
+                ];
+                foreach (double value in boundaryValues)
+                    AppendExpectedAndActual(value, format);
+
+                for (int i = 0; i < 1_000; i++)
+                    AppendExpectedAndActual((random.NextDouble() - 0.5) * 1_000_000, format);
+            }
+
+            Assert.Equal(expected.ToString(), actual.ToString());
+
+            void AppendExpectedAndActual(double value, string format)
+            {
+                expected.Append(value.ToString(format, CultureInfo.InvariantCulture)).Append('\n');
+                XGraphicsPdfRenderer.AppendPdfNumber(actual, value, format);
+                actual.Append('\n');
+            }
+        }
+
+        [Fact]
+        public void PdfContentWriter_PreservesRawEncodingAcrossChunksAndFormatting()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new PdfContentWriter(0));
+
+            var content = new PdfContentWriter(4);
+            content.Append("AB").Append('\u0101').Append("CDEF".AsSpan());
+            content.Append([(byte)'G', 0xFE]);
+            content.AppendFormat(CultureInfo.InvariantCulture, " {0} {1:0.##}", "name", 1.234);
+            content.AppendFormat(CultureInfo.InvariantCulture, "{0}{1}{2}", "X", "Y", "Z");
+
+            Assert.Equal(
+                [(byte)'A', (byte)'B', 0x01, (byte)'C', (byte)'D', (byte)'E', (byte)'F',
+                    (byte)'G', 0xFE, (byte)' ', (byte)'n', (byte)'a', (byte)'m', (byte)'e',
+                    (byte)' ', (byte)'1', (byte)'.', (byte)'2', (byte)'3',
+                    (byte)'X', (byte)'Y', (byte)'Z'],
+                content.ToArray());
+
             content.Clear();
-            XGraphicsPdfRenderer.AppendPdfNumber(content, double.MaxValue, "0.####");
-            Assert.Equal(double.MaxValue.ToString("0.####", CultureInfo.InvariantCulture), content.ToString());
+            Assert.Equal(0, content.Length);
+            Assert.Empty(content.ToArray());
         }
 
         [Fact]

--- a/src/PeachPDF.Tests/PdfSharpCore/Drawing/XGraphicsTests.cs
+++ b/src/PeachPDF.Tests/PdfSharpCore/Drawing/XGraphicsTests.cs
@@ -281,49 +281,6 @@ namespace PeachPDF.Tests.PdfSharpCoreTests.Drawing
         }
 
         [Fact]
-        public void PdfContentWriter_PreservesRawEncodingAcrossChunksAndFormatting()
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new PdfContentWriter(0));
-
-            var content = new PdfContentWriter(4);
-            content.Append("AB").Append('\u0101').Append("CDEF".AsSpan());
-            content.Append([(byte)'G', 0xFE]);
-            content.AppendFormat(CultureInfo.InvariantCulture, " {0} {1:0.##}", "name", 1.234);
-            content.AppendFormat(CultureInfo.InvariantCulture, "{0}{1}{2}", "X", "Y", "Z");
-
-            Assert.Equal(
-                [(byte)'A', (byte)'B', 0x01, (byte)'C', (byte)'D', (byte)'E', (byte)'F',
-                    (byte)'G', 0xFE, (byte)' ', (byte)'n', (byte)'a', (byte)'m', (byte)'e',
-                    (byte)' ', (byte)'1', (byte)'.', (byte)'2', (byte)'3',
-                    (byte)'X', (byte)'Y', (byte)'Z'],
-                content.ToArray());
-
-            content.Clear();
-            Assert.Equal(0, content.Length);
-            Assert.Empty(content.ToArray());
-        }
-
-        [Fact]
-        public void PdfContentWriter_AdaptiveChunksPreserveContentAcrossGrowthBoundaries()
-        {
-            const int length = 25_000;
-            var content = new PdfContentWriter();
-            var expected = new StringBuilder(length);
-
-            for (int i = 0; i < length; i++)
-            {
-                char value = (char)('!' + i % 90);
-                content.Append(value);
-                expected.Append(value);
-            }
-
-            string expectedText = expected.ToString();
-            Assert.Equal(length, content.Length);
-            Assert.Equal(Encoding.ASCII.GetBytes(expectedText), content.ToArray());
-            Assert.Equal(expectedText, content.ToString());
-        }
-
-        [Fact]
         public void PresizedCoreGraphicsPath_DoesNotGrowOrCopyWhileBuilding()
         {
             var warmup = new CoreGraphicsPath(2);

--- a/src/PeachPDF.Tests/PdfSharpCore/Drawing/XGraphicsTests.cs
+++ b/src/PeachPDF.Tests/PdfSharpCore/Drawing/XGraphicsTests.cs
@@ -304,6 +304,26 @@ namespace PeachPDF.Tests.PdfSharpCoreTests.Drawing
         }
 
         [Fact]
+        public void PdfContentWriter_AdaptiveChunksPreserveContentAcrossGrowthBoundaries()
+        {
+            const int length = 25_000;
+            var content = new PdfContentWriter();
+            var expected = new StringBuilder(length);
+
+            for (int i = 0; i < length; i++)
+            {
+                char value = (char)('!' + i % 90);
+                content.Append(value);
+                expected.Append(value);
+            }
+
+            string expectedText = expected.ToString();
+            Assert.Equal(length, content.Length);
+            Assert.Equal(Encoding.ASCII.GetBytes(expectedText), content.ToArray());
+            Assert.Equal(expectedText, content.ToString());
+        }
+
+        [Fact]
         public void PresizedCoreGraphicsPath_DoesNotGrowOrCopyWhileBuilding()
         {
             var warmup = new CoreGraphicsPath(2);

--- a/src/PeachPDF.Tests/PdfSharpCore/Fonts/ColrCpalTableTests.cs
+++ b/src/PeachPDF.Tests/PdfSharpCore/Fonts/ColrCpalTableTests.cs
@@ -278,6 +278,30 @@ namespace PeachPDF.Tests.PdfSharpCoreTests.Fonts
                 + "byte array per glyph.");
         }
 
+        [Fact]
+        public void CompositeGlyphClosure_DoesNotMoveSharedFontCursor()
+        {
+            var bytes = File.ReadAllBytes(BundledFonts.Ttf);
+            var face = new OpenTypeFontface(XFontSource.CreateCompiledFont(bytes));
+            int compositeGlyph = -1;
+            for (int glyph = 0; glyph < face.maxp.numGlyphs; glyph++)
+            {
+                if (NumberOfContours(face.glyf.GetGlyphData(glyph)) < 0)
+                {
+                    compositeGlyph = glyph;
+                    break;
+                }
+            }
+
+            Assert.NotEqual(-1, compositeGlyph);
+            var selected = new Dictionary<int, object> { [compositeGlyph] = null! };
+            face.Position = 17;
+
+            face.glyf.CompleteGlyphClosure(selected);
+
+            Assert.Equal(17, face.Position);
+        }
+
         private static void AssertColor(CpalTable cpal, int entry, byte r, byte g, byte b, byte a)
         {
             Assert.True(cpal.TryGetColor(0, entry, out var color));

--- a/src/PeachPDF/Fonts/OpenType/GlyphDataTable.cs
+++ b/src/PeachPDF/Fonts/OpenType/GlyphDataTable.cs
@@ -30,6 +30,7 @@
 #nullable disable warnings
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 
 //using Fixed = System.Int32;
@@ -124,36 +125,35 @@ namespace PeachPDF.Fonts.OpenType
         /// <summary>
         /// If the specified glyph is a composite glyph add the glyphs it is made of to the glyph table.
         /// </summary>
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.Synchronized)]
         void AddCompositeGlyphs(Dictionary<int, object> glyphs, int glyph)
         {
-            //int start = fontData.loca.GetOffset(glyph);
-            int start = GetOffset(glyph);
-            // Has no contour?
-            if (start == GetOffset(glyph + 1))
+            ReadOnlySpan<byte> glyphData = GetGlyphData(glyph);
+            if (glyphData.IsEmpty)
                 return;
-            _fontData.Position = start;
-            int numContours = _fontData.ReadShort();
-            // Is not a composite glyph?
+
+            int numContours = BinaryPrimitives.ReadInt16BigEndian(glyphData);
             if (numContours >= 0)
                 return;
-            _fontData.SeekOffset(8);
+
+            int offset = 10;
             for (; ; )
             {
-                int flags = _fontData.ReadUFWord();
-                int cGlyph = _fontData.ReadUFWord();
+                int flags = BinaryPrimitives.ReadUInt16BigEndian(glyphData[offset..]);
+                int cGlyph = BinaryPrimitives.ReadUInt16BigEndian(glyphData[(offset + 2)..]);
+                offset += 4;
+
                 if (!glyphs.ContainsKey(cGlyph))
                     glyphs.Add(cGlyph, null);
                 if ((flags & MORE_COMPONENTS) == 0)
                     return;
-                int offset = (flags & ARG_1_AND_2_ARE_WORDS) == 0 ? 2 : 4;
+
+                offset += (flags & ARG_1_AND_2_ARE_WORDS) == 0 ? 2 : 4;
                 if ((flags & WE_HAVE_A_SCALE) != 0)
                     offset += 2;
                 else if ((flags & WE_HAVE_AN_X_AND_Y_SCALE) != 0)
                     offset += 4;
                 if ((flags & WE_HAVE_A_TWO_BY_TWO) != 0)
                     offset += 8;
-                _fontData.SeekOffset(offset);
             }
         }
 

--- a/src/PeachPDF/PdfSharpCore/Drawing.Pdf/PdfContentWriter.cs
+++ b/src/PeachPDF/PdfSharpCore/Drawing.Pdf/PdfContentWriter.cs
@@ -1,0 +1,229 @@
+#region PeachPDF - A .NET library for rendering HTML to PDF
+//
+// Accumulates PDF page/form content directly as raw bytes. PDF content operators
+// are ASCII, while encoded text strings use the same byte-to-char identity mapping
+// as PdfEncoders.RawEncoding.
+//
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using PeachPDF.PdfSharpCore.Pdf.Internal;
+
+namespace PeachPDF.PdfSharpCore.Drawing.Pdf
+{
+    internal sealed class PdfContentWriter
+    {
+        private const int InitialChunkSize = 256;
+        private const int DefaultChunkSize = 16 * 1024;
+
+        private readonly int _initialChunkSize;
+        private readonly int _maximumChunkSize;
+        private readonly List<byte[]> _completedChunks = [];
+        private StringBuilder? _formatBuffer;
+        private byte[]? _currentChunk;
+        private int _currentCount;
+        private int _length;
+        private int _nextChunkSize;
+
+        public PdfContentWriter()
+        {
+            _initialChunkSize = InitialChunkSize;
+            _maximumChunkSize = DefaultChunkSize;
+            _nextChunkSize = InitialChunkSize;
+        }
+
+        public PdfContentWriter(int chunkSize)
+        {
+            if (chunkSize <= 0)
+                throw new ArgumentOutOfRangeException(nameof(chunkSize));
+
+            _initialChunkSize = chunkSize;
+            _maximumChunkSize = chunkSize;
+            _nextChunkSize = chunkSize;
+        }
+
+        public int Length => _length;
+
+        public PdfContentWriter Append(char value)
+        {
+            EnsureCurrentChunk();
+            _currentChunk![_currentCount++] = (byte)value;
+            _length++;
+            return this;
+        }
+
+        public PdfContentWriter Append(string? value)
+        {
+            if (value is not null)
+                Append(value.AsSpan());
+            return this;
+        }
+
+        public PdfContentWriter Append(ReadOnlySpan<char> value)
+        {
+            while (!value.IsEmpty)
+            {
+                EnsureCurrentChunk();
+                int count = Math.Min(value.Length, _currentChunk!.Length - _currentCount);
+                Span<byte> destination = _currentChunk.AsSpan(_currentCount, count);
+                for (int i = 0; i < count; i++)
+                    destination[i] = (byte)value[i];
+
+                _currentCount += count;
+                _length += count;
+                value = value[count..];
+            }
+
+            return this;
+        }
+
+        public PdfContentWriter Append(ReadOnlySpan<byte> value)
+        {
+            while (!value.IsEmpty)
+            {
+                EnsureCurrentChunk();
+                int count = Math.Min(value.Length, _currentChunk!.Length - _currentCount);
+                value[..count].CopyTo(_currentChunk.AsSpan(_currentCount));
+                _currentCount += count;
+                _length += count;
+                value = value[count..];
+            }
+
+            return this;
+        }
+
+        public PdfContentWriter AppendFormat(IFormatProvider? provider, string format, params object?[] args)
+        {
+            StringBuilder buffer = PrepareFormatBuffer();
+            try
+            {
+                buffer.AppendFormat(provider, format, args);
+                AppendFormatBuffer(buffer);
+                return this;
+            }
+            finally
+            {
+                buffer.Clear();
+            }
+        }
+
+        public PdfContentWriter AppendFormat(IFormatProvider? provider, string format, object? arg0)
+        {
+            StringBuilder buffer = PrepareFormatBuffer();
+            try
+            {
+                buffer.AppendFormat(provider, format, arg0);
+                AppendFormatBuffer(buffer);
+                return this;
+            }
+            finally
+            {
+                buffer.Clear();
+            }
+        }
+
+        public PdfContentWriter AppendFormat(
+            IFormatProvider? provider,
+            string format,
+            object? arg0,
+            object? arg1)
+        {
+            StringBuilder buffer = PrepareFormatBuffer();
+            try
+            {
+                buffer.AppendFormat(provider, format, arg0, arg1);
+                AppendFormatBuffer(buffer);
+                return this;
+            }
+            finally
+            {
+                buffer.Clear();
+            }
+        }
+
+        public PdfContentWriter AppendFormat(
+            IFormatProvider? provider,
+            string format,
+            object? arg0,
+            object? arg1,
+            object? arg2)
+        {
+            StringBuilder buffer = PrepareFormatBuffer();
+            try
+            {
+                buffer.AppendFormat(provider, format, arg0, arg1, arg2);
+                AppendFormatBuffer(buffer);
+                return this;
+            }
+            finally
+            {
+                buffer.Clear();
+            }
+        }
+
+        public byte[] ToArray()
+        {
+            if (_length == 0)
+                return [];
+
+            var result = new byte[_length];
+            int offset = 0;
+            foreach (byte[] chunk in _completedChunks)
+            {
+                chunk.CopyTo(result, offset);
+                offset += chunk.Length;
+            }
+
+            if (_currentCount > 0)
+                _currentChunk!.AsSpan(0, _currentCount).CopyTo(result.AsSpan(offset));
+
+            return result;
+        }
+
+        public void Clear()
+        {
+            _completedChunks.Clear();
+            _currentChunk = null;
+            _currentCount = 0;
+            _length = 0;
+            _nextChunkSize = _initialChunkSize;
+            _formatBuffer?.Clear();
+        }
+
+        public override string ToString()
+            => PdfEncoders.RawEncoding.GetString(ToArray());
+
+        private void EnsureCurrentChunk()
+        {
+            if (_currentChunk is not null && _currentCount < _currentChunk.Length)
+                return;
+
+            if (_currentChunk is not null)
+                _completedChunks.Add(_currentChunk);
+
+            _currentChunk = new byte[_nextChunkSize];
+            _currentCount = 0;
+            if (_nextChunkSize < _maximumChunkSize)
+            {
+                _nextChunkSize = _nextChunkSize <= _maximumChunkSize / 4
+                    ? _nextChunkSize * 4
+                    : _maximumChunkSize;
+            }
+        }
+
+        private StringBuilder PrepareFormatBuffer()
+        {
+            _formatBuffer ??= new StringBuilder();
+            _formatBuffer.Clear();
+            return _formatBuffer;
+        }
+
+        private void AppendFormatBuffer(StringBuilder buffer)
+        {
+            foreach (ReadOnlyMemory<char> chunk in buffer.GetChunks())
+                Append(chunk.Span);
+        }
+    }
+}

--- a/src/PeachPDF/PdfSharpCore/Drawing.Pdf/XGraphicsPdfRenderer.cs
+++ b/src/PeachPDF/PdfSharpCore/Drawing.Pdf/XGraphicsPdfRenderer.cs
@@ -60,7 +60,7 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             _colorMode = page._document.Options.ColorMode;
             _options = options;
             _gfx = gfx;
-            _content = new StringBuilder();
+            _content = new PdfContentWriter();
             page.RenderContent._pdfRenderer = this;
             _gfxState = new PdfGraphicsState(this);
         }
@@ -70,7 +70,7 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             _form = form;
             _colorMode = form.Owner.Options.ColorMode;
             _gfx = gfx;
-            _content = new StringBuilder();
+            _content = new PdfContentWriter();
             form.PdfRenderer = this;
             _gfxState = new PdfGraphicsState(this);
         }
@@ -78,10 +78,10 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
         /// <summary>
         /// Gets the content created by this renderer.
         /// </summary>
-        string GetContent()
+        byte[] GetContent()
         {
             EndPage();
-            return _content.ToString();
+            return _content.ToArray();
         }
 
         public XGraphicsPdfPageOptions PageOptions
@@ -94,7 +94,8 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             if (_page != null)
             {
                 PdfContent content2 = _page.RenderContent;
-                content2.CreateStream(PdfEncoders.RawEncoding.GetBytes(GetContent()));
+                content2.CreateStream(GetContent());
+                _content.Clear();
 
                 _gfx = null;
                 _page.RenderContent._pdfRenderer = null;
@@ -103,7 +104,8 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             }
             else if (_form != null)
             {
-                _form._pdfForm.CreateStream(PdfEncoders.RawEncoding.GetBytes(GetContent()));
+                _form._pdfForm.CreateStream(GetContent());
+                _content.Clear();
                 _gfx = null;
                 _form.PdfRenderer = null;
                 _form = null;
@@ -1467,7 +1469,7 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             _content.Append(" cm ");
         }
 
-        internal static void AppendPdfNumber(StringBuilder content, double value, string format)
+        internal static void AppendPdfNumber(PdfContentWriter content, double value, string format)
         {
             Span<char> buffer = stackalloc char[64];
             if (value.TryFormat(buffer, out int written, format.AsSpan(), CultureInfo.InvariantCulture))
@@ -2173,7 +2175,7 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
         internal PdfColorMode _colorMode;
         XGraphicsPdfPageOptions _options;
         XGraphics _gfx;
-        readonly StringBuilder _content;
+        readonly PdfContentWriter _content;
 
         /// <summary>
         /// The q/Q nesting level is 0.


### PR DESCRIPTION
Replaces the intermediate UTF-16 content-stream buffer with a chunked byte writer, reducing allocations and CPU usage in graphics-heavy PDFs.

### Changes

- Write PDF operators directly to adaptive byte buffers.
- Grow content chunks from 256 bytes to a 16 KiB cap.
- Preserve byte-exact numeric formatting and raw-encoding behavior.
- Avoid intermediate `StringBuilder`, `string`, and encoding allocations.
- Parse composite glyph components directly from their source byte spans.
- Prevent font subsetting from moving the process-wide shared font cursor.
- Adjust the allocation regression threshold for the reduced plain-block baseline.

### Test coverage

- Add dedicated tests for the complete `PdfContentWriter` public surface.
- Verify both constructors and invalid chunk sizes.
- Cover every `Append` and `AppendFormat` overload.
- Cover null, empty, exact-fit, and multi-chunk inputs.
- Verify all raw byte values from `0x00` through `0xFF`.
- Verify invariant formatting and format-buffer reuse.
- Exercise every adaptive growth boundary through repeated 16 KiB chunks.
- Verify `Clear()` resets the growth schedule and supports byte-exact reuse.
- Add regression coverage proving composite glyph closure leaves the shared font cursor unchanged.

### Additional fix

Ubuntu CI exposed a race between font subsetting and GSUB shaping. Both operations could access the same process-wide cached `OpenTypeFontface`, while composite glyph closure moved its shared `Position` cursor without coordinating with GSUB's lock.

Composite glyph closure now parses its local `ReadOnlySpan<byte>` directly and no longer touches the shared cursor.

### Performance

- Render allocations: **12.6 MB → 7.5 MB/document** (**40.3% lower**)
- Render time: approximately **10% faster**
- `char[]` allocations: **~90% lower**
- `string` allocations: **~82% lower**
- `StringBuilder` allocations: **~91% lower**
- Generated PDF size and normalized bytes unchanged

### Verification

- **10,563 tests passed**, 9 skipped, 0 failed
- **100% diff coverage** across 154 changed production lines
- Full solution rebuild with zero warnings
- CI verified the font-subsetting fix across Windows, Ubuntu, and macOS
- Final code review found no issues