### PR TITLE
Fix missing IsEmpty guard on fill/stroke constant-alpha dedup

### DIFF
--- a/.claude/recent-fixes/2026-09-10-fill-and-stroke-alpha-empty-guard.md
+++ b/.claude/recent-fixes/2026-09-10-fill-and-stroke-alpha-empty-guard.md
@@ -1,0 +1,63 @@
+# Fill/stroke constant-alpha dedup missing an IsEmpty guard
+
+## The load-bearing idea
+
+`PdfGraphicsState.RealizeFillColor` (`src/PeachPDF/PdfSharpCore/Drawing.Pdf/PdfGraphicsState.cs`)
+tracks the last-emitted fill color in `_realizedFillColor` to dedup `rg`/`ca` writes to the content
+stream. The RGB-change check already guarded against `_realizedFillColor` being `XColor.Empty` (the
+field's default, and what `RealizeBrush`'s gradient-pattern branch explicitly resets it to after a
+`/Pattern cs` switch) with `_realizedFillColor.IsEmpty || _realizedFillColor.Rgb != color.Rgb`. The
+alpha-change check three lines below it did not: `_realizedFillColor.A != color.A` alone. Since
+`XColor.Empty.A == 0`, a fill whose own alpha is genuinely `0` right after such a reset evaluated
+`0 != 0` as `false` and silently skipped emitting `/ca`, leaving the shape painted at whatever alpha
+the enclosing graphics state had (typically fully opaque) instead of invisible. Found via independent
+dual-renderer (PDFium + MuPDF) rasterization verification of #997 ("Draw color-glyph artwork once into
+a Form XObject") - a separate, pre-existing bug unrelated to that PR's own COLR paint-alpha fix (see
+that PR's own merged migration note on COLR paint alpha for the distinct, already-fixed issue it
+covers).
+
+Fixed by adding the same `IsEmpty` guard to the alpha check.
+
+## What was found by running it, not by reading it
+
+A post-change review pass (3 finder agents) independently converged on a second, unfixed instance of
+the identical defect: `RealizePen`'s stroke-alpha check (same file, `~line 229`) has the exact same
+shape - `_realizedStrokeColor.A != strokeAlpha` with no `IsEmpty` guard - even though its own sibling
+RGB check a few lines above (`~line 205`) already carries the guard, with a comment explicitly citing
+the fill side as precedent. `_realizedStrokeColor` starts at `XColor.Empty` and is reset to it after
+any brush/pattern stroke (`~line 247`), so a solid zero-alpha stroke (CSS/SVG `stroke-opacity: 0`) as
+the first stroke in a fresh state, or right after a gradient-stroked shape, hit the same silent-opaque
+bug on `/CA` instead of `/ca`. Fixed in the same change once confirmed reachable and reproduced by a
+regression test (reverting just the stroke guard made the new stroke test fail, confirming it isn't a
+false positive).
+
+The regression tests also went through one revision after review: the first version asserted `/ca 0`
+as a substring of the whole saved PDF, which - per this repo's own testing convention about
+content-stream-substring tests being weak proof for transparency-group correctness - could pass even
+if the emitted ExtGState were never actually wired to the draw via `gs`. Replaced with a helper
+(`AssertConstantAlphaAppliedBeforeOperator`) that finds the `gs` immediately preceding the `f`/`S`
+paint operator in the (decompressed) content stream, resolves that resource name to its indirect
+`ExtGState` object, and asserts the specific `/ca`/`/CA` key there - proving the ExtGState is both
+emitted and actually applied to the draw, not just present somewhere in the file.
+
+## Deliberately not done
+
+Manual dual-renderer (PDFium + MuPDF) visual verification was done ad hoc against a scratch PDF (an
+opaque blue background box behind a CSS `opacity` tile containing an SVG rect with `fill-opacity: 0`
+as the tile's first-ever fill), confirming both renderers agreed: pre-fix the transparent overlay
+washed the blue background to near-white (opaque, wrong color due to an unrelated fill-color-resolution
+quirk on zero-alpha SVG fills - not investigated further, out of scope for this fix since it doesn't
+affect alpha correctness), post-fix the blue background showed through correctly. That scratch
+repro was not committed as a test - the structural content-stream assertions above are the committed
+regression coverage, chosen because this bug is about PDF content-stream emission logic itself, not a
+paint/layout call-sequence or a genuinely visual compositing feature, so a structural assertion (this
+repo's testing conventions call it out as an acceptable alternative to rasterization) is proportionate.
+
+## Evidence
+
+Full net8.0 suite: 10200 passed / 0 failed / 9 skipped (pre-existing platform-specific skips). Diff
+coverage 100% (gate is 90%) against `main` on both changed lines. Zero-warning
+`dotnet build PeachPDF.slnx -t:Rebuild`. Both regression tests independently confirmed to fail when
+their respective `IsEmpty` guard is reverted (fill and stroke checked separately). Manual dual-renderer
+(PDFium + MuPDF) rasterization of a scratch repro confirmed the visual defect and its fix agree across
+both engines.

--- a/src/PeachPDF.Tests/PdfSharpCore/Drawing/XGraphicsTests.cs
+++ b/src/PeachPDF.Tests/PdfSharpCore/Drawing/XGraphicsTests.cs
@@ -1,3 +1,6 @@
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
 using PeachPDF.PdfSharpCore.Drawing;
 using PeachPDF.PdfSharpCore.Pdf;
 using PeachPDF.PdfSharpCore.Utils;
@@ -319,6 +322,91 @@ namespace PeachPDF.Tests.PdfSharpCoreTests.Drawing
             document.Save(stream);
 
             Assert.True(stream.Length > 0);
+        }
+
+        [Fact]
+        public void DrawRectangle_ZeroAlphaBrushAsFirstFillAfterStateReset_EmitsConstantAlphaExtGState()
+        {
+            // Regression test: PdfGraphicsState's fill-alpha tracking field (_realizedFillColor)
+            // starts out as XColor.Empty (A == 0) both on a freshly constructed renderer and right
+            // after a q/Save() that hasn't realized any fill color yet. RealizeFillColor's alpha-change
+            // check used to compare _realizedFillColor.A != color.A with no IsEmpty guard - so a first
+            // fill whose own alpha is genuinely 0 evaluated "0 != 0" as false and silently skipped
+            // emitting /ca, leaving the shape painted at whatever alpha the enclosing state had
+            // (typically fully opaque) instead of invisible.
+            var (document, page) = NewPage();
+            document.Options.CompressContentStreams = false;
+
+            using (var gfx = XGraphics.FromPdfPage(page))
+            {
+                var state = gfx.Save();
+                var brush = new XSolidBrush(XColor.FromArgb(0, 255, 0, 0));
+                gfx.DrawRectangle(brush, 10, 10, 20, 20);
+                gfx.Restore(state);
+            }
+
+            var pdfText = Save(document);
+            var contentStream = FirstContentStream(pdfText);
+
+            // Structural/adjacency assertion rather than a bare substring check (see CLAUDE.md's
+            // testing conventions): confirm the "gs" that switches on the constant-alpha ExtGState is
+            // the one immediately preceding this fill's "f" operator, then resolve that resource to its
+            // ExtGState object and confirm it actually declares "/ca 0" - not just that "/ca 0" occurs
+            // somewhere in the file.
+            AssertConstantAlphaAppliedBeforeOperator(pdfText, contentStream, "f", "ca", 0);
+        }
+
+        [Fact]
+        public void DrawLine_ZeroAlphaPenAsFirstStrokeAfterStateReset_EmitsConstantAlphaExtGState()
+        {
+            // Stroke-side twin of DrawRectangle_ZeroAlphaBrushAsFirstFillAfterStateReset_EmitsConstantAlphaExtGState:
+            // RealizePen's alpha-change check has the same _realizedStrokeColor.A != strokeAlpha
+            // comparison, with the same missing-IsEmpty-guard defect for a fresh/reset
+            // _realizedStrokeColor (== XColor.Empty, A == 0).
+            var (document, page) = NewPage();
+            document.Options.CompressContentStreams = false;
+
+            using (var gfx = XGraphics.FromPdfPage(page))
+            {
+                var state = gfx.Save();
+                var pen = new XPen(XColor.FromArgb(0, 0, 0, 0), 2);
+                gfx.DrawLine(pen, 10, 10, 30, 30);
+                gfx.Restore(state);
+            }
+
+            var pdfText = Save(document);
+            var contentStream = FirstContentStream(pdfText);
+
+            AssertConstantAlphaAppliedBeforeOperator(pdfText, contentStream, "S", "CA", 0);
+        }
+
+        static string Save(PdfDocument document)
+        {
+            using var stream = new MemoryStream();
+            document.Save(stream);
+            return Encoding.Latin1.GetString(stream.ToArray());
+        }
+
+        static string FirstContentStream(string pdfText)
+        {
+            var match = Regex.Match(pdfText, @"stream\r?\n(.*?)\r?\nendstream", RegexOptions.Singleline);
+            Assert.True(match.Success, "No content stream found in generated PDF.");
+            return match.Groups[1].Value;
+        }
+
+        static void AssertConstantAlphaAppliedBeforeOperator(string pdfText, string contentStream, string paintOperator, string alphaKey, double expectedAlpha)
+        {
+            var adjacency = Regex.Match(contentStream, $@"/(GS\d+) gs\r?\n(?:[^\r\n]*\r?\n)*?{paintOperator}\b");
+            Assert.True(adjacency.Success,
+                $"Expected a constant-alpha ExtGState \"gs\" immediately before the \"{paintOperator}\" operator.");
+
+            var gsResourceName = "/" + adjacency.Groups[1].Value;
+            var resourceRef = Regex.Match(pdfText, Regex.Escape(gsResourceName) + @"\s+(\d+)\s+0\s+R");
+            Assert.True(resourceRef.Success, $"Could not resolve {gsResourceName} to an indirect object.");
+
+            var extGStateObject = Regex.Match(pdfText, resourceRef.Groups[1].Value + @" 0 obj.*?endobj", RegexOptions.Singleline);
+            Assert.True(extGStateObject.Success, $"Could not find the ExtGState object referenced by {gsResourceName}.");
+            Assert.Matches(new Regex($@"/{alphaKey} {Regex.Escape(expectedAlpha.ToString(System.Globalization.CultureInfo.InvariantCulture))}\b"), extGStateObject.Value);
         }
     }
 }

--- a/src/PeachPDF/PdfSharpCore/Drawing.Pdf/PdfGraphicsState.cs
+++ b/src/PeachPDF/PdfSharpCore/Drawing.Pdf/PdfGraphicsState.cs
@@ -226,8 +226,14 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
             // 0 (e.g. right after any opaque solid stroke).
             double strokeAlpha = pen.Brush != null ? 1.0 : color.A;
 
-            if (_renderer.Owner.Version >= 14 && (_realizedStrokeColor.A != strokeAlpha || _realizedStrokeOverPrint != overPrint))
+            if (_renderer.Owner.Version >= 14 && (_realizedStrokeColor.IsEmpty || _realizedStrokeColor.A != strokeAlpha || _realizedStrokeOverPrint != overPrint))
             {
+                // The IsEmpty guard mirrors RealizeFillColor's identical fix: a fresh PdfGraphicsState,
+                // or right after a brush stroke resets _realizedStrokeColor to Empty (line 247 below),
+                // starts with A == 0. Without this guard, a solid stroke whose own alpha is genuinely 0
+                // right after such a reset evaluates "0 != 0" as false and skips emitting /CA, leaving
+                // the stroke at whatever alpha the enclosing graphics state had instead of invisible.
+                //
                 // Must create transparency group - checked before any object/resource is built, so a
                 // PDF/A-1 rejection never leaves a partially-built ExtGState behind.
                 if (strokeAlpha < 1)
@@ -340,8 +346,15 @@ namespace PeachPDF.PdfSharpCore.Drawing.Pdf
                 }
             }
 
-            if (_renderer.Owner.Version >= 14 && (_realizedFillColor.A != color.A || _realizedNonStrokeOverPrint != overPrint))
+            if (_renderer.Owner.Version >= 14 && (_realizedFillColor.IsEmpty || _realizedFillColor.A != color.A || _realizedNonStrokeOverPrint != overPrint))
             {
+                // The IsEmpty guard mirrors the RGB-change check above: a fresh PdfGraphicsState (new
+                // renderer/form, or right after RealizeBrush's gradient-pattern branch invalidates the
+                // fill color) starts with _realizedFillColor == XColor.Empty, whose A is 0. Without this
+                // guard, a fill whose own alpha is genuinely 0 right after such a reset evaluates
+                // "0 != 0" as false and skips emitting /ca, leaving the PDF's actual alpha at whatever
+                // the enclosing graphics state had (often opaque) instead of fully transparent.
+                //
                 // Must create transparency group - checked before any object/resource is built, so a
                 // PDF/A-1 rejection never leaves a partially-built ExtGState behind.
                 if (color.A < 1)


### PR DESCRIPTION
## Summary
- `PdfGraphicsState.RealizeFillColor`'s alpha-change check compared `_realizedFillColor.A != color.A` with no guard for `_realizedFillColor` being `XColor.Empty` (A == 0), unlike the adjacent RGB-change check a few lines above it. A fill whose own alpha is genuinely 0 right after a fresh graphics state (or a gradient-pattern reset) evaluated `0 != 0` as `false` and silently skipped emitting `/ca`, leaving the shape opaque instead of invisible.
- `RealizePen` had the identical gap on the stroke side (`/CA`).
- Both now carry the same `IsEmpty` guard the RGB-change checks already had.

## Test plan
- [x] Added `DrawRectangle_ZeroAlphaBrushAsFirstFillAfterStateReset_EmitsConstantAlphaExtGState` and `DrawLine_ZeroAlphaPenAsFirstStrokeAfterStateReset_EmitsConstantAlphaExtGState` — each asserts the emitted ExtGState is actually applied immediately before the paint operator (not just present somewhere in the file), and resolves it to its indirect object to check the specific `/ca`/`/CA` value.
- [x] Confirmed both tests fail when their respective `IsEmpty` guard is reverted.
- [x] Full `dotnet test --framework net8.0`: 10200 passed, 0 failed, 9 pre-existing skips.
- [x] Diff coverage 100% (gate is 90%).
- [x] `dotnet build PeachPDF.slnx -t:Rebuild`: 0 warnings.
- [x] Manual dual-renderer (PDFium + MuPDF) rasterization of a scratch repro confirmed the visual defect and fix agree across both engines.