### PR TITLE
Presize TokenValue's list from the count it already has

### DIFF
--- a/.claude/recent-fixes/2026-09-10-tokenvalue-presizes-from-a-known-count.md
+++ b/.claude/recent-fixes/2026-09-10-tokenvalue-presizes-from-a-known-count.md
@@ -1,0 +1,55 @@
+# TokenValue presizes from a count it already has
+
+Pure performance. No behaviour change.
+
+## What was wrong
+
+`TokenValue`'s only sequence constructor took `IEnumerable<Token>` and did
+`new List<Token>(tokens)`. That overload presizes **only** when the source is an
+`ICollection<T>`. `IReadOnlyList<T>` is not one — and neither is `TokenValue` itself, which
+implements `IReadOnlyList<Token>` and stops there — so it enumerated the source and grew the
+backing array 4, 8, 16, 32…, reallocating and copying at every step, for a sequence whose length
+was known before the first element was read. It also allocated an interface enumerator to do it.
+
+Converters build one of these per declared value (`Original = new TokenValue(tokens)` appears at a
+dozen sites), and every one of them has `IReadOnlyList<Token>` as its static parameter type. So the
+slow path was not an edge case, it was the only path.
+
+## The change
+
+A second constructor taking `IReadOnlyList<Token>`, which presizes from `Count` and copies by
+index. Overload resolution picks it at every one of those call sites without touching them.
+
+## Evidence
+
+Sampled thread-time profiles of the engine rendering a 26-document corpus — 15 warm-up sweeps past
+the plateau, 4 cores, 60-second window, waiting threads excluded:
+
+| frame | before | after |
+| --- | ---: | ---: |
+| **`List<CSS.Token>..ctor(IEnumerable)`** | **7.29%** | **1.67%** |
+| `Enumerable.Select().ToArray()` | 5.12% | 5.08% |
+| `FcConfigSubstitute` | 2.67% | 2.65% |
+| `GraphicsAdapter.DrawString` | 4.39% | 4.40% |
+
+Roughly 5.6 percentage points of engine CPU, and 77% of that frame's own cost. Everything else is
+unchanged; frames whose share rose did so because the same work is a larger fraction of a smaller
+total.
+
+**Allocation barely moves** — 2,260 MB to 2,254 MB over the corpus, −0.3%. That is the point worth
+recording: the win here is enumeration and copying, not bytes. A token list is short, so growing it
+wastes little memory and a lot of time. An allocation profile would have ranked this near the
+bottom; it was the largest frame in a CPU profile.
+
+`BuildingFromAKnownLengthList_GrowsItsArrayOnlyOnce` is mutation-verified: with the overload
+removed the same 64-token build allocates 5,256 bytes against a 2,560-byte one-array floor, and the
+test fails naming that number.
+
+The test deliberately wraps its source so it exposes `IReadOnlyList<Token>` and nothing else. Handing
+it the `List<Token>` directly would let the general overload presize from `ICollection<T>` and the
+test would pass against unfixed code — the same trap that cost a first attempt at the GPOS
+enumerator test.
+
+- Full net8.0 suite: 10,576 passed, 9 skipped, 0 failed.
+- Corpus of 26 real documents renders byte-identically after normalisation.
+- Rebuild: 0 warnings, 0 errors.

--- a/src/PeachPDF.Tests/CSS/TokenValueCapacityTests.cs
+++ b/src/PeachPDF.Tests/CSS/TokenValueCapacityTests.cs
@@ -1,0 +1,96 @@
+namespace PeachPDF.Tests.CSS
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using PeachPDF.CSS;
+    using Xunit;
+
+    /// <summary>
+    /// Building a <see cref="TokenValue"/> from a list whose length is already known allocates one
+    /// backing array, not a succession of them.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>new List&lt;T&gt;(IEnumerable&lt;T&gt;)</c> presizes only when the source is an
+    /// <see cref="ICollection{T}"/>. <see cref="IReadOnlyList{T}"/> is not one, and neither is
+    /// <c>TokenValue</c> itself, so the general overload enumerated the source and grew its array
+    /// 4, 8, 16, 32... — reallocating and copying at every step, for a sequence whose length was
+    /// known before the first element was read.
+    /// </para>
+    /// <para>
+    /// Converters build one of these per declared value, which is why it showed up as the largest
+    /// single frame in a sampled CPU profile of the engine (7.29% of non-waiting work, down to
+    /// 1.67% with the presizing overload). The cost is mostly the enumeration and the copying, not
+    /// the bytes, so this asserts on allocation only because allocation is the part a test can pin
+    /// exactly and identically on every machine.
+    /// </para>
+    /// </remarks>
+    public class TokenValueCapacityTests
+    {
+        [Fact]
+        public void BuildingFromAKnownLengthList_GrowsItsArrayOnlyOnce()
+        {
+            var tokens = new List<Token>();
+            for (var i = 0; i < 64; i++)
+                tokens.Add(new Token(TokenType.Ident, $"t{i}".AsMemory(), TextPosition.Empty));
+
+            // Deliberately NOT the List<Token> itself: List<T> is an ICollection<T>, so the general
+            // overload would presize from it and this test would pass against unfixed code. The
+            // wrapper exposes only IReadOnlyList<Token>, which is the shape every converter actually
+            // hands over.
+            IReadOnlyList<Token> source = new ReadOnlyListOnly(tokens);
+
+            // Warm: JIT both the constructor and the token list before anything is counted.
+            for (var i = 0; i < 3; i++) _ = new TokenValue(source);
+
+            // Per THREAD, not process-wide: the suite runs collections in parallel, so
+            // GC.GetTotalAllocatedBytes would count every other test's work too. This body is
+            // synchronous and never awaits, so it stays on one thread throughout.
+            const int builds = 200;
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            for (var i = 0; i < builds; i++) _ = new TokenValue(source);
+            var allocated = (GC.GetAllocatedBytesForCurrentThread() - before) / builds;
+
+            // One Token[64] is the floor. Growing 4->8->16->32->64 instead allocates all five arrays
+            // plus a boxed enumerator, which is a little over twice that. The bound sits between the
+            // two rather than at either, so it states "grew once" without pinning the exact byte
+            // count of a Token or of List<T>'s header.
+            var oneArray = 64 * System.Runtime.CompilerServices.Unsafe.SizeOf<Token>();
+            Assert.True(allocated < oneArray * 3 / 2,
+                $"building a 64-token TokenValue allocated {allocated:N0} bytes, more than 1.5x the "
+                + $"{oneArray:N0} bytes one Token[64] needs. The backing array is being grown "
+                + "repeatedly, which means the constructor did not presize from the known count.");
+        }
+
+        [Fact]
+        public void BuildingFromAKnownLengthList_KeepsEveryTokenInOrder()
+        {
+            var tokens = new List<Token>
+            {
+                new(TokenType.Ident, "solid".AsMemory(), TextPosition.Empty),
+                new(TokenType.Whitespace, " ".AsMemory(), TextPosition.Empty),
+                new(TokenType.Ident, "red".AsMemory(), TextPosition.Empty),
+            };
+
+            var value = new TokenValue(new ReadOnlyListOnly(tokens));
+
+            Assert.Equal(tokens.Count, value.Count);
+            for (var i = 0; i < tokens.Count; i++)
+            {
+                Assert.Equal(tokens[i].Type, value[i].Type);
+                Assert.Equal(tokens[i].Data, value[i].Data);
+            }
+        }
+
+        /// <summary>Exposes a list as <see cref="IReadOnlyList{T}"/> and nothing more, so nothing
+        /// downstream can discover an <see cref="ICollection{T}"/> and presize by accident.</summary>
+        private sealed class ReadOnlyListOnly(IReadOnlyList<Token> inner) : IReadOnlyList<Token>
+        {
+            public Token this[int index] => inner[index];
+            public int Count => inner.Count;
+            public IEnumerator<Token> GetEnumerator() => inner.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+    }
+}

--- a/src/PeachPDF/CSS/Model/TokenValue.cs
+++ b/src/PeachPDF/CSS/Model/TokenValue.cs
@@ -28,6 +28,28 @@ namespace PeachPDF.CSS
             _tokens = new List<Token>(tokens);
         }
 
+        /// <summary>
+        /// The overload nearly every caller actually binds to, and the reason it exists is capacity.
+        /// </summary>
+        /// <remarks>
+        /// <c>new List&lt;T&gt;(IEnumerable&lt;T&gt;)</c> presizes only when the source is an
+        /// <see cref="ICollection{T}"/>. <see cref="IReadOnlyList{T}"/> is not one - and neither is
+        /// <see cref="TokenValue"/> itself - so the general overload enumerated and grew the backing
+        /// array 4, 8, 16, 32..., reallocating and copying at every step, for a sequence whose length
+        /// was known before the first element was read. Converters build one of these per declared
+        /// value, so it was the single largest frame in a sampled CPU profile of the engine.
+        /// Indexing rather than enumerating also skips the interface enumerator the general overload
+        /// would allocate.
+        /// </remarks>
+        public TokenValue(IReadOnlyList<Token> tokens)
+        {
+            _tokens = new List<Token>(tokens.Count);
+            for (var i = 0; i < tokens.Count; i++)
+            {
+                _tokens.Add(tokens[i]);
+            }
+        }
+
         public static TokenValue FromString(string text)
         {
             var token = new Token(TokenType.Ident, text.AsMemory(), TextPosition.Empty);


### PR DESCRIPTION
`TokenValue`'s only sequence constructor took `IEnumerable<Token>` and did `new List<Token>(tokens)`. That overload presizes **only** when the source is an `ICollection<T>`. `IReadOnlyList<T>` is not one — and neither is `TokenValue` itself, which implements `IReadOnlyList<Token>` and stops there — so it enumerated the source and grew the backing array 4, 8, 16, 32…, reallocating and copying at every step, for a sequence whose length was known before the first element was read. It allocated an interface enumerator to do it, too.

Converters build one of these per declared value — `Original = new TokenValue(tokens)` appears at a dozen sites — and every one of them has `IReadOnlyList<Token>` as its static parameter type. So the slow path wasn't an edge case, it was the only path.

## The change

A second constructor taking `IReadOnlyList<Token>`, presizing from `Count` and copying by index. Overload resolution picks it at every existing call site without touching them.

## Evidence

Sampled thread-time profiles of the engine rendering a 26-document corpus — 15 warm-up sweeps past the plateau, 4 cores, 60-second window, waiting threads excluded:

| frame | before | after |
| --- | ---: | ---: |
| **`List<CSS.Token>..ctor(IEnumerable)`** | **7.29%** | **1.67%** |
| `Enumerable.Select().ToArray()` | 5.12% | 5.08% |
| `FcConfigSubstitute` | 2.67% | 2.65% |
| `GraphicsAdapter.DrawString` | 4.39% | 4.40% |

About **5.6 percentage points of engine CPU**, and 77% of that frame's own cost. Everything else is unchanged; frames whose share rose did so because the same work is a larger fraction of a smaller total.

## Allocation barely moves, and that's the interesting part

**2,260 MB → 2,254 MB over the corpus, −0.3%.**

I'd rather state that than bury it: the win here is enumeration and copying, not bytes. A token list is short, so growing it wastes little memory and a lot of time. An allocation profile ranks this near the bottom — it was the largest single frame in a CPU profile.

That's also why I went looking with a CPU profile at all: a 13.4% allocation reduction across two earlier changes bought only ~3% throughput, which said allocation had stopped being the constraint.

## Tests

`BuildingFromAKnownLengthList_GrowsItsArrayOnlyOnce` is mutation-verified — with the overload removed, the same 64-token build allocates **5,256 bytes against a 2,560-byte one-array floor**, and the test fails naming that number.

It deliberately wraps its source so only `IReadOnlyList<Token>` is visible. Handing it the `List<Token>` directly would let the general overload presize from `ICollection<T>` and the test would pass against unfixed code — the same trap that cost a first attempt at the GPOS enumerator test in #968.

- Full net8.0 suite: **10,576 passed**, 9 skipped, 0 failed.
- Diff coverage: **100%** (5 of 5 coverable added lines).
- A 26-document corpus renders **byte-identically** after normalising `/CreationDate`, `/ID` and the random font subset tags.
- Rebuild: 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gBHScYW9yHeYbkuLwEUq2
