### PR TITLE
Fix nested composite glyph subsetting

### DIFF
--- a/.claude/migration-notes/2026-09-11-nested-composite-diacritics-now-embed-correctly.md
+++ b/.claude/migration-notes/2026-09-11-nested-composite-diacritics-now-embed-correctly.md
@@ -1,0 +1,13 @@
+# Diacritics on nested-composite glyphs now embed correctly
+
+Previously (through the released v0.9.18): a font whose accented glyphs were authored as nested
+composites - a precomposed letter referencing a base letter plus a mark glyph, where that mark glyph is
+itself composite (common in large fonts that merge many scripts, e.g. Go Noto CJKCore) - would embed the
+mark's wrapper glyph but not the wrapper's own component, the mark's actual outline. The generated PDF
+rendered the base letter with no diacritic, even though the underlying text (and copy-paste via
+ToUnicode) was correct.
+
+Now: font subsetting resolves composite-glyph components transitively, at any nesting depth, so the
+diacritic mark's real outline is always included in the embedded subset and renders as authored. No
+document author action is needed; this only affects the specific class of fonts described above -
+fonts whose accented glyphs are simple glyphs, or single-level composites, were unaffected either way.

--- a/.claude/recent-fixes/2026-09-11-nested-composite-glyph-closure-in-font-subsets.md
+++ b/.claude/recent-fixes/2026-09-11-nested-composite-glyph-closure-in-font-subsets.md
@@ -1,0 +1,28 @@
+# Nested composite glyphs no longer lose components in font subsets
+
+`GlyphDataTable.CompleteGlyphClosure` decides which glyphs a PDF font subset must embed. It snapshotted
+the originally-requested glyph set and made one flat pass adding each glyph's direct composite
+components. A component that is itself composite never got its own components added, so a two-level
+nested composite silently dropped its innermost glyph from the embedded subset.
+
+Real fonts hit this for precomposed accented letters shaped as base + mark, where the mark is itself a
+composite wrapping the actual diacritic outline (issue #1009's reporter hit it with `Go Noto CJKCore`:
+`aacute` → `[a, glyph00814]`, and `glyph00814` → `[acute]`). The wrapper glyph index made it into the
+subset, so nothing threw - it just drew nothing, leaving the base letter rendered and the diacritic mark
+silently missing, while cmap/ToUnicode-driven copy-paste stayed correct. `SourceSans3-Regular.ttf`
+(`BundledFonts.Ttf`) reproduces the same two-level shape for real for `U+1EA0` ("Ạ"): `uni1EA0` → `[A,
+uni0323]`, `uni0323` → `[uni0307]`.
+
+Fix: `CompleteGlyphClosure` now drains a worklist queue instead of one fixed-size pass - each
+newly-discovered component glyph is enqueued so its own components get resolved in turn, closing the set
+transitively regardless of nesting depth. Still reads each glyph only through `GetGlyphData`'s
+`ReadOnlySpan<byte>` view, never through the shared `OpenTypeFontface.Position` cursor - see
+[fonts-composite-closure-does-not-move-the-shared-face-cursor](../invariants/fonts-composite-closure-does-not-move-the-shared-face-cursor.md),
+which this change does not touch.
+
+`GlyphDataTableTests.CompleteGlyphClosure_IncludesNestedCompositeComponents` reproduces the failure
+directly: it takes a real composite glyph from `BundledFonts.Ttf` and rewrites its accent component's own
+glyph record in place to make it composite too (the same shape `Go Noto CJKCore` uses), then asserts the
+resulting closure contains the doubly-nested component. `dotnet build PeachPDF.slnx -t:Rebuild`: 0
+warnings. Full `PeachPDF.Tests` suite passed on net8.0 and net10.0, with all changed executable lines
+covered by diff coverage.

--- a/src/PeachPDF.Tests/PdfSharpCore/Fonts/GlyphDataTableTests.cs
+++ b/src/PeachPDF.Tests/PdfSharpCore/Fonts/GlyphDataTableTests.cs
@@ -1,0 +1,81 @@
+using System.Buffers.Binary;
+using System.Text;
+using PeachPDF.Fonts.OpenType;
+using PeachPDF.PdfSharpCore.Drawing;
+using PeachPDF.PdfSharpCore.Pdf;
+using PeachPDF.Tests.TestSupport;
+
+namespace PeachPDF.Tests.PdfSharpCoreTests.Fonts
+{
+    public class GlyphDataTableTests
+    {
+        [Fact]
+        public void CompleteGlyphClosure_IncludesNestedCompositeComponents()
+        {
+            byte[] fontBytes = File.ReadAllBytes(BundledFonts.Ttf);
+            var sourceFace = new OpenTypeFontface(XFontSource.CreateCompiledFont(fontBytes));
+
+            int accentedGlyph = GlyphId(sourceFace, 'á');
+            int baseGlyph = GlyphId(sourceFace, 'a');
+            int accentGlyph = Assert.Single(GetComponents(sourceFace, accentedGlyph), glyph => glyph != baseGlyph);
+            int nestedGlyph = GlyphId(sourceFace, 'x');
+
+            Assert.True(NumberOfContours(sourceFace.glyf.GetGlyphData(accentGlyph)) >= 0);
+            Assert.DoesNotContain(nestedGlyph, GetComponents(sourceFace, accentedGlyph));
+
+            // Recast the immediate accent component as another composite. This reproduces the shape
+            // used by fonts such as Go Noto CJKCore: á -> (a, acute composite) -> acute outline.
+            // Its existing glyph record is large enough for this single-component composite.
+            Span<byte> accentData = fontBytes.AsSpan(sourceFace.glyf.GetOffset(accentGlyph));
+            BinaryPrimitives.WriteInt16BigEndian(accentData, -1);
+            BinaryPrimitives.WriteUInt16BigEndian(accentData[10..], 0x0003); // words + XY values
+            BinaryPrimitives.WriteUInt16BigEndian(accentData[12..], (ushort)nestedGlyph);
+            BinaryPrimitives.WriteInt16BigEndian(accentData[14..], 0);
+            BinaryPrimitives.WriteInt16BigEndian(accentData[16..], 0);
+
+            var nestedFace = new OpenTypeFontface(XFontSource.CreateCompiledFont(fontBytes));
+            var selected = new Dictionary<int, object> { [accentedGlyph] = null! };
+
+            nestedFace.glyf.CompleteGlyphClosure(selected);
+
+            Assert.Contains(baseGlyph, selected.Keys);
+            Assert.Contains(accentGlyph, selected.Keys);
+            Assert.Contains(nestedGlyph, selected.Keys);
+        }
+
+        private static int GlyphId(OpenTypeFontface face, char character)
+        {
+            var descriptor = new OpenTypeDescriptor("nested-composite-test", "nested-composite-test",
+                XFontStyle.Regular, face, new XPdfFontOptions(PdfFontEncoding.Unicode));
+            return descriptor.CharCodeToGlyphIndex(new Rune(character));
+        }
+
+        private static IReadOnlyList<int> GetComponents(OpenTypeFontface face, int glyph)
+        {
+            ReadOnlySpan<byte> data = face.glyf.GetGlyphData(glyph);
+            Assert.True(NumberOfContours(data) < 0);
+
+            var components = new List<int>();
+            int offset = 10;
+            while (true)
+            {
+                int flags = BinaryPrimitives.ReadUInt16BigEndian(data[offset..]);
+                components.Add(BinaryPrimitives.ReadUInt16BigEndian(data[(offset + 2)..]));
+                if ((flags & 0x0020) == 0)
+                    return components;
+
+                offset += 4;
+                offset += (flags & 0x0001) == 0 ? 2 : 4;
+                if ((flags & 0x0008) != 0)
+                    offset += 2;
+                else if ((flags & 0x0040) != 0)
+                    offset += 4;
+                else if ((flags & 0x0080) != 0)
+                    offset += 8;
+            }
+        }
+
+        private static short NumberOfContours(ReadOnlySpan<byte> glyphData) =>
+            BinaryPrimitives.ReadInt16BigEndian(glyphData);
+    }
+}

--- a/src/PeachPDF/Fonts/OpenType/GlyphDataTable.cs
+++ b/src/PeachPDF/Fonts/OpenType/GlyphDataTable.cs
@@ -113,19 +113,18 @@ namespace PeachPDF.Fonts.OpenType
         /// </summary>
         public void CompleteGlyphClosure(Dictionary<int, object> glyphs)
         {
-            int count = glyphs.Count;
-            int[] glyphArray = new int[glyphs.Count];
-            glyphs.Keys.CopyTo(glyphArray, 0);
             if (!glyphs.ContainsKey(0))
                 glyphs.Add(0, null);
-            for (int idx = 0; idx < count; idx++)
-                AddCompositeGlyphs(glyphs, glyphArray[idx]);
+
+            var pendingGlyphs = new Queue<int>(glyphs.Keys);
+            while (pendingGlyphs.Count > 0)
+                AddCompositeGlyphs(glyphs, pendingGlyphs, pendingGlyphs.Dequeue());
         }
 
         /// <summary>
         /// If the specified glyph is a composite glyph add the glyphs it is made of to the glyph table.
         /// </summary>
-        void AddCompositeGlyphs(Dictionary<int, object> glyphs, int glyph)
+        void AddCompositeGlyphs(Dictionary<int, object> glyphs, Queue<int> pendingGlyphs, int glyph)
         {
             ReadOnlySpan<byte> glyphData = GetGlyphData(glyph);
             if (glyphData.IsEmpty)
@@ -143,7 +142,10 @@ namespace PeachPDF.Fonts.OpenType
                 offset += 4;
 
                 if (!glyphs.ContainsKey(cGlyph))
+                {
                     glyphs.Add(cGlyph, null);
+                    pendingGlyphs.Enqueue(cGlyph);
+                }
                 if ((flags & MORE_COMPONENTS) == 0)
                     return;
 


### PR DESCRIPTION
## Summary

- Traverse TrueType composite-glyph dependencies transitively when building font subsets.
- Preserve nested accent outlines used by fonts such as Go Noto CJKCore.
- Add regression coverage for a composite glyph whose component is itself composite.

## Testing

- `dotnet build PeachPDF.slnx --configuration Release --no-restore` — 0 warnings, 0 errors
- Full `PeachPDF.Tests` suite — 10,763 passed and 9 platform-specific skips on both .NET 8 and .NET 10
- Coverage run on .NET 8 — all changed executable lines covered
- Rendered the reporter's attached HTML with its embedded font and visually confirmed the diacritics

Closes #1009