### PR TITLE
Scope System.IO.Pipelines package reference to net8.0

### DIFF
--- a/src/PeachPDF/PeachPDF.csproj
+++ b/src/PeachPDF/PeachPDF.csproj
@@ -35,7 +35,12 @@
 	<ItemGroup>
 		<PackageReference Include="DefaultDocumentation" Version="1.2.5" PrivateAssets="all" IncludeAssets="build" />
 		<PackageReference Include="MimeKit" Version="4.17.0" />
-		<PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
+		<!--
+			System.IO.Pipelines ships as part of the net10.0+ shared-framework reference assemblies
+			(Microsoft.NETCore.App.Ref), but not net8.0's - only net8.0 needs the standalone package
+			to resolve PipeReader in CSS/Model/CssStreamLoader.cs.
+		-->
+		<PackageReference Include="System.IO.Pipelines" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
 	</ItemGroup>
 	<!--
 		Raster image decode/encode (PdfSharpCore/Utils/PeachImageSource.cs). Replaced


### PR DESCRIPTION
## Summary
- The `System.IO.Pipelines` NuGet package (used by `PipeReader` in [CssStreamLoader.cs](src/PeachPDF/CSS/Model/CssStreamLoader.cs)) is only required on net8.0 - net10.0+ ship it as part of the `Microsoft.NETCore.App.Ref` shared-framework reference assemblies, confirmed by inspecting the installed ref packs (net8.0's `ref/net8.0/` has no `System.IO.Pipelines.dll`; net10.0/net11.0's do).
- Adds a `Condition="'$(TargetFramework)' == 'net8.0'"` to the `PackageReference` so it's only pulled in where it's actually needed.

## Test plan
- [x] `dotnet build PeachPDF.slnx -t:Rebuild` - all three target frameworks (net8.0, net10.0, net11.0) build with 0 warnings/errors
- [x] `dotnet test PeachPDF.Tests/PeachPDF.Tests.csproj --framework net8.0` - 10762 passed, 9 skipped, 0 failed