### PR TITLE
Stop replaced content reserving a phantom trailing space

### DIFF
--- a/.claude/accepted-gaps/final-line-trailing-space-counted-in-max-content-width.md
+++ b/.claude/accepted-gaps/final-line-trailing-space-counted-in-max-content-width.md
@@ -1,0 +1,22 @@
+# A block's own final line counts its trailing space in max-content width
+
+Tracked as **#1014**. Surfaced by the issue #1011 review; pre-existing.
+
+[css-text-3 §4.1.2](https://www.w3.org/TR/css-text-3/#white-space-phase-2) hangs a line's trailing
+white space, so it does not contribute to the line's width. `CssBox.GetMinMaxSumWords` applies this at
+a `<br>` — the one point in its walk where a line is known to have ended — but not at the end of a
+block, so a block whose last line ends in white space measures one space wider than it draws. Every
+shrink-to-fit consumer of that measurement (a table column, a float, an inline-block) inherits the
+extra space.
+
+The obvious repair is wrong and was checked: the walk carries **one** running `maxSum` across a whole
+subtree, so the last word of any given box is not the last word of the line whenever a sibling's
+content follows it there. In `<span>AB </span><span>CD</span>` that trailing space is an ordinary
+inter-word gap, and subtracting it would undercount the line by a space. Closing this properly means
+knowing where the line really ends during the intrinsic-size walk, which that walk is not structured
+to answer.
+
+Until issue #1011 this was masked in one direction: a `!HasSpaceAfter`-guarded subtraction sat at the
+end of that branch, put there to cancel the phantom word space `CssRect.ActualWordSpacing` used to
+give every `IsImage` word. With that term gone the guard selects only words whose spacing is provably
+zero, so the subtraction was removed — see the note left in its place in `GetMinMaxSumWords`.

--- a/.claude/accepted-gaps/justify-expands-at-every-word-boundary.md
+++ b/.claude/accepted-gaps/justify-expands-at-every-word-boundary.md
@@ -1,0 +1,22 @@
+# `text-align: justify` expands at every word boundary, not at justification opportunities
+
+Tracked as **#1013**. Found during the issue #1011 review; pre-existing, not introduced by it.
+
+`CssLayoutEngine.ApplyJustifyAlignment` (and its vertical counterpart in the column path) sums every
+word's own `Width` on a justified line and spreads `(availWidth - textSum) / wordCount` after **each**
+word, consulting `HasSpaceAfter` only as a floor for an overflowing line. Per
+[css-text-3 §7.3](https://www.w3.org/TR/css-text-3/#justification) expansion belongs at
+*justification opportunities* — for `text-justify: auto` in a Latin script, the word separators — not
+at every inline-box boundary.
+
+Measured at `font: 16px monospace`, `width: 200pt`, on a genuinely justified (non-final) line:
+`A<span>B</span> CD EF …` places `B` 6.186pt after `A`, where left alignment places it flush at
+`A`'s right edge and a browser renders `AB` contiguous. The same gap opens on both sides of an
+`<img>`/inline `<svg>` that has no source white space around it.
+
+Out of scope for issue #1011, which was about the *natural* inter-word gap
+(`CssRect.ActualWordSpacing`): that term is shared by every alignment and by intrinsic-width
+measurement, while this one lives entirely in the justify pass and needs a real
+justification-opportunity model (word separators, and the `text-justify` property PeachPDF does not
+implement) rather than a word count. Note that `CssRect.ActualWordSpacing`'s own remarks now state the
+"only source white space produces an advance" rule, and this is the one place that rule does not hold.

--- a/.claude/migration-notes/2026-09-12-replaced-content-no-longer-reserves-a-trailing-space.md
+++ b/.claude/migration-notes/2026-09-12-replaced-content-no-longer-reserves-a-trailing-space.md
@@ -1,0 +1,25 @@
+# An `<img>`/inline `<svg>` no longer adds a space after itself
+
+**Before (v0.9.18 and earlier):** every atomic inline — `<img>`, inline `<svg>`, `<object>`,
+`<video>`, `<iframe>`, and a `list-style-image`/`disc`/`circle`/`square` list marker — reserved one
+extra word space after itself,
+on top of whatever white space the source actually had. `<img>text` rendered with a full space
+between the image and the text; `<img> text` rendered with two.
+
+**Now:** the gap after an atomic inline comes only from white space in the source, matching every
+browser and [css-text-3 §4.1.1](https://www.w3.org/TR/css-text-3/#white-space-phase-1).
+`<img>text` is contiguous, `<img> text` gets exactly one space.
+
+**Why:** the extra term was inherited from the engine's original HtmlRenderer lineage and had no
+spec basis (issue #1011).
+
+**Unchanged:** `text-align: justify` still distributes its expansion over every word boundary on a
+justified line, so it can open a gap between two adjacent inline boxes that have no white space
+between them. That is a separate, pre-existing deviation (#1013), not part of this change.
+
+**What a document author may notice:** content that sits an icon directly against text — an inline
+`<img>`/`<svg>` badge, a generated `content: url(...)` image, an `inside` list marker — draws
+slightly tighter than before, and a line holding such content measures slightly narrower, so a
+shrink-to-fit box (a table column, a float, an inline-block) around it can come out narrower too.
+Markup that relied on the phantom space for separation should add the white space, margin or padding
+it actually wanted.

--- a/.claude/recent-fixes/2026-09-11-form-control-attributes-and-placeholder.md
+++ b/.claude/recent-fixes/2026-09-11-form-control-attributes-and-placeholder.md
@@ -74,11 +74,14 @@ Worth recording, because three of these were introduced *by* the change and none
 - **A form field gained a phantom trailing word-space.** `CssRect.ActualWordSpacing` adds a whole
   space's width for any `IsImage` word, so making `CssRectFormField.IsImage` true silently inserted
   one between a checkbox and the label after it - measured at 6.5977pt for 16px monospace, and
-  `margin: 0` could not remove it. Fixed by splitting the question: `CssRect.ReservesTrailingSpace`
-  (virtual, defaults to `IsImage`) is overridden false for a field. Measured after: gap 0 with
-  `margin: 0`, and exactly one space plus the UA margin otherwise, which is what a browser does.
-  **Images still over-reserve** (`<img> X` gets two spaces where a browser gives one) - pre-existing,
-  untouched here, and not covered by any accepted-gap file.
+  `margin: 0` could not remove it. Fixed at the time by splitting the question: `CssRect
+  .ReservesTrailingSpace` (virtual, defaulting to `IsImage`) was overridden false for a field.
+  Measured after: gap 0 with `margin: 0`, and exactly one space plus the UA margin otherwise, which
+  is what a browser does. It was also noted here that **images still over-reserve** (`<img> X` got
+  two spaces where a browser gives one). **Superseded:** issue #1011 deleted the phantom term and the
+  `ReservesTrailingSpace` property outright, since no atomic inline should reserve one - the field
+  now gets this behaviour from the base class. Don't go looking for that property; see
+  [2026-09-12-phantom-trailing-space-after-replaced-content.md](2026-09-12-phantom-trailing-space-after-replaced-content.md).
 - **The `/Tx` sequence was skipped when a field had no drawable content box.** An early return on a
   degenerate `contentRect` sat *above* `BeginVariableText`, so a field whose padding and border
   consume its box got no replaceable region - the exact append-instead-of-replace bug the sequence

--- a/.claude/recent-fixes/2026-09-12-phantom-trailing-space-after-replaced-content.md
+++ b/.claude/recent-fixes/2026-09-12-phantom-trailing-space-after-replaced-content.md
@@ -1,0 +1,82 @@
+# Replaced content no longer reserves a phantom trailing space (issue #1011)
+
+`CssRect.ActualWordSpacing` had two terms: one for a real trailing space (`HasSpaceAfter`) and a
+second, unconditional one for any `IsImage` word. The second is inherited straight from the original
+HtmlRenderer code (`git log -S` dates it to the initial commit), and it meant every atomic inline —
+`<img>`, inline `<svg>`, `<object>`/`<video>`, `<iframe>`, `CssRectShape`, and anything else
+answering `IsImage` — pushed whatever followed it one whole word space to the right. With source
+white space present the two terms stacked, so `<img> text` got **two** spaces. The form-field work in
+[2026-09-11-form-control-attributes-and-placeholder.md](2026-09-11-form-control-attributes-and-placeholder.md)
+(#1010) had already had to carve an exception out of it
+(`CssRectFormField.ReservesTrailingSpace => false`), which is what put the term under a name and made
+it findable.
+
+The fix deletes the term and the `ReservesTrailingSpace` property it was hiding behind, leaving
+`ActualWordSpacing` keyed on `HasSpaceAfter` alone. `CssRectFormField`'s override goes with it — it
+now gets the correct behaviour from the base class instead of opting out of a wrong one.
+
+## What the measurement said
+
+Numbers at `font: 16px monospace` (one space = 6.5977pt), gap between the atomic inline's right edge
+and the next word's left edge:
+
+| markup | before | after | Chromium |
+|---|---|---|---|
+| `<img>text` | 6.5977 (1 space) | 0 | 0 |
+| `<img> text` | 13.1953 (2 spaces) | 6.5977 | one space |
+| `<span>Y</span><span>X</span>` (control) | 0 | 0 | 0 |
+
+Chromium's own numbers came from driving the repo's existing Playwright dependency directly
+(`page.Locator(...).BoundingBoxAsync()` on the `<img>` and the following `<span>`): image right edge
+13.000, following text at 13.000 with no space and at 21.797 with one. That is the evidence the
+target is 0, not "0 looks tighter" — css-text-3 §4.1.1 makes white space the only thing that produces
+an advance between two adjacent inline-level boxes.
+
+## The thing that nearly read as a regression
+
+Removing the term also removes it from **inside list markers**, because a `disc`/`circle`/`square`
+marker's word is a `CssRectShape` and a `list-style-image` marker's is a `CssRectImage` — both
+`IsImage`. The `list_style_image` and `marker_styling` showcases visibly tighten as a result.
+
+This is correct, and worth not re-"fixing": PeachPDF's marker gap is the UA sheet's
+`li::marker { margin-right: 5px }` (`CssDefaults.cs`), a deliberate uniform stand-in for the
+per-counter-style `suffix` descriptor PeachPDF doesn't implement (see
+[.claude/accepted-gaps/marker-box-layout.md](../accepted-gaps/marker-box-layout.md)). The phantom
+space was *defeating* that rule for exactly the two marker kinds whose word happened to be `IsImage`,
+giving them 5px + one font-scaled space while a text marker got 5px. After the fix all three kinds
+measure the same 3.75pt (5px) gap — verified directly on `CssBoxMarker`'s word for
+disc/decimal/image × inside/outside. Chromium puts a font-independent 7px after an image marker
+(its own `LayoutListMarker` constant, also not a spec number), so 5px is nearer than the 13.8px the
+phantom space produced.
+
+## Two things the review pass turned up around it
+
+- **`CssBox.GetMinMaxSumWords`'s trailing `maxSum -= box.Words[^1].ActualWordSpacing` became
+  provably dead** — it was guarded on `!HasSpaceAfter`, which now selects exactly the words whose
+  spacing is zero, because cancelling the phantom term was its only job. Removed, with a note in its
+  place saying why it must *not* simply be inverted to hang a real trailing space: this walk carries
+  one running `maxSum` across a whole subtree, so a box's last word is not the line's last word when
+  a sibling follows it there (`<span>AB </span><span>CD</span>`). The residual §4.1.2 gap is recorded
+  in [.claude/accepted-gaps/final-line-trailing-space-counted-in-max-content-width.md](../accepted-gaps/final-line-trailing-space-counted-in-max-content-width.md)
+  (#1014).
+- **`text-align: justify` still opens a gap where there is no white space** — it spreads its
+  expansion over every word boundary rather than over justification opportunities, so on a justified
+  line `A<span>B</span>` measures 6.186pt apart where left alignment renders it flush. Pre-existing
+  and untouched, but it is the one place the rule this fix asserts does not hold, so the
+  `ActualWordSpacing` remarks now say so and it is filed as
+  [.claude/accepted-gaps/justify-expands-at-every-word-boundary.md](../accepted-gaps/justify-expands-at-every-word-boundary.md)
+  (#1013).
+
+## Evidence
+
+- Full suite 10 832 passed / 0 failed (net8.0); `dotnet build PeachPDF.slnx -t:Rebuild` 0 warnings.
+- 100% coverage on every changed line (the new `ActualWordSpacing` expression, 1.5M hits).
+- `AtomicInlineSpacingIntegrationTests` (9 tests) confirmed to fail 8/9 against the unfixed code
+  before being kept — the ninth is the all-text control, which must pass either way.
+- Probe document rasterized through **both PDFium and MuPDF**, which agree: `[■]` flush with no
+  source space, `[■ ]` with one.
+- All 113 showcases re-rendered and pixel-diffed against a baseline built from unmodified `main`:
+  exactly 4 change — `content_image`, `invoice`, `list_style_image`, `marker_styling` — each by
+  exactly the one-space shift the fix intends. **Build the baseline from stashed code, not from
+  `docs/showcase/`**: that directory was four days stale here and initially attributed `transform`
+  and `interactive_pdf_forms` diffs (really #1010's) to this change.

--- a/src/PeachPDF.Tests/Integration/AtomicInlineSpacingIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/AtomicInlineSpacingIntegrationTests.cs
@@ -1,0 +1,167 @@
+using PeachPDF.Html.Core.Dom;
+using PeachPDF.Tests.TestSupport;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PeachPDF.Tests.Integration
+{
+    /// <summary>
+    /// An atomic inline-level box reserves no space of its own after itself: per
+    /// <see href="https://www.w3.org/TR/css-text-3/#white-space-phase-1">css-text-3 §4.1.1</see> only
+    /// white space in the source produces an advance between two adjacent inline-level boxes, so
+    /// <c>&lt;img&gt;text</c> is exactly as contiguous as
+    /// <c>&lt;span&gt;Y&lt;/span&gt;&lt;span&gt;X&lt;/span&gt;</c>.
+    ///
+    /// <c>CssRect.ActualWordSpacing</c> used to add one unconditional word space after every
+    /// <c>CssRect.IsImage</c> word on top of whatever a real trailing space already contributed, so an
+    /// image or inline <c>&lt;svg&gt;</c> pushed what followed it a full space to the right, and one
+    /// followed by actual white space got two spaces' worth (issue #1011). The gap is measured against
+    /// the all-text control in the same document, at the same font, so it states the real invariant
+    /// ("the image behaves like a glyph run") rather than a font-dependent constant.
+    /// </summary>
+    public class AtomicInlineSpacingIntegrationTests
+    {
+        /// <summary>A 1x1 PNG - the content never matters here, only that the image decodes.</summary>
+        private const string Png =
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8"
+            + "z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+        private static readonly string Image =
+            $"<img src='{Png}' style='width:13px;height:13px' />";
+
+        private const string Svg = "<svg width='13' height='13'></svg>";
+
+        [Theory]
+        [InlineData("image")]
+        [InlineData("svg")]
+        public async Task AtomicInline_FollowedImmediatelyByText_ReservesNoGap(string kind)
+        {
+            var words = await WordsAsync($"{Replaced(kind)}text");
+
+            Assert.Equal(2, words.Count);
+            Assert.True(words[0].IsImage);
+            Assert.Equal(ReplacedWidthPt, words[0].Width, 0.01);
+            Assert.Equal(0, words[1].Left - words[0].Right, 0.01);
+        }
+
+        [Theory]
+        [InlineData("image")]
+        [InlineData("svg")]
+        public async Task AtomicInline_FollowedByOneSpace_ReservesExactlyOneSpace(string kind)
+        {
+            // The control is two adjacent text runs separated by the same single space, so "one
+            // space" is whatever this font actually measures rather than a hard-coded width.
+            var words = await WordsAsync($"{Replaced(kind)} text");
+            var oneSpace = await GapAfterFirstWordAsync("<span>Y</span> text");
+
+            Assert.Equal(2, words.Count);
+            Assert.Equal(ReplacedWidthPt, words[0].Width, 0.01);
+
+            var gap = words[1].Left - words[0].Right;
+            Assert.Equal(oneSpace, gap, 0.01);
+            Assert.True(gap > 0, $"A source space must still produce a real gap, but it was {gap}");
+        }
+
+        [Fact]
+        public async Task AdjacentTextRuns_ReserveNoGap_Control()
+        {
+            // The control the two cases above are compared against: nothing about an atomic inline is
+            // involved, so a regression here would mean the harness, not the fix, had moved.
+            var gap = await GapAfterFirstWordAsync("<span>Y</span><span>X</span>");
+
+            Assert.Equal(0, gap, 0.01);
+        }
+
+        [Theory]
+        [InlineData("image")]
+        [InlineData("svg")]
+        public async Task TwoAdjacentAtomicInlines_SitFlush(string kind)
+        {
+            // Neither one reserves anything, so the second starts exactly where the first ends - the
+            // case an icon strip (<img><img><img>) actually hits.
+            var replaced = Replaced(kind);
+            var words = await WordsAsync($"{replaced}{replaced}");
+
+            Assert.Equal(2, words.Count);
+            Assert.All(words, word => Assert.True(word.IsImage));
+            Assert.All(words, word => Assert.Equal(ReplacedWidthPt, word.Width, 0.01));
+            Assert.Equal(words[0].Right, words[1].Left, 0.01);
+        }
+
+        [Theory]
+        [InlineData("image")]
+        [InlineData("svg")]
+        public async Task AtomicInline_DoesNotWidenTheMaxContentWidthOfItsBlock(string kind)
+        {
+            // The phantom space lived in ActualWordSpacing, which CssBox.GetMinMaxWidth also sums via
+            // CssRect.FullWidth - so a block holding atomic inlines measured a whole space per inline
+            // wider than it draws, and every shrink-to-fit consumer of that measurement (a table
+            // column, a float, an inline-block) inherited the error. Two of them, because the old
+            // code discounted the *last* word's spacing at the end of GetMinMaxSumWords (the
+            // "remove the last word padding" line, deleted with the phantom term it existed to
+            // cancel) - so a single-inline block would have measured right by accident and this
+            // would not have been a guard at all.
+            var replaced = Replaced(kind);
+            double maxWidth = 0;
+            double wordWidthSum = 0;
+
+            await LayoutHarness.LayoutAsync(
+                LayoutHarness.Wrap($"<div id='d' style='font:16px monospace'>{replaced}{replaced}</div>"),
+                after: (root, _container, graphics) =>
+                {
+                    var block = LayoutHarness.FindById(root, "d")!;
+                    wordWidthSum = LayoutHarness.Descendants(block).SelectMany(box => box.Words).Sum(word => word.Width);
+                    block.GetMinMaxWidth(graphics, out _, out maxWidth);
+                    return Task.CompletedTask;
+                });
+
+            Assert.Equal(2 * ReplacedWidthPt, wordWidthSum, 0.01);
+            Assert.Equal(wordWidthSum, maxWidth, 0.01);
+        }
+
+        // ─── Helpers ─────────────────────────────────────────────────────────────
+
+        private static string Replaced(string kind) => kind switch
+        {
+            "image" => Image,
+            "svg" => Svg,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null)
+        };
+
+        /// <summary>
+        /// The horizontal distance between the end of the first word on the line and the start of the
+        /// second — the gap the engine reserved between them.
+        /// </summary>
+        private static async Task<double> GapAfterFirstWordAsync(string inlineContent)
+        {
+            var words = await WordsAsync(inlineContent);
+
+            Assert.Equal(2, words.Count);
+            return words[1].Left - words[0].Right;
+        }
+
+        /// <summary>
+        /// The atomic inline's own laid-out width, asserted alongside every gap so a "gap is zero"
+        /// assertion cannot pass by the replaced content collapsing to nothing. 13px at the
+        /// spec-correct 1px = 0.75pt.
+        /// </summary>
+        private const double ReplacedWidthPt = 13 * 0.75;
+
+        private static async Task<List<CssRect>> WordsAsync(string inlineContent)
+        {
+            // A monospace font keeps the control's space width stable across whatever font the host
+            // machine resolves for a generic family.
+            var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
+                $"<div id='d' style='font:16px monospace'>{inlineContent}</div>"));
+
+            var container = LayoutHarness.FindById(root, "d")!;
+
+            return LayoutHarness.Descendants(container)
+                .SelectMany(box => box.Words)
+                .OrderBy(word => word.Left)
+                .ToList();
+        }
+    }
+}

--- a/src/PeachPDF.Tests/Integration/FormFieldGeometryIntegrationTests.cs
+++ b/src/PeachPDF.Tests/Integration/FormFieldGeometryIntegrationTests.cs
@@ -114,12 +114,14 @@ namespace PeachPDF.Tests.Integration
         [Fact]
         public async Task AMarginlessControl_ReservesNoGapBeforeWhatFollowsIt()
         {
-            // CssRect.ActualWordSpacing gives any IsImage word one extra space's width after itself.
-            // A form field's phantom word answers IsImage for the box-model arithmetic above, but it
-            // has no source whitespace to stand in for, so it must opt out (CssRectFormField
-            // .ReservesTrailingSpace) - otherwise making it IsImage silently inserts a whole space
-            // between a checkbox and a label written immediately after it, which no browser does and
-            // which `margin: 0` could not remove.
+            // A form field's phantom word answers IsImage for the box-model arithmetic above, and
+            // CssRect.ActualWordSpacing used to give any IsImage word one extra space's width after
+            // itself - which inserted a whole space between a checkbox and a label written
+            // immediately after it, no browser does that, and `margin: 0` could not remove it. The
+            // field originally opted out of that term by itself (CssRectFormField
+            // .ReservesTrailingSpace); issue #1011 removed the term outright, since no atomic inline
+            // should reserve one - see AtomicInlineSpacingIntegrationTests. This stays as the
+            // form-control-shaped statement of the same rule.
             var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(
                 "<div style='font: 16px monospace'>"
                 + "<input id='f' type='checkbox' style='margin:0;padding:0;border:0' /><span id='after'>X</span>"
@@ -156,11 +158,6 @@ namespace PeachPDF.Tests.Integration
         // ─── Helpers ─────────────────────────────────────────────────────────────
 
         /// <summary>
-        /// The one line rectangle a field box resolves to — the exact value
-        /// <c>PdfGenerator.HandleFormFields</c> reads (<c>box.Rectangles</c>' first entry) and the
-        /// one <c>Fragment.PrimaryRect</c> hands the painter.
-        /// </summary>
-        /// <summary>
         /// The first word anywhere under <paramref name="box"/> - an inline element's own text can
         /// sit on an anonymous child rather than on the element's box.
         /// </summary>
@@ -176,6 +173,11 @@ namespace PeachPDF.Tests.Integration
             return null!;
         }
 
+        /// <summary>
+        /// The one line rectangle a field box resolves to — the exact value
+        /// <c>PdfGenerator.HandleFormFields</c> reads (<c>box.Rectangles</c>' first entry) and the
+        /// one <c>Fragment.PrimaryRect</c> hands the painter.
+        /// </summary>
         static async Task<RRect> FieldRect(string inputHtml)
         {
             var (root, _) = await LayoutHarness.LayoutAsync(LayoutHarness.Wrap(inputHtml));

--- a/src/PeachPDF/Html/Core/Dom/CssBox.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssBox.cs
@@ -7175,11 +7175,12 @@ namespace PeachPDF.Html.Core.Dom
                     if (word.IsLineBreak)
                     {
                         // The space that ended the line hangs and is not part of the line's width
-                        // (css-text-3 §4.1.2), the same rule the last-word subtraction below applies
-                        // to a box's final line. CssRect.FullWidth adds one unconditionally, so
-                        // without this every <br>-separated line measured one space too wide -- 2.6pt
-                        // on that five-line address block, enough to over-subscribe its flex row and wrap
-                        // the heading beside it.
+                        // (css-text-3 §4.1.2). A <br> is the only point in this walk where the line is
+                        // known to have ended, so it is the only place the rule can be applied - see
+                        // the note where the old last-word subtraction used to sit, below. Without
+                        // this every <br>-separated line measured one space too wide -- 2.6pt on that
+                        // five-line address block, enough to over-subscribe its flex row and wrap the
+                        // heading beside it.
                         widestLine = Math.Max(widestLine, maxSum - trailingSpace);
                         maxSum = marginSum;
                         trailingSpace = 0;
@@ -7246,9 +7247,20 @@ namespace PeachPDF.Html.Core.Dom
                     atLineStart = false;
                 }
 
-                // remove the last word padding
-                if (box.Words.Count > 0 && !box.Words[^1].HasSpaceAfter)
-                    maxSum -= box.Words[^1].ActualWordSpacing;
+                // No trailing-space subtraction here. There used to be one, guarded on
+                // `!HasSpaceAfter`, and its only job was to cancel the phantom word space
+                // CssRect.ActualWordSpacing gave every IsImage word; issue #1011 removed that term, so
+                // the guard now selects exactly the words whose ActualWordSpacing is provably zero.
+                //
+                // It cannot simply be inverted to hang a *real* trailing space (css-text-3 §4.1.2) the
+                // way the <br> branch above does: this walk carries ONE running maxSum across a whole
+                // subtree, so `box`'s last word is not the line's last word whenever a sibling's
+                // content follows it on the same line. In `<span>AB </span><span>CD</span>` that space
+                // is an ordinary inter-word gap, and subtracting it would undercount the line. A
+                // <br> is the one point in the walk where the line is known to have ended, which is
+                // why only that branch can do it - a block's own final line still measures one space
+                // wide when it ends in white space (issue #1014, and
+                // .claude/accepted-gaps/final-line-trailing-space-counted-in-max-content-width.md).
             }
             else
             {

--- a/src/PeachPDF/Html/Core/Dom/CssLayoutEngineFlex.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssLayoutEngineFlex.cs
@@ -1762,8 +1762,9 @@ namespace PeachPDF.Html.Core.Dom
                 if (word.IsSpaces && !word.IsLineBreak) { pending += word.FullWidth; continue; }
                 width += pending + word.FullWidth;
                 pending = 0;
-                // CssRect.FullWidth adds a word space unconditionally, so the last word on the line
-                // carries one that nothing follows.
+                // CssRect.FullWidth folds in the word's own trailing space, which on the last word
+                // of the line is one nothing follows (css-text-3 §4.1.2) - zero when the line's last
+                // word had no source space after it, in which case this subtracts nothing.
                 trailingSpacing = word.ActualWordSpacing;
             }
             return Math.Max(0, width - trailingSpacing);

--- a/src/PeachPDF/Html/Core/Dom/CssRect.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssRect.cs
@@ -126,6 +126,7 @@ namespace PeachPDF.Html.Core.Dom
         /// and a <c>::first-line</c> rule overrides <c>word-spacing</c>/<c>letter-spacing</c>.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Includes one <c>letter-spacing</c> unit alongside <c>word-spacing</c>: a real UA applies
         /// letter-spacing at every adjacent-character transition in a run, including the space
         /// character's own leading/trailing edges - since this engine never paints the space character
@@ -133,25 +134,29 @@ namespace PeachPDF.Html.Core.Dom
         /// that extra unit has to be folded in here for the inter-word gap to widen proportionally with
         /// letter-spacing the same way a real browser's does, instead of staying pinned to plain
         /// word-spacing regardless of how large letter-spacing gets.
+        /// </para>
+        /// <para>
+        /// It is keyed on <see cref="HasSpaceAfter"/> alone - a word gets an inter-word gap when the
+        /// source actually had white space after it, and never otherwise. In particular an atomic
+        /// inline (<see cref="IsImage"/>: an image, an inline <c>&lt;svg&gt;</c>, a form control)
+        /// reserves nothing on its own: per
+        /// <see href="https://www.w3.org/TR/css-text-3/#white-space-phase-1">css-text-3 §4.1.1</see>
+        /// white space is the only thing that produces an advance between two adjacent inline-level
+        /// boxes, and <c>&lt;img&gt;text</c> is as contiguous as
+        /// <c>&lt;span&gt;Y&lt;/span&gt;&lt;span&gt;X&lt;/span&gt;</c> is. This engine used to add an
+        /// unconditional extra word space after every such word, which put one phantom space after
+        /// every image and inline SVG and two after an image followed by real white space (issue
+        /// #1011). This is the natural gap only - <c>text-align: justify</c> separately spreads its
+        /// expansion over every word boundary on a justified line rather than over justification
+        /// opportunities, so it can still open a gap where there is no white space (see
+        /// <c>.claude/accepted-gaps/justify-expands-at-every-word-boundary.md</c>, issue #1013).
+        /// </para>
         /// </remarks>
         public double ActualWordSpacing =>
-            (HasSpaceAfter ? (FirstLineStyle?.ActualWordSpacing ?? OwnerBox.ActualWordSpacing) + (FirstLineStyle?.ActualLetterSpacing ?? OwnerBox.ActualLetterSpacing) : 0) +
-            (ReservesTrailingSpace ? (FirstLineStyle?.ActualWordSpacing ?? OwnerBox.ActualWordSpacing) : 0);
-
-        /// <summary>
-        /// Whether this word reserves one space's width after itself on top of whatever a trailing
-        /// space already contributes - a long-standing gap this engine has always given replaced
-        /// content, which is why it keys off <see cref="IsImage"/> by default.
-        /// </summary>
-        /// <remarks>
-        /// It exists as its own question because <see cref="IsImage"/> answers a different one - "is
-        /// this an atomic, non-text word carrying its owner box's replaced geometry", which is what
-        /// the box-model arithmetic in <c>CssLineBox.UpdateRectangle</c> needs. A form field is that
-        /// kind of word and must say so, but it never reserved this extra space and must not start:
-        /// a bare <c>&lt;input type=checkbox&gt; Label</c> would otherwise gain a whole space's worth
-        /// of gap it had no source whitespace for.
-        /// </remarks>
-        public virtual bool ReservesTrailingSpace => IsImage;
+            HasSpaceAfter
+                ? (FirstLineStyle?.ActualWordSpacing ?? OwnerBox.ActualWordSpacing)
+                  + (FirstLineStyle?.ActualLetterSpacing ?? OwnerBox.ActualLetterSpacing)
+                : 0;
 
         /// <summary>
         /// When set, this word lands on its block's first formatted line and a <c>::first-line</c>

--- a/src/PeachPDF/Html/Core/Dom/CssRectFormField.cs
+++ b/src/PeachPDF/Html/Core/Dom/CssRectFormField.cs
@@ -32,14 +32,6 @@ namespace PeachPDF.Html.Core.Dom
         public override bool IsImage => true;
 
         /// <summary>
-        /// False, unlike every other <see cref="IsImage"/> word. See
-        /// <see cref="CssRect.ReservesTrailingSpace"/>: a field has no source whitespace of its own
-        /// to stand in for, and reserving one would put a whole space's width between a checkbox and
-        /// the label written immediately after it.
-        /// </summary>
-        public override bool ReservesTrailingSpace => false;
-
-        /// <summary>
         /// Empty, not null - defensive only. <c>FragmentPainter.PaintWords</c> skips any
         /// <see cref="IsImage"/> word before it reaches <c>DrawString</c>, and
         /// <c>FormFieldFragmentPainter</c> handles this box's content anyway, but a null


### PR DESCRIPTION
CssRect.ActualWordSpacing had two terms: one for a real trailing space (HasSpaceAfter) and a second, unconditional one for any IsImage word. The second is inherited from the original HtmlRenderer code and has no spec basis, so every atomic inline -- <img>, inline <svg>, <object>, <video>, <iframe>, and a shape/image list marker -- pushed whatever followed it one whole word space to the right. With source white space present the two stacked, so "<img> text" got two spaces.

Delete the term and the ReservesTrailingSpace property it was hiding behind. CssRectFormField's override goes with it: the field now gets correct behaviour from the base class instead of opting out of wrong behaviour.

Per css-text-3 4.1.1 white space is the only thing that produces an advance between two adjacent inline-level boxes. Measured at 16px monospace (one space = 6.5977pt), gap after the atomic inline:

  <img>text    6.5977 -> 0          (Chromium: 0)
  <img> text  13.1953 -> 6.5977     (Chromium: one space)

Chromium's figures come from driving the existing Playwright dependency directly, so the target is measured rather than assumed.

Inside list markers now take their gap solely from the UA sheet's li::marker { margin-right: 5px }, uniformly across text, shape and image markers -- the phantom space had been defeating that rule for exactly the two marker kinds whose word happens to be IsImage.

Also removes the now-dead trailing subtraction at the end of CssBox.GetMinMaxSumWords, whose only job was cancelling the phantom term, leaving a note on why it must not simply be inverted, and corrects two comments that described FullWidth as adding a space unconditionally.

Two pre-existing deviations the review pass surfaced around this are recorded as accepted gaps rather than fixed here: justify expanding at every word boundary (#1013) and a block's final line counting its trailing space in max-content width (#1014).

Verified: full suite 10832/0 (net8.0), CLI 96/0, generators 119/0, solution rebuild 0 warnings, 100% coverage on the changed lines, probe rasterized through both PDFium and MuPDF, and all 113 showcases pixel-diffed against a baseline built from unmodified main -- exactly four change, each by the intended one-space shift.

Fixes #1011