### PR TITLE
Bump PackageVersion to 0.9.18

### DIFF
--- a/src/PeachPDF/PeachPDF.csproj
+++ b/src/PeachPDF/PeachPDF.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<AssemblyName>PeachPDF</AssemblyName>
 		<PackageId>PeachPDF</PackageId>
-		<PackageVersion>0.9.17</PackageVersion>
+		<PackageVersion>0.9.18</PackageVersion>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageIcon>peach.png</PackageIcon>
 		<PackageProjectUrl>https://peachpdf.net/</PackageProjectUrl>


### PR DESCRIPTION
## Summary
- Bumps `PackageVersion` in `src/PeachPDF/PeachPDF.csproj` from 0.9.17 to 0.9.18 ahead of the next release.
- No functional changes — release-mechanics-only bump. The `publish.yml` workflow reads this to tag, cut the GitHub release, and push the NuGet package.

## Test plan
- [x] Full solution builds clean in Release with zero warnings.