### PR TITLE
Ask fontconfig once per generic family, not once per document

### DIFF
--- a/.claude/recent-fixes/2026-09-10-fontconfig-is-asked-once-per-family.md
+++ b/.claude/recent-fixes/2026-09-10-fontconfig-is-asked-once-per-family.md
@@ -1,0 +1,66 @@
+# fontconfig is asked once per generic family, not once per document
+
+Pure performance. No behaviour change.
+
+## What was wrong
+
+`LinuxSystemFontResolver.ResolveGenericFamily` did a full fontconfig round trip on every call —
+`FcPatternCreate`, `FcPatternAddString`, `FcConfigSubstitute`, `FcDefaultSubstitute`, `FcFontMatch`,
+then marshalling the family name back out of native memory.
+
+It was called far more often than it looks. `PdfGenerator` holds its `PdfSharpAdapter` as an
+**instance** field, and that adapter's constructor resolves every generic family
+(`serif`/`sans-serif`/`monospace`/`cursive`/`fantasy`) plus `system-ui`. Callers construct a
+`PdfGenerator` per document, so rendering N documents made **7N identical native round trips**,
+every one of them returning the same answer.
+
+A sampled CPU profile put 2.67% of all non-waiting engine work in `FcConfigSubstitute` alone, with
+`FcFontMatch` on top of that, all under this one method.
+
+## Why caching is safe
+
+The answer cannot change while the process runs. `fcConfig` is a `Lazy<IntPtr>` over
+`FcInitLoadConfigAndFonts`, so fontconfig's configuration is loaded exactly once and every later
+query is asked of that same immutable config. A font installed mid-process would not be seen
+without a reload either way, so the cache changes no result — only how often the round trip is paid.
+
+The delegate handed to `GetOrAdd` is cached in a static field rather than written inline. A method
+group converted at the call site allocates a fresh delegate every call, which would have put back a
+per-call allocation while removing a per-call native round trip — the same trap #977 fixed for the
+GSUB/GPOS lookup caches.
+
+## Evidence
+
+Sampled thread-time profiles, 26-document corpus, 15 warm-up sweeps past the plateau, 4 cores,
+60-second window, waiting threads excluded:
+
+| frame | before | after |
+| --- | ---: | ---: |
+| **`FcConfigSubstitute`** | **2.67%** | **0.00%** |
+| `List<CSS.Token>..ctor(IEnumerable)` | 13.20% | 13.77% |
+| `Enumerable.Select().ToArray()` | 5.23% | 5.32% |
+| `GraphicsAdapter.DrawString` | 4.65% | 4.65% |
+
+Total work samples in the same window fell 140,082 to 136,329 — this is the first of these changes
+where the sampler saw measurably *less* work, rather than the same work redistributed.
+
+**Throughput, sustained rather than burst:** 45-second holds at concurrency 4 after a 15-sweep
+warm-up, interleaved, three reps each:
+
+| | docs/s |
+| --- | --- |
+| before | 92.97, 93.01, 92.30 |
+| after | **95.77, 95.62, 95.18** |
+
+**+2.85%**, winning every rep, with under 1% spread on each side. Worth recording that the
+instrument matters as much as the change: the burst probe used earlier in this work has a 10-15%
+run-to-run spread and could not have resolved this at all. A warmed, sustained hold can.
+
+`ResolveGenericFamily_OnLinux_AsksFontconfigOncePerFamily` asserts by **reference**, not equality:
+every uncached resolution marshals a fresh string out of native memory, so two uncached calls can be
+equal but never the same instance. `Assert.Equal` would pass against unfixed code. Mutation-verified
+— bypassing the cache fails it.
+
+- Full net8.0 suite: 10,582 passed, 9 skipped, 0 failed.
+- 26-document corpus: 26 pass / 0 review / 0 fail, byte-identical after normalisation.
+- Rebuild: 0 warnings, 0 errors.

--- a/src/PeachPDF.Tests/PdfSharpCore/LinuxSystemFontResolverTests.cs
+++ b/src/PeachPDF.Tests/PdfSharpCore/LinuxSystemFontResolverTests.cs
@@ -78,5 +78,37 @@ namespace PeachPDF.Tests.PdfSharpCoreTests
 
             Assert.False(string.IsNullOrWhiteSpace(resolved));
         }
+
+        /// <summary>
+        /// The fontconfig round trip happens once per family for the life of the process, not once per
+        /// caller.
+        /// </summary>
+        /// <remarks>
+        /// Asserted by reference, which is what makes it a real check: every uncached resolution
+        /// marshals a fresh <see cref="string"/> out of native memory, so two uncached calls can be
+        /// equal but can never be the same instance. <c>Assert.Equal</c> here would pass against
+        /// unfixed code and prove nothing.
+        /// <para>
+        /// It matters because <c>PdfGenerator</c> holds its <c>PdfSharpAdapter</c> as an instance
+        /// field and that constructor resolves every generic family plus <c>system-ui</c>, so a caller
+        /// rendering N documents used to make 7N identical native round trips.
+        /// </para>
+        /// </remarks>
+        [Fact]
+        public void ResolveGenericFamily_OnLinux_AsksFontconfigOncePerFamily()
+        {
+            if (!OperatingSystem.IsLinux() || OperatingSystem.IsAndroid()) return;
+
+            var first = LinuxSystemFontResolver.ResolveGenericFamily("sans-serif");
+
+            // Guards the guard: on a Linux host with no usable fontconfig the method returns null for
+            // every call, and Assert.Same(null, null) would pass without exercising anything. The
+            // sibling theory above already asserts this is non-null on a real Linux host.
+            Assert.NotNull(first);
+
+            var second = LinuxSystemFontResolver.ResolveGenericFamily("sans-serif");
+
+            Assert.Same(first, second);
+        }
     }
 }

--- a/src/PeachPDF/Fonts/LinuxSystemFontResolver.cs
+++ b/src/PeachPDF/Fonts/LinuxSystemFontResolver.cs
@@ -1,6 +1,7 @@
 #nullable disable warnings
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -28,6 +29,29 @@ namespace PeachPDF.Fonts
         [LibraryImport(libfontconfig)] private static partial IntPtr FcInitLoadConfigAndFonts();
 
         static readonly Lazy<IntPtr> fcConfig = new Lazy<IntPtr>(FcInitLoadConfigAndFonts);
+
+        /// <summary>
+        /// One fontconfig answer per generic family, for the life of the process.
+        /// </summary>
+        /// <remarks>
+        /// The answer cannot change while the process runs: <see cref="fcConfig"/> loads fontconfig's
+        /// configuration exactly once, so every later query is asked of the same immutable config and
+        /// returns the same family. Caching therefore changes no result, only how often the round trip
+        /// through native code is paid.
+        /// <para>
+        /// It was being paid a great deal. <c>PdfGenerator</c> holds its <c>PdfSharpAdapter</c> as an
+        /// instance field, that adapter's constructor resolves every generic family plus
+        /// <c>system-ui</c>, and callers construct a <c>PdfGenerator</c> per document - so a run of
+        /// N documents made 7N identical fontconfig round trips. A sampled CPU profile put 2.7% of all
+        /// engine work in <c>FcConfigSubstitute</c> and <c>FcFontMatch</c> under this one method.
+        /// </para>
+        /// </remarks>
+        static readonly ConcurrentDictionary<string, string?> GenericFamilyCache = new(StringComparer.Ordinal);
+
+        // Cached rather than written inline at the GetOrAdd call: a method-group conversion allocates a
+        // fresh delegate on every call, which would put back a per-call allocation while removing a
+        // per-call native round trip.
+        static readonly Func<string, string?> ResolveGenericFamilyUncachedDelegate = ResolveGenericFamilyUncached;
 
 
         [LibraryImport(libfontconfig)] public static partial FcPatternHandle FcPatternCreate();
@@ -169,7 +193,11 @@ namespace PeachPDF.Fonts
         /// Returns null if <c>libfontconfig.so.1</c> isn't available or resolution otherwise fails, so the
         /// caller can fall back to a reasonable hardcoded substitute.
         /// </summary>
-        public static string? ResolveGenericFamily(string genericFamily)
+        public static string? ResolveGenericFamily(string genericFamily) =>
+            GenericFamilyCache.GetOrAdd(genericFamily, ResolveGenericFamilyUncachedDelegate);
+
+        /// <inheritdoc cref="ResolveGenericFamily"/>
+        private static string? ResolveGenericFamilyUncached(string genericFamily)
         {
             try
             {


### PR DESCRIPTION
`LinuxSystemFontResolver.ResolveGenericFamily` did a full fontconfig round trip on every call — `FcPatternCreate`, `FcPatternAddString`, `FcConfigSubstitute`, `FcDefaultSubstitute`, `FcFontMatch`, then marshalling the family name back out of native memory.

It is called far more often than it looks. `PdfGenerator` holds its `PdfSharpAdapter` as an **instance** field, and that constructor resolves every generic family (`serif`/`sans-serif`/`monospace`/`cursive`/`fantasy`) plus `system-ui`. Callers construct a `PdfGenerator` per document, so rendering N documents made **7N identical native round trips**, every one returning the same answer.

A sampled CPU profile put **2.67% of all non-waiting engine work in `FcConfigSubstitute` alone**, with `FcFontMatch` on top, all under this one method.

## Why caching is safe

The answer cannot change while the process runs. `fcConfig` is a `Lazy<IntPtr>` over `FcInitLoadConfigAndFonts`, so fontconfig's configuration is loaded exactly once and every later query is asked of that same immutable config. A font installed mid-process would not be seen without a reload either way — so this changes no result, only how often the round trip is paid.

The delegate handed to `GetOrAdd` is cached in a static field rather than written inline. A method group converted at the call site allocates a fresh delegate on every call, which would put back a per-call allocation while removing a per-call native round trip — the same trap #977 fixed for the GSUB/GPOS lookup caches.

## Evidence

Sampled thread-time profiles, 26-document corpus, 15 warm-up sweeps past the plateau, 4 cores, 60-second window, waiting threads excluded:

| frame | before | after |
| --- | ---: | ---: |
| **`FcConfigSubstitute`** | **2.67%** | **0.00%** |
| `List<CSS.Token>..ctor(IEnumerable)` | 13.20% | 13.77% |
| `Enumerable.Select().ToArray()` | 5.23% | 5.32% |
| `GraphicsAdapter.DrawString` | 4.65% | 4.65% |

Total work samples in the same window fell **140,082 → 136,329** — the first change in this series where the sampler saw measurably *less* work, rather than the same work redistributed.

**Throughput — sustained, not burst.** 45-second holds at concurrency 4 after a 15-sweep warm-up, interleaved, three reps each:

| | docs/s |
| --- | --- |
| before | 92.97, 93.01, 92.30 |
| after | **95.77, 95.62, 95.18** |

**+2.85%**, winning every rep, with under 1% spread on each side.

Worth saying that the instrument mattered as much as the change here: a burst probe has a 10–15% run-to-run spread and could not have resolved this at all. A warmed, sustained hold can, which is why this PR quotes a throughput number where an earlier one of mine deliberately refused to.

## Tests

`ResolveGenericFamily_OnLinux_AsksFontconfigOncePerFamily` asserts by **reference**, not equality — every uncached resolution marshals a fresh string out of native memory, so two uncached calls can be equal but never the same instance. `Assert.Equal` would pass against unfixed code and prove nothing. It also asserts the first result is non-null before comparing, so it cannot pass vacuously on a host where fontconfig returns null for everything.

Mutation-verified: bypassing the cache fails it.

- Full net8.0 suite: **10,582 passed**, 9 skipped, 0 failed.
- 26-document corpus: **26 pass / 0 review / 0 fail**, byte-identical after normalisation.
- Rebuild: 0 warnings, 0 errors.

(The file is `[ExcludeFromCodeCoverage]` — it is Linux-only P/Invoke, so its lines never execute on the Windows and macOS CI legs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gBHScYW9yHeYbkuLwEUq2
